### PR TITLE
GDB-5263: Added cypress env for modifierKey ({cmd} on mac, {ctrl} elsewhere) and added improvements to the run-cypress-tests.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage/
 # Dev specific
 report/
 cypress/
+.downloads

--- a/scripts/run-cypress-tests.sh
+++ b/scripts/run-cypress-tests.sh
@@ -61,7 +61,7 @@ else
     echo "Using already downloaded GraphDB"
 fi
 
-TMPDIR=$(mktemp -d -t graphdb-cypress)
+TMPDIR=$(mktemp -d -t graphdb-cypress.XXXXXX)
 echo "Created temporary directory: $TMPDIR"
 
 if ! unzip -q "$GDB_ZIP" -d "$TMPDIR"; then

--- a/scripts/run-cypress-tests.sh
+++ b/scripts/run-cypress-tests.sh
@@ -1,32 +1,93 @@
 #!/usr/bin/env bash
 
-# Force quit if error occurs or if there is unbound variable
-set -eu
+# Force quit if there is an unbound variable
+set -u
 
+# Traps the INT signal (Ctrl-C) so that we can cleanup when the user aborts the run
+trap cleanup INT
+
+function cleanup() {
+    if [ -e "$TMPDIR" ]; then
+        # The PID file might not be there yet if GraphDB is still starting so wait and retry a couple of times if needed
+        for i in {1..3}; do
+            if [ ! -f "$TMPDIR/graphdb.pid" ]; then
+                echo "GraphDB PID file not found, sleep for 5 seconds and retry (attempt $i)"
+                sleep 5
+            fi
+            if [ -f "$TMPDIR/graphdb.pid" ]; then
+                echo "Killing GraphDB"
+                kill -9 $(cat "$TMPDIR/graphdb.pid")
+                break
+            fi
+        done
+        echo "Removing temporary directory"
+        rm -rf "$TMPDIR"
+    fi
+    exit $1
+}
+
+if [ -z "${GDB_VERSION:-}" ]; then
+    echo "GDB_VERSION must be set to run script. Don't run this script directly, use npm run test:acceptance"
+    cleanup 1
+fi
+
+# Make sure we are in the project root
+cd $(dirname $0)/..
 echo "Working directory: $(pwd)"
 
 echo "Running tests with GDB: $GDB_VERSION"
 
-GRAPHDB_DOWNLOAD_URL="http://maven.ontotext.com/repository/owlim-releases/com/ontotext/graphdb/graphdb-free/${GDB_VERSION}/graphdb-free-${GDB_VERSION}-dist.zip"
+DOWNLOADS=.downloads
+DOWNLOAD_URL="http://maven.ontotext.com/repository/owlim-releases/com/ontotext/graphdb/graphdb-free/${GDB_VERSION}/graphdb-free-${GDB_VERSION}-dist.zip"
+GDB_ZIP="$DOWNLOADS/graphdb-$GDB_VERSION.zip"
 
-echo "Downloading GraphDB from $GRAPHDB_DOWNLOAD_URL"
-# Clean previous runs
-rm -rf /tmp/graphdb.zip /tmp/graphdb-tmp /tmp/graphdb
-curl -sSL -u ${NEXUS_CREDENTIALS} ${GRAPHDB_DOWNLOAD_URL} -o /tmp/graphdb.zip
-unzip -q /tmp/graphdb.zip -d /tmp/graphdb-tmp
-mv /tmp/graphdb-tmp/graphdb* /tmp/graphdb
-rm -rf /tmp/graphdb.zip /tmp/graphdb-tmp
+if ! mkdir -p "$DOWNLOADS"; then
+    echo "Could not create $DOWNLOADS directory"
+    cleanup 1
+fi
+
+if [ ! -f "$GDB_ZIP" ]; then
+    if [ -z "${NEXUS_CREDENTIALS:-}" ]; then
+        echo "No credentials to download GraphDB. You can download GraphDB Free $GDB_VERSION and put it in $GDB_ZIP or set the NEXUS_CREDENTIALS environment variable"
+        cleanup 1
+    fi
+    echo "Downloading GraphDB from $DOWNLOAD_URL"
+    # Clean previous runs
+    if ! curl -sSL -u "${NEXUS_CREDENTIALS}" "${DOWNLOAD_URL}" -o "$GDB_ZIP"; then
+        echo "Could not download GraphDB"
+        cleanup 1
+    fi
+else
+    echo "Using already downloaded GraphDB"
+fi
+
+TMPDIR=$(mktemp -d -t graphdb-cypress)
+echo "Created temporary directory: $TMPDIR"
+
+if ! unzip -q "$GDB_ZIP" -d "$TMPDIR"; then
+    echo "Could not extract GraphDB"
+    cleanup 1
+fi
 
 echo "Starting GraphDB daemon"
