### PR TITLE
GDB-4123 Register unauthorized interceptor in core

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,20 +2,22 @@ import 'angular/core/services';
 import 'angular/controllers';
 import 'angular/core/angularCancelOnNavigateModule';
 import 'oclazyload';
+import 'angular/core/interceptors/unauthorized.interceptor';
 
 const modules = [
     'ngRoute',
     'graphdb.workbench.se.controllers',
     'graphdb.framework.core',
     'angularCancelOnNavigateModule',
-    'oc.lazyLoad'
+    'oc.lazyLoad',
+    'graphdb.framework.core.interceptors.unauthorized',
 ];
 
 const moduleDefinition = function (productInfo) {
     const workbench = angular.module('graphdb.workbench', modules);
 
-    workbench.config(['$routeProvider', '$locationProvider', '$menuItemsProvider', 'toastrConfig', 'localStorageServiceProvider', '$tooltipProvider',
-        function ($routeProvider, $locationProvider, $menuItemsProvider, toastrConfig, localStorageServiceProvider, $tooltipProvider) {
+    workbench.config(['$routeProvider', '$locationProvider', '$menuItemsProvider', 'toastrConfig', 'localStorageServiceProvider', '$tooltipProvider', '$httpProvider',
+        function ($routeProvider, $locationProvider, $menuItemsProvider, toastrConfig, localStorageServiceProvider, $tooltipProvider, $httpProvider) {
 
             angular.extend(toastrConfig, {
                 timeOut: 5000,
@@ -71,6 +73,8 @@ const moduleDefinition = function (productInfo) {
                     $menuItemsProvider.addItem(item);
                 });
             });
+
+            $httpProvider.interceptors.push('$unauthorizedInterceptor');
         }]);
 
     workbench.constant('isEnterprise', productInfo.productType === 'enterprise');

--- a/src/js/angular/security/app.js
+++ b/src/js/angular/security/app.js
@@ -1,7 +1,6 @@
 import 'angular/core/services';
 import 'angular/core/directives';
 import 'angular/security/controllers';
-import 'angular/core/interceptors/unauthorized.interceptor';
 import 'angular/core/services/jwt-auth.service';
 
 const modules = [
@@ -13,13 +12,4 @@ const modules = [
     'graphdb.framework.core.services.jwtauth'
 ];
 
-const securityApp = angular.module('graphdb.framework.security', modules);
-
-securityApp.config(['$locationProvider', '$httpProvider',
-    function ($locationProvider, $httpProvider) {
-        $httpProvider.interceptors.push('$unauthorizedInterceptor');
-
-        // use the HTML5 History API
-        $locationProvider.html5Mode(true);
-    }
-]);
+angular.module('graphdb.framework.security', modules);


### PR DESCRIPTION
Currently the interceptor is attached when you access one of the user endpoints (login, user*). This means that the interceptor is attached when you hit the login endpoint  after securityInit is triggered (in security initialization). This is error prone since if you do not hit the login page for some reason (error during security init), the interceptor will not be attached. 

