### PR TITLE
GDB-5019 Stop count queries, updates and disable sameAs for Virtual repositories

### DIFF
--- a/src/js/angular/core/directives/queryeditor/query-editor.controller.js
+++ b/src/js/angular/core/directives/queryeditor/query-editor.controller.js
@@ -49,7 +49,7 @@ function QueryEditorCtrl($scope, $timeout, toastr, $repositories, $modal, ModalS
         });
 
         scope.$on('repositoryIsSet', deleteCachedSparqlResults);
-        scope.$on('repositoryIsSet', overrideSameAsAndSkipCountIfNeeded);
+        scope.$on('repositoryIsSet', overrideSameAsAndNoCountIfNeeded);
     }
 
     $scope.resetCurrentTabConfig = function () {
@@ -711,7 +711,7 @@ function QueryEditorCtrl($scope, $timeout, toastr, $repositories, $modal, ModalS
         if (!checkQueryIntervalId) {
             checkQueryIntervalId = setInterval(showOrHideSaveAsDropDown, 200);
         }
-        overrideSameAsAndSkipCountIfNeeded();
+        overrideSameAsAndNoCountIfNeeded();
     }
 
     function getQueryID(element) {
@@ -857,20 +857,18 @@ function QueryEditorCtrl($scope, $timeout, toastr, $repositories, $modal, ModalS
     }
 
     /**
-     * In case of Ontop repository, sameAs and skipCountQueries
+     * In case of Ontop repository, sameAs and nocount
      * are overridden to true and #sameAs button is disabled
      */
-    function overrideSameAsAndSkipCountIfNeeded() {
+    function overrideSameAsAndNoCountIfNeeded() {
         let sameAsBtn = document.getElementById('sameAs')
         let isOntop = isOntopRepo();
         if (sameAsBtn) {
             sameAsBtn.disabled = isOntop;
         }
 
-        if (isOntop) {
-            $scope.skipCountQuery = true;
-            $scope.currentQuery.sameAs = true;
-        }
+        $scope.nocount = isOntop ? true : !principal.appSettings.EXECUTE_COUNT;
+        $scope.currentQuery.sameAs = isOntop ? true : principal.appSettings.DEFAULT_SAMEAS;
     }
 }
 

--- a/src/js/angular/core/directives/queryeditor/query-editor.controller.js
+++ b/src/js/angular/core/directives/queryeditor/query-editor.controller.js
@@ -848,7 +848,7 @@ function QueryEditorCtrl($scope, $timeout, toastr, $repositories, $modal, ModalS
     });
 
     function isOntopRepo() {
-        let activeRepo = $repositories.repositories.find(current => current.id === $repositories.getActiveRepository());
+        const activeRepo = $repositories.repositories.find(current => current.id === $repositories.getActiveRepository());
         if (activeRepo) {
             return activeRepo.sesameType === ONTOP_REPOSITORY_LABEL;
         }
@@ -861,8 +861,8 @@ function QueryEditorCtrl($scope, $timeout, toastr, $repositories, $modal, ModalS
      * are overridden to true and #sameAs button is disabled
      */
     function overrideSameAsAndNoCountIfNeeded() {
-        let sameAsBtn = document.getElementById('sameAs')
-        let isOntop = isOntopRepo();
+        const sameAsBtn = document.getElementById('sameAs')
+        const isOntop = isOntopRepo();
         if (sameAsBtn) {
             sameAsBtn.disabled = isOntop;
         }

--- a/src/js/angular/core/directives/queryeditor/query-editor.controller.js
+++ b/src/js/angular/core/directives/queryeditor/query-editor.controller.js
@@ -868,7 +868,7 @@ function QueryEditorCtrl($scope, $timeout, toastr, $repositories, $modal, ModalS
         }
 
         $scope.nocount = isOntop ? true : !principal.appSettings.EXECUTE_COUNT;
-        $scope.currentQuery.sameAs = isOntop ? true : principal.appSettings.DEFAULT_SAMEAS;
+        $scope.currentTabConfig.sameAs = isOntop ? true : principal.appSettings.DEFAULT_SAMEAS;
     }
 }
 


### PR DESCRIPTION
If sesameType "graphdb:OntopRepository" of active repository is detected #sameAs button is disabled, currentQuery.sameAs and nocount are set to true. On explain and update "Explain not supported for Virtual repositories." and "Updates are not supported for Virtual repositories." messages are shown to the user.