### PR TITLE
Optimize d3 library loading

### DIFF
--- a/src/js/angular/clustermanagement/app.js
+++ b/src/js/angular/clustermanagement/app.js
@@ -3,6 +3,7 @@ import 'angular/core/directives';
 import 'angular/clustermanagement/controllers';
 import 'angular/clustermanagement/directives';
 import 'angular/repositories/services';
+import 'd3/build/d3';
 import 'lib/d3-ONTO-chord-patch';
 
 const modules = [

--- a/src/js/angular/graphexplore/app.js
+++ b/src/js/angular/graphexplore/app.js
@@ -4,6 +4,7 @@ import 'angular/core/directives';
 import 'angular/repositories/services';
 import 'angular-ui-scroll/dist/ui-scroll.min';
 import 'angular-ui-scroll/dist/ui-scroll-jqlite.min';
+import 'd3/build/d3';
 import 'lib/d3-ONTO-chord-patch';
 import 'lib/d3-tip/d3-tip-patch';
 import 'angular-pageslide-directive/dist/angular-pageslide-directive';

--- a/src/js/angular/resources/app.js
+++ b/src/js/angular/resources/app.js
@@ -2,6 +2,7 @@ import 'angular/core/services';
 import 'angular/core/directives';
 import 'angular/resources/controllers';
 import 'angular/repositories/services';
+import 'd3/build/d3';
 import 'lib/nvd3/angular-nvd3';
 
 const modules = [

--- a/src/vendor.js
+++ b/src/vendor.js
@@ -5,7 +5,6 @@ import './css/lib/animate/animate.css';
 
 import 'jquery';
 import 'lib/angularjs/1.3.8/angular.js';
-import 'd3/build/d3';
 import 'lib/bootstrap/bootstrap.min';
 import 'angular/common/loading-hint.js';
 import 'bootstrap-switch/dist/js/bootstrap-switch.min';


### PR DESCRIPTION
Found that the d3 was referenced only in clustermanagement, graphexplore and resources modules, so the import was moved only for those modules and removed from the vendor's bundle. This way it won't be preloaded unnecessarily but only when it's needed.

Jira: https://ontotext.atlassian.net/browse/GDB-3891