### PR TITLE
GDB-5974-Add-a-hint-when-attaching-a-location-that-the-user-must-be-a…

### DIFF
--- a/src/js/angular/templates/modal/add-location.html
+++ b/src/js/angular/templates/modal/add-location.html
@@ -27,7 +27,7 @@
                     None
                 </label>
                 &nbsp;
-                <label class="col-form-label" tooltip="Basic authentication with username/password">
+                <label class="col-form-label" tooltip="Basic authentication with username/password. User must be an admin">
                     <input type="radio" name="authType" ng-model="newLocation.authType" value="basic"/>
                     Basic auth
                 </label>


### PR DESCRIPTION
…n-admin

Add a hint showing that the user must be an admin when attaching a remote GraphDB instance