-/tmp/graphdb/bin/graphdb -d \
-    -Dgraphdb.home=/tmp/graphdb \
+if ! "$TMPDIR/graphdb-free-${GDB_VERSION}/bin/graphdb" -d \
+    -p "$TMPDIR/graphdb.pid" \
     -Dgraphdb.workbench.home="$(pwd)/dist/" \
-    -Dgraphdb.workbench.importDirectory="$(pwd)/test-cypress/fixtures/graphdb-import/"
+    -Dgraphdb.workbench.importDirectory="$(pwd)/test-cypress/fixtures/graphdb-import/" ]; then
+    echo "Unable to start GraphDB"
+    cleanup 1
+fi
 
 cd test-cypress
 
 echo "Installing Cypress tests module"
-npm install
+if ! npm install; then
+    echo "Could not install tests module"
+    cleanup 1
+fi
 
 echo "Starting Cypress tests against GraphDB version ${GDB_VERSION}"
 npx cypress run --record=false --config baseUrl=http://localhost:7200,video=false
+
+# Stops GraphDB, removes the temporary directory and exits using the exit code of the last command (i.e. the test run)
+cleanup $?

--- a/test-cypress/integration/explore/similarity.spec.js
+++ b/test-cypress/integration/explore/similarity.spec.js
@@ -293,7 +293,7 @@ describe('Similarity screen validation', () => {
     }
 
     function addLuceneAnalyzer() {
-        cy.get('.analyzer-class').type('{ctrl}a{backspace}', {force: true})
+        cy.get('.analyzer-class').type(Cypress.env('modifierKey') + 'a{backspace}', {force: true})
             .invoke('val', LUCENE_ANALYZER).trigger('change', {force: true});
     }
 

--- a/test-cypress/integration/setup/jdbc.spec.js
+++ b/test-cypress/integration/setup/jdbc.spec.js
@@ -143,7 +143,7 @@ describe('JDBC configuration', () => {
 
     function clearQuery() {
         // Using force because the textarea is not visible
-        getQueryTextArea().type('{ctrl}a{backspace}', {force: true});
+        getQueryTextArea().type(Cypress.env('modifierKey') + 'a{backspace}', {force: true});
     }
 
     function getColumnTypesTab() {

--- a/test-cypress/integration/sparql/sparql.menu.spec.js
+++ b/test-cypress/integration/sparql/sparql.menu.spec.js
@@ -920,7 +920,8 @@ describe('SPARQL screen validation', () => {
             clearQuery();
 
             typeQuery(queryBegin, false);
-            typeQuery('Dry{ctrl} ', false, true);
+            // TODO: Need to test Alt-Enter too
+            typeQuery('Dry' + Cypress.env('modifierKey') + ' ', false, true);
 
             getAutoSuggestHints()
                 .should('be.visible')
@@ -946,7 +947,8 @@ describe('SPARQL screen validation', () => {
             clearQuery();
 
             typeQuery(queryBegin, false);
-            typeQuery('Dry{ctrl} ', false, true);
+            // TODO: Need to test Alt-Enter too
+            typeQuery('Dry' + Cypress.env('modifierKey') + ' ', false, true);
 
             getAutoSuggestHints().should('not.exist');
             getToast()
@@ -1101,7 +1103,7 @@ describe('SPARQL screen validation', () => {
 
     function clearQuery() {
         // Using force because the textarea is not visible
-        getQueryTextArea().type('{ctrl}a{backspace}', {force: true});
+        getQueryTextArea().type(Cypress.env('modifierKey') + 'a{backspace}', {force: true});
     }
 
     function typeQuery(query, clear = true, parseSpecialCharSequences = false) {

--- a/test-cypress/support/index.js
+++ b/test-cypress/support/index.js
@@ -23,4 +23,8 @@ import './commands';
 require('cypress-plugin-retries');
 Cypress.env('RETRIES', 2);
 
+// Configures an environment variable with the key used for common actions (cmd on mac, ctrl on other OS).
+// This variable must be used in all actions that type e.g. ctrl-a to select text.
+Cypress.env('modifierKey', Cypress.platform === 'darwin' ? '{cmd}' : '{ctrl}');
+
 require('cypress-failed-log');

--- a/test-cypress/support/sparql-commands.js
+++ b/test-cypress/support/sparql-commands.js
@@ -34,7 +34,7 @@ Cypress.Commands.add('verifyQueryAreaContains', (query) => {
 
 function clearQuery() {
     // Using force because the textarea is not visible
-    getQueryTextArea().type('{ctrl}a{backspace}', {force: true});
+    getQueryTextArea().type(Cypress.env('modifierKey') + 'a{backspace}', {force: true});
 }
 
 function getQueryArea() {


### PR DESCRIPTION
Made cypress tests pass on Mac (pressing command instead of control key).

Various improvements to the cypress test run script:
- External developers can download GraphDB Free and put the zip in a directory to run the tests
- Downloads from our Nexus will be cached in .downloads
- GraphDB will be extracted in a dynamic temporary directory and will be stopped on exit and the directory deleted
