### PR TITLE
Stabilizing import tests + code reorganization & simplification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,11 @@ addons:
 
 script:
   - npm run test:coverage
-  - npm run test:coveralls
   - npm run build
   - npm run sonar
 
 after_script:
+  - npm run test:coveralls
   - npm run test:cypress-ci
 
 deploy:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6100,9 +6100,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.once": {

--- a/scripts/run-cypress-tests.sh
+++ b/scripts/run-cypress-tests.sh
@@ -23,5 +23,5 @@ wait-on http://localhost:7200 -t 60000
 wait-on http://localhost:7300 -t 30000
 
 # Run the tests
-npx cypress run --record=true --config baseUrl=http://localhost:7300,video=false
+npx cypress run --record=false --config baseUrl=http://localhost:7300,video=false
 

--- a/src/index.html
+++ b/src/index.html
@@ -71,7 +71,7 @@
                         {{getActiveRepository()}}
                     </span>
                     <span ng-if="!getActiveRepository() && getReadableRepositories().length">Choose repository</span>
-                    <span ng-if="!getActiveRepository() && !getReadableRepositories().length">No accessible repositories</span>
+                    <span class="no-repositories" ng-if="!getActiveRepository() && !getReadableRepositories().length">No accessible repositories</span>
                 </a>
             </button>
             <ul class="dropdown-menu dropdown-menu-right pre-scrollable" aria-labelledby="dropdownMenuButton">

--- a/src/js/angular/import/templates/filesTable.html
+++ b/src/js/angular/import/templates/filesTable.html
@@ -24,19 +24,19 @@
         </div>
         <form class="form-inline">
             <div class="btn btn-link">
-                <input class="form-check-input" type="checkbox" ng-click="selectAllFiles()" ng-model="checkAll"
+                <input class="form-check-input select-all-files" type="checkbox" ng-click="selectAllFiles()" ng-model="checkAll"
                        ng-disabled="!hasImportable()" ng-change="switchBatch(true)" tooltip="Select all">
             </div>
             <div class="btn-group" dropdown ng-hide="!hasImportable() || !batch"
                  popover="Import the selected items"
                  popover-trigger="mouseenter"
                  popover-placement="top">
-                <button type="button" class="btn btn-primary" ng-click="setSettingsFor('')"><span class="icon-import"></span> Import</button>
-                <button type="button" class="btn btn-primary dropdown-toggle-split dropdown-toggle" dropdown-toggle>
+                <button type="button" class="btn btn-primary import-btn" ng-click="setSettingsFor('')"><span class="icon-import"></span> Import</button>
+                <button type="button" class="btn btn-primary dropdown-toggle-split dropdown-toggle import-dropdown-btn" dropdown-toggle>
                     <span class="sr-only"></span>
                 </button>
                 <ul class="dropdown-menu" role="menu">
-                    <li><button type="button" class="dropdown-item" ng-click="importSelected(true)">Import without changing settings</button></li>
+                    <li><button type="button" class="dropdown-item import-without-change-btn" ng-click="importSelected(true)">Import without changing settings</button></li>
                 </ul>
             </div>
             <button id="wb-import-clearStatuses"
@@ -73,18 +73,18 @@
 
     <table id="wb-import-fileInFiles" class="table table-striped table-hover">
         <tbody>
-        <tr
+        <tr class="import-file-row"
                 ng-repeat="file in files | filter: {name: fileQuery, type: getTypeFilter()}"
                 ng-show="files.length > 0">
             <td width="25">
                 <label class="m-0 d-inline-block">
-                    <input type="checkbox" ng-model="fileChecked[file.name]"
+                    <input type="checkbox" class="import-file-checkbox" ng-model="fileChecked[file.name]"
                            ng-disabled="!importable(file)" ng-change="switchBatch()">
                 </label>
             </td>
             <td>
                 <div class="d-inline-block" style="overflow: hidden; text-overflow: ellipsis;">
-                    <div>
+                    <div class="import-file-header">
                         <!-- no icon for server files -->
                         <i class="icon-file" ng-show="viewType === 'server' && file.type === 'file'"></i>
                         <i class="icon-folder" ng-show="file.type === 'directory'"></i>
@@ -94,15 +94,15 @@
                         <strong ng-show="file.type !== 'text'">{{file.name}}</strong>
                         <strong ng-show="file.type === 'text'"><a href="#" ng-click="pasteData(file)">{{file.name}}</a></strong>
                     </div>
-                    <div>
-                        <button role="button" class="btn btn-link btn-inline secondary b-0 p-0"
+                    <div class="import-status">
+                        <button role="button" class="btn btn-link btn-inline secondary b-0 p-0 import-status-reset"
                                 ng-click="resetStatus([file.name])"
                                 ng-show="file.status === 'DONE' || file.status === 'ERROR'"
                                 ng-disabled="batch"
                                 tooltip="Reset status" tooltip-trigger="mouseenter">
                             <span class="icon-close"></span>
                         </button>
-                        <span class="icon-info text-secondary"
+                        <span class="icon-info text-secondary import-status-info"
                               popover-class="impex-popover"
                               popover-template="popoverTemplateUrl"
                               popover-trigger="mouseenter"
@@ -110,20 +110,23 @@
                               popover-append-to-body="true"
                               ng-show="file.status === 'DONE' || file.status === 'ERROR'">
                         </span>
-                        <span ng-show="file.status == 'NONE' && file.message" class="text-info">
-                            <small>{{file.message}}</small>
-                        </span>
-                        <span ng-show="file.status == 'DONE'" class="text-success">
-                            <i class="icon-check"></i>
-                            <small>{{file.message}}</small>
-                        </span>
-                        <span ng-show="file.status == 'ERROR'" class="text-danger">
-                            <i class="icon-warning"></i>
-                            <small>{{file.message}}</small>
-                        </span>
-                        <span ng-show="file.status === 'IMPORTING' || file.status === 'UPLOADING' || file.status === 'PENDING' || file.status === 'INTERRUPTING'" class="text-secondary">
-                            <i class="icon-reload loader"></i>
-                            <small>{{toTitleCase(file.status)}}...</small>
+                        <span class="import-status-message">
+                            <span ng-show="file.status == 'NONE' && file.message" class="text-info">
+                                <small>{{file.message}}</small>
+                            </span>
+                            <span ng-show="file.status == 'DONE'" class="text-success">
+                                <i class="icon-check"></i>
+                                <small>{{file.message}}</small>
+                            </span>
+                            <span ng-show="file.status == 'ERROR'" class="text-danger">
+                                <i class="icon-warning"></i>
+                                <small>{{file.message}}</small>
+                            </span>
+                            <span class="text-secondary import-status-loader"
+                                ng-show="file.status === 'IMPORTING' || file.status === 'UPLOADING' || file.status === 'PENDING' || file.status === 'INTERRUPTING'">
+                                <i class="icon-reload loader"></i>
+                                <small>{{toTitleCase(file.status)}}...</small>
+                            </span>
                         </span>
                     </div>
                 </div>

--- a/src/js/angular/import/templates/settingsModal.html
+++ b/src/js/angular/import/templates/settingsModal.html
@@ -1,252 +1,270 @@
-
-            <div class="modal-header">
-                <button type="button" class="close" ng-click="cancel()"></button>
-                <h4 class="modal-title">Import settings</h4>
+<div class="modal-header">
+    <button type="button" class="close" ng-click="cancel()"></button>
+    <h4 class="modal-title">Import settings</h4>
+</div>
+<form name="settingsForm" class="settings-form">
+    <div class="modal-body">
+        <div class="form-horizontal">
+            <div class="form-group row">
+                <label class="col-lg-3 col-form-label">
+                    Base IRI
+                    <span class="btn btn-link p-0"
+                          popover="RDF data may contain relative IRIs. In order to make sense of them, they need to be resolved against a Base IRI. Typically data does not contain relative IRIs and this field may be left empty."
+                          popover-trigger="mouseenter"
+                          popover-placement="right">
+                                    <i class="icon icon-info"></i>
+                                </span>
+                </label>
+                <div class="col-lg-9">
+                    <input validate-uri name="baseURI" type="text" ng-model="settings['baseURI']" class="form-control"
+                           placeholder="http://exampleuri.com/examplepath">
+                    <div class="alert alert-danger" ng-show="hasError(settingsForm.$error.validateUri, 'baseURI')">Not a
+                        valid IRI!
+                    </div>
+                </div>
             </div>
