### PR TITLE
Added Cypress tests for the Swagger documentation page

### DIFF
--- a/src/pages/webapi.html
+++ b/src/pages/webapi.html
@@ -11,4 +11,4 @@
 	   popover-append-to-body="true"><span class="icon-info"></span></span>
 </h1>
 
-<iframe src="res/swagger/index.html" style="width: 100%; height: 90vh; border: none"></iframe>
+<iframe id="webapi_frame" src="res/swagger/index.html" style="width: 100%; height: 90vh; border: none"></iframe>

--- a/test-cypress/integration/help/rest-api.spec.js
+++ b/test-cypress/integration/help/rest-api.spec.js
@@ -1,0 +1,120 @@
+describe('Help / REST API', () => {
+
+    before(() => {
+        // Disables the security (only for this spec) to be able to interact with Swagger's iframe
+        // See https://github.com/cypress-io/cypress/issues/136
+        Cypress.config({chromeWebSecurity: false});
+    });
+
+    beforeEach(() => {
+        cy.visit('/webapi');
+        getSwaggerFrame()
+            .find('#message-bar')
+            .should('be.visible');
+    });
+
+    // TODO: Check explicitly for all controllers (name + summary) ?
+
+    it('should provide documentation and examples for GraphDB APIs', () => {
+        // The GraphDB API section should list the available controllers & each controller should have a heading and possible options
+        verifyControllerList(getGraphDBAPI());
+
+        // All controllers should be collapsed
+        verifyControllerListIsCollapsed(getGraphDBAPI());
+
+        // Examine the import controller
+        verifyControllerOptions('import-controller', 'Data import');
+    });
+
+    it('should provide documentation and examples for RDF4J APIs', () => {
+        // The RDF4J API section should list the available controllers & each controller should have a heading and possible options
+        verifyControllerList(getRDF4JAPI());
+
+        // All controllers should be collapsed
+        verifyControllerListIsCollapsed(getRDF4JAPI());
+
+        // Examine the import controller
+        verifyControllerOptions('repositories', 'Repository management');
+    });
+
+    function getSwaggerFrame() {
+        return cy.get('#webapi_frame').iframe();
+    }
+
+    function getGraphDBAPI() {
+        return getSwaggerFrame().find('#swagger-ui-container-graphdb');
+    }
+
+    function getRDF4JAPI() {
+        return getSwaggerFrame().find('#swagger-ui-container-rdf4j');
+    }
+
+    function getGraphDBController(id) {
+        return getGraphDBAPI().find('.resource .heading').contains(id).parentsUntil('#resources').last();
+    }
+
+    function verifyControllerList(controllerSection) {
+        controllerSection.within(($section) => {
+            cy.wrap($section)
+                .should('be.visible')
+                .find('.resource')
+                .should('be.visible')
+                .its('length')
+                .should('be.gt', 0)
+
+                // Go back to the section
+                .root()
+                .find('.resource > .heading')
+                .should('be.visible')
+                .find('.options')
+                .should('be.visible')
+                .find('.toggleEndpointList')
+                .should('be.visible')
+                .and('not.be.disabled');
+        });
+    }
+
+    function verifyControllerListIsCollapsed(controllerSection) {
+        controllerSection
+            .find('.resource .endpoints')
+            .should('not.be.visible');
+    }
+
+    function verifyControllerOptions(id, summary) {
+        getGraphDBController(id)
+            .should('be.visible')
+            .within(() => {
+                // Should have a heading text
+                // Note: selecting the first heading, otherwise it will select each endpoint heading too
+                cy.get('> .heading')
+                    .should('contain', summary)
+
+                    // Should allow certain operations from the heading
+                    .find('.options')
+                    .should('be.visible')
+                    .find('li')
+                    // Make sure we have selected only the controller options
+                    .should('have.length', 3)
+                    .and('contain', 'Show/Hide')
+                    .and('contain', 'List Operations')
+                    .and('contain', 'Expand Operations')
+
+                    // Expand the available endpoints and methods, should list their headings and options
+                    .find('.collapseResource')
+                    .click();
+
+                cy.get('.endpoints .heading').within(() => {
+                    cy.get('.path').should('be.visible');
+                    cy.get('.options').should('be.visible');
+                });
+                // Should not show examples, only paths & options
+                cy.get('.endpoints .content').should('not.be.visible');
+
+                // Expand all operations for the import controller
+                cy.get('> .heading .options .expandResource').click();
+                // For each endpoint there should be an example along with the path heading
+                cy.get('.endpoints .heading .path').should('be.visible');
+                cy.get('.endpoints .content').should('be.visible');
+            });
+    }
+});

--- a/test-cypress/support/commands.js
+++ b/test-cypress/support/commands.js
@@ -27,6 +27,32 @@
 import './repository-commands';
 import './import-commands';
 
+/**
+ * Cypress cannot directly work with iframes due to https://github.com/cypress-io/cypress/issues/136
+ *
+ * This command acts as a workaround that encapsulates the frame's content and makes it queryable and assertable.
+ */
+Cypress.Commands.add('iframe', {prevSubject: 'element'}, ($iframe) => {
+    Cypress.log({
+        name: 'iframe',
+        consoleProps() {
+            return {
+                iframe: $iframe,
+            };
+        },
+    });
+    return new Cypress.Promise(resolve => {
+        // Directly resolve the body if it is loaded, otherwise wait
+        if ($iframe.contents().find('body').children().length > 0) {
+            resolve($iframe.contents().find('body'));
+        } else {
+            $iframe.on('load', () => {
+                resolve($iframe.contents().find('body'));
+            });
+        }
+    });
+});
+
 // ================================================================================
 // ================================================================================
 // ========================= FOR REVIEW / REFACTOR/ REMOVAL =======================


### PR DESCRIPTION
Tested the presence of Swagger's iframe, GraphDB and RDF4J sections and the operations for each controller.

Added custom command for encapsulating iframes content due to Cypress inability to work with them out of the box. The command will yield the frame's body and allow further chaining of commands and assertions.