### PR TITLE
Fix test for not finding import button in modal dialog

### DIFF
--- a/test-cypress/steps/import-steps.js
+++ b/test-cypress/steps/import-steps.js
@@ -241,6 +241,7 @@ class ImportSteps {
         return cy.get('.modal')
             .should('be.visible')
             .and('not.have.class', 'ng-animate')
+            .and('have.class', 'in');
     }
 }
 


### PR DESCRIPTION
Animation library applies set of status classes around the base animated class. In this case the base animated class is `fade` and the animation lib applies classes like `in-add`, `in-add-active`, `in-remove`, 
 `in-remove-active`. When animation is complete it seems that just `fade in` classes remains.