### PR TITLE
Fix flaky test for similarity view

### DIFF
--- a/test-cypress/integration/explore/similarity.spec.js
+++ b/test-cypress/integration/explore/similarity.spec.js
@@ -10,7 +10,7 @@ describe('Similarity screen validation', () => {
     let repositoryId;
 
     beforeEach(() => {
-        repositoryId = 'repo-' + Date.now();
+        repositoryId = 'similarity-repo-' + Date.now();
         cy.createRepository({id: repositoryId});
         cy.presetRepositoryCookie(repositoryId);
 
@@ -107,11 +107,15 @@ describe('Similarity screen validation', () => {
 
     function openCreateNewIndexForm() {
         cy.get('.create-similarity-index').click();
+        // Wait for query editor to become ready because consecutive command for index creation might
+        // fail because the query may not be submitted with the request.
+        cy.waitUntilQueryIsVisible();
     }
 
     function setIndexName() {
         cy.url().should('eq', Cypress.config('baseUrl') + INDEX_CREATE_URL);
         cy.get('.similarity-index-name').type(INDEX_NAME);
+        cy.get('.similarity-index-name').invoke('val').then(value => expect(value).to.equal(INDEX_NAME));
     }
 
     function clickMoreOptionsMenu() {
@@ -158,6 +162,9 @@ describe('Similarity screen validation', () => {
 
     function switchToPredicationIndex() {
         cy.get('#create-predication-index').click();
+        // Wait for query editor to become ready because consecutive command for index creation might
+        // fail because the query may not be submitted with the request.
+        cy.waitUntilQueryIsVisible();
     }
 
     function cloneExistingIndex() {

--- a/test-cypress/support/commands.js
+++ b/test-cypress/support/commands.js
@@ -1,4 +1,5 @@
 import './repository-commands';
+import './sparql-commands';
 import './import-commands';
 
 /**

--- a/test-cypress/support/sparql-commands.js
+++ b/test-cypress/support/sparql-commands.js
@@ -1,0 +1,69 @@
+Cypress.Commands.add('pasteQuery', (query) => {
+    clearQuery();
+    // Using force because the textarea is not visible
+    getQueryTextArea().invoke('val', query).trigger('change', {force: true});
+    waitUntilQueryIsVisible();
+});
+
+Cypress.Commands.add('executeQuery', () => {
+    getRunQueryButton().click();
+    getLoader().should('not.be.visible');
+});
+
+Cypress.Commands.add('verifyResultsPageLength', (resultLength) => {
+    getResultsWrapper().should('be.visible');
+    getTableResultRows()
+        .should('have.length', resultLength);
+});
+
+Cypress.Commands.add('verifyResultsMessage', (msg) => {
+    getResultsMessage()
+        .should('be.visible')
+        .and('contain', msg);
+});
+
+Cypress.Commands.add('waitUntilQueryIsVisible', (query) => {
+    waitUntilQueryIsVisible();
+});
+
+// Helper functions
+
+function clearQuery() {
+    // Using force because the textarea is not visible
+    getQueryTextArea().type('{ctrl}a{backspace}', {force: true});
+}
+
+function getQueryArea() {
+    return cy.get('#queryEditor .CodeMirror');
+}
+
+function getQueryTextArea() {
+    return getQueryArea().find('textarea');
+}
+
+function waitUntilQueryIsVisible() {
+    getQueryArea().should(codeMirrorEl => {
+        const cm = codeMirrorEl[0].CodeMirror;
+        expect(cm.getValue().trim().length > 0).to.be.true;
+    });
+}
+
+function getRunQueryButton() {
+    return cy.get('#wb-sparql-runQuery');
+}
+
+function getLoader() {
+    return cy.get('.ot-loader-new-content');
+}
+
+function getTableResultRows() {
+    return getResultsWrapper().find('.resultsTable tbody tr');
+}
+
+function getResultsWrapper() {
+    return cy.get('#yasr-inner .yasr_results');
+}
+
+function getResultsMessage() {
+    return cy.get('#yasr-inner .alert-info.results-info', { timeout: 30000 });
+}


### PR DESCRIPTION
More time is needed for the query editor to be initialized before submitting requests for index creation.
Fixed by adding a wait for query editor to become ready because consecutive command for index creation might fail because the query may not be submitted with the request.