### PR TITLE
GDB-5350 RDF resource box does not render correctly

### DIFF
--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -156,7 +156,8 @@ module.exports = {
             },
             {
                 from: 'src/js/angular/core/directives/rdfresourcesearch/templates',
-                to: 'js/angular/core/directives/rdfresourcesearch/templates'
+                to: 'js/angular/core/directives/rdfresourcesearch/templates',
+                transform: replaceVersion
             },
             {
                 from: 'src/js/angular/templates',


### PR DESCRIPTION
The version transformation for the css file was missing from webpack configuration.