### PR TITLE
GDB-5340 Fix usability issues with search RDF box

### DIFF
--- a/src/css/bootstrap-graphdb-theme.css
+++ b/src/css/bootstrap-graphdb-theme.css
@@ -1068,7 +1068,7 @@ h3 [class^=icon-] {
     top: 0;
     right: 2rem;
     font-size: 0.9em;
-    z-index: 1010;
+    z-index: 1015;
     -moz-transition: all 0.1s ease-out; /* FF4+ */
     -o-transition: all 0.1s ease-out; /* Opera 10.5+ */
     -webkit-transition: all 0.1s ease-out; /* Saf3.2+, Chrome */
@@ -2248,7 +2248,7 @@ input.switch:checked ~ label:after {
 }
 
 /*-------------------------------------------------------------
-	Home page view resource
+	Search RDF resource box
 -------------------------------------------------------------*/
 
 #auto-complete-results-wrapper {
@@ -2279,6 +2279,12 @@ input.switch:checked ~ label:after {
 #auto-complete-results-wrapper div p {
     margin-bottom: 0;
     padding: 5px 25px;
+}
+
+#search-resource-box .clear-icon {
+    position: relative;
+    right: 45px;
+    z-index: 10;
 }
 
 /*-------------------------------------------------------------

--- a/src/css/rdf-resource-search.css
+++ b/src/css/rdf-resource-search.css
@@ -28,6 +28,10 @@
   transition: all 0.3s ease-in;
 }
 
+.show-rdf-search-box {
+  top: 40px;
+}
+
 @media (max-width: 768px) {
   .search-rdf-input {
     width: 85vw;

--- a/src/css/rdf-resource-search.css
+++ b/src/css/rdf-resource-search.css
@@ -10,19 +10,32 @@
 }
 
 .search-rdf-input {
+  white-space: nowrap;
   text-align: start;
   font-size: 14px;
   font-weight: 300;
 
-  max-width: 60vw;
-  position: absolute;
-  top: -150px;
-  right: 0;
-  width: 60vw;
+  max-width: 100vw;
+  position: fixed;
+  top: -550px;
+  right: 3em;
   z-index: 1;
   display: block;
   padding-right: 20px;
+  width: 60vw;
 
   -webkit-transition: all 0.3s ease-in; /* Safari */
   transition: all 0.3s ease-in;
+}
+
+@media (max-width: 768px) {
+  .search-rdf-input {
+    width: 85vw;
+  }
+}
+
+@media (max-width: 992px) {
+  .search-rdf-input {
+    width: 75vw;
+  }
 }

--- a/src/js/angular/core/directives/rdfresourcesearch/rdf-resource-search.directive.js
+++ b/src/js/angular/core/directives/rdfresourcesearch/rdf-resource-search.directive.js
@@ -36,26 +36,38 @@ function rdfResourceSearchDirective($rootScope, $timeout,
       $scope.showInput = function () {
         element.find('.search-rdf-btn')
             .addClass('hidden-xs-up');
-        element.find('.search-rdf-input').css('top', '0px');
+        element.find('.search-rdf-input').css('top', '20px');
         $timeout(function () {
           element.find('.close-rdf-search-btn')
               .removeClass('hidden-xs-up');
           element.find('search-resource-input .view-res-input')
               .focus();
+          document.body.addEventListener('mousedown', onDocumentClick);
         }, 200);
       };
 
       $scope.hideInput = function () {
-        element.find('.search-rdf-input').css('top', '-150px');
-        element.find('search-resource-input .view-res-input')[0].value = '';
-        element.find('search-resource-input .view-res-input').change();
+        element.find('.search-rdf-input').css('top', '-550px');
         element.find('.close-rdf-search-btn')
             .addClass('hidden-xs-up');
         $timeout(function () {
           element.find('.search-rdf-btn')
               .removeClass('hidden-xs-up')
               .css('z-index', '3');
+          document.body.removeEventListener('mousedown', onDocumentClick);
         }, 200);
+      };
+
+      function onDocumentClick(event) {
+        if (!(event.target.id === "search-box" || $(event.target).parents("#search-box").length)) {
+          $scope.hideInput();
+        }
+      }
+
+      $scope.onKeyDown = function(event) {
+        if (event.keyCode === 27) {
+          $scope.hideInput();
+        }
       };
     }
   };

