### PR TITLE
Properly bundle font-awesome

### DIFF
--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -48,8 +48,12 @@ module.exports = {
                 to: 'js/lib/bootstrap/bootstrap.min.css'
             },
             {
-                from: 'src/font/font-awesome',
-                to: 'font/font-awesome'
+                from: 'node_modules/font-awesome/css',
+                to: 'font/font-awesome/4.3.0/css'
+            },
+            {
+                from: 'node_modules/font-awesome/fonts',
+                to: 'font/font-awesome/4.3.0/fonts'
             },
             {
                 from: 'src/js/lib/nvd3/nv.d3.css',


### PR DESCRIPTION
Bundle font-awesome using its installation package in node_modules because it's unavailable in src anymore.