### PR TITLE
GDB-3939 yasr expect xhr argument to be first when call setResponse

### DIFF
--- a/src/js/angular/explore/controllers.js
+++ b/src/js/angular/explore/controllers.js
@@ -161,9 +161,10 @@ function ExploreCtrl($scope, $http, $location, toastr, $routeParams, $repositori
                 sameAs: $scope.sameAs
             },
             headers: headers
-        }).done(function (data, textStatus, jqXhrOrErrorString) {
+        }).done(function (data, textStatus, jqXhr) {
             toggleOntoLoader(false);
-            yasr.setResponse(data, textStatus, jqXhrOrErrorString);
+            // Pass the xhr argument first as the yasr expects it that way. See https://ontotext.atlassian.net/browse/GDB-3939
+            yasr.setResponse(jqXhr, textStatus);
         }).fail(function (data) {
             toastr.error('Could not get resource; ' + getError(data));
             toggleOntoLoader(false);

--- a/test-cypress/integration/explore/graphs.overview.spec.js
+++ b/test-cypress/integration/explore/graphs.overview.spec.js
@@ -113,5 +113,10 @@ describe('Graphs overview screen validation', () => {
         confirmDelete();
         verifyVisibleGraphsCount(1);
         verifyGraphExistence('The default graph');
+        // open default graph through the link and verify that the table view is rendered
+        cy.contains('The default graph').click();
+        cy.url().should('contain', Cypress.config('baseUrl') + '/resource');
+        cy.get('.resultsTable').should('be.visible')
+            .find('thead th').should('have.length', 5);
     });
 });


### PR DESCRIPTION
The library uses an older version of the jquery library which used to pass the xhr as first argument to the success callback. With the latest version thou, the first argument is the response data itself and that fact forces the yasr to falback the response rendering to the raw view plugin instead of the table view. This is due to inability to locate the response headers used internally to resolve the view type.

Fixed by inverting the arguments when pass them down to yasr.
Also extended tests to detect the proper view is rendered.

Jira: https://ontotext.atlassian.net/browse/GDB-3939