### PR TITLE
GDB-6254 IRIs with hashtag in them aren't properly resolved by $locat…

### DIFF
--- a/src/js/angular/sparql-template/controllers.js
+++ b/src/js/angular/sparql-template/controllers.js
@@ -66,7 +66,8 @@ SparqlTemplateCreateCtrl.$inject = ['$scope', '$location', 'toastr', '$repositor
 
 function SparqlTemplateCreateCtrl($scope, $location, toastr, $repositories, $window, $timeout, SparqlTemplatesRestService, RDF4JRepositoriesRestService, SparqlRestService, UriUtils, ModalService) {
 
-    $scope.templateID = $location.search().templateID || '';
+    const hash = $location.hash() || '';
+    $scope.templateID = ($location.search().templateID || '') + (hash ? (`#${hash}`) : '');
     $scope.title = ($scope.templateID ? 'Edit' : 'Create') + ' SPARQL Template';
     $scope.getNamespaces = getNamespaces;
     $scope.setLoader = setLoader;
@@ -285,7 +286,7 @@ function SparqlTemplateCreateCtrl($scope, $location, toastr, $repositories, $win
             checkIfTemplateExists()
                 .then(() => {
                     if (templateExist) {
-                        let modalMsg = `<div>SPARQL Template <strong>${$scope.currentQuery.templateID}</strong> already exists.</div><br>
+                        const modalMsg = `<div>SPARQL Template <strong>${$scope.currentQuery.templateID}</strong> already exists.</div><br>
                                         <div><span class="icon-2x icon-warning" style="color: #d54a33"/> Do you want to override the template query?</div>`;
                         ModalService.openSimpleModal({
                             title: 'Confirm save',
@@ -298,7 +299,7 @@ function SparqlTemplateCreateCtrl($scope, $location, toastr, $repositories, $win
                     } else {
                         saveNewTemplate();
                     }
-                })
+                });
         } else {
             if (!$scope.currentQuery.isPristine) {
                 SparqlTemplatesRestService.updateSparqlTemplate($scope.currentQuery).success(function () {


### PR DESCRIPTION
…ion.search() method, because hashtags could be found by $location.hash() method. Added check for hashtag on redirection and if such is found is added into IRI.