### PR TITLE
Sonar will not break the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ addons:
 script:
   - npm run test:coverage
   - npm run build
-  - npm run sonar
 
 after_script:
+  - npm run sonar
   - npm run test:coveralls
   - npm run test:acceptance
 


### PR DESCRIPTION
Due to some issues with the authorization token sonarcloud fails with
`ERROR: Error during SonarQube Scanner execution
ERROR: Not authorized. Please check the properties sonar.login and sonar.password.`
https://travis-ci.community/t/sonarcloud-fails-to-authorize/5845