### PR TITLE
Fix missing styles for ontorefine in GDB

### DIFF
--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -44,6 +44,14 @@ module.exports = {
                 to: 'js/lib/bootstrap-switch/3.2.2/bootstrap-switch.min.css'
             },
             {
+                from: 'src/js/lib/bootstrap/bootstrap.min.css',
+                to: 'js/lib/bootstrap/bootstrap.min.css'
+            },
+            {
+                from: 'src/font/font-awesome',
+                to: 'font/font-awesome'
+            },
+            {
                 from: 'src/js/lib/nvd3/nv.d3.css',
                 to: 'js/lib/nvd3/nv.d3.css'
             },


### PR DESCRIPTION
Styles bootstrap and font-awesome were exposed in dist for access from openrefine module which is deployed with GDB