### PR TITLE
Branches as string to sonar

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
     stage('Sonar') {
       steps {
         withSonarQubeEnv('SonarCloud') {
-          sh "node sonar-project.js --branch='${env.ghprbSourceBranch}' --target-branch='${env.ghprbTargetBranch}' --pull-request-id='${env.ghprbPullId}'"
+          sh "node sonar-project.js --branch='\"${env.ghprbSourceBranch}\"' --target-branch='\"${env.ghprbTargetBranch}\"' --pull-request-id='${env.ghprbPullId}'"
         }
       }
     }


### PR DESCRIPTION
Send branches as string to sonar cube, as otherwise it throws error when the branch is a number