### PR TITLE
GDB-5367 Refresh autocomplete status in rdf search box

### DIFF
--- a/src/js/angular/autocomplete/controllers.js
+++ b/src/js/angular/autocomplete/controllers.js
@@ -10,14 +10,15 @@ angular
     .controller('AutocompleteCtrl', AutocompleteCtrl)
     .controller('AddLabelCtrl', AddLabelCtrl);
 
-AutocompleteCtrl.$inject = ['$scope', '$interval', 'toastr', '$repositories', '$modal', '$timeout', 'AutocompleteRestService'];
+AutocompleteCtrl.$inject = ['$scope', '$interval', 'toastr', '$repositories', '$modal', '$timeout', 'AutocompleteRestService', '$autocompleteStatus'];
 
-function AutocompleteCtrl($scope, $interval, toastr, $repositories, $modal, $timeout, AutocompleteRestService) {
+function AutocompleteCtrl($scope, $interval, toastr, $repositories, $modal, $timeout, AutocompleteRestService, $autocompleteStatus) {
 
     const refreshEnabledStatus = function () {
         AutocompleteRestService.checkAutocompleteStatus()
             .success(function (data) {
                 $scope.autocompleteEnabled = data;
+                $autocompleteStatus.setAutocompleteStatus(data);
             }).error(function (data) {
                 toastr.error(getError(data));
             });

--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -11,6 +11,7 @@ import 'angular/core/services/jwt-auth.service';
 import 'angular/core/services/repositories.service';
 import {UserRole} from 'angular/utils/user-utils';
 import 'angular/utils/local-storage-adapter';
+import 'angular/core/services/autocomplete-status.service';
 
 angular
     .module('graphdb.workbench.se.controllers', [
@@ -28,7 +29,8 @@ angular
         'graphdb.framework.rest.autocomplete.service',
         'graphdb.framework.rest.monitoring.service',
         'graphdb.framework.rest.rdf4j.repositories.service',
-        'graphdb.framework.utils.localstorageadapter'
+        'graphdb.framework.utils.localstorageadapter',
+        'graphdb.framework.core.services.autocompleteStatus'
     ])
     .controller('mainCtrl', mainCtrl)
     .controller('homeCtrl', homeCtrl)
@@ -54,13 +56,21 @@ function homeCtrl($scope, $rootScope, $http, $repositories, $jwtAuth, Autocomple
         if ($scope.getActiveRepository()) {
             $scope.getNamespacesPromise = RDF4JRepositoriesRestService.getNamespaces($scope.getActiveRepository())
                 .success(function () {
-                    $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus()
-                        .success(function () {
-                            $scope.getActiveRepositorySize();
-                        });
+                    checkAutocompleteStatus();
                 });
         }
     }
+
+    function checkAutocompleteStatus() {
+        $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus()
+            .success(function () {
+                $scope.getActiveRepositorySize();
+            });
+    }
+
+    $scope.$on('autocompleteStatus', function() {
+        checkAutocompleteStatus();
+    });
 
     // Rather then rely on securityInit we monitory repositoryIsSet which is guaranteed to be called
     // after security was initialized. This way we avoid a race condition when the newly logged in
@@ -82,9 +92,9 @@ function homeCtrl($scope, $rootScope, $http, $repositories, $jwtAuth, Autocomple
     });
 }
 
-mainCtrl.$inject = ['$scope', '$menuItems', '$jwtAuth', '$http', 'toastr', '$location', '$repositories', '$rootScope', 'productInfo', '$timeout', 'ModalService', '$interval', '$filter', 'LicenseRestService', 'RepositoriesRestService', 'MonitoringRestService', 'SparqlRestService', '$sce', 'LocalStorageAdapter', 'LSKeys'];
+mainCtrl.$inject = ['$scope', '$menuItems', '$jwtAuth', '$http', 'toastr', '$location', '$repositories', '$rootScope', 'productInfo', '$timeout', 'ModalService', '$interval', '$filter', 'LicenseRestService', 'RepositoriesRestService', 'MonitoringRestService', 'SparqlRestService', '$sce', 'LocalStorageAdapter', 'LSKeys', '$autocompleteStatus'];
 
-function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repositories, $rootScope, productInfo, $timeout, ModalService, $interval, $filter, LicenseRestService, RepositoriesRestService, MonitoringRestService, SparqlRestService, $sce, LocalStorageAdapter, LSKeys) {
+function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repositories, $rootScope, productInfo, $timeout, ModalService, $interval, $filter, LicenseRestService, RepositoriesRestService, MonitoringRestService, SparqlRestService, $sce, LocalStorageAdapter, LSKeys, $autocompleteStatus) {
     $scope.mainTitle = 'GraphDB';
     $scope.descr = 'An application for searching, exploring and managing GraphDB semantic repositories.';
     $scope.productTypeHuman = '';

--- a/src/js/angular/core/directives.js
+++ b/src/js/angular/core/directives.js
@@ -246,9 +246,9 @@ function multiRequired() {
 
 const SEARCH_DISPLAY_TYPE = {table: 'table', visual: 'visual'};
 
-searchResourceInput.$inject = ['$location', 'toastr', 'ClassInstanceDetailsService', 'AutocompleteRestService', '$rootScope', '$q', '$sce', 'LocalStorageAdapter'];
+searchResourceInput.$inject = ['$location', 'toastr', 'ClassInstanceDetailsService', 'AutocompleteRestService', '$rootScope', '$q', '$sce', 'LocalStorageAdapter', 'LSKeys'];
 
-function searchResourceInput($location, toastr, ClassInstanceDetailsService, AutocompleteRestService, $rootScope, $q, $sce, LocalStorageAdapter) {
+function searchResourceInput($location, toastr, ClassInstanceDetailsService, AutocompleteRestService, $rootScope, $q, $sce, LocalStorageAdapter, LSKeys) {
     return {
         restrict: 'EA',
         scope: {
@@ -284,27 +284,27 @@ function searchResourceInput($location, toastr, ClassInstanceDetailsService, Aut
             let canceler;
 
             $scope.showClearInputIcon = false;
-            $scope.searchType = LocalStorageAdapter.get('rdf-search.search-type') || SEARCH_DISPLAY_TYPE.table;
+            $scope.searchType = LocalStorageAdapter.get(LSKeys.RDF_SEARCH_TYPE) || SEARCH_DISPLAY_TYPE.table;
 
             if (IS_SEARCH_PRESERVED) {
                 $scope.preserveInput = 'true';
-                $scope.searchInput = LocalStorageAdapter.get('rdf-search.search-input') || "";
-                expandedUri = LocalStorageAdapter.get('rdf-search.search-expanded-uri');
+                $scope.searchInput = LocalStorageAdapter.get(LSKeys.RDF_SEARCH_INPUT) || "";
+                expandedUri = LocalStorageAdapter.get(LSKeys.RDF_SEARCH_EXPANDED_URI);
             } else {
                 $scope.searchInput = "";
             }
 
             $scope.changeSearchType = function(type) {
                 $scope.searchType = type;
-                LocalStorageAdapter.set('rdf-search.search-type', $scope.searchType);
+                LocalStorageAdapter.set(LSKeys.RDF_SEARCH_TYPE, $scope.searchType);
             };
 
             $scope.clearInput = function() {
                 $scope.searchInput = '';
                 $scope.autoCompleteUriResults = [];
                 $scope.showClearInputIcon = false;
-                LocalStorageAdapter.remove('rdf-search.search-input');
-                LocalStorageAdapter.remove('rdf-search.search-expanded-uri');
+                LocalStorageAdapter.remove(LSKeys.RDF_SEARCH_INPUT);
+                LocalStorageAdapter.remove(LSKeys.RDF_SEARCH_EXPANDED_URI);
             };
 
             $scope.$watch('namespacespromise', function () {
@@ -429,8 +429,8 @@ function searchResourceInput($location, toastr, ClassInstanceDetailsService, Aut
                     callback({uri: textResource, description: resource.description, label: label, type: resource.type});
 
                     if (IS_SEARCH_PRESERVED) {
-                        LocalStorageAdapter.set('rdf-search.search-expanded-uri', expandedUri);
-                        LocalStorageAdapter.set('rdf-search.search-input', $scope.searchInput);
+                        LocalStorageAdapter.set(LSKeys.RDF_SEARCH_EXPANDED_URI, expandedUri);
+                        LocalStorageAdapter.set(LSKeys.RDF_SEARCH_INPUT, $scope.searchInput);
                     } else if ($scope.preserveInput === 'true') {
                         $scope.searchInput = textResource;
                         $scope.autoCompleteUriResults = [];

--- a/src/js/angular/core/directives/rdfresourcesearch/rdf-resource-search.directive.js
+++ b/src/js/angular/core/directives/rdfresourcesearch/rdf-resource-search.directive.js
@@ -13,13 +13,23 @@ function rdfResourceSearchDirective($rootScope, $timeout,
     templateUrl: 'js/angular/core/directives/rdfresourcesearch/templates/rdfResourceSearchTemplate.html',
     restrict: 'AE',
     link: function ($scope, element) {
+      let autocompleteStatus = false;
 
       function refreshRepositoryInfo() {
         if ($scope.getActiveRepository()) {
           $scope.getNamespacesPromise = RDF4JRepositoriesRestService.getNamespaces(
               $scope.getActiveRepository())
               .success(function () {
-                $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus();
+                checkAutocompleteStatus();
+              });
+        }
+      }
+
+      function checkAutocompleteStatus() {
+        if (!autocompleteStatus) {
+          $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus()
+              .success(function (autocompleteStatusResponse) {
+                autocompleteStatus = autocompleteStatusResponse;
               });
         }
       }

--- a/src/js/angular/core/directives/rdfresourcesearch/rdf-resource-search.directive.js
+++ b/src/js/angular/core/directives/rdfresourcesearch/rdf-resource-search.directive.js
@@ -13,7 +13,6 @@ function rdfResourceSearchDirective($rootScope, $timeout,
     templateUrl: 'js/angular/core/directives/rdfresourcesearch/templates/rdfResourceSearchTemplate.html',
     restrict: 'AE',
     link: function ($scope, element) {
-      let autocompleteStatus = false;
 
       function refreshRepositoryInfo() {
         if ($scope.getActiveRepository()) {
@@ -26,13 +25,12 @@ function rdfResourceSearchDirective($rootScope, $timeout,
       }
 
       function checkAutocompleteStatus() {
-        if (!autocompleteStatus) {
-          $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus()
-              .success(function (autocompleteStatusResponse) {
-                autocompleteStatus = autocompleteStatusResponse;
-              });
-        }
+        $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus();
       }
+
+      $scope.$on('autocompleteStatus', function() {
+        checkAutocompleteStatus();
+      });
 
       // Rather then rely on securityInit we monitory repositoryIsSet which is guaranteed to be called
       // after security was initialized. This way we avoid a race condition when the newly logged in

--- a/src/js/angular/core/services/autocomplete-status.service.js
+++ b/src/js/angular/core/services/autocomplete-status.service.js
@@ -1,0 +1,26 @@
+angular.module('graphdb.framework.core.services.autocompleteStatus', [])
+    .service('$autocompleteStatus', ['$rootScope', 'AutocompleteRestService', 'LocalStorageAdapter', 'LSKeys', autocompleteStatusService]);
+
+function autocompleteStatusService($rootScope, AutocompleteRestService, LocalStorageAdapter, LSKeys) {
+  const that = this;
+
+  this.setAutocompleteStatus = function (status) {
+    LocalStorageAdapter.set(LSKeys.AUTOCOMPLETE_ENABLED, status);
+    $rootScope.$broadcast('autocompleteStatus', status);
+  };
+
+  $rootScope.$watch(function () {
+    return LocalStorageAdapter.get(LSKeys.AUTOCOMPLETE_ENABLED);
+  }, function (value) {
+    that.setAutocompleteStatus(value);
+  }, true);
+
+  function refreshAutocompleteStatus() {
+    AutocompleteRestService.checkAutocompleteStatus()
+        .success(function (autocompleteStatusResponse) {
+          that.setAutocompleteStatus(autocompleteStatusResponse);
+        });
+  }
+
+  $rootScope.$on('repositoryIsSet', refreshAutocompleteStatus);
+}

--- a/src/js/angular/graphexplore/controllers/graphs-config.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-config.controller.js
@@ -140,7 +140,15 @@ function GraphConfigCtrl($scope, $timeout, $location, toastr, $repositories, $mo
             });
         };
 
-        $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus();
+        function checkAutocompleteStatus() {
+            $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus();
+        }
+
+        $scope.$on('autocompleteStatus', function() {
+            checkAutocompleteStatus();
+        });
+
+        checkAutocompleteStatus();
         $scope.getNamespacesPromise = RDF4JRepositoriesRestService.getNamespaces($scope.getActiveRepository());
 
         const validateQueryWithCallback = function (successCallback, query, queryType, params, all, oneOf) {

--- a/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -793,11 +793,19 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, toastr, $ti
                 });
 
                 $scope.getNamespacesPromise = RDF4JRepositoriesRestService.getNamespaces($scope.getActiveRepository());
-                $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus();
+                checkAutocompleteStatus();
             }).error(function (data) {
                 toastr.error(getError(data), 'Cannot get namespaces for repository. View will not work properly!');
             });
     }
+
+    function checkAutocompleteStatus() {
+        $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus();
+    }
+
+    $scope.$on('autocompleteStatus', function() {
+        checkAutocompleteStatus();
+    });
 
     $scope.$on('repositoryIsSet', function (event, args) {
         initForRepository();

--- a/src/js/angular/similarity/controllers/similarity-list.controller.js
+++ b/src/js/angular/similarity/controllers/similarity-list.controller.js
@@ -118,7 +118,7 @@ function SimilarityCtrl($scope, $interval, toastr, $repositories, ModalService, 
             RDF4JRepositoriesRestService.getNamespaces($scope.getActiveRepository())
                 .success(function (data) {
                     $scope.getNamespacesPromise = RDF4JRepositoriesRestService.getNamespaces($scope.getActiveRepository());
-                    $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus();
+                    checkAutocompleteStatus();
                     $scope.usedPrefixes = {};
                     data.results.bindings.forEach(function (e) {
                         $scope.usedPrefixes[e.prefix.value] = e.namespace.value;
@@ -133,6 +133,14 @@ function SimilarityCtrl($scope, $interval, toastr, $repositories, ModalService, 
                     toastr.error(getError(data), 'Cannot get namespaces for repository. View will not work properly;');
                 });
         }
+    });
+
+    function checkAutocompleteStatus() {
+        $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus();
+    }
+
+    $scope.$on('autocompleteStatus', function() {
+        checkAutocompleteStatus();
     });
 
     $scope.loading = false;

--- a/src/js/angular/utils/local-storage-adapter.js
+++ b/src/js/angular/utils/local-storage-adapter.js
@@ -16,7 +16,11 @@ angular
         'TUTORIAL_STATE': 'tutorial-state',
         'MENU_STATE': 'menu-state',
         'HIDE_GRAPH_CONFIG_HELP': 'hide-graph-config-help',
-        'GRAPHS_VIZ': 'graphs-viz'
+        'GRAPHS_VIZ': 'graphs-viz',
+        'AUTOCOMPLETE_ENABLED': 'autocomplete.enabled',
+        'RDF_SEARCH_TYPE': 'rdf-search.search-type',
+        'RDF_SEARCH_INPUT': 'rdf-search.search-input',
+        'RDF_SEARCH_EXPANDED_URI': 'rdf-search.search-expanded-uri'
     });
 
 LocalStorageAdapter.$inject = ['localStorageService', 'LSKeys'];

--- a/test/autocomplete/autocomplete.spec.js
+++ b/test/autocomplete/autocomplete.spec.js
@@ -14,6 +14,11 @@ mocks.service('$repositories', function () {
     this.getDegradedReason = function () {
     };
 });
+mocks.service('$autocompleteStatus', function () {
+        this.setAutocompleteStatus = function (status) {
+            return;
+        };
+    });
 
 describe('Autocomplete', function () {
 
@@ -32,10 +37,11 @@ describe('Autocomplete', function () {
         let $httpBackend;
         let createController;
         let modalInstance;
+        let $autocompleteStatus;
 
         beforeEach(angular.mock.module('Mocks'));
 
-        beforeEach(angular.mock.inject(function (_$rootScope_, _$http_, _$interval_, _toastr_, _$repositories_, _$timeout_, _$controller_, _AutocompleteRestService_, _$httpBackend_, $q) {
+        beforeEach(angular.mock.inject(function (_$rootScope_, _$http_, _$interval_, _toastr_, _$repositories_, _$timeout_, _$controller_, _AutocompleteRestService_, _$httpBackend_, $q, _$autocompleteStatus_) {
             $scope = _$rootScope_.$new();
             $http = _$http_;
             $interval = _$interval_;
@@ -47,6 +53,7 @@ describe('Autocomplete', function () {
             $controller = _$controller_;
             AutocompleteRestService = _AutocompleteRestService_;
             $httpBackend = _$httpBackend_;
+            $autocompleteStatus = _$autocompleteStatus_;
 
             createController = () => $controller('AutocompleteCtrl', {
                 $scope: $scope,
@@ -56,7 +63,8 @@ describe('Autocomplete', function () {
                 $repositories: $repositories,
                 $modal: $modal,
                 $timeout: $timeout,
-                AutocompleteRestService
+                AutocompleteRestService,
+                $autocompleteStatus
             });
 
             createController();


### PR DESCRIPTION
Added a `autocompleteStatus` service which sets the autocomplete enabled status to local storage.
The service also monitors local storage for change (supporting different tabs) and broadcasts the status on change.
Added watchers for all search resource inputs.