### PR TITLE
GDB-4400 Provides font auto resize to match parent directive

### DIFF
--- a/src/js/angular/core/directives/fit-text.directive.js
+++ b/src/js/angular/core/directives/fit-text.directive.js
@@ -1,5 +1,6 @@
+// This is a rework of the ng-FitText.js which can be found here https://github.com/patrickmarabeas/ng-FitText.js
 angular
-    .module('graphdb.framework.explore.directives.fittext', [])
+    .module('graphdb.framework.core.directives.fittext', [])
     .directive('fitText', fitTextDirective);
 
 fitTextDirective.$inject = ['$timeout'];
@@ -34,7 +35,6 @@ function fitTextDirective($timeout) {
             const lineHeight = computed['line-height'];
             const display = computed['display'];
             let resizePromise;
-
 
             function calculate() {
                 const ratio = (config.calcSize * newlines) / domElem.offsetWidth / newlines;

--- a/src/js/angular/explore/app.js
+++ b/src/js/angular/explore/app.js
@@ -5,7 +5,7 @@ import 'angular/explore/controllers';
 import 'angular/explore/directives';
 import 'angular-xeditable/dist/js/xeditable.min';
 import 'lib/angucomplete-alt/angucomplete-alt-onto.min';
-import 'angular/explore/fit-text.directive';
+import 'angular/core/directives/fit-text.directive';
 
 const modules = [
     'ngRoute',
@@ -15,7 +15,7 @@ const modules = [
     'graphdb.framework.explore.services',
     'graphdb.framework.explore.controllers',
     'graphdb.framework.explore.directives',
-    'graphdb.framework.explore.directives.fittext'
+    'graphdb.framework.core.directives.fittext'
 ];
 
 angular.module('graphdb.framework.explore', modules);

--- a/src/js/angular/explore/app.js
+++ b/src/js/angular/explore/app.js
@@ -5,6 +5,7 @@ import 'angular/explore/controllers';
 import 'angular/explore/directives';
 import 'angular-xeditable/dist/js/xeditable.min';
 import 'lib/angucomplete-alt/angucomplete-alt-onto.min';
+import 'angular/explore/fit-text.directive';
 
 const modules = [
     'ngRoute',
@@ -13,7 +14,8 @@ const modules = [
     'angucomplete-alt-onto',
     'graphdb.framework.explore.services',
     'graphdb.framework.explore.controllers',
-    'graphdb.framework.explore.directives'
+    'graphdb.framework.explore.directives',
+    'graphdb.framework.explore.directives.fittext'
 ];
 
 angular.module('graphdb.framework.explore', modules);

--- a/src/js/angular/explore/fit-text.directive.js
+++ b/src/js/angular/explore/fit-text.directive.js
@@ -1,0 +1,98 @@
+angular
+    .module('graphdb.framework.explore.directives.fittext', [])
+    .directive('fitText', fitTextDirective);
+
+fitTextDirective.$inject = ['$timeout'];
+
+function fitTextDirective($timeout) {
+    return {
+        restrict: 'A',
+        scope: {
+            min: '=',
+            max: '='
+        },
+        link: function (scope, element, attrs) {
+
+            const config = {
+                'debounce': _.debounce,
+                'delay': 100,
+                'loadDelay': 10,
+                'compressor': 1,
+                'min': attrs.fitTextMin || 'inherit',
+                'max': attrs.fitTextMax || 'inherit',
+                'calcSize': 10,
+                'lines': 1
+            };
+
+            const parent = element.parent();
+            const domElem = element[0];
+            const domElemStyle = domElem.style;
+            const computed = window.getComputedStyle(element[0], null);
+            const newlines = element.children().length || config.lines;
+            const minFontSize = config.min === 'inherit' ? computed['font-size'] : config.min;
+            const maxFontSize = config.max === 'inherit' ? computed['font-size'] : config.max;
+            const lineHeight = computed['line-height'];
+            const display = computed['display'];
+            let resizePromise;
+
+
+            function calculate() {
+                const ratio = (config.calcSize * newlines) / domElem.offsetWidth / newlines;
+                return Math.max(Math.min(getMaxFontSize(ratio), parseFloat(maxFontSize)), parseFloat(minFontSize));
+            }
+
+            function getMaxFontSize(ratio) {
+                const paddingLeft = parseFloat(getComputedStyle(parent[0]).paddingLeft);
+                const paddingRight = parseFloat(getComputedStyle(parent[0]).paddingRight);
+
+                return (parent[0].offsetWidth - (paddingLeft + paddingRight)) * ratio * config.compressor;
+            }
+
+            function resize() {
+                if (domElem.offsetHeight * domElem.offsetWidth === 0) {
+                    return;
+                }
+
+                // Preset standard values for making the size calculation
+                domElemStyle.fontSize = config.calcSize + 'px';
+                domElemStyle.lineHeight = '1';
+                domElemStyle.display = 'inline-block';
+
+                // Set usage values
+                domElemStyle.fontSize = calculate() + 'px';
+                domElemStyle.lineHeight = lineHeight;
+                domElemStyle.display = display;
+            }
+
+            function resizer() {
+                if (resizePromise) {
+                    $timeout.cancel(resizePromise);
+                }
+
+                resizePromise = $timeout(function () {
+                    resize();
+                }, config.loadDelay);
+            }
+
+            scope.$watch(function () {
+                return [
+                    parent[0].offsetWidth,
+                    element[0].offsetWidth
+                ].join('_');
+            }, function () {
+                resizer();
+            });
+
+            $(window).on('resize', config.debounce(function () {
+                scope.$apply(resizer)
+            }, config.delay));
+
+            scope.$on('$destroy', function () {
+                if (resizePromise) {
+                    $timeout.cancel(resizePromise);
+                }
+                $(window).off('resize');
+            });
+        }
+    };
+}

--- a/src/pages/explore.html
+++ b/src/pages/explore.html
@@ -27,7 +27,7 @@
         <div class="thumb" ng-show="{{details.img}}">
             <a href="{{details.img}}"><img ng-src="{{details.img}}" alt="details image"/></a>
         </div>
-        <h1>
+        <h1 fit-text fit-text-min="30">
             <a href="sparql?query=describe%20{{encodeURIComponent(tripleParam)}}" tooltip="{{tripleParam}}" tooltip-trigger="mouseenter">
                 {{getRdfStarLocalNames(tripleParam)}}
             </a>


### PR DESCRIPTION
 The directive manipulates the font size of DOM elements that they fill the width of a parent element. Desired max and min font size can be passed as argument, or get from source. Works with window resize, dynamic recalculates font size on parent changes. Line heights and display property are preserved.

 Related to GDB-4400 Resource view: Reduce the font of nested triples in the resource view