### PR TITLE
Fix the menu for selecting a repository

### DIFF
--- a/src/js/angular/directives/queryeditor/query-editor.directive.js
+++ b/src/js/angular/directives/queryeditor/query-editor.directive.js
@@ -1,5 +1,4 @@
 import 'angular/rest/connectors.rest.service';
-import 'lib/bootstrap/bootstrap.min';
 import YASQE from 'lib/yasqe.bundled.min';
 import YASR from 'lib/yasr.bundled';
 

--- a/src/vendor.js
+++ b/src/vendor.js
@@ -6,5 +6,6 @@ import './css/lib/animate/animate.css';
 import 'jquery';
 import 'lib/angularjs/1.3.8/angular.js';
 import 'd3/build/d3';
+import 'lib/bootstrap/bootstrap.min';
 import 'angular/common/loading-hint.js';
 import 'bootstrap-switch/dist/js/bootstrap-switch.min';


### PR DESCRIPTION
The menu relied on the bootstrap's dropdown plugin but the bootstrap framework itself was imported in the query editor directive. This was OK before code to be split and modules lazy loaded because it was loaded as a monolith at once and the bootstrap was present when workbench was initialized.

Fixed by moved the bootstrap loading in the vendor's bundle which is always loaded initially as all modules there are needed throughout the application.