### PR TITLE
GDB-5261 Refactor workbench tests to be OS independent

### DIFF
--- a/test-cypress/integration/sparql/sparql.menu.spec.js
+++ b/test-cypress/integration/sparql/sparql.menu.spec.js
@@ -868,7 +868,10 @@ describe('SPARQL screen validation', () => {
             // Wait until editor is initialized with the query and then assert the whole query
             getQueryArea().should('contain', 'INSERT DATA');
             cy.fixture('queries/add-statement.txt').then((query) => {
-                verifyQueryAreaEquals(query);
+                // Convert new line symbols to \n regardless of OS. Query in SPARQL editor uses \n for new line.
+                const EOLregex = /(\r\n|\r|\n)/g;
+                const reformattedQuery = query.replace(EOLregex, '\n');
+                verifyQueryAreaEquals(reformattedQuery);
             });
         });
 


### PR DESCRIPTION
Queries in SPARQL editor use `\n` as new line character regardless of OS. When comparing with text from a fixture, it's new line chars must be converted to `\n` only.