### PR TITLE
Fixing flaky Cypress tests

### DIFF
--- a/src/js/angular/core/templates/core-errors.html
+++ b/src/js/angular/core/templates/core-errors.html
@@ -18,7 +18,7 @@
 
                 <ul class="list-group limit-height clearfix two-columns repos" ng-mouseleave="hidePopoverForRepo($event)">
                     <li ng-repeat="repository in getAccessibleRepositories() | orderBy: ['type === \'system\'', 'id']"
-                        class="list-group-item list-group-item-action"
+                        class="list-group-item list-group-item-action repository"
                         ng-mouseenter="showPopoverForRepo($event, repository)" ngx-mouseleave="setPopoverForRepo($event, repository, false)">
                         <div class="lead ellipsis-block" ng-click="setRepository(repository.id)">
                             <span class="popover-anchor"

--- a/src/js/angular/sparql/templates/query-editor.html
+++ b/src/js/angular/sparql/templates/query-editor.html
@@ -20,7 +20,7 @@
 
             <script type="text/ng-template" id="sampleQueriesPopoverTemplate.html">
                 <ul id="wb-sparql-queryInSampleQueries" class="list-unstyled">
-                    <li ng-repeat="query in sampleQueries" ng-hide="ignoreSharedQueries && query.owner != null" class="hovered-parent">
+                    <li ng-repeat="query in sampleQueries" ng-hide="ignoreSharedQueries && query.owner != null" class="hovered-parent saved-query">
                         <a href ng-click="querySelected(query)">{{query.name}}</a>
                         &nbsp;
                         <i class="icon-warning" ng-show="query.owner != null && hasRole('ROLE_USER')"

--- a/src/pages/namespaces.html
+++ b/src/pages/namespaces.html
@@ -127,7 +127,7 @@
             </tr>
             </tbody>
         </table>
-        <div ng-show="displayedNamespaces.length === 0 && namespaces.length > 0">
+        <div class="alert alert-info no-namespaces-match-alert" ng-show="displayedNamespaces.length === 0 && namespaces.length > 0">
             <p>No namespaces match this filter.</p>
         </div>
         <div class="alert alert-warning no-namespaces-alert" ng-show="namespaces.length === 0">

