### PR TITLE
Gdb 4053 respect negotiate authentication

### DIFF
--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -240,8 +240,8 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $cookies, toastr, $locati
     $scope.isFreeAccessEnabled = function () {
         return $jwtAuth.isFreeAccessEnabled();
     };
-    $scope.isNegotiateAuth = function() {
-        return $jwtAuth.isNegotiateAuth();
+    $scope.hasExternalAuthUser = function() {
+        return $jwtAuth.hasExternalAuthUser();
     };
     $scope.isDefaultAuthEnabled = function () {
         return $jwtAuth.isDefaultAuthEnabled();

--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -240,6 +240,9 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $cookies, toastr, $locati
     $scope.isFreeAccessEnabled = function () {
         return $jwtAuth.isFreeAccessEnabled();
     };
+    $scope.isNegotiateAuth = function() {
+        return $jwtAuth.isNegotiateAuth();
+    }
     $scope.isDefaultAuthEnabled = function () {
         return $jwtAuth.isDefaultAuthEnabled();
     };

--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -329,7 +329,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $cookies, toastr, $locati
     };
 
     $scope.isIgnoreSharedQueries = function () {
-        return $jwtAuth.getPrincipal().appSettings.IGNORE_SHARED_QUERIES;
+        return $jwtAuth.getPrincipal() && $jwtAuth.getPrincipal().appSettings.IGNORE_SHARED_QUERIES;
     };
 
     $scope.logout = function () {

--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -242,7 +242,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $cookies, toastr, $locati
     };
     $scope.isNegotiateAuth = function() {
         return $jwtAuth.isNegotiateAuth();
-    }
+    };
     $scope.isDefaultAuthEnabled = function () {
         return $jwtAuth.isDefaultAuthEnabled();
     };

