### PR TITLE
GDB-3924 Fix error no image in visual graph

### DIFF
--- a/src/pages/graphs-visualizations.html
+++ b/src/pages/graphs-visualizations.html
@@ -416,7 +416,7 @@
                 </div>
             </div>
 
-            <div ng-show="nodeImage" class="rdf-image mb-1"
+            <div ng-if="nodeImage" class="rdf-image mb-1"
                  ng-attr-style="{{'background-image: url(' + nodeImage + ')'}}">
             </div>
 


### PR DESCRIPTION
Loading node details in visual graph loads also an image if present. ng-show tries to fetch the image even there is none. Replaced with ng-if to remove this element at all. 