### PR TITLE
All special characters are considered as "punc" token from YASQUE. 

### DIFF
--- a/src/js/lib/yasqe.bundled.js
+++ b/src/js/lib/yasqe.bundled.js
@@ -29450,9 +29450,7 @@ var getCompleteToken = function(yasqe, token, cur) {
 		ch: token.start
 	});
 	// not start of line, and not whitespace
-	if (
-		prevToken.type != null && prevToken.type != "ws" && token.type != null && token.type != "ws"
-	) {
+	if (prevToken.type != null && prevToken.type != "ws" && prevToken.type != "punc" && token.type != null && token.type != "ws") {
 		token.start = prevToken.start;
 		token.string = prevToken.string + token.string;
 		return getCompleteToken(yasqe, token, {


### PR DESCRIPTION
Added check for "punc" element, when getCompleteToken is taken from Code Mirror.