### PR TITLE
Rewrote SPARQL page specifications

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ trim_trailing_whitespace = false
 
 [*.yml]
 indent_size = 2
+
+[*.txt]
+insert_final_newline = false

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage/
 # Dev specific
 .env
 report/
+cypress/

--- a/cypress.json
+++ b/cypress.json
@@ -6,5 +6,6 @@
     "pluginsFile": "test-cypress/plugins/index.js",
     "screenshotsFolder": "report/cypress/screenshots",
     "supportFile": "test-cypress/support/index.js",
-    "videosFolder": "report/cypress/videos"
+    "videosFolder": "report/cypress/videos",
+    "video": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2579,6 +2579,33 @@
         }
       }
     },
+    "cypress-failed-log": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/cypress-failed-log/-/cypress-failed-log-2.5.1.tgz",
+      "integrity": "sha512-SmTMVoV247Ovu4xinhhyfPTc6+JM9YrR0nVW4VKkNHtGSmeW0mzyqfUwiygnR1rS91N0sFYk5HSYMm8hzb+EZw==",
+      "dev": true,
+      "requires": {
+        "debug": "4.1.1",
+        "logdown": "3.2.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "cypress-plugin-retries": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cypress-plugin-retries/-/cypress-plugin-retries-1.2.2.tgz",
@@ -6197,6 +6224,15 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
+      }
+    },
+    "logdown": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/logdown/-/logdown-3.2.8.tgz",
+      "integrity": "sha512-ia/AslkwnxwWzaReeADifBwfh2xtUd/T/qdsnkrPlQbefKt4LkUWGSn/xWuhEwY3p2zSIhAZYcWCEGGIy9Lr2w==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0"
       }
     },
     "loglevel": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "babel-preset-es2015": "^6.24.1",
         "coveralls": "^3.0.5",
         "cypress": "^3.4.1",
+        "cypress-failed-log": "^2.5.1",
         "cypress-plugin-retries": "^1.2.2",
         "eslint": "^5.16.0",
         "eslint-config-google": "^0.13.0",

--- a/scripts/run-cypress-tests.sh
+++ b/scripts/run-cypress-tests.sh
@@ -23,5 +23,5 @@ wait-on http://localhost:7200 -t 60000
 wait-on http://localhost:7300 -t 30000
 
 # Run the tests
-npx cypress run --record=false --config baseUrl=http://localhost:7300,video=false
+npx cypress run --record=false --config baseUrl=http://localhost:7300
 