--- a/src/js/angular/core/directives/rdfresourcesearch/rdf-resource-search.directive.js
+++ b/src/js/angular/core/directives/rdfresourcesearch/rdf-resource-search.directive.js
@@ -36,31 +36,26 @@ function rdfResourceSearchDirective($rootScope, $timeout,
       $scope.showInput = function () {
         element.find('.search-rdf-btn')
             .addClass('hidden-xs-up');
-        element.find('.search-rdf-input').css('top', '20px');
+        element.find('.search-rdf-input').addClass('show-rdf-search-box');
         $timeout(function () {
-          element.find('.close-rdf-search-btn')
-              .removeClass('hidden-xs-up');
-          element.find('search-resource-input .view-res-input')
-              .focus();
+          element.find('.close-rdf-search-btn').removeClass('hidden-xs-up');
+          element.find('search-resource-input .view-res-input').focus();
           window.addEventListener('mousedown', onWindowClick);
         }, 200);
       };
 
       $scope.hideInput = function () {
-        element.find('.search-rdf-input').css('top', '-550px');
-        element.find('.close-rdf-search-btn')
-            .addClass('hidden-xs-up');
+        element.find('.search-rdf-input').removeClass('show-rdf-search-box');
+        element.find('.close-rdf-search-btn').addClass('hidden-xs-up');
         $timeout(function () {
-          element.find('.search-rdf-btn')
-              .removeClass('hidden-xs-up')
-              .css('z-index', '3');
+          element.find('.search-rdf-btn').removeClass('hidden-xs-up');
           element.blur();
           window.removeEventListener('mousedown', onWindowClick);
         }, 200);
       };
 
       function onWindowClick(event) {
-        if (!(event.target.id === "search-box" || $(event.target).parents("#search-box").length)) {
+        if (!(event.target.id === "search-box" || $(event.target).closest("#search-box").length)) {
           $scope.hideInput();
         }
       }

--- a/src/js/angular/core/directives/rdfresourcesearch/rdf-resource-search.directive.js
+++ b/src/js/angular/core/directives/rdfresourcesearch/rdf-resource-search.directive.js
@@ -42,7 +42,7 @@ function rdfResourceSearchDirective($rootScope, $timeout,
               .removeClass('hidden-xs-up');
           element.find('search-resource-input .view-res-input')
               .focus();
-          document.body.addEventListener('mousedown', onDocumentClick);
+          window.addEventListener('mousedown', onWindowClick);
         }, 200);
       };
 
@@ -54,11 +54,12 @@ function rdfResourceSearchDirective($rootScope, $timeout,
           element.find('.search-rdf-btn')
               .removeClass('hidden-xs-up')
               .css('z-index', '3');
-          document.body.removeEventListener('mousedown', onDocumentClick);
+          element.blur();
+          window.removeEventListener('mousedown', onWindowClick);
         }, 200);
       };
 