--- a/src/js/angular/core/interceptors/unauthorized.interceptor.js
+++ b/src/js/angular/core/interceptors/unauthorized.interceptor.js
@@ -7,8 +7,13 @@ angular.module('graphdb.framework.core.interceptors.unauthorized', [
         return {
             'responseError': function (response) {
                 if (response.status === 401) {
-                    $rootScope.redirectToLogin();
-                    return $q.reject(response);
+                    if (response.config.url.indexOf('rest/security/authenticatedUser') < 0 && !$rootScope.hasExternalAuthUser()) {
+                        // Redirect to login page only if this isn't the endpoint that checks
+                        // the externally logged user and when no external authentication is available.
+                        // This check is essential for making free access and external auth working.
+                        $rootScope.redirectToLogin();
+                        return $q.reject(response);
+                    }
                 } else if (response.status === 403) {
                     if ($rootScope.setPermissionDenied($location.path())) {
                         console.log('Permission to page denied. Some errors in the console are normal.'); // eslint-disable-line no-console

--- a/src/js/angular/core/services/jwt-auth.service.js
+++ b/src/js/angular/core/services/jwt-auth.service.js
@@ -229,7 +229,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
             };
 
             this.isAuthenticated = function () {
-                return !this.securityEnabled || this.principal;
+                return !this.securityEnabled || this.auth !== undefined;
             };
 
             this.hasPermission = function () {

--- a/src/js/angular/core/services/jwt-auth.service.js
+++ b/src/js/angular/core/services/jwt-auth.service.js
@@ -35,6 +35,9 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                 }
                 $location.path('/login');
             };
+            $rootScope.hasExternalAuthUser = function () {
+                return jwtAuth.hasExternalAuthUser();
+            };
 
             this.principalCookieName = 'com.ontotext.graphdb.principal' + $location.port();
             this.authCookieName = 'com.ontotext.graphdb.auth' + $location.port();
@@ -64,37 +67,37 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                         const freeAccessData = res.data.freeAccess;
                         that.freeAccess = freeAccessData.enabled;
                         if (that.freeAccess) {
-                            that.freeAccessPrincipal = {authorities: freeAccessData.authorities, appSettings: freeAccessData.appSettings};
-                            if (that.auth === undefined) {
-                                that.principal = that.freeAccessPrincipal;
-
-                            }
-                            $rootScope.$broadcast('securityInit', that.securityEnabled, that.principal, that.freeAccess);
-                        } else {
-                            // update the user principal only when there is one
-                            if (that.principal) {
-                                SecurityRestService.getUser(that.principal.username).then(function (res) {
-                                    that.principal.appSettings = res.data.appSettings;
-                                    if (!that.auth) {
-                                        that.externalAuthUser = true;
-                                    }
-                                    $rootScope.$broadcast('securityInit', that.securityEnabled, true, that.freeAccess);
-                                    // Don't update the authorities for the time being as those returned by this API
-                                    // aren't expanded. User will need to logout and login again to get updated authorities.
-                                    // that.principal.authorities = res.data.grantedAuthorities;
-                                }, function() {
-                                    $rootScope.$broadcast('securityInit', that.securityEnabled, false, that.freeAccess);
-                                });
-                            } else {
-                                SecurityRestService.getAuthenticatedUser().
-                                success(function(data, status, headers) {
-                                    that.externalAuthUser = true;
-                                    that.authenticate(data, headers);
-                                }).error(function() {
-                                    $rootScope.$broadcast('securityInit', that.securityEnabled, false, that.freeAccess);
-                                });
-                            }
+                            that.freeAccessPrincipal = {
+                                authorities: freeAccessData.authorities,
+                                appSettings: freeAccessData.appSettings
+                            };
                         }
+
+                        SecurityRestService.getAuthenticatedUser().
+                        success(function(data, status, headers) {
+                            if (that.auth) {
+                                // There is a previous authentication via JWT, it's still valid
+                                // so refresh the principal
+                                that.externalAuthUser = false;
+                                that.principal = data;
+                                $rootScope.$broadcast('securityInit', that.securityEnabled, true, that.freeAccess);
+                                // console.log('previous JWT authentication ok');
+                            } else {
+                                // There is no previous authentication but we got a principal via
+                                // an external authentication mechanism (e.g. Kerberos)
+                                that.externalAuthUser = true;
+                                that.authenticate(data, headers); // this will emit securityInit
+                                // console.log('external authentication ok');
+                            }
+                        }).finally(function() {
+                            // Strictly speaking we should try this in the error() callback but
+                            // for some reason it doesn't get called.
+                            if (!that.hasExplicitAuthentication()) {
+                                that.principal = that.freeAccessPrincipal;
+                                $rootScope.$broadcast('securityInit', that.securityEnabled, false, that.freeAccess);
+                                // console.log('free access fallback');
+                            }
+                        });
                     } else {
                         that.clearCookies();
                         const overrideAuthData = res.data.overrideAuth;
@@ -105,12 +108,12 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                                 authorities: overrideAuthData.authorities,
                                 appSettings: overrideAuthData.appSettings
                             };
-                            $rootScope.$broadcast('securityInit', that.securityEnabled, that.principal, that.hasOverrideAuth);
+                            $rootScope.$broadcast('securityInit', that.securityEnabled, true, that.hasOverrideAuth);
 
                         } else {
                             SecurityRestService.getAdminUser().then(function (res) {
                                 that.principal = {username: 'admin', appSettings: res.data.appSettings, authorities: res.data.grantedAuthorities}
-                                $rootScope.$broadcast('securityInit', that.securityEnabled, that.principal, that.hasOverrideAuth);
+                                $rootScope.$broadcast('securityInit', that.securityEnabled, true, that.hasOverrideAuth);
                             });
                         }
                     }
@@ -178,7 +181,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                     }, function (err) {
                         toastr.error(err.data.error.message, 'Error');
                     });
-                    $rootScope.$broadcast('securityInit', this.securityEnabled, this.principal, this.freeAccess);
+                    $rootScope.$broadcast('securityInit', this.securityEnabled, this.hasExplicitAuthentication(), this.freeAccess);
                 }
             };
 
@@ -202,12 +205,16 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                 $cookieStore.put(this.principalCookieName, this.principal);
                 this.setAuthHeaders();
                 $rootScope.deniedPermissions = {};
