### PR TITLE
Enable sonar analysis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ addons:
   chrome: stable
   sonarcloud:
     organization: "ontotext-ad"
-    token:
-      secure: $SONAR_TOKEN
   # Needed for Cypress tests
   apt:
     packages:
@@ -27,9 +25,9 @@ addons:
 script:
   - npm run test:coverage
   - npm run build
+  - npm run sonar
 
 after_script:
-  - npm run sonar
   - npm run test:coveralls
   - npm run test:acceptance
 


### PR DESCRIPTION
Removed token property from .travis.yml as it's not needed and seems to break the task.