### PR TITLE
Retry failed tests, reduced tests in memory

### DIFF
--- a/test-cypress/cypress.json
+++ b/test-cypress/cypress.json
@@ -8,5 +8,6 @@
     "supportFile": "support/index.js",
     "videosFolder": "report/videos",
     "video": false,
-    "defaultCommandTimeout": 30000
+    "defaultCommandTimeout": 30000,
+    "numTestsKeptInMemory": 10
 }

--- a/test-cypress/package.json
+++ b/test-cypress/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "cypress": "^3.4.1",
         "cypress-failed-log": "^2.5.1",
-        "cypress-plugin-retries": "^1.2.2"
+        "cypress-plugin-retries": "^1.4.0"
     },
     "bin": {
         "graphdb-workbench-cypress": "bin/graphdb-workbench-cypress"

--- a/test-cypress/support/index.js
+++ b/test-cypress/support/index.js
@@ -21,6 +21,6 @@ import './commands';
 
 // Configures retry count for failed tests TODO: Remove after tests are stabilized
 require('cypress-plugin-retries');
-Cypress.env('RETRIES', 0);
+Cypress.env('RETRIES', 2);
 
 require('cypress-failed-log');


### PR DESCRIPTION
Updated retries plugin, added 2 retries on test fail in order to identify flaky tests vs not working tests, added config to keep less tests in memory (may fix a hang that happens sometimes)