-                $rootScope.$broadcast('securityInit', this.securityEnabled, this.principal, this.freeAccess);
+                $rootScope.$broadcast('securityInit', this.securityEnabled, this.hasExplicitAuthentication(), this.freeAccess);
             };
 
             this.hasExternalAuthUser = function () {
                 return this.externalAuthUser;
-            }
+            };
+
+            this.hasExplicitAuthentication = function () {
+                return this.auth !== undefined || this.externalAuthUser;
+            };
 
             this.getPrincipal = function () {
                 return this.principal;

--- a/src/js/angular/core/services/jwt-auth.service.js
+++ b/src/js/angular/core/services/jwt-auth.service.js
@@ -192,12 +192,14 @@ angular.module('graphdb.framework.core.services.jwtauth', [
             this.setAuthHeaders();
 
             this.authenticate = function (data, headers) {
+                this.clearCookies();
                 var authHeader = headers('Authorization');
                 if (authHeader && authHeader.indexOf('Negotiate') > -1) {
                     this.negotiateAuth = true;
                     $cookies[this.negotiateCookieName] = true;
                 } else {
                     this.auth = authHeader;
+                    this.negotiateAuth = false;
                     $cookies[this.authCookieName] = this.auth;
                 }
 

--- a/src/js/angular/core/services/jwt-auth.service.js
+++ b/src/js/angular/core/services/jwt-auth.service.js
@@ -214,6 +214,10 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                 return this.auth !== undefined || this.negotiateAuth;
             }
 
+            this.isNegotiateAuth = function () {
+                return this.negotiateAuth;
+            }
+
             this.getPrincipal = function () {
                 return this.principal;
             };

--- a/src/js/angular/rest/security.rest.service.js
+++ b/src/js/angular/rest/security.rest.service.js
@@ -6,6 +6,7 @@ SecurityRestService.$inject = ['$http'];
 
 const SECURITY_ENDPOINT = 'rest/security';
 const SECURITY_USER_ENDPOINT = `${SECURITY_ENDPOINT}/user`;
+const SECURITY_AUTHENTICATED_ENDPOINT = `${SECURITY_ENDPOINT}/authenticatedUser`;
 const SECURITY_FREEACCESS_ENDPOINT = `${SECURITY_ENDPOINT}/freeaccess`;
 const ROLES_ENDPOINT = 'rest/roles';
 
@@ -23,11 +24,16 @@ function SecurityRestService($http) {
         getSecurityConfig,
         toggleSecurity,
         getRoles,
-        getRolesMapping
+        getRolesMapping,
+        getAuthenticatedUser
     };
 
     function getUser(username) {
         return $http.get(`${SECURITY_USER_ENDPOINT}/${encodeURIComponent(username)}`);
+    }
+
+    function getAuthenticatedUser() {
+        return $http.get(`${SECURITY_AUTHENTICATED_ENDPOINT}`);
     }
 
     function getAdminUser() {

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -50,12 +50,12 @@
 						<div class="form-group" ng-class="{'has-danger': passwordError}">
 							<div class="input-group">
 								<span class="input-group-addon" tooltip="Pasword" tooltip-trigger="mouseenter"><em class="icon-lock icon-2x text-muted"></em></span>
-								<input id="wb-user-password" placeholder="{{passwordPlaceholder}}" name="password" class="form-control form-control-lg" type="password"	ng-model="user.password" ng-hide="user.external">
-								<span ng-show="user.external">This is a user authenticated via an external module. The password cannot be changed from GraphDB.</span>
+								<input id="wb-user-password" placeholder="{{passwordPlaceholder}}" name="password" class="form-control form-control-lg" type="password"	ng-model="user.password" ng-hide="user.external || hasExternalAuthUser()">
+								<span ng-show="user.external || hasExternalAuthUser()">This is a user authenticated via an external module. The password cannot be changed from GraphDB.</span>
 							</div>
 							<div ng-show="passwordError" class="form-control-feedback">{{passwordError}}</div>
 						</div>
-						<div class="form-group" ng-class="{'has-danger': confirmPasswordError}" ng-hide="user.external">
+						<div class="form-group" ng-class="{'has-danger': confirmPasswordError}" ng-hide="user.external || hasExternalAuthUser()">
 							<div class="input-group">
 								<span class="input-group-addon" tooltip="Confirm password" tooltip-trigger="mouseenter"><em class="icon-lock icon-2x text-muted"></em></span>
 								<input id="wb-user-confirmpassword" placeholder="Confirm password" name="password_confirm" class="form-control form-control-lg" type="password" ng-model="user.confirmpassword">

--- a/src/template.html
+++ b/src/template.html
@@ -85,7 +85,7 @@
             </button>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="btnUserGroup">
                 <a class="dropdown-item" href="settings">My settings</a>
-                <a class="dropdown-item" ng-click="logout()" title="Sign out" ng-href="./login">Logout</a>
+                <a class="dropdown-item" ng-click="logout()" title="Sign out" ng-href="./login" ng-if="!isNegotiateAuth()">Logout</a>
             </div>
         </div>
         <div class="btn-group" ng-show="isSecurityEnabled() && !isUserLoggedIn() && !isCurrentPath('login')">

--- a/src/template.html
+++ b/src/template.html
@@ -85,7 +85,7 @@
             </button>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="btnUserGroup">
                 <a class="dropdown-item" href="settings">My settings</a>
-                <a class="dropdown-item" ng-click="logout()" title="Sign out" ng-href="./login" ng-if="!isNegotiateAuth()">Logout</a>
+                <a class="dropdown-item" ng-click="logout()" title="Sign out" ng-href="./login" ng-if="!hasExternalAuthUser()">Logout</a>
             </div>
         </div>
         <div class="btn-group" ng-show="isSecurityEnabled() && !isUserLoggedIn() && !isCurrentPath('login')">

--- a/test/export/controllers.spec.js
+++ b/test/export/controllers.spec.js
@@ -54,6 +54,8 @@ describe('==> ExportCtrl tests', function () {
             freeAccess: {enabled: false},
             overrideAuth: {enabled: false}
         });
+
+        $httpBackend.when('GET', 'rest/security/authenticatedUser').respond(401, 'Authentication required');
     }));
 
     afterEach(function () {

--- a/test/resource/controllers.spec.js
+++ b/test/resource/controllers.spec.js
@@ -27,6 +27,8 @@ describe('=> ExploreCtrl tests', function () {
             freeAccess: {enabled: false},
             overrideAuth: {enabled: false}
         });
+
+        $httpBackend.when('GET', 'rest/security/authenticatedUser').respond(401, 'Authentication required');
     }));
 
     afterEach(function () {
@@ -106,6 +108,8 @@ describe('=> EditResourceCtrl', function () {
             freeAccess: {enabled: false},
             overrideAuth: {enabled: false}
         });
+
+        $httpBackend.when('GET', 'rest/security/authenticatedUser').respond(401, 'Authentication required');
     }));
 
     afterEach(function () {

--- a/test/security/controllers.spec.js
+++ b/test/security/controllers.spec.js
@@ -39,6 +39,8 @@ describe('==> Controllers tests', function () {
             });
             var httpGetActiveLocation = $httpBackend.when('GET', 'rest/locations/active').respond(200, {});
             var httpGetRepositories = $httpBackend.when('GET', 'rest/repositories').respond(200, {});
+
+            $httpBackend.when('GET', 'rest/security/authenticatedUser').respond(401, 'Authentication required');
         }));
 
         afterEach(function () {
@@ -132,6 +134,7 @@ describe('==> Controllers tests', function () {
             var httpGetActiveLocation = $httpBackend.when('GET', 'rest/locations/active').respond(200, {});
             var httpGetRepositories = $httpBackend.when('GET', 'rest/repositories').respond(200, {});
             $httpBackend.when('GET', 'rest/security/freeaccess').respond(200, {enabled: false});
+            $httpBackend.when('GET', 'rest/security/authenticatedUser').respond(401, 'Authentication required');
         }));
 
         afterEach(function () {
@@ -343,6 +346,8 @@ describe('==> Controllers tests', function () {
             var httpGetActiveLocation = $httpBackend.when('GET', 'rest/locations/active').respond(200, {});
             var httpGetRepositories = $httpBackend.when('GET', 'rest/repositories').respond(200, {});
 
+            $httpBackend.when('GET', 'rest/security/authenticatedUser').respond(401, 'Authentication required');
+
             $scope.user.username = 'testov';
             $scope.user.password = 'testova';
             $scope.user.confirmpassword = 'testova';
@@ -520,6 +525,7 @@ describe('==> Controllers tests', function () {
             });
             var httpGetActiveLocation = $httpBackend.when('GET', 'rest/locations/active').respond(200, {});
             var httpGetRepositories = $httpBackend.when('GET', 'rest/repositories').respond(200, {});
+            $httpBackend.when('GET', 'rest/security/authenticatedUser').respond(401, 'Authentication required');
         }));
 
         afterEach(function () {
@@ -683,6 +689,7 @@ describe('==> Controllers tests', function () {
             });
             var httpGetActiveLocation = $httpBackend.when('GET', 'rest/locations/active').respond(200, {});
             var httpGetRepositories = $httpBackend.when('GET', 'rest/repositories').respond(200, {});
+            $httpBackend.when('GET', 'rest/security/authenticatedUser').respond(401, 'Authentication required');
         }));
 
         afterEach(function () {

--- a/test/security/services.spec.js
+++ b/test/security/services.spec.js
@@ -29,6 +29,8 @@ describe('$jwtAuth tests', function () {
             grantedAuthorities: []
         });
 
+        $httpBackend.when('GET', 'rest/security/authenticatedUser').respond(401, 'Authentication required');
+
         /*
         //requests that starts from repository/services.js after the security is OK
         httpGetActiveLocation = $httpBackend.when('GET', 'rest/locations/active').respond(200, {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -41,7 +41,9 @@ module.exports = merge(commonConfig, {
             target: 'http://localhost:7200',
             onProxyRes: proxyRes => {
                 var key = 'www-authenticate';
-                proxyRes.headers[key] = proxyRes.headers[key] && proxyRes.headers[key].split(',');
+                if (proxyRes.headers[key]) {
+                    proxyRes.headers[key] = proxyRes.headers[key].split(',');
+                }
             }
         }]
     }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -4,6 +4,10 @@ const commonConfig = require('./webpack.config.common');
 const {CleanWebpackPlugin} = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
+const host = 'localhost';
+const portHere = 9000;
+const portThere = 7200;
+
 module.exports = merge(commonConfig, {
     mode: 'development',
     output: {
@@ -34,15 +38,16 @@ module.exports = merge(commonConfig, {
     //    disableHostCheck: true,
         contentBase: path.join(__dirname, 'dist/'),
         compress: true,
-        port: 9000,
+        port: portHere,
+        host: host,
         historyApiFallback: true,
         proxy: [{
             context: ['/rest', '/repositories', '/orefine', '/protocol', '/rdf-bridge'],
-            target: 'http://localhost:7200',
+            target: 'http://' + host + ':' + portThere,
             onProxyRes: proxyRes => {
                 var key = 'www-authenticate';
                 if (proxyRes.headers[key]) {
-                    proxyRes.headers[key] = proxyRes.headers[key].split(',');
+                    proxyRes.headers[key] = proxyRes.headers[key].split(', ');
                 }
             }
         }]

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -31,13 +31,18 @@ module.exports = merge(commonConfig, {
         new CleanWebpackPlugin()
     ],
     devServer: {
+    //    disableHostCheck: true,
         contentBase: path.join(__dirname, 'dist/'),
         compress: true,
         port: 9000,
         historyApiFallback: true,
         proxy: [{
             context: ['/rest', '/repositories', '/orefine', '/protocol', '/rdf-bridge'],
-            target: 'http://localhost:7200'
+            target: 'http://localhost:7200',
+            onProxyRes: proxyRes => {
+                var key = 'www-authenticate';
+                proxyRes.headers[key] = proxyRes.headers[key] && proxyRes.headers[key].split(',');
+            }
         }]
     }
 });


### PR DESCRIPTION
When security is on and we do not have valid principal and auth token (current user session), try to authenticate with kerberos. Send a request during security initialization to GDB to get currently authenticated user if present and if it is authenticated with negotiate header leave security to negotiate mechanism. This means leave the browser set the 'Authorization' header obtained from kerberos.
This mimics in the workbench automatic user login. In these cases logout for the user is not visible. 
Redirect to login when authentication fails.
A cookie 'auth.negotiate' is kept because we need to know that when we have principal but no auth token, this is because authentication is left to negotiate mechanism.