### PR TITLE
Reconfigured coverage to include sources without tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -34,7 +34,7 @@ module.exports = function(config) {
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
       'src/js/angular/**/*.js': ['coverage'],
-      'src/app.js': ['coverage']
+      'src/*.js': ['coverage']
     },
 
 
@@ -46,6 +46,7 @@ module.exports = function(config) {
 
     // optionally, configure the reporter
     coverageReporter: {
+      includeAllSources: true,
       type: 'lcov',
       dir : 'coverage/',
       subdir: '.'

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,7 @@
 sonar.projectKey=Ontotext-AD_graphdb-workbench
 sonar.projectName=graphdb-workbench
-sonar.sources=src/js/angular
+sonar.sources=src
+sonar.exclusions=src/res/**/*,src/font/**/*,src/js/lib/**/*,src/css/fonts/**/*,src/css/lib/**/*
 sonar.tests=test
 sonar.language=js
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Without this the coverage report was misleading.

Configured sonar to analyze styles and pages instead of just the java
script (excluding libraries)