### PR TITLE
GDB-4386 remove force resolution from test-cypress/package.json and prepare versions for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "graphdb-workbench",
-  "version": "1.3.0-RC2",
+  "version": "1.3.0-RC3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "graphdb-workbench",
-    "version": "1.3.0-RC2",
+    "version": "1.3.0-RC3",
     "description": "The web application for GraphDB APIs",
     "scripts": {
         "build": "webpack --config=webpack.config.prod.js",

--- a/test-cypress/package-lock.json
+++ b/test-cypress/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "graphdb-workbench-tests",
-  "version": "1.3.0-RC2",
+  "version": "1.3.0-RC3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test-cypress/package.json
+++ b/test-cypress/package.json
@@ -1,9 +1,8 @@
 {
     "name": "graphdb-workbench-tests",
-    "version": "1.3.0-RC2",
+    "version": "1.3.0-RC3",
     "description": "Cypress tests for GraphDB workbench",
     "scripts": {
-        "preinstall": "npx npm-force-resolutions",
         "start": "cypress open",
         "test": "cypress run"
     },


### PR DESCRIPTION
Force resolution execution in package.json breaks package installation, remove it and bump version for release