-            <form name="settingsForm">
-            <div class="modal-body">
-                <div class="form-horizontal">
-                        <div class="form-group row">
-                            <label class="col-lg-3 col-form-label">
-                                Base IRI
-                                <span class="btn btn-link p-0"
-                                      popover="RDF data may contain relative IRIs. In order to make sense of them, they need to be resolved against a Base IRI. Typically data does not contain relative IRIs and this field may be left empty."
-                                      popover-trigger="mouseenter"
-                                      popover-placement="right">
+            <div class="form-group row">
+                <label class="col-lg-3 col-form-label">
+                    Target graphs
+                    <span class="btn btn-link p-0"
+                          popover="Data is imported into one or more graphs. Some RDF formats may specify graphs, while others do not support that. The latter are treated as if they specify the default graph."
+                          popover-trigger="mouseenter"
+                          popover-placement="right">
                                     <i class="icon icon-info"></i>
                                 </span>
-                            </label>
-                            <div class="col-lg-9">
-                                <input validate-uri name="baseURI" type="text" ng-model="settings['baseURI']" class="form-control" placeholder="http://exampleuri.com/examplepath">
-                                <div class="alert alert-danger" ng-show="hasError(settingsForm.$error.validateUri, 'baseURI')">Not a valid IRI!</div>
-                            </div>
-                        </div>
-                        <div class="form-group row">
-                            <label class="col-lg-3 col-form-label">
-                                Target graphs
-                                <span class="btn btn-link p-0"
-                                      popover="Data is imported into one or more graphs. Some RDF formats may specify graphs, while others do not support that. The latter are treated as if they specify the default graph."
-                                      popover-trigger="mouseenter"
-                                      popover-placement="right">
+                </label>
+                <div class="col-lg-9">
+                    <div>
+                        <label popover="Import into the graph(s) specified by the data source."
+                               popover-trigger="mouseenter">
+                            <input type="radio" ng-model="target" value="data"
+                                   ng-change="settingsForm.context.$setValidity('validateUri', true)">
+                            From data
+                        </label>
+                        &nbsp;
+                        <label popover="Import everything into the default graph."
+                               popover-trigger="mouseenter">
+                            <input type="radio" ng-model="target" value="default"
+                                   ng-change="settingsForm.context.$setValidity('validateUri', true)">
+                            The default graph
+                        </label>
+                        &nbsp;
+                        <label popover="Import everything into a user-specified named graph."
+                               popover-trigger="mouseenter">
+                            <input type="radio" ng-model="target" value="named" class="named-graph-option">
+                            Named graph
+                        </label>
+                    </div>
+                    <div>
+                        <input validate-uri name="context" type="text" ng-required="target === 'named'"
+                               ng-disabled="target !== 'named'" ng-model="settings.context" class="form-control named-graph-input"
+                               placeholder="http://example.com/graph...">
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <div class="col-lg-9 offset-lg-3">
+                    <label class="col-form-label"
+                           popover="{{isMultiple ? 'This mode is not supported when importing multiple items.' : 'Enable this to replace the data in one or more graphs with the imported data.'}}"
+                           popover-trigger="mouseenter"
+                           popover-placement="top">
+                        <input type="checkbox" ng-model="enableReplace" ng-disabled="isMultiple">
+                        Enable replacement of existing data
+                    </label>
+                </div>
+            </div>
+            <div class="form-group row" ng-show="enableReplace">
+                <label class="col-lg-3 col-form-label">
+                    Replaced graphs
+                    <span class="btn btn-link p-0"
+                          popover="Replaced graphs provide an easy way to update one or more graphs with a new version of the data. All specified graphs will be cleared before the import is run. This option provides the most flexibility when the target graphs are determined from data."
+                          popover-trigger="mouseenter"
+                          popover-placement="right">
                                     <i class="icon icon-info"></i>
                                 </span>
-                            </label>
-                            <div class="col-lg-9">
-                                <div>
-                                <label popover="Import into the graph(s) specified by the data source."
-                                       popover-trigger="mouseenter">
-                                    <input type="radio" ng-model="target" value="data" ng-change="settingsForm.context.$setValidity('validateUri', true)">
-                                    From data
-                                </label>
-                                &nbsp;
-                                <label popover="Import everything into the default graph."
-                                       popover-trigger="mouseenter">
-                                    <input type="radio" ng-model="target" value="default" ng-change="settingsForm.context.$setValidity('validateUri', true)">
-                                    The default graph
-                                </label>
-                                &nbsp;
-                                <label popover="Import everything into a user-specified named graph."
-                                       popover-trigger="mouseenter">
-                                    <input type="radio" ng-model="target" value="named">
-                                    Named graph
-                                </label>
-                                </div>
-                                <div>
-                                    <input validate-uri name="context" type="text" ng-required="target === 'named'" ng-disabled="target !== 'named'" ng-model="settings.context" class="form-control" placeholder="http://example.com/graph...">
-                                </div>
-                            </div>
+                </label>
+                <label class="col-lg-9 col-form-label" ng-show="target === 'default' || target === 'named'">
+                    <span ng-show="target === 'default'">The default graph</span>
+                    <span ng-show="target === 'named'">{{settings.context}}</span>
+                    <span class="text-muted">(same as the target graph)</span>
+                </label>
+                <div class="col-lg-9" ng-show="target === 'data'">
+                    <div class="row">
+                        <div class="col-lg-9">
+                            <input name="replaceGraph" ng-model="replaceGraph" type="text" class="form-control"
+                                   placeholder="http://example.com/graph..."
+                                   ng-keypress="checkEnterReplaceGraph($event, replaceGraph)"
+                                   popover="If a graph ends in *, it will be treated as a prefix matching all named graphs starting with that prefix excluding the *."
+                                   popover-placement="top"
+                                   popover-trigger="mouseenter">
                         </div>
