### PR TITLE
Added wait before verifying the SPARQL download menu

### DIFF
--- a/test-cypress/integration/sparql/sparql.menu.spec.js
+++ b/test-cypress/integration/sparql/sparql.menu.spec.js
@@ -418,6 +418,10 @@ describe('SPARQL screen validation', () => {
         it('Test download query results in Supported formats', () => {
             executeQuery();
 
+            // Wait until results are visible before verifying the download menu
+            getResultsWrapper().should('be.visible');
+            verifyResultsPageLength(70);
+
             openDownloadAsMenu();
 
             getDownloadAsFormatButtons()


### PR DESCRIPTION
Sometimes the test fails because the dropdown menu button is not fully visualized most likely because the results are not yet rendered