### PR TITLE
Cypress tests stabilization

### DIFF
--- a/test-cypress/integration/explore/similarity.spec.js
+++ b/test-cypress/integration/explore/similarity.spec.js
@@ -433,7 +433,8 @@ describe('Similarity screen validation', () => {
     }
 
     function verifyQueryIsChanged() {
-        cy.get('#queryEditor .CodeMirror').should('contain', 'OPTIONAL { ?result <http://dbpedia.org/ontology/birthPlace> ?birthDate .');
+        const query = 'OPTIONAL { ?result <http://dbpedia.org/ontology/birthPlace> ?birthDate .';
+        cy.verifyQueryAreaContains(query);
     }
 
     function getToast() {

--- a/test-cypress/integration/sparql/sparql.menu.spec.js
+++ b/test-cypress/integration/sparql/sparql.menu.spec.js
@@ -5,6 +5,10 @@ const FILE_TO_IMPORT = 'wine.rdf';
 describe('SPARQL screen validation', () => {
     let repositoryId;
 
+    const EDIT_SAVED_QUERY_COMMAND = '.icon-edit';
+    const DELETE_SAVED_QUERY_COMMAND = '.icon-trash';
+    const OPEN_SAVED_QUERY_COMMAND = '.icon-link';
+
     const DEFAULT_QUERY = 'select * where { \n' +
         '\t?s ?p ?o .\n' +
         '} limit 100';
@@ -548,7 +552,7 @@ describe('SPARQL screen validation', () => {
                 .and('contain', savedQueryName);
 
             // Press the pen icon to edit the custom query created earlier
-            editSaveQueryFromPopup(savedQueryName);
+            executeSavedQueryCommand(savedQueryName, EDIT_SAVED_QUERY_COMMAND);
 
             getPopover().should('not.exist');
             waitUntilSavedQueryModalIsVisible();
@@ -570,7 +574,7 @@ describe('SPARQL screen validation', () => {
                 .should('be.visible')
                 .and('contain', savedQueryName);
 
-            editSaveQueryFromPopup(savedQueryName);
+            executeSavedQueryCommand(savedQueryName, EDIT_SAVED_QUERY_COMMAND);
 
             waitUntilSavedQueryModalIsVisible();
 
@@ -587,7 +591,7 @@ describe('SPARQL screen validation', () => {
                 .and('contain', savedQueryName);
 
             // Press the trash bin to delete the custom query created earlier
-            deleteSaveQueryFromPopup(savedQueryName);
+            executeSavedQueryCommand(savedQueryName, DELETE_SAVED_QUERY_COMMAND);
 
             // Confirm dialog
             confirmModal();
@@ -699,7 +703,7 @@ describe('SPARQL screen validation', () => {
             openSavedQueriesPopup();
             getPopover().should('be.visible');
 
-            openSavedQueryLinkFromPopup(queryName);
+            executeSavedQueryCommand(queryName, OPEN_SAVED_QUERY_COMMAND);
 
             const expectedUrl = Cypress.config().baseUrl + '/sparql?savedQueryName=' + encodeURI(queryName) + '&owner=admin';
             getModal()
@@ -1088,37 +1092,18 @@ describe('SPARQL screen validation', () => {
         getPopover().should('be.visible');
         getSavedQueryFromPopup(savedQueryName)
             .find('a')
-            .click();
-    }
-
-    function editSaveQueryFromPopup(savedQueryName) {
-        getSavedQueryFromPopup(savedQueryName)
-            .trigger('mouseover')
-            .find('.actions-bar')
-            .should('be.visible')
-            .find('.icon-edit')
-            .parent('.btn')
-            // Cypress sometimes determines the element has 0x0 dimensions...
+            // the popup is opened and the link with the text is visible but cypress think it's 0x0px width/height
             .click({force: true});
     }
 
-    function deleteSaveQueryFromPopup(savedQueryName) {
+    function executeSavedQueryCommand(savedQueryName, commandSelector) {
         getSavedQueryFromPopup(savedQueryName)
-            .trigger('mouseover')
+        // Current implementation of the saved queries popup always render the action bar next to
+        // each query item but it's just hidden with opacity: 0. So IMO it's safe to force it here.
+            .trigger('mouseover', {force: true})
             .find('.actions-bar')
             .should('be.visible')
-            .find('.icon-trash')
-            .parent('.btn')
-            // Cypress sometimes determines the element has 0x0 dimensions...
-            .click({force: true});
-    }
-
-    function openSavedQueryLinkFromPopup(savedQueryName) {
-        getSavedQueryFromPopup(savedQueryName)
-            .trigger('mouseover')
-            .find('.actions-bar')
-            .should('be.visible')
-            .find('.icon-link')
+            .find(commandSelector)
             .parent('.btn')
             // Cypress sometimes determines the element has 0x0 dimensions...
             .click({force: true});

--- a/test-cypress/support/sparql-commands.js
+++ b/test-cypress/support/sparql-commands.js
@@ -22,8 +22,12 @@ Cypress.Commands.add('verifyResultsMessage', (msg) => {
         .and('contain', msg);
 });
 
-Cypress.Commands.add('waitUntilQueryIsVisible', (query) => {
+Cypress.Commands.add('waitUntilQueryIsVisible', () => {
     waitUntilQueryIsVisible();
+});
+
+Cypress.Commands.add('verifyQueryAreaContains', (query) => {
+    verifyQueryAreaContains(query);
 });
 
 // Helper functions
@@ -45,6 +49,14 @@ function waitUntilQueryIsVisible() {
     getQueryArea().should(codeMirrorEl => {
         const cm = codeMirrorEl[0].CodeMirror;
         expect(cm.getValue().trim().length > 0).to.be.true;
+    });
+}
+
+function verifyQueryAreaContains(query) {
+    // Using the CodeMirror instance because getting the value from the DOM is very cumbersome
+    getQueryArea().should(codeMirrorEl => {
+        const cm = codeMirrorEl[0].CodeMirror;
+        expect(cm.getValue().includes(query)).to.be.true;
     });
 }
 


### PR DESCRIPTION
* Forced click on saved query link. I think it's safe to force it there as other validations are successful before: opened popover, present link with the query name title.
* Removed some code duplications.
* Verify sparql query value directly through codemirror api instead through the editor's UI as it's not easy to detect when the editor has finished the rendering which makes the tests flaky.
* Force mouseover event in saved queries popover to show the action bar. Current implementation of the saved queries popup always render the action bar next to each query item but it's just hidden with opacity: 0. So IMO it's safe to force it here.