-                        <div class="form-group row">
-                            <div class="col-lg-9 offset-lg-3">
-                                <label class="col-form-label"
-                                       popover="{{isMultiple ? 'This mode is not supported when importing multiple items.' : 'Enable this to replace the data in one or more graphs with the imported data.'}}"
-                                       popover-trigger="mouseenter"
-                                       popover-placement="top">
-                                    <input type="checkbox" ng-model="enableReplace" ng-disabled="isMultiple">
-                                    Enable replacement of existing data
-                                </label>
-                            </div>
-                        </div>
-                        <div class="form-group row" ng-show="enableReplace">
-                            <label class="col-lg-3 col-form-label">
-                                Replaced graphs
-                                <span class="btn btn-link p-0"
-                                    popover="Replaced graphs provide an easy way to update one or more graphs with a new version of the data. All specified graphs will be cleared before the import is run. This option provides the most flexibility when the target graphs are determined from data."
-                                    popover-trigger="mouseenter"
-                                    popover-placement="right">
-                                    <i class="icon icon-info"></i>
-                                </span>
-                            </label>
-                            <label class="col-lg-9 col-form-label" ng-show="target === 'default' || target === 'named'">
-                                <span ng-show="target === 'default'">The default graph</span>
-                                <span ng-show="target === 'named'">{{settings.context}}</span>
-                                <span class="text-muted">(same as the target graph)</span>
-                            </label>
-                            <div class="col-lg-9" ng-show="target === 'data'">
-                                <div class="row">
-                                    <div class="col-lg-9">
-                                        <input name="replaceGraph" ng-model="replaceGraph" type="text" class="form-control" placeholder="http://example.com/graph..."
-                                            ng-keypress="checkEnterReplaceGraph($event, replaceGraph)"
-                                            popover="If a graph ends in *, it will be treated as a prefix matching all named graphs starting with that prefix excluding the *."
-                                            popover-placement="top"
-                                            popover-trigger="mouseenter">
-                                    </div>
-                                    <div class="col-lg-3 col-lg-no-padding">
-                                        <div class="btn-group" dropdown>
-                                            <button type="button" class="btn btn-primary" ng-click="addReplaceGraph(replaceGraph)"><span class="icon-plus"></span> Add graph</button>
-                                            <button type="button" class="btn btn-primary dropdown-toggle-split dropdown-toggle" dropdown-toggle>
-                                                <span class="sr-only"></span>
-                                            </button>
-                                            <ul class="dropdown-menu" role="menu">
-                                                <li><button type="button" class="dropdown-item" ng-click="addReplaceGraph('default')">Add default graph</button></li>
-                                            </ul>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div>
-                                    <table>
-                                        <tr>
-                                            <th>
-                                                <span ng-show="settings.replaceGraphs.length">Replaced graphs</span>
-                                                <span ng-show="!settings.replaceGraphs.length">No replaced graphs added</span>
-                                            </th>
-                                        </tr>
-                                        <tr ng-repeat="g in settings.replaceGraphs">
-                                            <td>
-                                                <span ng-show="g !== 'default'">{{g}}</span>
-                                                <span ng-show="g === 'default'">The default graph</span>
-                                                <button type="button" class="btn btn-link btn-sm secondary" ng-click="settings.replaceGraphs.splice($index, 1)">
-                                                    <i class="icon icon-trash"></i>
-                                                </button>
-                                            </td>
-                                        </tr>
-                                    </table>
-                                </div>
-                            </div>
-                            <div class="col-lg-9 offset-lg-3">
-                                <label class="col-form-label">
-                                    <input type="checkbox" ng-model="agree" ng-required="enableReplace">
-                                    <b>I understand that data in the replaced graphs will be cleared before importing new data.</b>
-                                </label>
-                            </div>
-                        </div>
-                        <div class="text-xs-center">
-                            <button type="button" ng-click="switchParserSettings()" class="btn btn-link btn-sm">
-                                <span ng-hide="showAdvancedSettings">Show advanced settings<i class="icon-caret-down"></i></span>
-                                <span ng-show="showAdvancedSettings">Hide advanced settings<i class="icon-caret-up"></i></span>
-                            </button>
-                        </div>
-
-                        <div ng-show="hasParserSettings && showAdvancedSettings">
-                        <div class="form-group row">
-                            <label class="col-lg-3 col-form-label">BNodes</label>
-                            <div class="col-lg-9">
-                                <div>
-                                    <label>
-                                        <input name="preserveBNodeIDs" type="checkbox" ng-model="settings['parserSettings']['preserveBNodeIds']"
-                                               popover="Assign its own internal blank node identifiers or use the blank node ids it finds in the file."
-                                               popover-trigger="mouseenter"
-                                               popover-placement="bottom"> Preserve BNode IDs
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="form-group row">
-                            <label class="col-lg-3 col-form-label">Datatype</label>
-                            <div class="col-lg-9">
-                                <div>
-                                    <label>
-                                        <input name="failOnUnknownDataTypes" type="checkbox"
-                                               ng-model="settings['parserSettings']['failOnUnknownDataTypes']"
-                                               popover="Fail on unknown datatypes"
-                                               popover-trigger="mouseenter"
-                                               popover-placement="bottom"> Fail parsing if datatypes are not recognised
-                                    </label>
-                                </div>
-                                <div>
-                                    <label>
-                                        <input name="verifyDataTypeValues"  type="checkbox"
-                                               ng-model="settings['parserSettings']['verifyDataTypeValues']"
-                                               popover="Validate recognised datatype values"
-                                               popover-trigger="mouseenter"
-                                               popover-placement="bottom"> Verify recognised datatypes
-                                    </label>
-                                </div>
-                                <div>
-                                    <label>
-                                        <input name="normalizeDataTypeValues" type="checkbox"
-                                        ng-model="settings['parserSettings']['normalizeDataTypeValues']"
-                                        popover="Normalize recognised datatype values"
-                                        popover-trigger="mouseenter"
-                                        popover-placement="bottom"> Normalize recognised datatypes values
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label class="col-lg-3 col-form-label">Language tags</label>
-                            <div class="col-lg-9">
-                                <div>
-                                    <label>
-                                        <input name="failOnUnknownLanguageTags" type="checkbox"
-                                               ng-model="settings['parserSettings']['failOnUnknownLanguageTags']"
-                                               popover="Fail on unknown languages"
-                                               popover-trigger="mouseenter"
-                                               popover-placement="bottom"> Fail parsing if languages are not recognised
-                                    </label>
-                                </div>
-                                <div>
-                                    <label>
-                                        <input name="verifyLanguageTags" type="checkbox"
-                                               ng-model="settings['parserSettings']['verifyLanguageTags']"
-                                               popover="Validate recognised language tags"
-                                               popover-trigger="mouseenter"
-                                               popover-placement="bottom"> Verify language based on a given set of definitions for valid languages
-                                    </label>
-                                </div>
-                                <div>
-                                    <label>
-                                        <input name="normalizeLanguageTags" type="checkbox"
-                                               ng-model="settings['parserSettings']['normalizeLanguageTags']"
-                                               popover="Normalize language tags"
-                                               popover-trigger="mouseenter"
-                                               popover-placement="bottom"> Normalize recognised language tags
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label class="col-lg-3 col-form-label">Error handling</label>
-                            <div class="col-lg-9">
-                                <label>
-                                    <input name="stopOnError" type="checkbox"
-                                           ng-model="settings['parserSettings']['stopOnError']"
-                                           popover="By default parser stops on error. When set on false errors are reported in the log and parsing continues."
-                                           popover-trigger="mouseenter"
-                                           popover-placement="bottom"> Should stop on error
-                                </label>
+                        <div class="col-lg-3 col-lg-no-padding">
+                            <div class="btn-group" dropdown>
+                                <button type="button" class="btn btn-primary" ng-click="addReplaceGraph(replaceGraph)">
+                                    <span class="icon-plus"></span> Add graph
+                                </button>
+                                <button type="button" class="btn btn-primary dropdown-toggle-split dropdown-toggle"
+                                        dropdown-toggle>
+                                    <span class="sr-only"></span>
+                                </button>
+                                <ul class="dropdown-menu" role="menu">
+                                    <li>
+                                        <button type="button" class="dropdown-item"
+                                                ng-click="addReplaceGraph('default')">Add default graph
+                                        </button>
+                                    </li>
+                                </ul>
                             </div>
                         </div>
                     </div>
-
-                        <div ng-show="showAdvancedSettings" class="form-group row">
-                            <label class="col-lg-3 col-form-label">Debug</label>
-                            <div class="col-lg-9 col-form-label">
-                                <input type="checkbox" ng-model="settings['forceSerial']" id="force-serial">
-                                <label for="force-serial" popover="Forces the use of the serial statements pipeline. Not recommended. Use for debugging only."
-                                       popover-placement="bottom"
-                                       popover-trigger="mouseenter">Force serial pipeline</label>
-                            </div>
-                        </div>
-
-
+                    <div>
+                        <table>
+                            <tr>
+                                <th>
+                                    <span ng-show="settings.replaceGraphs.length">Replaced graphs</span>
+                                    <span ng-show="!settings.replaceGraphs.length">No replaced graphs added</span>
+                                </th>
+                            </tr>
+                            <tr ng-repeat="g in settings.replaceGraphs">
+                                <td>
+                                    <span ng-show="g !== 'default'">{{g}}</span>
+                                    <span ng-show="g === 'default'">The default graph</span>
+                                    <button type="button" class="btn btn-link btn-sm secondary"
+                                            ng-click="settings.replaceGraphs.splice($index, 1)">
+                                        <i class="icon icon-trash"></i>
+                                    </button>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+                <div class="col-lg-9 offset-lg-3">
+                    <label class="col-form-label">
+                        <input type="checkbox" ng-model="agree" ng-required="enableReplace">
+                        <b>I understand that data in the replaced graphs will be cleared before importing new data.</b>
+                    </label>
                 </div>
             </div>
-            <div class="modal-footer">
-				<button type="button" class="btn btn-link pull-left" ng-click="reset()">Restore defaults</button>
-                <button type="button" class="btn btn-secondary" ng-click="cancel()">Cancel</button>
-                <button type="submit" class="btn btn-primary" ng-click="ok()"><span class="import"></span> Import</button>
+            <div class="text-xs-center">
+                <button type="button" ng-click="switchParserSettings()" class="btn btn-link btn-sm toggle-advanced-settings">
+                    <span ng-hide="showAdvancedSettings">Show advanced settings<i class="icon-caret-down"></i></span>
+                    <span ng-show="showAdvancedSettings">Hide advanced settings<i class="icon-caret-up"></i></span>
+                </button>
             </div>