--- a/src/js/angular/sparql/directives/sparql-tab.directive.js
+++ b/src/js/angular/sparql/directives/sparql-tab.directive.js
@@ -30,7 +30,7 @@ define([],
                 $scope.deleteTab = deleteTab;
                 $scope.editCurrentTab = editCurrentTab;
                 $scope.selectThisTab = selectThisTab;
-                
+
                 function selectThisTab(e) {
                     e.preventDefault();
                     e.stopPropagation();
@@ -134,7 +134,7 @@ define([],
             return {
                 restrict: 'AE',
                 // for some reason when you extract this template in a file and use templateUrl it selects all tabs when editing the tab name, not only the currently selected one
-                template: '<a class="nav-link" role="tab" data-toggle="tab" blur="submit" editable-text="tab.name" e-form="editCurrentlySelectedOnly" ng-click="selectThisTab($event)" ng-dblclick="editCurrentTab()" ><span ng-class="{\'text-muted\': !tab.name}">{{ tab.name || \'Unnamed\'}}</span><button type="button" ng-click="deleteTab($event)" class="btn btn-link btn-sm secondary" title="Delete tab"><i class="icon-close"></i></button></a>',
+                template: '<a class="nav-link" role="tab" data-toggle="tab" blur="submit" editable-text="tab.name" e-form="editCurrentlySelectedOnly" ng-click="selectThisTab($event)" ng-dblclick="editCurrentTab()" ><span ng-class="{\'text-muted\': !tab.name}">{{ tab.name || \'Unnamed\'}}</span><button type="button" ng-click="deleteTab($event)" class="btn btn-link btn-sm secondary delete-sparql-tab-btn" title="Delete tab"><i class="icon-close"></i></button></a>',
                 replace: true,
                 controller: SparqlTabCtrl
             };

--- a/src/js/angular/sparql/templates/modal/query-sample.html
+++ b/src/js/angular/sparql/templates/modal/query-sample.html
@@ -4,12 +4,13 @@
     <button type="button" class="close" ng-click="cancel()"></button>
     <h3 class="modal-title">{{title}}</h3>
 </div>
-<form novalidate ng-submit="ok()" name="form">
+<form novalidate ng-submit="ok()" name="form" class="save-query-form">
     <div class="modal-body">
         <input id="wb-sparql-sampleName" required type="text" ng-model="query.name" class="form-control"
                ng-change="queryExists = false"
                placeholder="Enter Title"/>
-        <label for="share-query" tooltip="If checked other users will be able to see the query but not delete or edit it.">
+        <label for="share-query"
+               tooltip="If checked other users will be able to see the query but not delete or edit it.">
             <input id="share-query" type="checkbox" ng-model="query.shared">
             Share query with other users
         </label>
@@ -17,21 +18,27 @@
         <br>
         <textarea id="wb-sparql-sampleValue" required rows="8" class="form-control" ng-model="query.body"
                   placeholder="Create your Sample Query" ng-blur="errorMsg = ''"></textarea>
-        <div ng-show="form.$error.required.length">
-            <div ng-hide="query.name" class="alert alert-danger" style="margin-top: 5px;">Name cannot be empty!</div>
-            <div ng-hide="query.body" class="alert alert-danger" style="margin-top: 5px;">Query cannot be empty!</div>
-        </div>
-        <div ng-hide="form.$error.required.length" ng-if="queryExists" class="alert alert-danger"
-             style="margin-top: 5px;">Query with name <b>&#39;{{query.name}}&#39;</b> already
-            exists!
+        <div class="saved-query-errors">
+            <div ng-show="form.$error.required.length" >
+                <div ng-hide="query.name" class="alert alert-danger empty-query-name-err" style="margin-top: 5px;">
+                    Name cannot be empty!
+                </div>
+                <div ng-hide="query.body" class="alert alert-danger empty-query-err" style="margin-top: 5px;">
+                    Query cannot be empty!
+                </div>
+            </div>
+            <div ng-hide="form.$error.required.length" ng-if="queryExists" class="alert alert-danger query-exists-error"
+                 style="margin-top: 5px;">
+                Query with name <b>&#39;{{query.name}}&#39;</b> already exists!
+            </div>
         </div>
     </div>
     <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" ng-click="cancel()">Cancel</button>
-        <button id="wb-sparql-submit" class="btn btn-primary" ng-click="ok()" type="submit">{{okButtonText}}</button>
+        <button type="button" class="btn btn-secondary cancel-btn" ng-click="cancel()">Cancel</button>
+        <button id="wb-sparql-submit" class="btn btn-primary create-btn" ng-click="ok()" type="submit">
+            {{okButtonText}}
+        </button>
     </div>
 </form>
 
 <!-- End QuerySample modal -->
-    
-    

--- a/src/js/angular/sparql/templates/query-editor.html
+++ b/src/js/angular/sparql/templates/query-editor.html
@@ -166,7 +166,7 @@
 
         <div class="yasr" id="yasr-inner">
             <div ng-hide="nostatus || currentTabConfig.queryType || queryIsRunning"
-                 class="alert alert-info no-icon">No results from previous run.
+                 class="alert alert-info no-icon no-query-run">No results from previous run.
                 Click Run or press Ctrl/Cmd-Enter to execute the current query or update.
             </div>
             <!--ng-show="!queryIsRunning">-->
@@ -181,22 +181,22 @@
             </div>
             <h6 class="alert alert-danger no-icon additional" ng-show="!queryIsRunning && !nostatus && currentTabConfig.errorMessage">Error: {{currentTabConfig.errorMessage}}</h6>
             <h6 class="alert alert-warning no-icon additional" ng-show="!queryIsRunning && !nostatus && currentTabConfig.warningMessage">Warning: {{currentTabConfig.warningMessage}}</h6>
-            <div class="alert alert-info no-icon"
+            <div class="alert alert-info no-icon results-info"
                  ng-show="!nostatus && currentTabConfig.queryType && currentTabConfig.queryType != 'UPDATE' && currentTabConfig.queryType != 'ERROR' && !queryIsRunning">
                 <div class="text-xs-right">
                     <span class="icon-warning icon-lg"
                             ng-show="getStaleWarningMessage()"
                             tooltip="{{getStaleWarningMessage()}}" tooltip-trigger="mouseenter"
                             tooltip-append-to-body="true"></span>
-                    <span ng-show="currentTabConfig.queryType != 'ASK'">
+                    <span ng-show="currentTabConfig.queryType != 'ASK'" class="results-description">
                         {{getResultsDescription()}}
                     </span>
-                    <span ng-show="currentTabConfig.timeTook">
+                    <span ng-show="currentTabConfig.timeTook" class="query-duration">
                         Query took {{getHumanReadableSeconds(currentTabConfig.timeTook, true)}}, {{ getHumanReadableTimestamp(currentTabConfig.timeFinished) }}.
                     </span>
                 </div>
             </div>
-            <div class='alert alert-info no-icon results-info update-info'
+            <div class='alert alert-info no-icon update-info'
                  ng-show="!nostatus && currentTabConfig.queryType == 'UPDATE' && !queryIsRunning">
                 {{getUpdateDescription()}}
                 <span ng-show="currentTabConfig.timeTook">

--- a/src/pages/sparql.html
+++ b/src/pages/sparql.html
@@ -10,17 +10,17 @@
 
     <div ng-show="getActiveRepositoryNoError()" class="pull-right mt-1">
         <div id="hideEditor" class="btn-group btn-group-sm" ng-click="showHideEditor()">
-            <button class="btn btn-secondary btn-sm" ng-model="viewMode" btn-radio="'yasr'" uncheckable>
+            <button class="btn btn-secondary btn-sm editor-only-btn" ng-model="viewMode" btn-radio="'yasr'" uncheckable>
                 Editor only
             </button>
-            <button class="btn btn-secondary btn-sm" ng-model="viewMode" btn-radio="'none'" uncheckable>
+            <button class="btn btn-secondary btn-sm editor-and-results-btn" ng-model="viewMode" btn-radio="'none'" uncheckable>
                 Editor and results
             </button>
-            <button class="btn btn-secondary btn-sm" ng-model="viewMode" btn-radio="'editor'" uncheckable>
+            <button class="btn btn-secondary btn-sm results-only-btn" ng-model="viewMode" btn-radio="'editor'" uncheckable>
                 Results only
             </button>
 
-            <button class="btn btn-link btn-sm p-0 ml-1"
+            <button class="btn btn-link btn-sm p-0 ml-1 toggle-horizontal-view-btn"
                     ng-click="changeViewMode(currentQuery.id)"
                     tooltip="Switch to {{orientationViewMode ? 'vertical' : 'horizontal'}} view"
                     tooltip-placement="left">

--- a/test-cypress/fixtures/queries/add-statement.txt
+++ b/test-cypress/fixtures/queries/add-statement.txt
@@ -1,0 +1,8 @@
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+INSERT DATA
+      {
+      GRAPH <http://example> {
+          <http://example/book1> dc:title "A new book" ;
+                                 dc:creator "A.N.Other" .
+          }
+      }

--- a/test-cypress/fixtures/queries/construct-query.sparql
+++ b/test-cypress/fixtures/queries/construct-query.sparql
@@ -1,0 +1,19 @@
+PREFIX cat: <[http://dbpedia.org/resource/Category:]>
+PREFIX foaf: <[http://xmlns.com/foaf/0.1/]>
+PREFIX gp: <[http://wifo5-04.informatik.uni-mannheim.de/gutendata/resource/people/]>
+PREFIX owl: <[http://www.w3.org/2002/07/owl#]>
+PREFIX rdf: <[http://www.w3.org/1999/02/22-rdf-syntax-ns#]>
+PREFIX rdfs: <[http://www.w3.org/2000/01/rdf-schema#]>
+PREFIX skos: <[http://www.w3.org/2004/02/skos/core#]>
+CONSTRUCT
+{
+    <http://dbpedia.org/resource/Joseph_Hocking> ?dbpProperty ?dbpValue .
+    gp:Hocking_Joseph ?gutenProperty ?gutenValue .
+}
+WHERE
+{
+    SERVICE <http://factforge.net/repositories/ff-news>
+    {
+        <http://dbpedia.org/resource/Joseph_Hocking> ?dbpProperty ?dbpValue .
+    }
+}

--- a/test-cypress/fixtures/queries/prefix-query.sparql
+++ b/test-cypress/fixtures/queries/prefix-query.sparql
@@ -1,0 +1,7 @@
+PREFIX wordn-sc: <http://example.org>
+select * where {
+    ?sub rdfs:subClassOf ?c .
+    ?c a owl:Restriction;
+       owl:onProperty wordn-sc:word;
+       owl:someValuesFrom wordn-sc:Word .
+}

--- a/test-cypress/fixtures/url-import-template.json
+++ b/test-cypress/fixtures/url-import-template.json
@@ -1,0 +1,26 @@
+{
+    "name": "https://www.w3.org/TR/owl-guide/wine.rdf",
+    "status": "NONE",
+    "message": "",
+    "context": null,
+    "replaceGraphs": [],
+    "baseURI": null,
+    "forceSerial": false,
+    "type": "url",
+    "format": "",
+    "data": "https://www.w3.org/TR/owl-guide/wine.rdf",
+    "timestamp": 1565777709509,
+    "parserSettings": {
+        "preserveBNodeIds": false,
+        "failOnUnknownDataTypes": false,
+        "verifyDataTypeValues": false,
+        "normalizeDataTypeValues": false,
+        "failOnUnknownLanguageTags": false,
+        "verifyLanguageTags": true,
+        "normalizeLanguageTags": false,
+        "verifyURISyntax": true,
+        "verifyRelativeURIs": true,
+        "stopOnError": true
+    },
+    "xRequestIdHeaders": null
+}

--- a/test-cypress/integration/sparql/sparql.menu.spec.js
+++ b/test-cypress/integration/sparql/sparql.menu.spec.js
@@ -1,807 +1,1109 @@
-describe('SPARQL screen validation', function () {
-    let repoId = 'sparqlRepo' + Date.now();
+import ImportSteps from '../../steps/import-steps';
 
-    let modifiedDefaultQuery = 'prefix spif: <http://spinrdf.org/spif#>\n' +
+describe('SPARQL screen validation', () => {
+    let repositoryId;
+
+    const DEFAULT_QUERY = 'select * where { \n' +
+        '\t?s ?p ?o .\n' +
+        '} limit 100';
+
+    const DEFAULT_QUERY_MODIFIED = 'prefix spif: <http://spinrdf.org/spif#>\n' +
         'select * {\n' +
-        '   ?x spif:for (1 2000)\n' +
+        '    ?x spif:for (1 2000)\n' +
         '} limit 1001';
 
-    let defaultQuery = 'select * where { \n' +
-        '\t?s ?p ?o .\n' +
-        '} limit 100 ';
+    function createRepoAndVisit(repoOptions = {}) {
+        repositoryId = 'sparql-' + Date.now();
+        repoOptions.id = repositoryId;
+        cy.createRepository(repoOptions);
+        cy.warmRepositoryNamespaces(repositoryId);
 
-    let verifyQueryResultLengthOnPage = function (resultLength, pageNumber) {
-        cy.get(`#yasr-inner table.resultsTable[id*='DataTables_Table_'] > tbody > tr`)
-            .should('have.length', resultLength);
-    };
+        // Avoids having to select the repository through the UI
+        cy.presetRepositoryCookie(repositoryId);
 
-    let verifyNumberOfPages = function (numberOfPages) {
-        cy.get('#yasr > ul > li')
-            .should('have.length', numberOfPages);
-    };
+        visitSparql(true);
+    }
 
-    let convertRdfFormatToDataAccepts = function (data_accepts) {
-        switch (data_accepts) {
-            case 'JSON':
-                return 'application/sparql-results+json';
-            case 'JSON-LD':
-                return 'application/ld+json';
-            case 'XML':
-                return 'application/sparql-results+xml';
-            case 'CSV':
-                return 'text/csv';
-            case 'TSV':
-                return 'text/tab-separated-values';
-            case 'Binary RDF Results':
-                return 'application/x-binary-rdf-results-table';
-        }
-    };
-
-    let selectDownloadAs = function (rdfFormat) {
-        cy.get('.saveAsDropDown > .btn').should("be.visible", {timeout: 5000});
-        cy.get(".ot-loader-new-content").should("not.be.visible");
-
-        cy.get('.saveAsDropDown > .btn').click({timeout: 5000});
-        cy.get('#yasr-inner .dropdown-menu > li:contains(' + rdfFormat + ') a')
-            .should("have.attr", 'href').and('include', '#');
-        cy.get('#yasr-inner .dropdown-menu > li:contains(' + rdfFormat + ') a')
-            .should("have.attr", 'data-accepts').and('include', convertRdfFormatToDataAccepts(rdfFormat));
-    };
-    Cypress.on('uncaught:exception', (err, runnable) => {
-        // returning false here prevents Cypress from
-        // failing the test
-        return false
-    });
-    // This handles the thrown exception on time out
-    let handleUncaughtException = function () {
-        cy.on('uncaught:exception', (err, runnable) => {
-            // returning false here prevents Cypress from
-            // failing the test
-            return false
-        });
-    };
-
-    let executeSavedQuery = function (queryName) {
-        cy.get(".ot-loader-new-content").should("not.be.visible");
-        cy.get('a#wb-sparql-toggleSampleQueries').click().wait(200);
-        cy.get('.popover-content').should("be.visible")
-        cy.get('.popover-content #wb-sparql-queryInSampleQueries li').contains(queryName).should("be.visible");
-        cy.get('.popover-content #wb-sparql-queryInSampleQueries li').contains(queryName).click().wait(500);
-
-        cy.get(".ot-loader-new-content").should("not.be.visible");
-        cy.get('#wb-sparql-runQuery').click().wait(500);
-    };
-
-    let deleteCurrentTab = function () {
-        cy.get(".ot-loader-new-content").should("not.be.visible");
-        cy.wait(1000);
-        cy.get('.active > .nav-link > .btn[title="Delete tab"]').should("be.visible");
-        cy.wait(1000);
-        cy.get('.active > .nav-link > .btn[title="Delete tab"]').click();
-        cy.wait(2000);
-        cy.get('.modal-dialog > .modal-content > .modal-footer > .btn-primary').click();
-    };
-
-    let verifyRedirectionToCopiedQueryURL = function () {
-        cy.get('#clipboardURI').then(($element) => {
-            // Copy link to query from popup menu. In order this method to be consistent
-            // for both tests URL to current query and URL to saved query should do the replacement
-            let linkToQuery = $element.val().replace(/\+/g, '%20');
-            // Close popup menu
-            cy.get('.modal-footer > .btn.btn-secondary').click().wait(1000);
-            // Redirect to another view for example 'http://localhost:8888/import#user'
-            cy.navigateToPageS('Import', 'RDF');
-
-            // Verify successful redirection to another view
-            cy.url()
-                .then(($url) => {
-                    expect($url.valueOf()).not.to.be.eq(linkToQuery);
-                });
-
-            // And from that view visit the copied link
-            cy.visit(linkToQuery);
-
-            // Verify successful redirection to copied URL
-            cy.url().should("eq", linkToQuery);
-
-            cy.wait(1000);
-            cy.navigateToPageS('Import', 'RDF');
-            cy.navigateToPageS('SPARQL');
-        });
-    };
-
-    before(function () {
-        //handleUncaughtException();
-        cy.navigateToPageS('Setup', 'Repositories');
-        // Create new one
-        cy.createNewRepoS(repoId).wait(2000);
-        cy.setRepoDefaultS(repoId);
-        cy.selectRepoS(repoId);
-    });
-
-    beforeEach(function () {
-        cy.navigateToPageS('SPARQL');
-    });
-
-    after(function () {
-        cy.deleteRepoS(repoId);
-    });
-
-    it('Test execute default query', function () {
-        cy.get('#wb-sparql-runQuery').should("be.visible");
-        cy.get(".ot-loader-new-content").should("not.be.visible");
-        cy.wait(1000);
-        cy.get('#wb-sparql-runQuery').click();
-        verifyQueryResultLengthOnPage(70, 0);
-    });
-
-    it('Test open a new tab', function () {
-        // Verify that there is only one tab opened
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a').should('have.length', 1);
-        // Click add new tab button
-        cy.get('#wb-sparql-addNewTab').should("be.visible");
-        cy.get('#wb-sparql-addNewTab').click();
-
-        // Verify that as result of clicking addNewTab button we've opened one more tab
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a').should('have.length', 2);
-        // Get last added tab
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a').last()
-            .then(($el) => {
-                // Verify that its name is "Unnamed"
-                expect($el.text()).to.be.eq('Unnamed');
-                // Verify that the default query is inserted automatically
-                cy.get('.CodeMirror-code')
-                    .then(($element) => {
-                        expect($element.text()).to.contain("1select * where { 2    ?s ?p ?o .3} limit 100 4​");
-                    });
-                // Verify that no results are displayed
-                cy.get('#yasr-inner').contains("No results from previous run.\n" +
-                    "                Click Run or press Ctrl/Cmd-Enter to execute the current query or update.\n").should('be.visible');
-            });
-        deleteCurrentTab();
-
-    });
-
-    it('Test modify default query', function () {
-        // Run custom query returning 1001 results
-        cy.executeCustomQuery(modifiedDefaultQuery);
-        // Verify that 1001 results are displayed over 2 pages
-        verifyNumberOfPages(2);
-        // Verify that the first page contains 1000 results
-        verifyQueryResultLengthOnPage(1000, 0);
-        // Select second page
-        cy.get('#yasr > ul > li')
-            .each(($el, index) => {
-                if (!$el.hasClass('ng-scope active')) {
-                    cy.get(`.navbar-right > :nth-child(${index + 1}) > .ng-binding`).click().wait(1000);
+    function visitSparql(resetLocalStorage) {
+        cy.visit('/sparql', {
+            onBeforeLoad: (win) => {
+                if (resetLocalStorage) {
+                    // Needed because the workbench app is very persistent with its local storage (it's hooked on before unload event)
+                    // TODO: Add a test that tests this !
+                    win.localStorage.clear();
+                    win.sessionStorage.clear();
                 }
-            });
-        // Verify that the second page contains 1 result
-        verifyQueryResultLengthOnPage(1, 1);
+            }
+        });
+
+        waitUntilSparqlPageIsLoaded();
+    }
+
+    function waitUntilSparqlPageIsLoaded() {
+        // Workbench loading screen should not be visible
+        cy.get('.ot-splash').should('not.be.visible');
+
+        // Editor should have an active tab
+        getActiveTab().should('be.visible');
+
+        // Run query button should be clickable
+        getRunQueryButton().should('be.visible').and('not.be.disabled');
+
+        // No active loader
+        getLoader().should('not.be.visible');
+
+        waitUntilQueryIsVisible();
+    }
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
     });
 
-    it('Test filter query results', function () {
-        // Import Wine dataset
-        cy.navigateToPageS('Import', 'RDF');
-        cy.openImportURLDialogS('https://www.w3.org/TR/owl-guide/wine.rdf');
-        cy.clickImportUrlBtn();
-        cy.clickImportBtnOnPopUpMenu().wait(2000);
-        // Navigate back to SPARQL page
-        cy.navigateToPageS('SPARQL');
-        // Execute default query
-        cy.executeCustomQuery(defaultQuery);
-        // In the search field below the SPARQL editor enter ""White"
-        cy.get('input[type="search"]').type('White').wait(1000);
-        // Verify that 6 results containing ""White"" are displayed
-        verifyQueryResultLengthOnPage(6, 0);
-    });
+    context('SPARQL queries & filtering', () => {
+        beforeEach(() => createRepoAndVisit());
 
-    it('Test download query results in Supported formats', function () {
-        cy.get('#wb-sparql-runQuery').should("be.visible");
-        cy.get(".ot-loader-new-content").should("not.be.visible");
-        cy.wait(1000);
-        cy.get('#wb-sparql-runQuery').click();
-        selectDownloadAs('JSON');
-        selectDownloadAs('XML');
-        selectDownloadAs('CSV');
-        selectDownloadAs('TSV');
-        selectDownloadAs('Binary RDF Results');
-    });
+        it('Test execute default query', () => {
+            getTabs().should('have.length', 1);
 
-    it('Test switch result format tabs', function () {
-        // This here is because our UI is throwing exceptions when
-        // switching between result format tabs
-        // Run the default query
-        cy.get('#wb-sparql-runQuery').should("be.visible");
-        cy.get(".ot-loader-new-content").should("not.be.visible");
-        cy.wait(1000);
-        cy.get('#wb-sparql-runQuery').click();
-        // Switch to "Raw Response"
-        cy.get(".ot-loader-new-content").should("not.be.visible");
-        cy.get('.select_rawResponse', {timeout: 2000}).click();
-        // Validate result
-        cy.get('.yasr_results > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > ' +
-            '[style="position: relative; top: 0px;"] > .CodeMirror-lines > div > .CodeMirror-code > div > pre').should('be.visible');
-        // Switch to "Pivot table"
-        cy.get('.select_pivot').click();
-        // Validate result
-        cy.get('.yasr_results > .pivotTable > table.pvtUi').should('be.visible');
-        // Switch to "Google chart"
-        cy.get('.select_gchart').click();
-        // Validate result
-        cy.get('.yasr_results > #yasr-inner_gchartWrapper').should('be.visible');
+            verifyQueryAreaEquals(DEFAULT_QUERY);
 
-        cy.get('.select_table').click();
-    });
+            // No queries should have been run for this tab
+            getNoQueryRun().should('be.visible');
 
-    it('Test change views', function () {
-        // Switch the editor to "Editor only"
-        cy.get('#hideEditor > [btn-radio="\'yasr\'"]').click();
-        // Verify that only Editor tab is displayed
-        cy.get('#queryEditor').should('be.visible');
-        cy.get('#yasr-inner').should('not.be.visible');
+            executeQuery();
 
-        // Switch the editor to "Editor and results"
-        cy.get('#hideEditor > [btn-radio="\'none\'"]').click();
-        // Verify that both Editor and Results tabs are displayed
-        cy.get('#queryEditor').should('be.visible');
-        cy.get('#yasr-inner').should('be.visible');
+            verifyResultsPageLength(70);
+        });
 
-        // Switch the editor to "Results only"
-        cy.get('#hideEditor > [btn-radio="\'editor\'"]').click();
-        // Verify that only Results tab is displayed
-        cy.get('#queryEditor').should('not.be.visible');
-        cy.get('#yasr-inner').should('be.visible');
+        it('Test modify default query', () => {
+            // Run custom query returning 1001 results
+            typeQuery(DEFAULT_QUERY_MODIFIED);
 
-        // Return the editor to "Editor and results"
-        cy.get('#hideEditor > [btn-radio="\'none\'"]').click();
+            verifyQueryAreaEquals(DEFAULT_QUERY_MODIFIED);
 
-        // Change the orientation to vertical
-        cy.get('button[class="btn btn-link btn-sm p-0 ml-1"]').click();
-        // Verify that all elements are visible and properly displayed.
-        // TODO: Still have to find way to verify that elements are properly displayed in vertical way?
-        cy.get('#queryEditor').should('be.visible');
-        cy.get('#yasr-inner').should('be.visible');
+            // Verify pasting also works
+            pasteQuery(DEFAULT_QUERY_MODIFIED);
 
+            verifyQueryAreaEquals(DEFAULT_QUERY_MODIFIED);
 
-        // Run the default query on vertical mode
-        cy.get('#wb-sparql-runQuery').click();
-        // Verify that all results are properly scaled/displayed
+            executeQuery();
 
-        // Return the orientation to horizontal
-        cy.get('button[class="btn btn-link btn-sm p-0 ml-1"]').click();
-    });
+            getResultPages().should('have.length', 2);
 
-    it('Test save invalid Sample Queries', function () {
-        // Try to save Sample Queries without specifying query name
-        cy.get('#wb-sparql-saveQuery').as('openSaveQueryDialog');
+            verifyResultsPageLength(1000);
 
-        cy.get('@openSaveQueryDialog').click()
-            .then(() => {
-                cy.get('#wb-sparql-submit').click();
-                // Confirm the error message: “Name should not be empty”
-                cy.get('.modal-body > div[ng-show="form.$error.required.length"] > div[ng-hide="query.name"]')
-                    .should('be.visible').and('contain', 'Name cannot be empty!');
+            goToPage(2);
+
+            verifyResultsPageLength(1);
+        });
+
+        it('Test filter query results', () => {
+            cy.importFromUrl(repositoryId, 'https://www.w3.org/TR/owl-guide/wine.rdf');
+
+            executeQuery();
+
+            // In the search field below the SPARQL editor enter 'White'
+            getResultFilterField()
+                .should('have.value', '')
+                .type('White')
+                .should('have.value', 'White');
+
+            // Verify that 6 results containing ''White'' are displayed
+            verifyResultsPageLength(6);
+        });
+
+        it('Test execute queries with prefixes', () => {
+            cy.fixture('queries/prefix-query.sparql').then(prefixQuery => {
+                // Yasqe blows when inserting prefixes for some reason....
+                disableExceptions();
+
+                typeQuery(prefixQuery);
             });
 
-        // Type query name, remove content add try to save the query
-        cy.get('#wb-sparql-sampleName').type('My query');
-        cy.get('#wb-sparql-sampleValue').clear();
-        // Confirm the error message: “Query should not be empty”
-        cy.get('#wb-sparql-submit').click();
-        cy.get('.modal-body > div[ng-show="form.$error.required.length"] > div[ng-hide="query.body"]', {timeout: 5000})
-            .should('be.visible').and('contain', 'Query cannot be empty!');
+            // Should have inserted the prefixes
+            verifyQueryAreaContains('PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>');
+            verifyQueryAreaContains('PREFIX owl: <http://www.w3.org/2002/07/owl#>');
 
-        // Close "Create New Saved Query" dialog
-        cy.get('[novalidate] > .modal-footer > .btn-secondary')
-            .click().wait(500);
-        cy.get('#wb-sparql-saveQuery').click();
-        // Enter a name that already exists - "Add statements"
-        cy.get('#wb-sparql-sampleName').type('Add statements').wait(500);
-        // Verify that a toast message notifying about the duplicated name is displayed.
-        cy.get('#wb-sparql-submit').click();
-        cy.get('.modal-body > div[ng-if="queryExists"] ').should('contain', 'Query with name \'Add statements\' already\n' +
-            '            exists!');
+            executeQuery();
+
+            getResultsMessage()
+                .should('be.visible');
+            getResultsWrapper()
+                .should('be.visible');
+        });
+
+        it('Test execute (Describe) query', () => {
+            let describeQuery = 'DESCRIBE <http://www.ontotext.com/SYSINFO> FROM <http://www.ontotext.com/SYSINFO>';
+
+            pasteQuery(describeQuery);
+
+            verifyQueryAreaEquals(describeQuery);
+
+            executeQuery();
+
+            getResultsMessage()
+                .should('be.visible')
+                .and('contain', 'Showing results')
+                .and('contain', 'Query took');
+            getResultsWrapper()
+                .should('be.visible');
+
+            // Confirm that all tabs Raw Response, Pivot Table, Google chart are enabled
+            getTableResponseButton().should('be.visible').and('not.be.disabled');
+            getRawResponseButton().should('be.visible').and('not.be.disabled');
+            getPivotTableButton().should('be.visible').and('not.be.disabled');
+            getGoogleChartButton().should('be.visible').and('not.be.disabled');
+
+            openDownloadAsMenu();
+
+            getDownloadAsFormatButtons()
+                .should('have.length', 10)
+                .contains('JSON-LD')
+                .should('have.attr', 'data-accepts')
+                .and('include', 'application/ld+json')
+        });
+
+        it('Test execute (ASK) query', () => {
+            let askQuery = 'ASK WHERE { ?s ?p ?o .FILTER (regex(?o, "ontotext.com")) }';
+
+            pasteQuery(askQuery);
+            executeQuery();
+
+            // Confirm that all tabs (Table, Pivot Table, Google chart) are disabled
+            getTableResponseButton().should('not.be.visible');
+            getRawResponseButton().should('not.be.visible');
+            getPivotTableButton().should('not.be.visible');
+            getGoogleChartButton().should('not.be.visible');
+
+            getBooleanResult().should('be.visible').and('contain', 'NO');
+        });
+
+        it('Test execute (CONSTRUCT) query', () => {
+            cy.fixture('queries/construct-query.sparql').then(constructQuery => {
+                pasteQuery(constructQuery);
+            });
+
+            executeQuery();
+
+            getResultsMessage()
+                .should('be.visible');
+            getResultsWrapper()
+                .should('be.visible');
+
+            // Confirm that all tabs (Table, Pivot Table, Google chart) are disabled
+            getTableResponseButton().should('be.visible').and('not.be.disabled');
+            getRawResponseButton().should('be.visible').and('not.be.disabled');
+            getPivotTableButton().should('be.visible').and('not.be.disabled');
+            getGoogleChartButton().should('be.visible').and('not.be.disabled');
+
+            openRawResponse();
+            getResultsDownloadButton().should('be.visible').and('not.be.disabled');
+        });
+
+        it('Test execute query with and without "Including inferred" selected', () => {
+            let insertQuery = 'INSERT DATA { <urn:a> <http://a/b> <urn:b> . <urn:b> <http://a/b> <urn:c> . }';
+
+            pasteQuery(insertQuery);
+            executeQuery();
+
+            getUpdateMessage().should('be.visible');
+            getResultsWrapper().should('not.be.visible');
+
+            // Should be enabled by default
+            getInferenceButton()
+                .find('.icon-inferred-on')
+                .should('be.visible');
+
+            pasteQuery(DEFAULT_QUERY);
+            executeQuery();
+
+            // Confirm that all statements are available (70 from ruleset, 2 explicit and 2 inferred)
+            getResultsWrapper().should('be.visible');
+
+            verifyResultsPageLength(74);
+
+            // Uncheck ‘Include inferred’
+            getInferenceButton()
+                .click()
+                .find('.icon-inferred-off')
+                .should('be.visible');
+
+            // Confirm that only inferred statements (only 2) are available
+            executeQuery();
+            verifyResultsPageLength(2);
+        });
     });
 
-    it('Test create, edit and delete saved query', function () {
-        let savedQueryName = 'Count query' + Date.now();
-        let queryToSave = 'select (count (*) as ?cnt)\n' +
+    context('SPARQL queries with OWL-Horst Optimized', () => {
+        beforeEach(() => createRepoAndVisit({
+            params: {
+                ruleset: {
+                    value: 'owl-horst-optimized'
+                },
+                disableSameAs: {
+                    value: false
+                }
+            }
+        }));
+
+        it('Test execute query including inferred with ruleset "OWL-Horst (Optimized)"', () => {
+            cy.importFromUrl(repositoryId, 'https://www.w3.org/TR/owl-guide/wine.rdf');
+
+            let defaultQueryWithoutLimit = 'select * where { \n' +
+                '\t?s ?p ?o .\n' +
+                '}';
+
+            pasteQuery(defaultQueryWithoutLimit);
+            executeQuery();
+
+            getResultsMessage()
+                .should('be.visible')
+                .and('contain', '1,000 of 7,065');
+            getResultsWrapper()
+                .should('be.visible');
+            verifyResultsPageLength(1000);
+
+            // Disable the inference from the ">>" icon on the right of the SPARQL editor.
+            getInferenceButton()
+                .click()
+                .find('.icon-inferred-off')
+                .should('be.visible');
+            executeQuery();
+
+            // Verify that there are 1,839 results
+            getResultsMessage()
+                .should('be.visible')
+                .and('contain', '1,000 of 1,839');
+        });
+
+        it('Test execute query including inferred with ruleset "OWL-Horst (Optimized)" enabled sameAs functionality', () => {
+            let updateToExecute = 'PREFIX : <http://test.com/>\n' +
+                'PREFIX owl: <http://www.w3.org/2002/07/owl#>\n' +
+                '\n' +
+                'INSERT DATA {\n' +
+                '  :a owl:sameAs :b .\n' +
+                '}';
+
+            const selectQuery = 'PREFIX : <http://test.com/>\n' +
+                '\n' +
+                'select * where { \n' +
+                '  :a ?p ?o .\n' +
+                '}';
+
+            pasteQuery(updateToExecute);
+            executeQuery();
+            getUpdateMessage()
+                .should('be.visible')
+                .and('contain', 'Added 1 statements');
+
+            // Should be enabled by default
+            getSameAsButton()
+                .find('.icon-sameas-on')
+                .should('be.visible');
+
+            pasteQuery(selectQuery);
+            executeQuery();
+            verifyResultsPageLength(2);
+
+            getSameAsButton()
+                .click()
+                .find('.icon-sameas-off')
+                .should('be.visible');
+
+            executeQuery();
+            verifyResultsPageLength(1);
+        });
+    });
+
+    context('SPARQL view & download', () => {
+        beforeEach(() => createRepoAndVisit());
+
+        it('Test open a new tab', () => {
+            getNewTabButton().click();
+
+            // Verify that as result of clicking addNewTab button we've opened one more tab
+            getTabs().should('have.length', 2);
+
+            getLastTab()
+                .should('have.class', 'active')
+                .find('.nav-link')
+                .should('have.text', 'Unnamed');
+
+            verifyQueryAreaContains(DEFAULT_QUERY);
+
+            // No queries for new tab
+            getNoQueryRun().should('be.visible');
+        });
+
+        it('Test rename a tab', () => {
+            let firstTabName = 'Select query';
+            let secondTabName = 'Update query';
+
+            renameTab(1, firstTabName);
+
+            // Still one after renaming
+            getTabs().should('have.length', 1);
+
+            addTab();
+
+            renameTab(2, secondTabName);
+
+            // TODO: Add spec/steps for cancelling rename
+
+            // Still two after renaming
+            getTabs().should('have.length', 2);
+            verifyTabName(1, firstTabName);
+            verifyTabName(2, secondTabName);
+
+            // Go to a different workbench section and then back
+            ImportSteps.visitUserImport();
+
+            visitSparql();
+
+            // Still two after navigation
+            getTabs().should('have.length', 2);
+            verifyTabName(1, firstTabName);
+            verifyTabName(2, secondTabName);
+        });
+
+        it('Test close a tab', () => {
+            addTab();
+            addTab();
+            addTab();
+
+            renameTab(1, 'Tab 1');
+            renameTab(2, 'Tab 2');
+            renameTab(3, 'Tab 3');
+            renameTab(4, 'Tab 4');
+
+            closeTab(2);
+            confirmModal();
+            getModal().should('not.exist');
+
+            closeTab(3);
+            confirmModal();
+            getModal().should('not.exist');
+
+            getTabs().should('have.length', 2);
+
+            verifyTabName(1, 'Tab 1');
+            verifyTabName(2, 'Tab 3');
+        });
+
+        it('Test close all tabs except the selected one', () => {
+            addTab();
+            addTab();
+            addTab();
+
+            renameTab(1, 'Tab 1');
+            renameTab(2, 'Tab 2');
+            renameTab(3, 'Tab 3');
+            renameTab(4, 'Tab 4');
+
+            // Holding the shift down until the next command
+            cy.get('body').type('{shift}', {release: false});
+            closeTab(3);
+            confirmModal();
+            getModal().should('not.exist');
+
+            getTabs().should('have.length', 1);
+            verifyTabName(1, 'Tab 3');
+        });
+
+        it('Test download query results in Supported formats', () => {
+            executeQuery();
+
+            openDownloadAsMenu();
+
+            getDownloadAsFormatButtons()
+                .should('have.length', 5);
+
+            verifyDownloadMenuFormat('JSON', 'application/sparql-results+json');
+            verifyDownloadMenuFormat('XML', 'application/sparql-results+xml');
+            verifyDownloadMenuFormat('CSV', 'text/csv');
+            verifyDownloadMenuFormat('TSV', 'text/tab-separated-values');
+            verifyDownloadMenuFormat('Binary RDF Results', 'application/x-binary-rdf-results-table');
+        });
+
+        it('Test switch result format tabs', () => {
+            executeQuery();
+
+            openRawResponse();
+            getResultsWrapper()
+                .find('.CodeMirror-code')
+                .should('be.visible');
+
+            openPivotTable();
+            getResultsWrapper()
+                .find('.pivotTable table.pvtUi')
+                .should('be.visible');
+
+            // GCharts blows sometimes and breaks the test
+            disableExceptions();
+
+            openGoogleChart();
+            getResultsWrapper()
+                .find('#yasr-inner_gchartWrapper .google-visualization-table')
+                .should('be.visible');
+        });
+
+        it('Test change views', () => {
+            viewEditorOnly();
+
+            // Verify that only Editor tab is displayed
+            cy.get(EDITOR_SELECTOR).should('be.visible');
+            cy.get(YASR_INNER_SELECTOR).should('not.be.visible');
+
+            viewEditorAndResults();
+
+            // Verify that both Editor and Results tabs are displayed
+            cy.get(EDITOR_SELECTOR).should('be.visible');
+            cy.get(YASR_INNER_SELECTOR).should('be.visible');
+
+            viewResultsOnly();
+
+            // Verify that only Results tab is displayed
+            cy.get(EDITOR_SELECTOR).should('not.be.visible');
+            cy.get(YASR_INNER_SELECTOR).should('be.visible');
+
+            viewEditorAndResults();
+
+            // Check that they are horizontal
+            cy.get('#sparql-content > div').should('have.class', 'row');
+            cy.get(YASR_SELECTOR).should('not.have.class', 'vertical');
+
+            // Change the orientation to vertical
+            changeViewOrientation();
+
+            // Verify that all elements are visible and properly displayed.
+            cy.get(EDITOR_SELECTOR).should('be.visible');
+            cy.get(YASR_INNER_SELECTOR).should('be.visible');
+
+            // Check that they are vertical
+            cy.get('#sparql-content > div').should('not.have.class', 'row');
+            cy.get(YASR_SELECTOR).should('have.class', 'vertical');
+
+            // Run the default query on vertical mode
+            executeQuery();
+            // Verify that all results are properly scaled/displayed
+            verifyResultsPageLength(70);
+
+            // Return the orientation to horizontal
+            changeViewOrientation();
+
+            cy.get('#sparql-content > div').should('have.class', 'row');
+            cy.get(YASR_SELECTOR).should('not.have.class', 'vertical');
+        });
+    });
+
+    context('Saved queries & links', () => {
+        beforeEach(() => createRepoAndVisit());
+
+        const QUERY_FOR_SAVING = 'select (count (*) as ?cnt)\n' +
             'where {\n' +
             '    ?s ?p ?o .\n' +
             '}';
 
-        // Type a query different than the default one or the saved ones:
-        cy.get('.CodeMirror textarea').should("be.visible");
-        cy.get(".ot-loader-new-content").should("not.be.visible");
-        cy.wait(100);
-
-        cy.get('.CodeMirror textarea').type('{ctrl}a{backspace}', {force: true}).wait(500);
-        cy.get('.CodeMirror textarea').invoke('val', queryToSave).trigger('change', {force: true}).wait(500);
-
-        cy.get('#wb-sparql-saveQuery').click();
-        // Enter an unique name
-        cy.get('#wb-sparql-sampleName').clear().wait(500);
-        cy.get('#wb-sparql-sampleName').type(savedQueryName);
-
-
-        cy.get('#wb-sparql-submit').click().wait(500);
-
-        // Verify that the query is saved
-        cy.get('a#wb-sparql-toggleSampleQueries').click();
-        cy.get('.popover-content')
-            .should('contain', savedQueryName);
-
-        let modifiedSavedQuery = 'select (count (*) as ?cnt)\n' +
+        const QUERY_FOR_SAVING_MODIFIED = 'select (count (*) as ?cnt)\n' +
             'where {\n' +
             '    ?s1 ?p1 ?o1 .\n' +
             '}';
-        // Click on the saved queries icon
-        // Press the pen icon to edit the custom query created earlier
-        cy.get('a#wb-sparql-toggleSampleQueries').click();
 
-        cy.get('.popover-content');
-        cy.get('.popover-content #wb-sparql-queryInSampleQueries > li:contains("' + savedQueryName + '") span[class="icon-edit"]')
-            .should("be.visible");
-        cy.get('.popover-content #wb-sparql-queryInSampleQueries > li:contains("' + savedQueryName + '") span[class="icon-edit"]')
-            .click({force: true});
-        cy.get('#wb-sparql-sampleValue').clear().wait(500);
-        cy.get('#wb-sparql-sampleValue').invoke('val', modifiedSavedQuery).trigger('change', {force: true}).wait(500);
-        cy.get('#wb-sparql-submit').click().wait(200);
-
-        // Verify that the query is edited.
-        // Select the query from the saved queries again
-        cy.get('a#wb-sparql-toggleSampleQueries').click();
-        cy.get('.popover-content');
-        cy.get('#wb-sparql-queryInSampleQueries > li:contains("' + savedQueryName + '") span[class="icon-edit"]')
-            .should("be.visible");
-        cy.get('#wb-sparql-queryInSampleQueries > li:contains("' + savedQueryName + '") span[class="icon-edit"]')
-            .click({force: true});
-
-        cy.get('#wb-sparql-sampleValue', {timeout: 3000});
-        cy.wait(2000); //todo: we need this as the value of the saved query is loaded dynamically, and first some old text is loaded
-        cy.get('#wb-sparql-sampleValue', {timeout: 3000})
-            .then(($element) => {
-                // Verify that the new query is inserted in the SPARQL editor.
-                expect($element.val()).to.be.eq(modifiedSavedQuery);
-            });
-
-        // Close edit saved query dialog
-        cy.get('#wb-sparql-submit').click().wait(200);
-
-        // Click on the saved queries icon
-        cy.get('a#wb-sparql-toggleSampleQueries').click();
-        cy.get('.popover-content');
-        // Press the trash bin to delete the custom query created earlier
-        cy.get('#wb-sparql-queryInSampleQueries > li:contains("' + savedQueryName + '") span[class="icon-trash"]')
-            .click({force: true});
-        cy.get('.modal-dialog > .modal-content > .modal-footer > .btn-primary').click().wait(1000);
-
-
-        // Verify that the query is deleted
-        cy.get('a#wb-sparql-toggleSampleQueries').click();
-        cy.get('.popover-content')
-            .should('not.contain', savedQueryName);
-
-    });
-
-    it('Test run saved queries', function () {
-        // Execute all default saved queries
-        // Verify that they impact the results as expected:
-
-        // Execute the default sample Add Statements
-        // Click on the Run button
-        executeSavedQuery("Add statements");
-        // Verify query information: “Added 2 statements”
-        cy.verifyUpdateMessage('Added 2 statements.');
-        deleteCurrentTab();
-
-        // Execute the default sample Remove statements
-        executeSavedQuery("Remove statements");
-        // Verify query information: “Removed 2 statements.”
-        cy.verifyUpdateMessage('Removed 2 statements.');
-        deleteCurrentTab();
-
-        // Execute the default sample Clear Graph
-        executeSavedQuery("Clear graph");
-        // Verify query information: “The number of statements did not change.”
-        cy.verifyUpdateMessage('The number of statements did not change.');
-        deleteCurrentTab();
-
-        // Execute the default SPARQL Select template
-        executeSavedQuery("SPARQL Select template");
-        // Verify query information: "Showing results from 1 to"
-        cy.verifyQueryResultsS();
-
-        deleteCurrentTab();
-    });
-
-    it('Test saved query link', function () {
-        let addStmts = 'Add statements';
-        // Click on the saved queries icon
-        cy.get('a#wb-sparql-toggleSampleQueries').click();
-        cy.get('.popover-content');
-
-        cy.get('#wb-sparql-queryInSampleQueries > li')
-            .each(($el, index) => { //todo: to be fixed
-                if ($el.text().trim() === addStmts) {
-                    // Press the link icon to generate a link for a query
-                    cy.get('#wb-sparql-queryInSampleQueries > li span[class="icon-link"]')
-                        .eq(index).click();
-                    verifyRedirectionToCopiedQueryURL();
-                }
-            });
-        deleteCurrentTab();
-    });
-
-    it('Test URL to current query', function () {
-        // Press the link icon to generate a link for a query
-        cy.get('#wb-sparql-copyToClipboardQuery').should("be.visible");
-        cy.get('#wb-sparql-copyToClipboardQuery').click().wait(1000);
-        verifyRedirectionToCopiedQueryURL();
-    });
-
-    it('Test rename a tab', function () {
-        let firstTabName = 'Select query';
-        let secondTabName = 'Update query';
-
-        cy.get(".ot-loader-new-content").should("not.be.visible").wait(500);
-
-        // Rename the initial tab.
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li[role="presentation"] > a[role="tab"]', {timeout: 1000})
-            .should("be.visible");
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li[role="presentation"] > a[role="tab"]', {timeout: 1000})
-            .last().dblclick().wait(700);
-
-        cy.get('.editable-controls.form-group > input', {timeout: 1000}).type(firstTabName);
-        cy.get('span.editable-buttons > [type="submit"]', {timeout: 1000}).click({timeout: 1000}).wait(300);
-
-        // Verify that the name persists
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a').contains(firstTabName);
-
-        // Go to a different workbench section
-        cy.navigateToPageS('Import', 'RDF');
-
-        // Return to SPARQL
-        cy.navigateToPageS('SPARQL');
-        cy.get(".ot-loader-new-content").should("not.be.visible");
-        cy.wait(1000);
-        // Verify that the tab name persists
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a').contains(firstTabName);
-
-        // Open a new tab
-        cy.get('#wb-sparql-addNewTab').click().wait(300);
-
-        // Verify that as result of clicking addNewTab button we've opened one more tab
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a')
-            .should('have.length', 2);
-        // Get last added tab
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a')
-            .last()
-            .then(($el) => { //todo: fix this
-                // Verify that its name is "Unnamed"
-                expect($el.text()).to.be.eq('Unnamed');
-            });
-
-        // Verify that the first tab's name persists
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a').contains(firstTabName);
-        cy.get(".ot-loader-new-content").should("not.be.visible");
-
-        // Rename the second tab
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li[role="presentation"] > a[role="tab"]', {timeout: 1000})
-            .last()
-            .dblclick().wait(500);
-
-        cy.get('.editable-controls.form-group > input', {timeout: 1000}).type(secondTabName);
-        cy.get('span.editable-buttons > [type="submit"]').click();
-
-        // Go to a different workbench section
-        cy.navigateToPageS('Import', 'RDF');
-
-        // Return to SPARQL
-        cy.navigateToPageS('SPARQL');
-
-        // Verify that the tabs names persist
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a').contains(firstTabName);
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a').contains(secondTabName);
-
-        deleteCurrentTab();
-    });
-
-    it('Test delete a tab', function () {
-        // Verify that there is only one tab opened
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a').should('have.length', 1);
-        // Add a new tab
-        cy.get('#wb-sparql-addNewTab').click();
-        // Verify that as result of clicking addNewTab button we've opened one more tab
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a').should('have.length', 2);
-        // Delete the second tab
-        deleteCurrentTab();
-        // Verify that there is only one tab left opened
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a').should('have.length', 1);
-    });
-
-    it('Test close all tabs except the selected one', function () {
-        for (let index = 1; index <= 2; index++) {
-            // Open a two more tabs
-            cy.get('#wb-sparql-addNewTab').click();
-            // Change the query in each one of them
-            cy.get('.CodeMirror textarea').type('{ctrl}a{backspace}', {force: true});
-            cy.get('.CodeMirror textarea').invoke('val', 'select * where { \n' +
-                '\t?s' + index + ' ?p' + index + ' ?o' + index + ' .\n' +
-                '} limit 100 ').trigger('change', {force: true});
+        function waitUntilSavedQueryModalIsVisible() {
+            getModal().should('be.visible');
+            getSavedQueryForm().should('be.visible');
+            getSubmitSavedQueryBtn()
+                .should('be.visible')
+                .and('not.be.disabled');
         }
 
-        // Verify that number of opened tabs are 3
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a').should('have.length', 3);
+        it('Test create, edit and delete saved query', () => {
+            let savedQueryName = 'Saved query - ' + Date.now();
 
-        // Click on the middle tab close button while holding down the SHIFT key.
-        cy.get('.CodeMirror textarea').type('{shift}', {force: true, release: false});
-        cy.get(':nth-child(2) > .nav-link > .btn > .icon-close').click();
+            pasteQuery(QUERY_FOR_SAVING);
 
-        // Verify that a dialog box is displayed, notifying that you are about to close all tabs except the one selected.
-        cy.get('.modal-dialog > .modal-content > .modal-body.ng-scope')
-            .then(($el) => {
-                expect($el.text()).to.be.eq('\n    Are you sure you want to delete all query tabs except selected tab?\n');
+            saveQuery();
+            waitUntilSavedQueryModalIsVisible();
+
+            getSavedQueryNameField()
+                .type(savedQueryName)
+                .should('have.value', savedQueryName);
+            submitSavedQuery();
+
+            getSavedQueryForm().should('not.exist');
+
+            // Verify that the query is saved
+            openSavedQueriesPopup();
+            getPopover()
+                .should('be.visible')
+                .and('contain', savedQueryName);
+
+            // Press the pen icon to edit the custom query created earlier
+            editSaveQueryFromPopup(savedQueryName);
+
+            getPopover().should('not.exist');
+            waitUntilSavedQueryModalIsVisible();
+
+            getSavedQueryNameField().should('have.value', savedQueryName);
+            getSavedQueryField()
+                .should('have.value', QUERY_FOR_SAVING)
+                .clear()
+                .type(QUERY_FOR_SAVING_MODIFIED)
+                .should('have.value', QUERY_FOR_SAVING_MODIFIED);
+            submitSavedQuery();
+
+            getSavedQueryForm().should('not.exist');
+
+            // Verify that the query is edited.
+            // Select the query from the saved queries again
+            openSavedQueriesPopup();
+            editSaveQueryFromPopup(savedQueryName);
+
+            waitUntilSavedQueryModalIsVisible();
+
+            getSavedQueryNameField().should('have.value', savedQueryName);
+            getSavedQueryField().should('have.value', QUERY_FOR_SAVING_MODIFIED);
+
+            // Close edit saved query dialog
+            submitSavedQuery();
+
+            // Click on the saved queries icon
+            openSavedQueriesPopup();
+            // Press the trash bin to delete the custom query created earlier
+            deleteSaveQueryFromPopup(savedQueryName);
+
+            // Confirm dialog
+            confirmModal();
+            getModal().should('not.exist');
+            getPopover().should('not.exist');
+
+            // Verify that the query is deleted
+            openSavedQueriesPopup();
+            getPopover().should('not.contain', savedQueryName);
+        });
+
+        it('Test save invalid Sample Queries', () => {
+            // Try to save Sample Queries without specifying query name
+            saveQuery();
+            waitUntilSavedQueryModalIsVisible();
+
+            submitSavedQuery();
+            getSavedQueryErrors()
+                .find('.empty-query-name-err')
+                .should('be.visible')
+                .and('contain', 'Name cannot be empty!');
+
+            // Type query name, remove content add try to save the query
+            getSavedQueryNameField()
+                .type('My query')
+                .should('have.value', 'My query');
+            getSavedQueryField()
+                .clear()
+                .should('not.have.value');
+
+            submitSavedQuery();
+            getSavedQueryErrors()
+                .find('.empty-query-err')
+                .should('be.visible')
+                .and('contain', 'Query cannot be empty!');
+
+            // TODO: Avoid closing...
+            // Close "Create New Saved Query" dialog
+            cancelSavedQuery();
+
+            // Try to create saved query with a name that already exists - "Add statements"
+            saveQuery();
+            waitUntilSavedQueryModalIsVisible();
+
+            getSavedQueryNameField()
+                .type('Add statements')
+                .should('have.value', 'Add statements');
+
+            submitSavedQuery();
+            getSavedQueryErrors()
+                .find('.query-exists-error')
+                .should('be.visible')
+                .and('contain', 'Query with name \'Add statements\' already exists!');
+        });
+
+        it('Test run saved queries', () => {
+            // Execute all default saved queries
+
+            // Execute the default sample Add Statements
+            selectSavedQuery('Add statements');
+            getTabs().should('have.length', 2);
+            getActiveTabLink().should('have.text', 'Add statements');
+            getQueryArea().should('contain', 'INSERT DATA');
+            executeQuery();
+            // Verify query information: “Added 2 statements”
+            getUpdateMessage()
+                .should('contain', 'Added 2 statements.')
+                .and('contain', 'Update took');
+
+            // Execute the default sample Remove statements
+            selectSavedQuery('Remove statements');
+            getTabs().should('have.length', 3);
+            getActiveTabLink().should('have.text', 'Remove statements');
+            getQueryArea().should('contain', 'DELETE DATA');
+            executeQuery();
+            getUpdateMessage()
+                .should('contain', 'Removed 2 statements.')
+                .and('contain', 'Update took');
+
+            // Execute the default sample Clear Graph
+            selectSavedQuery('Clear graph');
+            getTabs().should('have.length', 4);
+            getActiveTabLink().should('have.text', 'Clear graph');
+            getQueryArea().should('contain', 'CLEAR GRAPH');
+            executeQuery();
+            getUpdateMessage()
+                .should('contain', 'The number of statements did not change.')
+                .and('contain', 'Update took');
+
+            // Execute the default SPARQL Select template
+            selectSavedQuery('SPARQL Select template');
+            getTabs().should('have.length', 5);
+            getActiveTabLink().should('have.text', 'SPARQL Select template');
+            getQueryArea().should('contain', 'SELECT');
+            executeQuery();
+            getUpdateMessage().should('not.be.visible');
+            getResultsMessage()
+                .should('contain', 'Showing results from 1 to 74 of 74')
+                .and('contain', 'Query took');
+
+            verifyResultsPageLength(74);
+        });
+
+        it('Test saved query link', () => {
+            const queryName = 'Add statements';
+            openSavedQueriesPopup();
+            openSavedQueryLinkFromPopup(queryName);
+
+            const expectedUrl = Cypress.config().baseUrl + '/sparql?savedQueryName=' + encodeURI(queryName);
+            getModal()
+                .should('be.visible')
+                .find('#clipboardURI')
+                .should('have.value', expectedUrl);
+
+            // Visit performs full page load
+            cy.visit(expectedUrl);
+            waitUntilSparqlPageIsLoaded();
+
+            getTabs().should('have.length', 2);
+            getActiveTabLink().should('have.text', queryName);
+
+            // Wait until editor is initialized with the query and then assert the whole query
+            getQueryArea().should('contain', 'INSERT DATA');
+            cy.fixture('queries/add-statement.txt').then((query) => {
+                verifyQueryAreaEquals(query);
             });
-        cy.get('.modal-dialog > .modal-content > .modal-footer > .btn-primary').click().wait(1000);
+        });
 
-        // Confirm and verify that all other tabs have been closed and only the selected one is left in the editor.
-        cy.get('#sparql-content > div > div > ul.nav.nav-tabs > li > a').should('have.length', 1);
+        it('Test URL to current query', () => {
+            const query = 'SELECT ?s ?p ?o WHERE {?s ?p ?o .} LIMIT 100';
+            pasteQuery(query);
+
+            // Press the link icon to generate a link for a query
+            getQueryLinkBtn().click();
+
+            // TODO: Test with tab name -> should open such tab if it was deleted
+
+            // TODO: Test with different values for infer & same as
+
+            const encodedQuery = 'SELECT+%3Fs+%3Fp+%3Fo+WHERE+%7B%3Fs+%3Fp+%3Fo+.%7D+LIMIT+100';
+            const expectedUrl = Cypress.config().baseUrl + '/sparql?name=&infer=true&sameAs=true&query=' + encodedQuery;
+            getModal()
+                .should('be.visible')
+                .find('#clipboardURI')
+                .should('have.value', expectedUrl);
+
+            // Visit performs full page load
+            cy.visit(expectedUrl);
+            waitUntilSparqlPageIsLoaded();
+
+            getTabs().should('have.length', 1);
+
+            // Wait until editor is initialized with the query and then assert the whole query
+            getQueryArea().should('contain', 'SELECT');
+            verifyQueryAreaEquals(query);
+        });
     });
 
-    it('Test execute queries with prefixes', function () {
+    const TABS_SELECTOR = '#sparql-content .nav-tabs .sparql-tab';
+    const EDITOR_SELECTOR = '#queryEditor';
+    const YASR_SELECTOR = '#yasr';
+    const YASR_INNER_SELECTOR = '#yasr-inner';
 
-        let queryToExecute = 'PREFIX wordn-sc: <http://example.org>\n' +
-            'select * where {\n' +
-            '?sub rdfs:subClassOf ?c .\n' +
-            '?c a owl:Restriction;\n' +
-            'owl:onProperty wordn-sc:word;\n' +
-            'owl:someValuesFrom wordn-sc:Word .\n' +
-            '}';
+    function executeQuery() {
+        getRunQueryButton().click();
+        getLoader().should('not.be.visible');
+    }
 
-        // Type a new query
-        cy.get('.CodeMirror textarea').type('{ctrl}a{backspace}', {force: true});
-        cy.get('.CodeMirror textarea').type(queryToExecute, {force: true});
+    function getLoader() {
+        return cy.get('.ot-loader-new-content');
+    }
 
-        // Confirm that prefixes rdfs, owl and wordn-sc have been added automatically
-        cy.get('.CodeMirror-code')
-            .then(($el) => {
-                expect($el.text()).to.contain('2PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>' +
-                    '3PREFIX owl: <http://www.w3.org/2002/07/owl#>');
+    // TODO: waitAnimation() command ?
+    function getPopover() {
+        return cy.get('.popover').should('not.have.class', 'ng-animate');
+    }
+
+    function getRunQueryButton() {
+        return cy.get('#wb-sparql-runQuery');
+    }
+
+    function getTableResultRows() {
+        return getResultsWrapper().find('.resultsTable tbody tr');
+    }
+
+    function verifyResultsPageLength(resultLength) {
+        getTableResultRows()
+            .should('have.length', resultLength);
+    }
+
+    function getResultPagination() {
+        return cy.get('#yasr .nav.pagination');
+    }
+
+    function getResultPages() {
+        return getResultPagination().find('li')
+    }
+
+    function getModal() {
+        return cy.get('.modal').should('not.have.class', 'ng-animate');
+    }
+
+    function confirmModal() {
+        getModal()
+            .should('be.visible')
+            .find('.modal-footer')
+            .should('be.visible')
+            .find('.btn-primary')
+            .click();
+    }
+
+    function getTabs() {
+        return cy.get(TABS_SELECTOR);
+    }
+
+    function getActiveTab() {
+        return cy.get(TABS_SELECTOR + '.active')
+    }
+
+    function getActiveTabLink() {
+        return cy.get(TABS_SELECTOR + '.active .nav-link')
+    }
+
+    function getNewTabButton() {
+        return cy.get('#wb-sparql-addNewTab');
+    }
+
+    function addTab() {
+        getNewTabButton().click();
+    }
+
+    function getLastTab() {
+        return getTabs().last();
+    }
+
+    function renameTab(position, newName) {
+        getTabs().eq(position - 1).then(tab => {
+            cy.wrap(tab)
+            // First click is to focus it in case it's not the active tab
+                .click()
+                .find('.nav-link')
+                .dblclick();
+            cy.wrap(tab)
+                .find('.editable-input')
+                .type(newName)
+                .should('have.value', newName);
+            cy.wrap(tab)
+                .find('.editable-buttons .btn-primary')
+                .click()
+                .should('not.exist');
+        });
+    }
+
+    function verifyTabName(position, name) {
+        getTabs().eq(position - 1)
+            .should('be.visible')
+            .find('.nav-link')
+            .should('have.text', name);
+    }
+
+    function getTabCloseBtn(position) {
+        return getTabs().eq(position - 1).find('.delete-sparql-tab-btn');
+    }
+
+    function closeTab(position) {
+        getTabCloseBtn(position).click();
+    }
+
+    function verifyQueryAreaContains(query) {
+        // Using the CodeMirror instance because getting the value from the DOM is very cumbersome
+        getQueryArea().should(codeMirrorEl => {
+            const cm = codeMirrorEl[0].CodeMirror;
+            expect(cm.getValue().includes(query)).to.be.true;
+        });
+    }
+
+    function verifyQueryAreaEquals(query) {
+        // Using the CodeMirror instance because getting the value from the DOM is very cumbersome
+        getQueryArea().should(codeMirrorEl => {
+            const cm = codeMirrorEl[0].CodeMirror;
+            expect(cm.getValue().trim()).to.equal(query.trim());
+        });
+    }
+
+    function waitUntilQueryIsVisible() {
+        getQueryArea().should(codeMirrorEl => {
+            const cm = codeMirrorEl[0].CodeMirror;
+            expect(cm.getValue().trim().length > 0).to.be.true;
+        });
+    }
+
+    function getQueryArea() {
+        return cy.get('#queryEditor .CodeMirror');
+    }
+
+    function getQueryTextArea() {
+        return getQueryArea().find('textarea');
+    }
+
+    function getNoQueryRun() {
+        return cy.get('#yasr-inner .no-query-run');
+    }
+
+    function clearQuery() {
+        // Using force because the textarea is not visible
+        getQueryTextArea().type('{ctrl}a{backspace}', {force: true});
+    }
+
+    function typeQuery(query) {
+        clearQuery();
+        getQueryTextArea().type(query, {force: true, parseSpecialCharSequences: false});
+    }
+
+    function pasteQuery(query) {
+        clearQuery();
+        getQueryTextArea().invoke('val', query).trigger('change', {force: true});
+        waitUntilQueryIsVisible();
+    }
+
+    function goToPage(page) {
+        getResultPages().contains(page).click();
+        getLoader().should('not.be.visible');
+    }
+
+    function getResultFilterField() {
+        return cy.get('#yasr input[type="search"]');
+    }
+
+    function getTableResponseButton() {
+        return cy.get('#yasr .select_table');
+    }
+
+    function getRawResponseButton() {
+        return cy.get('#yasr .select_rawResponse');
+    }
+
+    function openRawResponse() {
+        getRawResponseButton().click();
+    }
+
+    function getPivotTableButton() {
+        return cy.get('#yasr .select_pivot');
+    }
+
+    function openPivotTable() {
+        getPivotTableButton().click();
+    }
+
+    function getGoogleChartButton() {
+        return cy.get('#yasr .select_gchart');
+    }
+
+    function openGoogleChart() {
+        getGoogleChartButton().click();
+    }
+
+    function getEditorOnlyButton() {
+        return cy.get('#hideEditor .editor-only-btn');
+    }
+
+    function viewEditorOnly() {
+        getEditorOnlyButton().click();
+    }
+
+    function getEditorAndResultsButton() {
+        return cy.get('#hideEditor .editor-and-results-btn');
+    }
+
+    function viewEditorAndResults() {
+        getEditorAndResultsButton().click();
+    }
+
+    function getResultsOnlyButton() {
+        return cy.get('#hideEditor .results-only-btn');
+    }
+
+    function viewResultsOnly() {
+        getResultsOnlyButton().click();
+    }
+
+    function getViewOrientationButton() {
+        return cy.get('#hideEditor .toggle-horizontal-view-btn');
+    }
+
+    function changeViewOrientation() {
+        getViewOrientationButton().click();
+    }
+
+    function getSaveQueryBtn() {
+        return cy.get('#wb-sparql-saveQuery');
+    }
+
+    function saveQuery() {
+        getSaveQueryBtn().click();
+    }
+
+    function getSavedQueryForm() {
+        return cy.get('.modal .save-query-form');
+    }
+
+    function getSubmitSavedQueryBtn() {
+        return cy.get('#wb-sparql-submit');
+    }
+
+    function submitSavedQuery() {
+        getSubmitSavedQueryBtn().click();
+    }
+
+    function getSavedQueryNameField() {
+        return cy.get('#wb-sparql-sampleName');
+    }
+
+    function getSavedQueryErrors() {
+        return getSavedQueryForm().find('.saved-query-errors');
+    }
+
+    function getSavedQueryField() {
+        return cy.get('#wb-sparql-sampleValue');
+    }
+
+    function getCancelSavedQueryBtn() {
+        return cy.get('.modal-footer .cancel-btn');
+    }
+
+    function cancelSavedQuery() {
+        getCancelSavedQueryBtn().click();
+    }
+
+    function getSavedQueriesPopupBtn() {
+        return cy.get('#wb-sparql-toggleSampleQueries');
+    }
+
+    function openSavedQueriesPopup() {
+        getSavedQueriesPopupBtn().click();
+    }
+
+    function getSavedQueryFromPopup(savedQueryName) {
+        return cy.get('#wb-sparql-queryInSampleQueries')
+            .contains(savedQueryName)
+            .parentsUntil('#wb-sparql-queryInSampleQueries');
+    }
+
+    function selectSavedQuery(savedQueryName) {
+        openSavedQueriesPopup();
+        getSavedQueryFromPopup(savedQueryName)
+            .find('a')
+            .click();
+    }
+
+    function editSaveQueryFromPopup(savedQueryName) {
+        getSavedQueryFromPopup(savedQueryName)
+            .within(() => {
+                cy.get('a').trigger('mouseover');
+                cy.get('.icon-edit').click();
             });
+    }
 
-        // Click on the Run button
-        cy.get('div#runButton > #wb-sparql-runQuery').as('runQuery');
-
-        cy.get('@runQuery').click();
-    });
-
-    it('Test execute (Describe) query', function () {
-        let queryToExecute = 'DESCRIBE <http://www.ontotext.com/SYSINFO> FROM <http://www.ontotext.com/SYSINFO>';
-
-        // Type a DESCRIBE query
-        cy.executeCustomQuery(queryToExecute).as('executeQuery');
-
-        // Verify query results (Showing n ...)
-        cy.verifyQueryResultsS();
-
-
-        // Confirm that all tabs Raw Response, Pivot Table, Google chart are enabled
-        cy.get('.select_rawResponse').should('be.visible').and('not.be.disabled');
-        cy.get('.select_pivot').should('be.visible').and('not.be.disabled');
-        cy.get('.select_gchart').should('be.visible').and('not.be.disabled');
-
-        // Click on Download As
-        // Confirm the available file formats (all supported file formats are available
-        cy.get('.saveAsDropDown > .btn').should("be.visible");
-        cy.get('.saveAsDropDown > .btn').click();
-
-        cy.get('#yasr-inner .dropdown-menu > li')
-            .then(($el) => { //todo: fix this
-                // Number of supported formats is 10
-                expect($el.length).to.be.eq(10);
+    function deleteSaveQueryFromPopup(savedQueryName) {
+        getSavedQueryFromPopup(savedQueryName)
+            .within(() => {
+                cy.get('a').trigger('mouseover');
+                cy.get('.icon-trash').click();
             });
+    }
 
+    function openSavedQueryLinkFromPopup(savedQueryName) {
+        getSavedQueryFromPopup(savedQueryName)
+            .within(() => {
+                cy.get('a').trigger('mouseover');
+                cy.get('.icon-link').click();
+            });
+    }
 
-        // Select a file format
-        // Confirm that query results has been downloaded
-        selectDownloadAs('JSON-LD');
-    });
+    function getUpdateMessage() {
+        return cy.get('#yasr-inner .alert-info.update-info');
+    }
 
-    it('Test execute (ASK) query', function () {
+    function getResultsMessage() {
+        return cy.get('#yasr-inner .alert-info.results-info');
+    }
 
-        let queryToExecute = 'ASK WHERE { ?s ?p ?o .FILTER (regex(?o, \"ontotext.com\")) }';
+    function getQueryLinkBtn() {
+        return cy.get('#wb-sparql-copyToClipboardQuery');
+    }
 
-        // Type a ASK query
-        cy.executeCustomQuery(queryToExecute).as('executeQuery');
+    function getResultsWrapper() {
+        return cy.get('#yasr-inner .yasr_results');
+    }
 
-        // Confirm that all tabs (Table, Pivot Table, Google chart) are disabled
-        cy.get('.select_table').should('not.be.visible');
-        cy.get('.select_rawResponse').should('not.be.visible');
-        cy.get('.select_pivot').should('not.be.visible');
-        cy.get('.select_gchart').should('not.be.visible');
+    function getResultsHeader() {
+        return cy.get('#yasr .yasr_header');
+    }
 
-    });
+    function getDownloadAsMenuButton() {
+        return getResultsHeader().find('.saveAsDropDown > .btn');
+    }
 
-    it('Test execute (CONSTRUCT) query', function () {
+    function openDownloadAsMenu() {
+        getDownloadAsMenuButton().click();
+    }
 
-        let queryToExecute = 'PREFIX cat: <[http://dbpedia.org/resource/Category:]>\n' +
-            'PREFIX foaf: <[http://xmlns.com/foaf/0.1/]>\n' +
-            'PREFIX gp: <[http://wifo5-04.informatik.uni-mannheim.de/gutendata/resource/people/]>\n' +
-            'PREFIX owl: <[http://www.w3.org/2002/07/owl#]>\n' +
-            'PREFIX rdf: <[http://www.w3.org/1999/02/22-rdf-syntax-ns#]>\n' +
-            'PREFIX rdfs: <[http://www.w3.org/2000/01/rdf-schema#]>\n' +
-            'PREFIX skos: <[http://www.w3.org/2004/02/skos/core#]>\n' +
-            'CONSTRUCT\n' +
-            '{\n' +
-            '    <http://dbpedia.org/resource/Joseph_Hocking> ?dbpProperty ?dbpValue .\n' +
-            '    gp:Hocking_Joseph ?gutenProperty ?gutenValue .\n' +
-            '}\n' +
-            'WHERE\n' +
-            '{\n' +
-            '    SERVICE <http://factforge.net/repositories/ff-news>\n' +
-            '    {\n' +
-            '        <http://dbpedia.org/resource/Joseph_Hocking> ?dbpProperty ?dbpValue .\n' +
-            '    }\n' +
-            '}';
+    function getDownloadAsFormatButtons() {
+        return getResultsHeader().find('.saveAsDropDown .dropdown-menu .dropdown-item');
+    }
 
-        // Type a CONSTRUCT query
-        cy.executeCustomQuery(queryToExecute).as('executeQuery');
+    function verifyDownloadMenuFormat(rdfFormat, mimetype) {
+        getDownloadAsFormatButtons()
+            .contains(rdfFormat)
+            .should('be.visible')
+            .and('have.attr', 'data-accepts')
+            .and('include', mimetype);
+    }
 
-        // Verify query results (Showing n ...)
-        cy.verifyQueryResultsS();
+    function disableExceptions() {
+        cy.on('uncaught:exception', () => {
+            return false;
+        });
+    }
 
-        // Confirm that all tabs (Table, Pivot Table, Google chart) are disabled
-        cy.get('.select_table').should('be.visible');
-        cy.get('.select_rawResponse').should('be.visible');
-        cy.get('.select_pivot').should('be.visible');
-        cy.get('.select_gchart').should('be.visible');
+    function getBooleanResult() {
+        return getResultsWrapper().find('.booleanBootResult');
+    }
 
-        // Select a file format
-        // Confirm that query results has been downloaded
-        cy.get('.select_rawResponse').as('select_rawResponse');
+    function getResultsDownloadButton() {
+        return getResultsHeader().find('.yasr_downloadIcon');
+    }
 
-        cy.get('@select_rawResponse').click();
+    function getInferenceButton() {
+        return cy.get('#inference');
+    }
 
-        cy.get('.yasr_downloadIcon').should('be.visible');
+    function getSameAsButton() {
+        return cy.get('#sameAs');
+    }
 
-    });
-
-    it('Test execute query with and without "Including inferred" selected', function () {
-        let testRepo = 'test-repo' + Date.now();
-        // First navigate to create repository
-        cy.navigateToPageS('Setup', 'Repositories');
-        // // Create new repository
-        cy.createNewRepoS(testRepo).wait(1000);
-        cy.setRepoDefaultS(testRepo);
-        cy.selectRepoS(testRepo).wait(1000);
-
-        cy.navigateToPageS('SPARQL');
-
-        let queryToExecute = 'INSERT DATA { <urn:a> <http://a/b> <urn:b> . <urn:b> <http://a/b> <urn:c> . }';
-
-        // Type a query with inference
-        cy.executeCustomQuery(queryToExecute);
-        // Execute default query with ‘Include inferred’ which is selected by default
-        cy.executeCustomQuery(defaultQuery);
-
-        // Confirm that all statements are available (70 from ruleset, 2 explicit and 2 inferred)
-        cy.verifyQueryResultsS(74);
-
-        // Uncheck ‘Include inferred’ using the same query
-        cy.get('#inference').as('uncheckIncludeInferred');
-
-        cy.get('@uncheckIncludeInferred').click();
-
-        // Click on the Run button
-        cy.get('div#runButton > #wb-sparql-runQuery').as('rerunQuery');
-
-
-        cy.get('@rerunQuery').click();
-
-        // Confirm that only inferred statements (only 2) are available
-        cy.verifyQueryResultsS(2);
-
-        cy.get('@uncheckIncludeInferred').click();
-        // Should delete the created repository
-        cy.deleteRepoS(testRepo).wait(1000);
-    });
-
-    it('Test execute query including inferred with ruleset "OWL-Horst (Optimized)"', function () {
-        let testRepo = 'test-repo' + Date.now();
-        // First navigate to create repository for this test
-        cy.navigateToPageS('Setup', 'Repositories');
-        // Create new repository
-        cy.createNewRepoS(testRepo, 'OWL-Horst (Optimized)').wait(1000);
-        cy.setRepoDefaultS(testRepo);
-        // Select the newly created repository
-        cy.selectRepoS(testRepo).wait(1000);
-
-        // Upload the wines ontology
-        cy.navigateToPageS('Import', 'RDF');
-        cy.openImportURLDialogS('https://www.w3.org/TR/owl-guide/wine.rdf');
-        cy.clickImportUrlBtn();
-        cy.clickImportBtnOnPopUpMenu().wait(1000);
-
-        let defaultQueryWithoutLimit = 'select * where { \n' +
-            '\t?s ?p ?o .\n' +
-            '}';
-
-        // Navigate back to SPARQL page
-        cy.navigateToPageS('SPARQL')
-
-        // Go to SPARQL and execute a SELECT query without a limit
-        cy.executeCustomQuery(defaultQueryWithoutLimit);
-
-        // Verify that there are 7,065 results
-        cy.verifyQueryResultsS('1,000 of 7,065');
-
-        // Disable the inference from the ">>" icon on the right of the SPARQL editor.
-        cy.get('#inference').as('disableInference');
-
-        cy.get('@disableInference').click();
-
-        // Execute the same query again
-        cy.get('div#runButton > #wb-sparql-runQuery').as('rerunQuery');
-
-        cy.get('@rerunQuery').click();
-        // Verify that there are 1,839 results
-        cy.verifyQueryResultsS('1,000 of 1,839');
-
-        cy.get('@disableInference').click();
-        // Should delete the created repository
-        cy.deleteRepoS(testRepo).wait(1000);
-    });
-
-    it('Test execute query including inferred with ruleset "OWL-Horst (Optimized)" enabled sameAs functionality', function () {
-        let testRepo = 'test-repo' + Date.now();
-        // First navigate to create repository for this test
-        cy.navigateToPageS('Setup', 'Repositories');
-        // // Create new repository with enabled sameAs functionality
-        cy.createNewRepoS(testRepo, 'OWL-Horst (Optimized)', true);
-        cy.setRepoDefaultS(testRepo);
-        cy.selectRepoS(testRepo).wait(1000);
-
-        let updateToExecute = 'PREFIX : <http://test.com/>\n' +
-            'PREFIX owl: <http://www.w3.org/2002/07/owl#>\n' +
-            '\n' +
-            'INSERT DATA {\n' +
-            '  :a owl:sameAs :b .\n' +
-            '}';
-
-        // Navigate back to SPARQL page
-        cy.navigateToPageS('SPARQL');
-        // Go to SPARQL and run the following update
-        cy.executeCustomQuery(updateToExecute);
-
-        // Verify that one statement has been inserted
-        cy.verifyUpdateMessage('Added 1 statements.');
-
-        // click "Expand results over owl:sameAs = OFF" icon on the right of the SPARQL editor.
-        cy.get('button#sameAs > span.icon-2-5x').as('disableSameAs');
-
-        cy.get('@disableSameAs').click();
-        // Execute following query
-        cy.executeCustomQuery('PREFIX : <http://test.com/>\n' +
-            '\n' +
-            'select * where { \n' +
-            '        :a ?p ?o .\n' +
-            '}');
-        // Verify that there is only one result displaying the link ":a owl:sameAs :a"
-        cy.verifyQueryResultsS(1);
-
-        // turn "Expand results over owl:sameAs = "to" ON"
-        cy.get('button#sameAs > span.icon-2-5x').click();
-
-        // Execute the same query
-        cy.get('div#runButton > #wb-sparql-runQuery').click();
-
-
-        // Verify that there are two results displaying the links between ":a owl:sameAs :a" and ":a owl:sameAs :b"
-        cy.verifyQueryResultsS(2);
-
-        // Should delete the created repository
-        cy.deleteRepoS(testRepo).wait(1000);
-    });
 });

--- a/test-cypress/plugins/index.js
+++ b/test-cypress/plugins/index.js
@@ -14,4 +14,7 @@
 module.exports = (on, config) => {
     // `on` is used to hook into various events Cypress emits
     // `config` is the resolved Cypress config
-}
+    on('task', {
+        failed: require('cypress-failed-log/src/failed')()
+    })
+};

--- a/test-cypress/support/commands.js
+++ b/test-cypress/support/commands.js
@@ -25,6 +25,7 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 import './repository-commands';
+import './import-commands';
 
 // ================================================================================
 // ================================================================================

--- a/test-cypress/support/import-commands.js
+++ b/test-cypress/support/import-commands.js
@@ -1,0 +1,45 @@
+import urlImportTemplate from '../fixtures/url-import-template.json';
+import snippetImportTemplate from '../fixtures/snippet-import-template.json';
+
+const IMPORT_URL = '/rest/data/import/upload/';
+const POLL_INTERVAL = 200;
+
+Cypress.Commands.add('importFromUrl', (repositoryId, url, importSettings = {}) => {
+
+    const importData = Cypress._.defaultsDeep(importSettings, urlImportTemplate);
+    importData.name = url;
+    importData.data = url;
+
+    cy.request({
+        method: 'POST',
+        url: IMPORT_URL + repositoryId + '/url',
+        body: importData,
+    }).should((response) => expect(response.status).to.equal(202))
+        .then({timeout: 30000}, () => waitImport(repositoryId, url));
+});
+
+Cypress.Commands.add('importRDFTextSnippet', (repositoryId, rdf, importSettings = {}, waitTimeout = 4000) => {
+    const importData = Cypress._.defaultsDeep(importSettings, snippetImportTemplate);
+    importData.data = rdf;
+
+    cy.request({
+        method: 'POST',
+        url: IMPORT_URL + repositoryId + '/text',
+        body: importData,
+    }).should((response) => expect(response.status).to.equal(202));
+    waitImport(repositoryId, importData.name, waitTimeout);
+});
+
+function waitImport(repositoryId, name) {
+    cy.request({
+        method: 'GET',
+        url: IMPORT_URL + repositoryId,
+    }).then((response) => {
+        const importStatus = Cypress._.find(response.body, (importStatus) => importStatus.name === name);
+        if (importStatus.status === 'DONE') {
+            return;
+        }
+        cy.wait(POLL_INTERVAL);
+        waitImport(repositoryId, name);
+    });
+}

--- a/test-cypress/support/index.js
+++ b/test-cypress/support/index.js
@@ -22,3 +22,5 @@ import './commands';
 // Configures retry count for failed tests TODO: Remove after tests are stabilized
 require('cypress-plugin-retries');
 Cypress.env('RETRIES', 0);
+
+require('cypress-failed-log');

--- a/test-cypress/support/repository-commands.js
+++ b/test-cypress/support/repository-commands.js
@@ -1,9 +1,7 @@
 import repoTemplate from '../fixtures/repo-template.json';
-import snippetImportTemplate from '../fixtures/snippet-import-template.json';
 
 export const REPOSITORIES_URL = '/rest/repositories/';
 const AUTOCOMPLETE_URL = '/rest/autocomplete/';
-const IMPORT_URL = '/rest/data/import/upload/';
 
 const POLL_INTERVAL = 200;
 
@@ -23,29 +21,14 @@ Cypress.Commands.add('deleteRepository', (id) => {
     cy.request('DELETE', url).should((response) => expect(response.status).to.equal(200));
 });
 
-Cypress.Commands.add('importRDFTextSnippet', (repositoryId, rdf, importSettings = {}, waitTimeout = 4000) => {
-    const importData = Cypress._.defaultsDeep(importSettings, snippetImportTemplate);
-    importData.data = rdf;
-
-    cy.request({
-        method: 'POST',
-        url: IMPORT_URL + repositoryId + '/text',
-        body: importData,
-    }).should((response) => expect(response.status).to.equal(202));
-    waitImport(repositoryId, importData.name, waitTimeout);
+Cypress.Commands.add('presetRepositoryCookie', (id) => {
+    cy.setCookie('com.ontotext.graphdb.repository' + window.location.port, id);
 });
 
-let waitImport = function(repositoryId, name, pollTimeout) {
-    cy.expect(pollTimeout).to.be.greaterThan(0);
-    cy.wait(POLL_INTERVAL);
-    cy.request({
-        method: 'GET',
-        url: IMPORT_URL + repositoryId,
-    }).then((response) => {
-        if (response.status === 200 && Cypress._.find(response.body, function(o) {return o.name === name}).status === 'DONE') return;
-        waitImport(repositoryId, name, pollTimeout - response.duration - POLL_INTERVAL);
-    });
-};
+Cypress.Commands.add('warmRepositoryNamespaces', (id) => {
+    const url = '/repositories/' + id + '/namespaces';
+    cy.request('GET', url).should((response) => expect(response.status).to.equal(200));
+});
 
 Cypress.Commands.add('enableAutocomplete', (repositoryId, waitTimeout = 10000) => {
     cy.request({


### PR DESCRIPTION
* The specification now makes use of the repo creation and deletion via REST commands
* Simplified selectors and functions
* Added proper checks

Added Cypress command for URL importing via REST call.
Moved the RDF snippet import command to import-commands.js

Added a few selectors in the sparql templates for easier selection in
the Cypress tests.