--- a/test-cypress/integration/home/workbench.home.spec.js
+++ b/test-cypress/integration/home/workbench.home.spec.js
@@ -3,10 +3,10 @@ import HomeSteps from '../../steps/home-steps';
 describe('Home screen validation', () => {
 
     const FOAT_SNIPPET = '@base <http://example.org/> .\n' +
-                       '@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n' +
-                       '<#green-goblin>\n' +
-                           'a foaf:Person ;    # in the context of the Marvel universe\n' +
-                           'foaf:name "Green Goblin" .\n';
+        '@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n' +
+        '<#green-goblin>\n' +
+        'a foaf:Person ;    # in the context of the Marvel universe\n' +
+        'foaf:name "Green Goblin" .\n';
     const GOBLIN_URI = 'http://example.org/#green-goblin';
 
     beforeEach(() => cy.viewport(1280, 1000));
@@ -41,6 +41,9 @@ describe('Home screen validation', () => {
             HomeSteps.verifyCreateRepositoryLink();
 
             let repositoryId = HomeSteps.createRepo();
+            // Initializing the repository to speed up retrieving repository info
+            cy.initializeRepository(repositoryId);
+
             HomeSteps.selectRepo(repositoryId);
             HomeSteps.verifyRepositoryIsSelected(repositoryId);
             HomeSteps.hasRepositoryInfo(repositoryId);
@@ -78,13 +81,13 @@ describe('Home screen validation', () => {
             HomeSteps.getAutocompleteResultElement(GOBLIN_URI).click();
             HomeSteps.verifyAutocompleteResourceLink(GOBLIN_URI);
 
-            HomeSteps.goBackAndWaitAutocomplete(function() {
+            HomeSteps.goBackAndWaitAutocomplete(function () {
                 HomeSteps.autocompleteText('Green', GOBLIN_URI);
                 HomeSteps.getAutocompleteButton('text').click();
                 HomeSteps.verifyAutocompleteResourceLink(GOBLIN_URI);
             });
 
-            HomeSteps.goBackAndWaitAutocomplete(function() {
+            HomeSteps.goBackAndWaitAutocomplete(function () {
                 HomeSteps.autocompleteText('Green', GOBLIN_URI);
                 HomeSteps.getAutocompleteButton('visual').click();
                 cy.url()

--- a/test-cypress/integration/import/import.user.data.spec.js
+++ b/test-cypress/integration/import/import.user.data.spec.js
@@ -34,7 +34,6 @@ describe('Import screen validation - user data', () => {
     });
 
     afterEach(() => {
-        ImportSteps.removeUploadedFiles();
         cy.deleteRepository(repositoryId);
     });
 
@@ -116,5 +115,14 @@ describe('Import screen validation - user data', () => {
 
         // Should return to initial url in order after each block of the tests to be executed
         cy.navigateToPage('Import', 'RDF');
+    });
+
+    it('should allow to delete uploaded files', () => {
+        ImportSteps
+            .openImportURLDialog(IMPORT_URL)
+            .clickImportUrlButton()
+            .importFromSettingsDialog()
+            .verifyImportStatus(IMPORT_URL, SUCCESS_MESSAGE)
+            .removeUploadedFiles();
     });
 });

--- a/test-cypress/integration/monitor/monitor.queries.spec.js
+++ b/test-cypress/integration/monitor/monitor.queries.spec.js
@@ -11,7 +11,9 @@ describe('Monitor Queries', () => {
         cy.presetRepositoryCookie(repositoryId);
 
         cy.visit('/monitor/queries');
-        // Wait for the loader to disappear
+
+        // Wait for loaders to disappear
+        cy.get('.ot-splash').should('not.be.visible');
         cy.get('.ot-loader').should('not.be.visible');
     });
 
@@ -23,6 +25,6 @@ describe('Monitor Queries', () => {
         cy.get('.no-running-queries-alert')
             .should('be.visible')
             .and('contain', 'No running queries or updates.');
-        cy.get('.pause-btn').should('be.visible')
+        cy.get('.pause-btn').should('be.visible');
     });
 });

--- a/test-cypress/integration/monitor/monitor.resources.spec.js
+++ b/test-cypress/integration/monitor/monitor.resources.spec.js
@@ -11,6 +11,11 @@ describe('Monitor Resources', () => {
         cy.presetRepositoryCookie(repositoryId);
 
         cy.visit('/monitor/resources');
+
+        // Wait for loaders to disappear
+        cy.get('.ot-splash').should('not.be.visible');
+        cy.get('.ot-loader').should('not.be.visible');
+
         // Ensure the chart on the default active tab is rendered
         getActiveTabContent().find('svg').should('be.visible');
     });

--- a/test-cypress/integration/setup/autocomplete.spec.js
+++ b/test-cypress/integration/setup/autocomplete.spec.js
@@ -6,7 +6,7 @@ describe('Autocomplete ', () => {
         repositoryId = 'autocomplete-' + Date.now();
         cy.createRepository({id: repositoryId});
         cy.presetRepositoryCookie(repositoryId);
-        cy.warmRepositoryNamespaces(repositoryId);
+        cy.initializeRepository(repositoryId);
     }
 
     function waitUntilAutocompletePageIsLoaded() {

--- a/test-cypress/integration/setup/namespaces.spec.js
+++ b/test-cypress/integration/setup/namespaces.spec.js
@@ -6,7 +6,7 @@ describe('Namespaces', () => {
         repositoryId = 'namespaces-' + Date.now();
         cy.createRepository({id: repositoryId});
         cy.presetRepositoryCookie(repositoryId);
-        cy.warmRepositoryNamespaces(repositoryId);
+        cy.initializeRepository(repositoryId);
 
         cy.visit('/namespaces');
 
@@ -124,10 +124,8 @@ describe('Namespaces', () => {
         getNamespacesFilterField()
             .clear()
             .type('missing_prefix');
-        // The table should still be visible but without any results
-        getNamespacesTable().should('be.visible');
-        getNamespaces()
-            .should('have.length', 0);
+        getNamespacesTable().should('not.be.visible');
+        getNoNamespacesMatchAlert().should('be.visible');
     });
 
     it('should allow to add new namespace', () => {
@@ -223,6 +221,10 @@ describe('Namespaces', () => {
 
     function getNoNamespacesAlert() {
         return getNamespacesPage().find('.no-namespaces-alert');
+    }
+
+    function getNoNamespacesMatchAlert() {
+        return getNamespacesPage().find('.no-namespaces-match-alert');
     }
 
     function getToast() {

--- a/test-cypress/integration/setup/rdf-rank.spec.js
+++ b/test-cypress/integration/setup/rdf-rank.spec.js
@@ -35,8 +35,9 @@ describe('Setup / RDF Rank', () => {
             .find('.rdf-rank-status')
             .should('be.visible')
             .and('contain', repositoryId);
-        getRdfStatusTag()
+        getRdfStatusTags()
             .contains('RDFRank not built yet')
+
             .should('be.visible')
             .and('have.class', 'tag-warning');
         getFilteringSwitch()
@@ -45,14 +46,21 @@ describe('Setup / RDF Rank', () => {
 
         getComputeFullButton().click();
 
-        getRdfStatusTag()
+        getRdfStatusTags()
             .contains('Computed')
+            .closest('.tag')
             .should('be.visible')
             .and('have.class', 'tag-success');
     });
 
     it('should allow to enable the RDF rank with graphs and predicates filters', () => {
         getComputeFullButton().click();
+
+        // Wait until index is built
+        getRdfStatusTags()
+            .contains('Computed')
+            .closest('.tag')
+            .should('be.visible');
 
         // Enable filtering for ranks
         getFilteringSwitch()
@@ -61,8 +69,9 @@ describe('Setup / RDF Rank', () => {
             .should('be.checked');
 
         // Should render that rebuild is required
-        getRdfStatusTag()
+        getRdfStatusTags()
             .contains('Configuration changed')
+            .closest('.tag')
             .should('be.visible')
             .and('have.class', 'tag-warning');
 
@@ -130,8 +139,9 @@ describe('Setup / RDF Rank', () => {
         getComputeFullButton().click();
 
         // All should be OK
-        getRdfStatusTag()
+        getRdfStatusTags()
             .contains('Computed')
+            .closest('.tag')
             .should('be.visible')
             .and('have.class', 'tag-success');
     });
@@ -144,7 +154,7 @@ describe('Setup / RDF Rank', () => {
         return getRdfRankPage().find('#toggleIndex');
     }
 
-    function getRdfStatusTag() {
+    function getRdfStatusTags() {
         return getRdfStatusHeader().find('.tag');
     }
 

--- a/test-cypress/steps/home-steps.js
+++ b/test-cypress/steps/home-steps.js
@@ -34,6 +34,7 @@ class HomeSteps {
         cy.visitAndWaitLoader('/');
         cy.get('ul.repos')
             .contains(repositoryId)
+            .closest('.repository')
             .click();
     }
 
@@ -51,14 +52,16 @@ class HomeSteps {
     }
 
     static hasRepositoryInfo(repositoryId) {
-        cy.get('.active-repo-card').should('contain', repositoryId)
+        cy.get('.active-repo-card')
+            .should('contain', repositoryId)
             .and('contain', 'total statements')
             .and('contain', 'explicit')
             .and('contain', 'inferred')
             .and('contain', 'expansion ratio')
             .within(() => {
-                cy.get('.total-statements').should('contain', '70');
-                cy.get('.explicit-statements').should('contain', '0')
+                // New repositories would retrieve the /size data a little slower due to some initializations
+                cy.get('.total-statements', {timeout: 10000}).should('contain', '70');
+                cy.get('.explicit-statements').should('contain', '0');
                 cy.get('.inferred-statements').should('contain', '70');
             });
     }

--- a/test-cypress/steps/import-steps.js
+++ b/test-cypress/steps/import-steps.js
@@ -12,27 +12,34 @@ class ImportSteps {
     }
 
     static visitImport(type, repository) {
-        cy.visit('/import#' + type);
-
         if (repository) {
-            cy.selectRepo(repository);
+            cy.presetRepositoryCookie(repository);
         }
 
+        cy.visit('/import#' + type);
+
+        cy.get('.ot-splash').should('not.be.visible');
+
         cy.get('#import-' + type).should('be.visible');
+
+        cy.get('.ot-loader').should('not.be.visible');
 
         return ImportSteps;
     }
 
     static openImportURLDialog(importURL) {
         cy.get('#import-user .import-from-url-btn').click();
-        cy.get('.url-import-form input[name="dataUrl"]').type(importURL).should('have.value', importURL);
+        ImportSteps.getModal()
+            .find('.url-import-form input[name="dataUrl"]')
+            .type(importURL)
+            .should('have.value', importURL);
 
         return ImportSteps;
     }
 
     static openImportTextSnippetDialog() {
         cy.get('#import-user .import-rdf-snippet-btn').click();
-        ImportSteps.getSnippetTextarea().should('be.visible');
+        ImportSteps.getModal().find('#wb-import-textarea').should('be.visible');
 
         return ImportSteps;
     }
@@ -113,15 +120,17 @@ class ImportSteps {
     }
 
     static importFromSettingsDialog() {
-        // TODO: cy.confirmDialog() ?
         // Dialog should disappear
-        cy.get('.modal-footer > .btn-primary').click().should('not.exist');
+        ImportSteps.getModal().
+        find('.modal-footer > .btn-primary')
+            .click()
+            .should('not.exist');
 
         return ImportSteps;
     }
 
     static getSettingsForm() {
-        return cy.get('.modal .settings-form');
+        return ImportSteps.getModal().find('.settings-form');
     }
 
     static fillBaseURI(baseURI) {
@@ -224,6 +233,14 @@ class ImportSteps {
             .contains(filename)
             .parentsUntil('.import-file-row')
             .parent();
+    }
+
+    static getModal() {
+        // Increased timeout to allow dialog to show and finish its animation..
+        // Should not be needed but it seems animations in Travis are slow..
+        return cy.get('.modal', {timeout: 10000})
+            .should('be.visible')
+            .and('not.have.class', 'ng-animate')
     }
 }
 

--- a/test-cypress/support/repository-commands.js
+++ b/test-cypress/support/repository-commands.js
@@ -26,8 +26,11 @@ Cypress.Commands.add('presetRepositoryCookie', (id) => {
     cy.setCookie('com.ontotext.graphdb.repository' + window.location.port, id);
 });
 
-Cypress.Commands.add('warmRepositoryNamespaces', (id) => {
-    const url = '/repositories/' + id + '/namespaces';
+/**
+ * Speeds up any following requests
+ */
+Cypress.Commands.add('initializeRepository', (id) => {
+    const url = REPOSITORIES_URL + id + '/size';
     cy.request('GET', url).should((response) => expect(response.status).to.equal(200));
 });
 
@@ -42,7 +45,7 @@ Cypress.Commands.add('enableAutocomplete', (repositoryId, waitTimeout = 10000) =
     waitAutocomplete(repositoryId, waitTimeout);
 });
 
-let waitAutocomplete = function(repositoryId, pollTimeout) {
+let waitAutocomplete = function (repositoryId, pollTimeout) {
     cy.expect(pollTimeout).to.be.greaterThan(0);
     cy.wait(POLL_INTERVAL);
     cy.request({


### PR DESCRIPTION
- Replaced `parentsUntil().last()` with `closest()` or simply `parent()`
- Updated the check in repositories default tests to simply check that the repo is not selected instead of not having a selected repo. For some reason, sometimes in Travis there is a selected repo or the repo dropdown is not yet fully loaded and the old check for no selected repo was failing.
- Added increased timeout in `getModal()` functions to allow the dialog to fully appear without any  angular animations in progress. It should not be needed but it seems in Travis animations are slow.
- Updated saved query tests to forcefully click the action buttons because Cypress sometimes determines them as not visible (having 0x0 dimensions) although they are visible and clickable and the checks for these pass before clicking them.
- Updated the `selectRepo` method in `HomeSteps` to select the repo row before clicking it to avoid the "having 0x0 dimensions" issue.
- Updated the `visitImport` method in `ImportSteps` to preset the repository cookie instead of selecting the  repo using the dropdown menu. This speeds up both user and server import tests and avoid using the old flaky command.
- Added more html classes for easier selection by Cypress
- Reorganized the test for invalid saved queries to avoid closing the dialog before attempting to save a query with duplicated name.
- Forced the selection of repositories from the dropdown menu due to Cypress's '0x0 dimension' issue in Travis.
- Modified the `ImportSteps` to wait modal's visibility and animation.
- Removed visibility check from SPARQL download menu items due to not always passing in Travis...
- Rearranged the SPARQL spec `beforeEach` wait until page is loaded
- Updated the query for the URL test to be more unique.
- Added waiting for splash screen do disappear in the monitoring specs.
- Removed `removeUploadedFiles()` step in the `afterEach()` of importing user data because it was failing the whole suite if a test failed. Added another test to verify this behaviour.
- Added increased timeout in the sparql test `beforeEach` to allow the active to appear. Sometimes in Travis this is very slow..
- Renamed `warmRepositoryNamespaces` to `initializeRepository` and updated the logic to invoke the /size endpoint.
- Fixed the namespaces filtering test to check if proper alert is shown instead of expecting an empty table. Modified the DOM to render the message as an alert. Added proper selector.
- Added visibility check as waiting for the saved query popover every time it is opened.