### PR TITLE
GDB-5021 Check for repository of type Ontop in "Autocomplete", "RDF Rank", "Connectors" and "Import" views

### DIFF
--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -294,7 +294,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $cookies, toastr, $locati
         const activeRepository = $repositories.getActiveRepository();
         // If the parameter noSystem is true then we don't allow write access to the SYSTEM repository
         return $jwtAuth.canWriteRepo($repositories.getActiveLocation(), activeRepository)
-            && (activeRepository !== 'SYSTEM' || !noSystem);
+            && (activeRepository !== 'SYSTEM' || !noSystem) && !$scope.isActiveRepoOntopType();
     };
 
     $scope.getActiveRepositoryObject = function () {
@@ -302,6 +302,10 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $cookies, toastr, $locati
             return repo.id === $scope.getActiveRepository();
         });
     };
+
+    $scope.isActiveRepoOntopType = function () {
+        return $repositories.isActiveRepoOntopType();
+    }
 
     $scope.toHumanReadableType = function (type) {
         switch (type) {

--- a/src/js/angular/core/directives/queryeditor/query-editor.controller.js
+++ b/src/js/angular/core/directives/queryeditor/query-editor.controller.js
@@ -22,8 +22,6 @@ function QueryEditorCtrl($scope, $timeout, toastr, $repositories, $modal, ModalS
         sameAs: true
     };
 
-    const ONTOP_REPOSITORY_LABEL = 'graphdb:OntopRepository';
-
     let principal = $jwtAuth.getPrincipal();
     let checkQueryIntervalId;
     if (principal) {
@@ -49,7 +47,6 @@ function QueryEditorCtrl($scope, $timeout, toastr, $repositories, $modal, ModalS
         });
 
         scope.$on('repositoryIsSet', deleteCachedSparqlResults);
-        scope.$on('repositoryIsSet', overrideSameAsAndNoCountIfNeeded);
     }
 
     $scope.resetCurrentTabConfig = function () {
@@ -289,7 +286,7 @@ function QueryEditorCtrl($scope, $timeout, toastr, $repositories, $modal, ModalS
                 return;
             }
 
-            if (isOntopRepo()) {
+            if ($repositories.isActiveRepoOntopType()) {
                 toastr.warning('Explain not supported for Virtual repositories.');
                 return;
             }
@@ -305,7 +302,7 @@ function QueryEditorCtrl($scope, $timeout, toastr, $repositories, $modal, ModalS
 
             $scope.lastRunQueryMode = window.editor.getQueryMode();
 
-            if ($scope.lastRunQueryMode === 'update' && isOntopRepo()) {
+            if ($scope.lastRunQueryMode === 'update' && $repositories.isActiveRepoOntopType()) {
                 toastr.warning('Updates are not supported for Virtual repositories.');
                 return;
             }
@@ -847,28 +844,19 @@ function QueryEditorCtrl($scope, $timeout, toastr, $repositories, $modal, ModalS
         angular.element($window).unbind('resize', resize);
     });
 
-    function isOntopRepo() {
-        const activeRepo = $repositories.repositories.find(current => current.id === $repositories.getActiveRepository());
-        if (activeRepo) {
-            return activeRepo.sesameType === ONTOP_REPOSITORY_LABEL;
-        }
-
-        return false;
-    }
-
     /**
      * In case of Ontop repository, sameAs and nocount
      * are overridden to true and #sameAs button is disabled
      */
     function overrideSameAsAndNoCountIfNeeded() {
         const sameAsBtn = document.getElementById('sameAs')
-        const isOntop = isOntopRepo();
+        const isOntop = $repositories.isActiveRepoOntopType();
         if (sameAsBtn) {
             sameAsBtn.disabled = isOntop;
         }
 
         $scope.nocount = isOntop ? true : !principal.appSettings.EXECUTE_COUNT;
-        $scope.currentTabConfig.sameAs = isOntop ? true : principal.appSettings.DEFAULT_SAMEAS;
+        $scope.currentQuery.sameAs = isOntop ? true : principal.appSettings.DEFAULT_SAMEAS;
     }
 }
 

--- a/src/js/angular/core/services/repositories.service.js
+++ b/src/js/angular/core/services/repositories.service.js
@@ -28,6 +28,7 @@ repositories.service('$repositories', ['$http', '$cookies', '$cookieStore', 'toa
         this.degradedReason = '';
 
         const that = this;
+        const ONTOP_REPOSITORY_LABEL = 'graphdb:OntopRepository';
 
         const loadingDone = function (err) {
             that.loading = false;
@@ -191,7 +192,7 @@ repositories.service('$repositories', ['$http', '$cookies', '$cookieStore', 'toa
         this.getWritableRepositories = function () {
             const that = this;
             return _.filter(this.getRepositories(), function (repo) {
-                return $jwtAuth.canWriteRepo(that.location, repo.id)
+                return $jwtAuth.canWriteRepo(that.location, repo.id) && !that.isOntopRepo(repo.id)
             });
         };
 
@@ -202,6 +203,24 @@ repositories.service('$repositories', ['$http', '$cookies', '$cookieStore', 'toa
         this.isSystemRepository = function () {
             return this.repository === 'SYSTEM';
         };
+
+        this.isActiveRepoOntopType = function () {
+            let activeRepo = this.repositories.find(current => current.id === this.getActiveRepository());
+            if (activeRepo) {
+                return activeRepo.sesameType === ONTOP_REPOSITORY_LABEL;
+            }
+
+            return false;
+        }
+
+        this.isOntopRepo = function (repoId) {
+            let activeRepo = this.repositories.find(current => current.id === repoId);
+            if (activeRepo) {
+                return activeRepo.sesameType === ONTOP_REPOSITORY_LABEL;
+            }
+
+            return false;
+        }
 
         this.setRepositoryHeaders = function () {
             $http.defaults.headers.common['X-GraphDB-Repository'] = this.repository;

--- a/src/js/angular/core/templates/core-errors.html
+++ b/src/js/angular/core/templates/core-errors.html
@@ -4,7 +4,8 @@
             <div class="card repository-errors">
                 <div class="alert alert-warning lead">
                     <div ng-hide="getActiveRepository()" >Some functionalities are not available because you are not connected to any repository.</div>
-                    <div ng-show="getActiveRepository() && isWriteRequired && !canWriteActiveRepo()">Some functionalities are not available because you have no write permission to repository <strong>{{getActiveRepository()}}</strong>.</div>
+                    <div ng-show="getActiveRepository() && isWriteRequired && !canWriteActiveRepo()">Some functionalities are not available because <span ng-show="!isActiveRepoOntopType()">you have no write permission to </span>repository
+                        <strong>{{getActiveRepository()}}</strong><span ng-show="isActiveRepoOntopType()"> is read-only virtual repository</span>.</div>
                     <small>
                         <span ng-show="getAccessibleRepositories().length">
                             Click one of the repositories below to connect to it<span ng-show="canManageRepositories()"> or create a new repository</span>.


### PR DESCRIPTION
Added check for Virtual repositories in some views that need write access to them. If such repository is detected, proper message is shown to the user, saying "Some functionalities are not available because repository <repo_name> is read-only virtual repository" and are listed such repos, which are not Virtual. Removed unnecessary added listener on repositoryIsSet in query-editor.controller.js