-            </form>
+
+            <div ng-show="hasParserSettings && showAdvancedSettings" class="advanced-settings">
+                <div class="form-group row">
+                    <label class="col-lg-3 col-form-label">BNodes</label>
+                    <div class="col-lg-9">
+                        <div>
+                            <label>
+                                <input name="preserveBNodeIDs" type="checkbox"
+                                       ng-model="settings['parserSettings']['preserveBNodeIds']"
+                                       popover="Assign its own internal blank node identifiers or use the blank node ids it finds in the file."
+                                       popover-trigger="mouseenter"
+                                       popover-placement="bottom"> Preserve BNode IDs
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <label class="col-lg-3 col-form-label">Datatype</label>
+                    <div class="col-lg-9">
+                        <div>
+                            <label>
+                                <input name="failOnUnknownDataTypes" type="checkbox"
+                                       ng-model="settings['parserSettings']['failOnUnknownDataTypes']"
+                                       popover="Fail on unknown datatypes"
+                                       popover-trigger="mouseenter"
+                                       popover-placement="bottom"> Fail parsing if datatypes are not recognised
+                            </label>
+                        </div>
+                        <div>
+                            <label>
+                                <input name="verifyDataTypeValues" type="checkbox"
+                                       ng-model="settings['parserSettings']['verifyDataTypeValues']"
+                                       popover="Validate recognised datatype values"
+                                       popover-trigger="mouseenter"
+                                       popover-placement="bottom"> Verify recognised datatypes
+                            </label>
+                        </div>
+                        <div>
+                            <label>
+                                <input name="normalizeDataTypeValues" type="checkbox"
+                                       ng-model="settings['parserSettings']['normalizeDataTypeValues']"
+                                       popover="Normalize recognised datatype values"
+                                       popover-trigger="mouseenter"
+                                       popover-placement="bottom"> Normalize recognised datatypes values
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-group row">
+                    <label class="col-lg-3 col-form-label">Language tags</label>
+                    <div class="col-lg-9">
+                        <div>
+                            <label>
+                                <input name="failOnUnknownLanguageTags" type="checkbox"
+                                       ng-model="settings['parserSettings']['failOnUnknownLanguageTags']"
+                                       popover="Fail on unknown languages"
+                                       popover-trigger="mouseenter"
+                                       popover-placement="bottom"> Fail parsing if languages are not recognised
+                            </label>
+                        </div>
+                        <div>
+                            <label>
+                                <input name="verifyLanguageTags" type="checkbox"
+                                       ng-model="settings['parserSettings']['verifyLanguageTags']"
+                                       popover="Validate recognised language tags"
+                                       popover-trigger="mouseenter"
+                                       popover-placement="bottom"> Verify language based on a given set of definitions
+                                for valid languages
+                            </label>
+                        </div>
+                        <div>
+                            <label>
+                                <input name="normalizeLanguageTags" type="checkbox"
+                                       ng-model="settings['parserSettings']['normalizeLanguageTags']"
+                                       popover="Normalize language tags"
+                                       popover-trigger="mouseenter"
+                                       popover-placement="bottom"> Normalize recognised language tags
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-group row">
+                    <label class="col-lg-3 col-form-label">Error handling</label>
+                    <div class="col-lg-9">
+                        <label>
+                            <input name="stopOnError" type="checkbox"
+                                   ng-model="settings['parserSettings']['stopOnError']"
+                                   popover="By default parser stops on error. When set on false errors are reported in the log and parsing continues."
+                                   popover-trigger="mouseenter"
+                                   popover-placement="bottom"> Should stop on error
+                        </label>
+                    </div>
+                </div>
+            </div>
+
+            <div ng-show="showAdvancedSettings" class="form-group row">
+                <label class="col-lg-3 col-form-label">Debug</label>
+                <div class="col-lg-9 col-form-label">
+                    <input type="checkbox" ng-model="settings['forceSerial']" id="force-serial">
+                    <label for="force-serial"
+                           popover="Forces the use of the serial statements pipeline. Not recommended. Use for debugging only."
+                           popover-placement="bottom"
+                           popover-trigger="mouseenter">Force serial pipeline</label>
+                </div>
+            </div>
+
+
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-link pull-left" ng-click="reset()">Restore defaults</button>
+        <button type="button" class="btn btn-secondary" ng-click="cancel()">Cancel</button>
+        <button type="submit" class="btn btn-primary" ng-click="ok()"><span class="import"></span> Import</button>
+    </div>
+</form>

--- a/src/js/angular/import/templates/textSnippet.html
+++ b/src/js/angular/import/templates/textSnippet.html
@@ -15,22 +15,24 @@
 
 <div class="modal-footer">
     <div class="mb-1">
-        <span popover="Enable this option to start the import when you click the Import button. If it is disabled the import will be added to the list but not started automatically."
-              popover-trigger="mouseenter"
-              popover-placement="top">
+        <span
+            popover="Enable this option to start the import when you click the Import button. If it is disabled the import will be added to the list but not started automatically."
+            popover-trigger="mouseenter"
+            popover-placement="top">
             <input id="import-now-checkbox" type="checkbox" ng-model="startImport"/>
             <label for="import-now-checkbox">Start import automatically</label>
         </span>
     </div>
     <div>
         <button type="button" ng-click="cancel()" class="btn btn-secondary">Cancel</button>
-        <div class="btn-group" dropdown>
-            <button type="button" class="btn btn-secondary dropdown-toggle" dropdown-toggle>
+        <div class="btn-group import-format-dropdown" dropdown>
+            <button type="button" class="btn btn-secondary dropdown-toggle import-format-dropdown-btn" dropdown-toggle>
                 Format: {{importFormat.name}}
             </button>
             <ul class="dropdown-menu" role="menu">
-                <li ng-repeat="format in importFormats"><a ng-click="setFormat(format)"
-                       class="dropdown-item">{{format.name}}</a></li>
+                <li ng-repeat="format in importFormats">
+                    <a ng-click="setFormat(format)" class="dropdown-item">{{format.name}}</a>
+                </li>
             </ul>
         </div>
         <button id="wb-import-importText" class="btn btn-primary" type="button"

--- a/src/js/angular/import/templates/urlImport.html
+++ b/src/js/angular/import/templates/urlImport.html
@@ -4,7 +4,7 @@
 </div>
 
 <div class="modal-body">
-    <form name="urlForm" ng-submit="importUrlForm($event)" ng-hide="loader" novalidate>
+    <form name="urlForm" class="url-import-form" ng-submit="importUrlForm($event)" ng-hide="loader" novalidate>
         <div class="input-group mb-1">
             <input required validate-uri id="dataUrl" name="dataUrl" placeholder="Data URL" type="url"
                    ng-model="dataUrl" class="form-control"
@@ -29,8 +29,8 @@
     </div>
     <div>
         <button type="button" ng-click="cancel()" class="btn btn-secondary">Cancel</button>
-        <div class="btn-group" dropdown>
-            <button class="btn btn-secondary dropdown-toggle" dropdown-toggle>
+        <div class="btn-group import-format-dropdown" dropdown>
+            <button class="btn btn-secondary dropdown-toggle import-format-dropdown-btn" dropdown-toggle>
                 Format: {{importFormat.name}}
             </button>
             <ul class="dropdown-menu" role="menu">

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -37,7 +37,7 @@
                  ng-class="$parent.viewType == 'user' ? 'active' : ''">
                 <div class="row mb-2 upload-buttons">
                     <div class="col-xs-12 col-md-6 col-lg-4 mb-1">
-                        <div class="btn btn-outline-primary btn-lg text-xs-left d-block"
+                        <div class="btn btn-outline-primary btn-lg text-xs-left d-block upload-rdf-files-btn"
                              popover="The supported RDF formats are {{fileFormatsHuman}}"
                              popover-trigger="mouseenter"
                              popover-placement="bottom">
@@ -57,7 +57,7 @@
                         </div>
                     </div>
                     <div class="col-xs-12 col-md-6 col-lg-4 mb-1">
-                        <div class="btn btn-outline-primary btn-lg text-xs-left d-block" role="button" ng-click="rdfDataFromURL()"
+                        <div class="btn btn-outline-primary btn-lg text-xs-left d-block import-from-url-btn" role="button" ng-click="rdfDataFromURL()"
                              popover="The supported RDF formats are {{fileFormatsHuman}}"
                              popover-trigger="mouseenter"
                              popover-placement="bottom">
@@ -71,7 +71,7 @@
                         </div>
                     </div>
                     <div class="col-xs-12 col-md-6 col-lg-4 mb-1">
-                        <div class="btn btn-outline-primary btn-lg text-xs-left d-block" role="button" ng-click="pasteData()"
+                        <div class="btn btn-outline-primary btn-lg text-xs-left d-block import-rdf-snippet-btn" role="button" ng-click="pasteData()"
                              popover="The supported RDF formats are {{textFileFormatsHuman}}"
                              popover-trigger="mouseenter"
                              popover-placement="bottom">

