### PR TITLE
Fix ui related issues

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -58,6 +58,7 @@ const moduleDefinition = function (productInfo) {
 
             // Extra triggers for tooltip/popover so we can do fancier stuff (see core-errors for example)
             $tooltipProvider.setTriggers({'show': 'hide'});
+            $tooltipProvider.options({appendToBody: true});
 
             // Due to angular weirdness and what gets injected where we can't inject the productInfo constant
             // at the time of module creation so we pass it to $menuItemsProvider. The info can be used

--- a/src/css/rdf-details-side-panel.css
+++ b/src/css/rdf-details-side-panel.css
@@ -3,6 +3,8 @@
     -webkit-box-shadow: -1px 3px 10px 0 rgba(0, 0, 0, 0.3);
     -moz-box-shadow: -1px 3px 10px 0 rgba(0, 0, 0, 0.3);
     box-shadow: -1px 3px 10px 0 rgba(0, 0, 0, 0.3);
+    /* force it because pageslide sets the top:0 property inline and we need to override it */
+    top: 45px !important;
 }
 
 .rdf-list {

--- a/src/pages/domainRangeInfo.html
+++ b/src/pages/domainRangeInfo.html
@@ -54,7 +54,6 @@
              onclose="onclose"
              ps-side="right"
              ps-custom-height="calc(100vh - 55px)"
-             ps-custom-top="45px"
              ps-size="25vw">
             <div class="rdf-side-panel-content break-word-alt p-1">
                 <button class="close mb-1 ml-1" ng-click="showPredicatesInfoPanel = false"></button>

--- a/src/pages/graphs-visualizations.html
+++ b/src/pages/graphs-visualizations.html
@@ -214,7 +214,6 @@
         onopen="onopen"
         onclose="onclose"
         ps-side="right"
-        ps-custom-top="45px"
         ps-custom-height="calc(100vh - 55px)"
         ps-size="{{pageslideExpanded ? '80vw' : '25vw'}}">
     <div class="rdf-side-panel-content break-word-alt p-1 pt-2">

--- a/src/pages/rdfClassHierarchyInfo.html
+++ b/src/pages/rdfClassHierarchyInfo.html
@@ -128,7 +128,6 @@
                 onclose="onclose"
                 ps-side="right"
 				ps-custom-height="calc(100vh - 55px)"
-                ps-custom-top="45px"
 				ps-size="25vw">
             <div class="break-word-alt p-1">
                 <button class="close mb-1 ml-1"


### PR DESCRIPTION
* The tooltip from angular-ui-bootstrap is configured once when it's loaded.
* The angular-pageslide-directive which was updated to its latest version 2.2.0 seems to have dropped the support for ps-custom-top parameter. Fixed by setting the top position within the stylesheet.

Ticket: https://ontotext.atlassian.net/browse/GDB-4050