### PR TITLE
GDB-3936 Flaky connector test

### DIFF
--- a/test-cypress/integration/setup/connectors-lucene.spec.js
+++ b/test-cypress/integration/setup/connectors-lucene.spec.js
@@ -117,7 +117,7 @@ describe('Setup / Connectors - Lucene', () => {
     }
 
     function getConnectorCreationDialog() {
-        return cy.get('.creating-connector-dialog');
+        return cy.get('.modal-content > .modal-header.creating-connector-dialog');
     }
 
     function getConnectorStatusToastMessage() {


### PR DESCRIPTION
Seems that there are two elements with class creating-connector-dialog and sometimes the wrong is checked for visibility. From jenkins:

_This element '<div.modal-header.creating-connector-dialog>' is not visible because its parent '<div.ng-hide>' has CSS property: 'display: none'_

Tune the selector with the parent class. We are looking for the element in the modal.