--- a/test-cypress/fixtures/example.json
+++ b/test-cypress/fixtures/example.json
@@ -1,4 +1,0 @@
-{
-  "username": "sava",
-  "password": "123"
-}

--- a/test-cypress/fixtures/repo-template.json
+++ b/test-cypress/fixtures/repo-template.json
@@ -1,0 +1,107 @@
+{
+    "id": "",
+    "params": {
+        "queryTimeout": {
+            "label": "Query time-out (seconds)",
+            "name": "queryTimeout",
+            "value": "0"
+        },
+        "imports": {
+            "label": "Imported RDF files(';' delimited)",
+            "name": "imports",
+            "value": ""
+        },
+        "inMemoryLiteralProperties": {
+            "label": "Cache literal language tags",
+            "name": "inMemoryLiteralProperties",
+            "value": "true"
+        },
+        "ruleset": {
+            "label": "Ruleset",
+            "name": "ruleset",
+            "value": "rdfsplus-optimized"
+        },
+        "readOnly": {
+            "label": "Read-only",
+            "name": "readOnly",
+            "value": "false"
+        },
+        "title": {
+            "label": "Repository title",
+            "name": "title",
+            "value": "GraphDB Free repository"
+        },
+        "checkForInconsistencies": {
+            "label": "Check for inconsistencies",
+            "name": "checkForInconsistencies",
+            "value": "false"
+        },
+        "disableSameAs": {
+            "label": "Disable owl:sameAs",
+            "name": "disableSameAs",
+            "value": "true"
+        },
+        "enableLiteralIndex": {
+            "label": "Enable literal index",
+            "name": "enableLiteralIndex",
+            "value": "true"
+        },
+        "entityIndexSize": {
+            "label": "Entity index size",
+            "name": "entityIndexSize",
+            "value": "10000000"
+        },
+        "defaultNS": {
+            "label": "Default namespaces for imports(';' delimited)",
+            "name": "defaultNS",
+            "value": ""
+        },
+        "enableContextIndex": {
+            "label": "Use context index",
+            "name": "enableContextIndex",
+            "value": "false"
+        },
+        "baseURL": {
+            "label": "Base URL",
+            "name": "baseURL",
+            "value": "http://example.org/owlim#"
+        },
+        "queryLimitResults": {
+            "label": "Limit query results",
+            "name": "queryLimitResults",
+            "value": "0"
+        },
+        "entityIdSize": {
+            "label": "Entity ID bit-size",
+            "name": "entityIdSize",
+            "value": "32"
+        },
+        "throwQueryEvaluationExceptionOnTimeout": {
+            "label": "Throw exception on query time-out",
+            "name": "throwQueryEvaluationExceptionOnTimeout",
+            "value": "false"
+        },
+        "repositoryType": {
+            "label": "Repository type",
+            "name": "repositoryType",
+            "value": "file-repository"
+        },
+        "id": {
+            "label": "Repository ID",
+            "name": "id",
+            "value": "repo-test"
+        },
+        "storageFolder": {
+            "label": "Storage folder",
+            "name": "storageFolder",
+            "value": "storage"
+        },
+        "enablePredicateList": {
+            "label": "Use predicate indices",
+            "name": "enablePredicateList",
+            "value": "true"
+        }
+    },
+    "title": "",
+    "type": "free"
+}