-      function onDocumentClick(event) {
+      function onWindowClick(event) {
         if (!(event.target.id === "search-box" || $(event.target).parents("#search-box").length)) {
           $scope.hideInput();
         }

--- a/src/js/angular/core/directives/rdfresourcesearch/templates/rdfResourceSearchTemplate.html
+++ b/src/js/angular/core/directives/rdfresourcesearch/templates/rdfResourceSearchTemplate.html
@@ -1,13 +1,15 @@
 <link href="css/rdf-resource-search.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 
 <div ng-if="getActiveRepository() && !isLoadingLocation() && hasActiveLocation()" ng-cloak>
-    <div class="card search-rdf-input">
+    <div id="search-box" class="card search-rdf-input" ng-keydown="onKeyDown($event)">
         <div class="card-block">
             <search-resource-input namespacespromise="getNamespacesPromise"
-                                   placeholder="Search RDF resources"
                                    autocompletepromisestatus="getAutocompletePromise"
                                    empty="empty"
-                                   open-in-new-tab="true">
+                                   open-in-new-tab="true"
+                                   preserve-search="true"
+                                   radio-buttons="true"
+                                   clear-input-icon="true">
             </search-resource-input>
             <button class="btn btn-link close-rdf-search-btn"
                     tooltip="Close search" tooltip-placement="bottom"

--- a/src/js/angular/core/templates/search-resource-input.html
+++ b/src/js/angular/core/templates/search-resource-input.html
@@ -7,17 +7,21 @@
         <i class="icon-close" aria-hidden="true" ng-click="clearInput()"></i>
     </button>
     <span ng-if="!radioButtons" class="input-group-btn">
-        <button ng-if="textButton !== ''" type="button" class="btn btn-primary autocomplete-text-btn" ng-click="checkIfValidAndSearchText()">{{textButton ? textButton : 'Table'}}</button>
+        <button ng-if="textButton !== ''" type="button" class="btn btn-primary autocomplete-text-btn" ng-click="checkIfValidAndSearchText()">
+            {{textButtonLabel}}
+        </button>
     </span>
     <span ng-if="!radioButtons" class="input-group-btn show-btn">
-        <button ng-if="visualButton !== ''" type="button" class="btn btn-primary autocomplete-visual-btn" ng-click="checkIfValidAndSearchVisual()">{{visualButton ? visualButton : 'Visual'}}</button>
+        <button ng-if="visualButton !== ''" type="button" class="btn btn-primary autocomplete-visual-btn" ng-click="checkIfValidAndSearchVisual()">
+            {{visualButtonLabel}}
+        </button>
     </span>
     <span ng-if="radioButtons" class="input-group-btn">
-        <button class="btn btn-secondary display-type-table-btn" ng-model="searchType" btn-radio="'table'" ng-click="changeSearchType('table')">
-            Table
+        <button class="btn btn-secondary display-type-table-btn" ng-model="searchType" btn-radio="searchDisplayType.table" ng-click="changeSearchType(searchDisplayType.table)">
+            {{textButtonLabel}}
         </button>
-        <button class="btn btn-secondary display-type-visual-btn" ng-model="searchType" btn-radio="'visual'" ng-click="changeSearchType('visual')">
-            Visual
+        <button class="btn btn-secondary display-type-visual-btn" ng-model="searchType" btn-radio="searchDisplayType.visual" ng-click="changeSearchType(searchDisplayType.visual)">
+            {{visualButtonLabel}}
         </button>
     </span>
 </div>

--- a/src/js/angular/core/templates/search-resource-input.html
+++ b/src/js/angular/core/templates/search-resource-input.html
@@ -1,12 +1,24 @@
-<div class="input-group input-group-lg">
+<div id="search-resource-box" class="input-group" ng-class="{'input-group-lg': !radioButtons}" style="white-space: nowrap">
     <input type="text" class="form-control view-res-input" placeholder="{{placeholder}}" ng-model="searchInput"
            ng-change="onChange()"
            ng-keydown="onKeyDown($event)">
-    <span class="input-group-btn">
-        <button ng-if="textButton !== ''" type="button" class="btn btn-primary autocomplete-text-btn" ng-click="checkIfValidAndSearchText()">{{textButton ? textButton : 'Text'}}</button>
+    <button ng-if="clearInputIcon && showClearInputIcon" class="btn btn-link clear-icon"
+          tooltip="Clear" tooltip-placement="bottom" tooltip-trigger="mouseenter">
+        <i class="icon-close" aria-hidden="true" ng-click="clearInput()"></i>
+    </button>
+    <span ng-if="!radioButtons" class="input-group-btn">
+        <button ng-if="textButton !== ''" type="button" class="btn btn-primary autocomplete-text-btn" ng-click="checkIfValidAndSearchText()">{{textButton ? textButton : 'Table'}}</button>
     </span>
-    <span class="input-group-btn show-btn">
+    <span ng-if="!radioButtons" class="input-group-btn show-btn">
         <button ng-if="visualButton !== ''" type="button" class="btn btn-primary autocomplete-visual-btn" ng-click="checkIfValidAndSearchVisual()">{{visualButton ? visualButton : 'Visual'}}</button>
+    </span>
+    <span ng-if="radioButtons" class="input-group-btn">
+        <button class="btn btn-secondary display-type-table-btn" ng-model="searchType" btn-radio="'table'" ng-click="changeSearchType('table')">
+            Table
+        </button>
+        <button class="btn btn-secondary display-type-visual-btn" ng-model="searchType" btn-radio="'visual'" ng-click="changeSearchType('visual')">
+            Visual
+        </button>
     </span>
 </div>
 <div id="auto-complete-results-wrapper">

--- a/src/pages/home.html
+++ b/src/pages/home.html
@@ -35,7 +35,8 @@
                     <search-resource-input
                             namespacespromise="getNamespacesPromise"
                             autocompletepromisestatus="getAutocompletePromise"
-                            empty="empty">
+                            empty="empty"
+                            radio-buttons="true">
                     </search-resource-input>
                 </div>
             </div>

--- a/src/template.html
+++ b/src/template.html
@@ -21,7 +21,6 @@
 
 <div class="status-bar" ng-hide="isSecurityEnabled() && !isUserLoggedIn() && !isFreeAccessEnabled()" ng-cloak>
     <div class="btn-group btn-group-lg" role="group" aria-label="Button group with nested dropdown">
-        <rdf-resource-search class="btn p-0"></rdf-resource-search>
         <div class="btn alert alert-warning no-icon" ng-if="!license.valid && showLicense"
              tooltip="{{license.message}}" tooltip-placement="bottom" tooltip-trigger="mouseenter">
             <span class="icon-warning"></span> No valid license
@@ -49,6 +48,7 @@
                 </a>
             </span>
         </div>
+        <rdf-resource-search class="float-xs-left p-0"></rdf-resource-search>
         <div id="repositorySelectDropdown" class="btn-group" role="group" ng-show="!embedded">
             <button id="btnReposGroup" type="button" class="btn btn-lg btn-secondary dropdown-toggle"
                     data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/test-cypress/integration/home/workbench.home.spec.js
+++ b/test-cypress/integration/home/workbench.home.spec.js
@@ -110,7 +110,7 @@ describe('Home screen validation', () => {
     });
 
     context('"View resource" autocomplete', () => {
-        it.only('Test homepage autocomplete when it is enabled', () => {
+        it('Test homepage autocomplete when it is enabled', () => {
             const repositoryId = HomeSteps.createRepo();
             HomeSteps.selectRepo(repositoryId);
 

--- a/test-cypress/integration/home/workbench.home.spec.js
+++ b/test-cypress/integration/home/workbench.home.spec.js
@@ -85,7 +85,7 @@ describe('Home screen validation', () => {
         it('Test create and select new repository via home page', () => {
             HomeSteps.verifyCreateRepositoryLink();
 
-            let repositoryId = HomeSteps.createRepo();
+            const repositoryId = HomeSteps.createRepo();
             // Initializing the repository to speed up retrieving repository info
             cy.initializeRepository(repositoryId);
 
@@ -97,7 +97,7 @@ describe('Home screen validation', () => {
         });
 
         it('Test saved SPARQL queries links on home page and confirm dialog appearance', () => {
-            let repositoryId = HomeSteps.createRepo();
+            const repositoryId = HomeSteps.createRepo();
             HomeSteps.selectRepo(repositoryId);
 
             HomeSteps.verifyQueryLink('Add statements', true, '/sparql?savedQueryName=Add%20statements&owner=admin&execute');
@@ -110,8 +110,8 @@ describe('Home screen validation', () => {
     });
 
     context('"View resource" autocomplete', () => {
-        it('Test homepage autocomplete when it is enabled', () => {
-            let repositoryId = HomeSteps.createRepo();
+        it.only('Test homepage autocomplete when it is enabled', () => {
+            const repositoryId = HomeSteps.createRepo();
             HomeSteps.selectRepo(repositoryId);
 
             // Type an invalid resource
@@ -122,6 +122,7 @@ describe('Home screen validation', () => {
             cy.enableAutocomplete(repositoryId);
 
             HomeSteps.visitAndWaitLoader().then((el) => el)
+                .then(() => HomeSteps.getAutocompleteDisplayTypeButton('table').click())
                 .then(() => HomeSteps.autocompleteText('Green', GOBLIN_URI))
                 .then(() => HomeSteps.getAutocompleteResultElement(GOBLIN_URI).click());
 
@@ -129,13 +130,8 @@ describe('Home screen validation', () => {
 
             HomeSteps.goBackAndWaitAutocomplete(function () {
                 HomeSteps.autocompleteText('Green', GOBLIN_URI);
-                HomeSteps.getAutocompleteButton('text').click();
-                HomeSteps.verifyAutocompleteResourceLink(GOBLIN_URI);
-            });
-
-            HomeSteps.goBackAndWaitAutocomplete(function () {
-                HomeSteps.autocompleteText('Green', GOBLIN_URI);
-                HomeSteps.getAutocompleteButton('visual').click();
+                HomeSteps.getAutocompleteDisplayTypeButton('visual').click();
+                HomeSteps.getAutocompleteResultElement(GOBLIN_URI).click();
                 cy.url()
                     .should('contain', '/graphs-visualizations?uri=http:%2F%2Fexample.org%2F%23green-goblin');
             });
@@ -144,7 +140,7 @@ describe('Home screen validation', () => {
         });
 
         it('should not suggest resources in "View resources" when autocomplete is not enabled', () => {
-            let repositoryId = HomeSteps.createRepo();
+            const repositoryId = HomeSteps.createRepo();
             cy.importRDFTextSnippet(repositoryId, FOAT_SNIPPET);
 
             HomeSteps.visitAndWaitLoader();
@@ -152,6 +148,8 @@ describe('Home screen validation', () => {
 
             HomeSteps.getAutocompleteInput().type('Green');
             HomeSteps.noAutocompleteToast();
+
+            cy.deleteRepository(repositoryId);
         });
     });
 

--- a/test-cypress/steps/home-steps.js
+++ b/test-cypress/steps/home-steps.js
@@ -123,6 +123,10 @@ class HomeSteps {
         return cy.get('.home-rdf-resource-search search-resource-input .autocomplete-' + type + '-btn');
     }
 
+    static getAutocompleteDisplayTypeButton(type) {
+        return cy.get('.home-rdf-resource-search search-resource-input .display-type-' + type + '-btn');
+    }
+
     static goBackAndWaitAutocomplete(callback) {
         cy.server();
         cy.route('/rest/autocomplete/enabled').as('getAutocompleteStatus');


### PR DESCRIPTION
 - Search box position is now fixed (won't move with status items)
 - Can be closed with 'escape' or click outside
 - Added option to choose search type with radio buttons
 - If using radio buttons, choice is persisted in local storage
 - Changed default 'text' label to 'table'
 - Added option to persist the search (input and suggest) in local store
 - Added clear button to clear input and persisted search data
 - Various css fixes (z-index, width)
 - Fixed issue when prefix is selected, suggests are removed. New search is now initiated, and focus is set on input