### PR TITLE
GDB-4127 Proxy rdf-bridge properly

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -36,7 +36,7 @@ module.exports = merge(commonConfig, {
         port: 9000,
         historyApiFallback: true,
         proxy: [{
-            context: ['/rest', '/repositories', '/orefine', '/protocol'],
+            context: ['/rest', '/repositories', '/orefine', '/protocol', '/rdf-bridge'],
             target: 'http://localhost:7200'
         }]
     }


### PR DESCRIPTION
When executing queries from onto-refine rdf-bridge endpoint is hit. This should be proxied also in workbench dev mode.