--- a/test-cypress/integration/import/import.server.files.spec.js
+++ b/test-cypress/integration/import/import.server.files.spec.js
@@ -1,137 +1,71 @@
-describe('Import screen validation', function () {
-    let existingRepo = 'w11' + Date.now();
-    let baseURI = 'http://purl.org/dc/elements/1.1/';
-    let context = 'http://example.org/context';
-    let messageSuccess = 'Imported successfully';
-    let fileToImport = 'italian_public_schools_links.nt.gz';
-    let blankNodeFile = 'bnodes.ttl';
+import ImportSteps from '../../steps/import-steps';
 
-    before(function () {
-        cy.visit('/repository');
-        // Create new one
-        cy.createNewRepo(existingRepo).wait(2000);
+describe('Import screen validation - server files', () => {
+
+    let repositoryId;
+
+    const BASE_URI = 'http://purl.org/dc/elements/1.1/';
+    const CONTEXT = 'http://example.org/context';
+    const SUCCESS_MESSAGE = 'Imported successfully';
+    const FILE_FOR_IMPORT = 'italian_public_schools_links.nt.gz';
+    const BLANK_NODE_FILE = 'bnodes.ttl';
+
+    beforeEach(() => {
+        repositoryId = 'server-import-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        ImportSteps.visitServerImport(repositoryId);
     });
 
-    beforeEach(function () {
-        cy.visit('/import#user').wait(1000);
-        cy.selectRepo(existingRepo);
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
     });
 
-    afterEach(function () {
-        cy.checkAllServerFiles(true);
-        cy.resetStatusOfUploadedFiles().wait(1000);
-        cy.checkAllServerFiles(false);
+    it('Test import Server files successfully without changing settings', () => {
+        ImportSteps
+            .selectServerFile(FILE_FOR_IMPORT)
+            .importServerFiles()
+            .verifyImportStatus(FILE_FOR_IMPORT, SUCCESS_MESSAGE)
+            .verifyImportStatusDetails(FILE_FOR_IMPORT, '"preserveBNodeIds": false,');
     });
 
-    after(function () {
-        cy.navigateToPage('Setup', 'Repositories');
-        cy.deleteRepo(existingRepo).wait(1000);
+    it('Test import Server files successfully with changing settings', () => {
+        ImportSteps.selectServerFile(FILE_FOR_IMPORT)
+            .importServerFiles(true)
+            .fillBaseURI(BASE_URI)
+            .selectNamedGraph()
+            .fillNamedGraph(CONTEXT)
+            .expandAdvancedSettings()
+            .enablePreserveBNodes()
+            .importFromSettingsDialog()
+            .verifyImportStatus(FILE_FOR_IMPORT, SUCCESS_MESSAGE)
+            .verifyImportStatusDetails(FILE_FOR_IMPORT, [CONTEXT, BASE_URI, '"preserveBNodeIds": true,']);
     });
 
-    it('Test import Server files successfully without changing settings', function () {
-        cy.chooseServerFilesTab();
-        cy.selectDistinctFileToImport(fileToImport);
-        cy.importChangingSettings().wait(2000);
-        cy.verifyMessageOccurs(messageSuccess);
+    it('Test import all Server files successfully without changing settings', () => {
+        ImportSteps
+            .selectAllServerFiles()
+            .importServerFiles()
+            .verifyImportStatus(FILE_FOR_IMPORT, SUCCESS_MESSAGE)
+            .verifyImportStatus(BLANK_NODE_FILE, SUCCESS_MESSAGE);
     });
 
-    it('Test import Server files successfully with changing base uri', function () {
-        cy.chooseServerFilesTab();
-        cy.selectDistinctFileToImport(fileToImport);
-        cy.importChangingSettings(true);
-        cy.fillBaseURIInputField(baseURI).wait(1000);
-        cy.clickImportBtnOnPopUpMenu().wait(1500);
-        cy.verifyMessageOccurs(messageSuccess);
-        cy.confirmTextPresentsInDistinctFileInfo(baseURI, fileToImport);
+    it('Test import with resetting status of imported file', () => {
+        ImportSteps
+            .selectServerFile(FILE_FOR_IMPORT)
+            .importServerFiles()
+            .verifyImportStatus(FILE_FOR_IMPORT, SUCCESS_MESSAGE)
+            .resetStatusOfUploadedFile(FILE_FOR_IMPORT)
+            .verifyNoImportStatus(FILE_FOR_IMPORT);
     });
 
-    it('Test import Server files successfully with changing context on newly created repository', function () {
-        let repoId = 'repo1' + Date.now();
-        // First navigate to create repository
-        cy.navigateToPage('Setup', 'Repositories');
-        // Create new one
-        cy.createNewRepo(repoId).wait(2000);
-        cy.selectRepo(repoId).wait(1000);
-        // Should return to import page
-        cy.navigateToPage('Import', 'RDF');
-
-        cy.chooseServerFilesTab();
-        cy.selectDistinctFileToImport(fileToImport);
-        cy.importChangingSettings(true);
-        cy.selectNamedGraphCheck();
-        cy.fillNamedGraphInputField(context).wait(1000);
-        cy.clickImportBtnOnPopUpMenu().wait(2000);
-        cy.verifyMessageOccurs(messageSuccess);
-        cy.confirmTextPresentsInDistinctFileInfo(context, fileToImport);
-
-        // First navigate to create repository
-        cy.navigateToPage('Setup', 'Repositories');
-        cy.deleteRepo(repoId).wait(1000);
-        cy.selectRepo(existingRepo).wait(1000);
-        // Should return to import page
-        cy.navigateToPage('Import', 'RDF');
-        cy.chooseServerFilesTab();
+    it('Test import with resetting status of all imported files', () => {
+        ImportSteps
+            .selectAllServerFiles()
+            .importServerFiles()
+            .verifyImportStatus(FILE_FOR_IMPORT, SUCCESS_MESSAGE)
+            .verifyImportStatus(BLANK_NODE_FILE, SUCCESS_MESSAGE)
+            .resetStatusOfUploadedFiles()
+            .verifyNoImportStatus(BLANK_NODE_FILE)
+            .verifyNoImportStatus(FILE_FOR_IMPORT);
     });
-
-    it('Test import Server file successfully with preserve BNodes IDs = false', function () {
-        let repoId = 'repo2' + Date.now();
-        // First navigate to create repository
-        cy.navigateToPage('Setup', 'Repositories');
-        // Create new one
-        cy.createNewRepo(repoId).wait(2000);
-        cy.selectRepo(repoId).wait(1000);
-        // Should return to import page
-        cy.navigateToPage('Import', 'RDF');
-
-        cy.chooseServerFilesTab();
-        cy.selectDistinctFileToImport(blankNodeFile);
-        cy.importChangingSettings().wait(2000);
-        cy.verifyMessageOccurs(messageSuccess);
-        cy.confirmTextPresentsInDistinctFileInfo('"preserveBNodeIds": false,', blankNodeFile);
-
-        // First navigate to create repository
-        cy.navigateToPage('Setup', 'Repositories');
-        cy.deleteRepo(repoId).wait(1000);
-        cy.selectRepo(existingRepo).wait(1000);
-        // Should return to import page
-        cy.navigateToPage('Import', 'RDF');
-        cy.chooseServerFilesTab();
-    });
-
-
-    it('Test import Server file successfully with preserve BNodes IDs = true', function () {
-        let repoId = 'repo3' + Date.now();
-        // First navigate to create repository
-        cy.navigateToPage('Setup', 'Repositories');
-        // Create new one
-        cy.createNewRepo(repoId).wait(2000);
-        cy.selectRepo(repoId).wait(1000);
-        // Should return to import page
-        cy.navigateToPage('Import', 'RDF');
-
-        cy.chooseServerFilesTab();
-
-        cy.selectDistinctFileToImport(blankNodeFile);
-        cy.importChangingSettings(true);
-        cy.expandAdvancedSettings();
-        cy.get('[name="preserveBNodeIDs"]').check();
-        cy.clickImportBtnOnPopUpMenu().wait(1500);
-        cy.verifyMessageOccurs(messageSuccess);
-        cy.confirmTextPresentsInDistinctFileInfo('"preserveBNodeIds": true,', blankNodeFile);
-
-        // First navigate to create repository
-        cy.navigateToPage('Setup', 'Repositories');
-        cy.deleteRepo(repoId).wait(1000);
-        cy.selectRepo(existingRepo).wait(1000);
-        // Should return to import page
-        cy.navigateToPage('Import', 'RDF');
-        cy.chooseServerFilesTab();
-    });
-
-    it('Test import all Server files successfully without changing settings', function () {
-        cy.chooseServerFilesTab();
-        cy.checkAllServerFiles(true);
-        cy.importChangingSettings().wait(2000);
-        cy.verifyMessageOccurs(messageSuccess);
-    });
-})
+});

--- a/test-cypress/integration/import/import.user.data.spec.js
+++ b/test-cypress/integration/import/import.user.data.spec.js
@@ -1,121 +1,115 @@
-describe('Import screen validation - users', function () {
-    let existingRepo = 'w11' + Date.now();
-    let rdfTextSnippet1 = '@prefix d:<http://learningsparql.com/ns/data#>.\n' +
-        '@prefix dm:<http://learningsparql.com/ns/demo#>.\n' +
-        '\n' +
+import ImportSteps from '../../steps/import-steps';
+
+describe('Import screen validation - user data', () => {
+
+    let repositoryId;
+
+    const RDF_TEXT_SNIPPET_1 = '@prefix d:<http://learningsparql.com/ns/data#>.\n' +
+        '@prefix dm:<http://learningsparql.com/ns/demo#>.\n\n' +
         'd:item342 dm:shipped "2011-02-14"^^<http://www.w3.org/2001/XMLSchema#date>.\n' +
         'd:item342 dm:quantity 4.\n' +
         'd:item342 dm:invoiced true.\n' +
         'd:item342 dm:costPerItem 3.50.';
 
-    let rdfTextSnippet2 = '@prefix ab:<http://learningsparql.com/ns/addressbook#>.\n' +
-        '\n' +
+    const RDF_TEXT_SNIPPET_2 = '@prefix ab:<http://learningsparql.com/ns/addressbook#>.\n\n' +
         'ab:richard ab:homeTel "(229)276-5135".\n' +
         'ab:richard ab:email "richard49@hotmail.com".\n' +
         'ab:richard ab:email "richard491@hotmail.com".';
 
-    let baseURI = 'http://purl.org/dc/elements/1.1/';
-    let context = 'http://example.org/graph';
+    const BASE_URI = 'http://purl.org/dc/elements/1.1/';
+    const CONTEXT = 'http://example.org/graph';
 
-    let importURL = 'https://www.w3.org/TR/owl-guide/wine.rdf';
-    let textSnippet = 'Text snippet';
-    let invalidRDFfFormat = 'JSON-LD';
-    let validURLRDFfFormat = 'RDF/XML';
-    let validSnippetRDFfFormat = 'Turtle';
-    let rdfErrorMessage = 'RDF Parse Error:';
-    let messageSuccess = 'Imported successfully';
+    const IMPORT_URL = 'https://www.w3.org/TR/owl-guide/wine.rdf';
+    const TEXT_SNIPPET = 'Text snippet';
+    const INVALID_URL_RDF_FORMAT = 'JSON-LD';
+    const VALID_URL_RDF_FORMAT = 'RDF/XML';
+    const VALID_SNIPPET_RDF_FORMAT = 'Turtle';
+    const RDF_ERROR_MESSAGE = 'RDF Parse Error:';
+    const SUCCESS_MESSAGE = 'Imported successfully';
 
-    before(function () {
-        cy.visit('/repository');
-        // Create new one
-        cy.createNewRepo(existingRepo).wait(2000);
+    beforeEach(() => {
+        repositoryId = 'user-import-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        ImportSteps.visitUserImport(repositoryId);
     });
 
-    beforeEach(function () {
-        cy.visit('/import#user').wait(1000);
-        cy.selectRepo(existingRepo);
+    afterEach(() => {
+        ImportSteps.removeUploadedFiles();
+        cy.deleteRepository(repositoryId);
     });
 
-    afterEach(function () {
-        cy.removeUploadedFiles();
-        cy.get('#wb-import-fileInFiles').should('be.hidden');
+    it('Test import file via URL successfully with Auto format selected', () => {
+        ImportSteps
+            .openImportURLDialog(IMPORT_URL)
+            .clickImportUrlButton()
+            // Without changing settings
+            .importFromSettingsDialog()
+            .verifyImportStatus(IMPORT_URL, SUCCESS_MESSAGE);
     });
 
-    after(function () {
-        cy.navigateToPage('Setup', 'Repositories');
-        cy.deleteRepo(existingRepo).wait(1000);
+    it('Test import file via URL with invalid RDF format selected', () => {
+        ImportSteps
+            .openImportURLDialog(IMPORT_URL)
+            .selectRDFFormat(INVALID_URL_RDF_FORMAT)
+            .clickImportUrlButton()
+            .importFromSettingsDialog()
+            .verifyImportStatus(IMPORT_URL, RDF_ERROR_MESSAGE);
     });
 
-    it('Test import file via URL successfully with Auto format selected', function () {
-        cy.openImportURLDialog(importURL);
-        cy.clickImportUrlBtn();
-        cy.clickImportBtnOnPopUpMenu();
-        cy.verifyFileUpload(importURL);
-        cy.verifyMessageOccurs(messageSuccess);
+    it('Test import file via URL successfully with valid RDF format selected', () => {
+        ImportSteps
+            .openImportURLDialog(IMPORT_URL)
+            .selectRDFFormat(VALID_URL_RDF_FORMAT)
+            .clickImportUrlButton()
+            .importFromSettingsDialog()
+            .verifyImportStatus(IMPORT_URL, SUCCESS_MESSAGE);
     });
 
-    it('Test import file via URL with invalid RDF format selected', function () {
-        cy.openImportURLDialog(importURL);
-        cy.selectRDFFormat(invalidRDFfFormat);
-        cy.clickImportUrlBtn();
-        cy.clickImportBtnOnPopUpMenu();
-        cy.verifyFileUpload(importURL);
-        cy.verifyMessageOccurs(rdfErrorMessage);
+    it('Test import RDF text snippet successfully with Auto format selected', () => {
+        ImportSteps
+            .openImportTextSnippetDialog()
+            .fillRDFTextSnippet(RDF_TEXT_SNIPPET_1)
+            .clickImportTextSnippetButton()
+            .importFromSettingsDialog()
+            .verifyImportStatus(TEXT_SNIPPET, SUCCESS_MESSAGE);
     });
 
-    it('Test import file via URL successfully with valid RDF format selected', function () {
-        cy.openImportURLDialog(importURL);
-        cy.selectRDFFormat(validURLRDFfFormat);
-        cy.clickImportUrlBtn();
-        cy.clickImportBtnOnPopUpMenu();
-        cy.verifyFileUpload(importURL);
-        cy.verifyMessageOccurs(messageSuccess);
+    it('Test import RDF text snippet with invalid RDF format selected', () => {
+        ImportSteps
+            .openImportTextSnippetDialog()
+            .fillRDFTextSnippet(RDF_TEXT_SNIPPET_1)
+            .selectRDFFormat(INVALID_URL_RDF_FORMAT)
+            .clickImportTextSnippetButton()
+            .importFromSettingsDialog()
+            .verifyImportStatus(TEXT_SNIPPET, RDF_ERROR_MESSAGE);
     });
 
-
-    it('Test import RDF text snippet successfully with Auto format selected', function () {
-        cy.openImportTextSnippetDialog();
-        cy.fillRDFTextSnippet(rdfTextSnippet1);
-        cy.clickImportRDFTextSnippetBtn();
-        cy.clickImportBtnOnPopUpMenu();
-        cy.verifyFileUpload(textSnippet);
-        cy.verifyMessageOccurs(messageSuccess);
+    it('Test import RDF text snippet successfully with valid RDF format selected', () => {
+        ImportSteps
+            .openImportTextSnippetDialog()
+            .fillRDFTextSnippet(RDF_TEXT_SNIPPET_1)
+            .selectRDFFormat(VALID_SNIPPET_RDF_FORMAT)
+            .clickImportTextSnippetButton()
+            .importFromSettingsDialog()
+            .verifyImportStatus(TEXT_SNIPPET, SUCCESS_MESSAGE);
     });
 
-    it('Test import RDF text snippet with invalid RDF format selected', function () {
-        cy.openImportTextSnippetDialog();
-        cy.fillRDFTextSnippet(rdfTextSnippet1);
-        cy.selectRDFFormat(invalidRDFfFormat);
-        cy.clickImportRDFTextSnippetBtn();
-        cy.clickImportBtnOnPopUpMenu();
-        cy.verifyFileUpload(textSnippet);
-        cy.verifyMessageOccurs(rdfErrorMessage);
-    });
+    it('Test import RDF text snippet successfully with filled base URI and context', () => {
+        ImportSteps
+            .openImportTextSnippetDialog()
+            .fillRDFTextSnippet(RDF_TEXT_SNIPPET_2)
+            .clickImportTextSnippetButton()
+            .fillBaseURI(BASE_URI)
+            .selectNamedGraph()
+            .fillNamedGraph(CONTEXT)
+            .importFromSettingsDialog()
+            .verifyImportStatus(TEXT_SNIPPET, SUCCESS_MESSAGE);
 
-    it('Test import RDF text snippet successfully with valid RDF format selected', function () {
-        cy.openImportTextSnippetDialog();
-        cy.fillRDFTextSnippet(rdfTextSnippet1);
-        cy.selectRDFFormat(validSnippetRDFfFormat);
-        cy.clickImportRDFTextSnippetBtn();
-        cy.clickImportBtnOnPopUpMenu();
-        cy.verifyFileUpload(textSnippet);
-        cy.verifyMessageOccurs(messageSuccess);
-    });
-
-    it('Test import RDF text snippet successfully with filled base URI and context', function () {
-        cy.openImportTextSnippetDialog();
-        cy.fillRDFTextSnippet(rdfTextSnippet2);
-        cy.clickImportRDFTextSnippetBtn();
-        cy.fillBaseURIInputField(baseURI);
-        cy.selectNamedGraphCheck();
-        cy.fillNamedGraphInputField(context);
-        cy.clickImportBtnOnPopUpMenu();
-        cy.verifyFileUpload(textSnippet);
-        cy.verifyMessageOccurs(messageSuccess);
+        // TODO: Refactor
 
         // Go to Graphs overview
         cy.navigateToPage('Explore', 'Graphs overview');
-        let graphName = context.slice(0, context.lastIndexOf('.'));
+        let graphName = CONTEXT.slice(0, CONTEXT.lastIndexOf('.'));
         // Verify that created graph is found
         cy.get('.form-control').type(graphName);
         cy.get('#export-graphs').should('be.visible').should('contain', graphName);

--- a/test-cypress/integration/repository/repository-commands.spec.js
+++ b/test-cypress/integration/repository/repository-commands.spec.js
@@ -1,0 +1,43 @@
+import {REPOSITORIES_URL} from '../../support/repository-commands';
+
+describe('Repository commands test', () => {
+
+    let repoId;
+    beforeEach(() => {
+        repoId = 'repo-' + Date.now();
+    });
+
+    it('should create repository via REST call', () => {
+        cy.createRepository({
+            id: repoId,
+            params: {
+                ruleset: {
+                    value: 'owl-horst-optimized'
+                }
+            }
+        });
+
+        cy.request({
+            method: 'GET',
+            url: REPOSITORIES_URL + repoId,
+            headers: {
+                'Accept': 'application/json'
+            }
+        }).should((response) => {
+            expect(response.status).to.equal(200); // 200 OK
+            expect(response.body.id).to.equal(repoId);
+            expect(response.body.params.ruleset.value).to.equal('owl-horst-optimized');
+        });
+    });
+
+    it('should delete repository via REST call', () => {
+        cy.createRepository({id: repoId});
+        cy.deleteRepository(repoId);
+
+        cy.request({
+            method: 'HEAD',
+            url: REPOSITORIES_URL + repoId,
+            failOnStatusCode: false
+        }).should((response) => expect(response.status).to.equal(404));
+    });
+});

--- a/test-cypress/steps/import-steps.js
+++ b/test-cypress/steps/import-steps.js
@@ -1,0 +1,224 @@
+/**
+ * Reusable functions for interacting with the import page.
+ */
+class ImportSteps {
+
+    static visitUserImport(repository) {
+        ImportSteps.visitImport('user', repository);
+    }
+
+    static visitServerImport(repository) {
+        ImportSteps.visitImport('server', repository);
+    }
+
+    static visitImport(type, repository) {
+        cy.visit('/import#' + type);
+
+        if (repository) {
+            cy.selectRepo(repository);
+        }
+
+        cy.get('#import-' + type).should('be.visible');
+
+        return ImportSteps;
+    }
+
+    static openImportURLDialog(importURL) {
+        cy.get('#import-user .import-from-url-btn').click();
+        cy.get('.url-import-form input[name="dataUrl"]').type(importURL).should('have.value', importURL);
+
+        return ImportSteps;
+    }
+
+    static openImportTextSnippetDialog() {
+        cy.get('#import-user .import-rdf-snippet-btn').click();
+        ImportSteps.getSnippetTextarea().should('be.visible');
+
+        return ImportSteps;
+    }
+
+    static clickImportUrlButton() {
+        cy.get('#wb-import-importUrl').click();
+
+        return ImportSteps;
+    }
+
+    static selectRDFFormat(rdfFormat) {
+        cy.get('.modal-footer .import-format-dropdown').within(() => {
+            cy.get('.import-format-dropdown-btn').click();
+            cy.get('.dropdown-item').contains(rdfFormat).click().should('not.be.visible');
+        });
+
+        return ImportSteps;
+    }
+
+    static fillRDFTextSnippet(snippet) {
+        ImportSteps.getSnippetTextarea().type(snippet).should('have.value', snippet);
+
+        return ImportSteps;
+    }
+
+    static clickImportTextSnippetButton() {
+        cy.get('#wb-import-importText').click();
+
+        return ImportSteps;
+    }
+
+    static removeUploadedFiles() {
+        ImportSteps.selectAllUserFiles();
+        cy.get('#wb-import-removeEntries').click();
+        cy.get('#wb-import-fileInFiles').should('be.hidden');
+
+        return ImportSteps;
+    }
+
+    static selectAllUserFiles() {
+        cy.get('#import-user .select-all-files').check();
+
+        return ImportSteps;
+    }
+
+    static getSnippetTextarea() {
+        return cy.get('#wb-import-textarea');
+    }
+
+    static selectServerFile(filename) {
+        ImportSteps.getServerFileElement(filename).find('.import-file-checkbox').click();
+
+        return ImportSteps;
+    }
+
+    static selectAllServerFiles() {
+        cy.get('#import-server .select-all-files').check();
+
+        return ImportSteps;
+    }
+
+    static importServerFiles(changeSettings) {
+        if (changeSettings) {
+            // TODO: Check for dialog?
+            cy.get('#import-server .import-btn').click();
+        } else {
+            cy.get('#import-server .import-dropdown-btn').click();
+            cy.get('#import-server .import-without-change-btn').click();
+        }
+
+        return ImportSteps;
+    }
+
+    static importFromSettingsDialog() {
+        // TODO: cy.confirmDialog() ?
+        // Dialog should disappear
+        cy.get('.modal-footer > .btn-primary').click().should('not.exist');
+
+        return ImportSteps;
+    }
+
+    static getSettingsForm() {
+        return cy.get('.modal .settings-form');
+    }
+
+    static fillBaseURI(baseURI) {
+        ImportSteps.getSettingsForm().find('input[name="baseURI"]').type(baseURI).should('have.value', baseURI);
+
+        return ImportSteps;
+    }
+
+    static selectNamedGraph() {
+        ImportSteps.getSettingsForm().find('.named-graph-option').check();
+
+        return ImportSteps;
+    }
+
+    static fillNamedGraph(namedGraph) {
+        ImportSteps.getSettingsForm().find('.named-graph-input').type(namedGraph).should('have.value', namedGraph);
+
+        return ImportSteps;
+    }
+
+    static expandAdvancedSettings() {
+        ImportSteps.getSettingsForm().within(() => {
+            cy.get('.toggle-advanced-settings').click();
+            cy.get('.advanced-settings').should('be.visible');
+        });
+
+        return ImportSteps;
+    }
+
+    static enablePreserveBNodes() {
+        ImportSteps.getSettingsForm().find('input[name="preserveBNodeIDs"]').check();
+
+        return ImportSteps;
+    }
+
+    static resetStatusOfUploadedFiles() {
+        // Button should disappear
+        cy.get('#import-server #wb-import-clearStatuses').click().should('not.be.visible');
+
+        return ImportSteps;
+    }
+
+    static resetStatusOfUploadedFile(filename) {
+        // List is re-rendered -> ensure it is detached
+        ImportSteps
+            .getServerFileElement(filename)
+            .find('.import-status .import-status-reset')
+            .click()
+            .should('not.exist');
+
+        return ImportSteps;
+    }
+
+    static verifyImportStatusDetails(fileToSelect, details) {
+        ImportSteps.getServerFileElement(fileToSelect).find('.import-status .import-status-info').then(infoIconEl => {
+            cy.wrap(infoIconEl).should('be.visible');
+            cy.wrap(infoIconEl).trigger('mouseover');
+
+            cy.get('.popover-content').then(content => {
+                cy.wrap(content).should('be.visible');
+
+                if (details instanceof Array) {
+                    details.forEach(text => {
+                        cy.wrap(content).should('contain', text);
+                    })
+                } else {
+                    cy.wrap(content).should('contain', details);
+                }
+            });
+
+            cy.wrap(infoIconEl).trigger('mouseout');
+            cy.get('.popover-content').should('not.be.visible').and('not.exist');
+        });
+
+        return ImportSteps;
+    }
+
+    static verifyImportStatus(filename, message) {
+        // Increase the default timeout to allow longer imports to finish
+        ImportSteps
+            .getServerFileElement(filename)
+            .find('.import-status .import-status-message', {timeout: 30000})
+            .should('be.visible').and('contain', message);
+
+        return ImportSteps;
+    }
+
+    static verifyNoImportStatus(filename) {
+        ImportSteps
+            .getServerFileElement(filename)
+            .find('.import-status')
+            .should('not.be.visible');
+
+        return ImportSteps;
+    }
+
+    static getServerFileElement(filename) {
+        // Find the element containing the filename and get then the parent row element
+        return cy.get('#wb-import-fileInFiles .import-file-header')
+            .contains(filename)
+            .parentsUntil('.import-file-row')
+            .parent();
+    }
+}
+
+export default ImportSteps;

--- a/test-cypress/support/commands.js
+++ b/test-cypress/support/commands.js
@@ -24,6 +24,14 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+import './repository-commands';
+
+// ================================================================================
+// ================================================================================
+// ========================= FOR REVIEW / REFACTOR/ REMOVAL =======================
+// ================================================================================
+// ================================================================================
+
 let openImportURLDialog = Cypress.Commands.add('openImportURLDialog', (importURL) => {
     cy.get('i[class="icon-link icon-lg pull-left"]').click();
     cy.get('#dataUrl').type(importURL);
@@ -79,13 +87,16 @@ Cypress.Commands.add('selectRDFLinkButton', () => {
 
 
 Cypress.Commands.add('selectRepo', (repoId) => {
-    cy.get('#repositorySelectDropdown')
-        .click({force: true})
-        .then(() => {
-            cy.get('.dropdown-item', {timeout: 1000})
-                .contains(repoId)
-                .click({force: true});
-        });
+    cy.get('#repositorySelectDropdown', {timeout: 30000}).should('be.visible');
+
+    // Wait until repositories GET request finishes and the menu is updated
+    cy.get('#repositorySelectDropdown .no-repositories').should('not.be.visible');
+
+    cy.get('#repositorySelectDropdown').click().within(() => {
+        // TODO: Force is necessary because the repo name could be hidden in quite long menu -> try to fix it
+        // After selecting the repository, the menu item should be detached from the DOM as possible selection
+        cy.get('.dropdown-item', {timeout: 1000}).contains(repoId).click({force: true}).should('not.exist');
+    });
 });
 
 Cypress.Commands.add('selectRepoS', (repoId) => {
@@ -257,6 +268,7 @@ let navigateToPageS = Cypress.Commands.add('navigateToPageS', (mainMenu, subMenu
 });
 
 let createNewRepo = Cypress.Commands.add('createNewRepo', (repoId, rulesetToSelect, enableSameAs) => {
+    // TODO: Sometimes the page is not yet loaded and this fails ?!
     cy.get('#wb-repositories-addRepositoryLink', {timeout: 1000})
         .click({force: true});
 

--- a/test-cypress/support/index.js
+++ b/test-cypress/support/index.js
@@ -21,4 +21,4 @@ import './commands';
 
 // Configures retry count for failed tests TODO: Remove after tests are stabilized
 require('cypress-plugin-retries');
-Cypress.env('RETRIES', 2);
+Cypress.env('RETRIES', 1);

--- a/test-cypress/support/repository-commands.js
+++ b/test-cypress/support/repository-commands.js
@@ -1,0 +1,19 @@
+import repoTemplate from '../fixtures/repo-template.json';
+
+export const REPOSITORIES_URL = '/rest/repositories/';
+
+Cypress.Commands.add('createRepository', (options = {}) => {
+    cy.request({
+        method: 'POST',
+        url: REPOSITORIES_URL,
+        body: Cypress._.defaultsDeep(options, repoTemplate),
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    }).should((response) => expect(response.status).to.equal(201)); // 201 Created
+});
+
+Cypress.Commands.add('deleteRepository', (id) => {
+    const url = REPOSITORIES_URL + id;
+    cy.request('DELETE', url).should((response) => expect(response.status).to.equal(200));
+});


### PR DESCRIPTION
Added import-steps file with static utility functions for working with the user and server import pages.
Added several classes in the import templates to simplify selectors in Cypress and ease the testing.

Additional changes:

- Changed retry count to 1 instead of 2.
- Tried to stabilize the selectRepo command
- Moved coveralls step in after_scrip section in Travis config. Sometimes the coveralls service is down which breaks any build in the meantime.