### PR TITLE
GDB-6345 Copying ES connector results in wrong indexCreateSettings in…

### DIFF
--- a/src/js/angular/externalsync/controllers.js
+++ b/src/js/angular/externalsync/controllers.js
@@ -85,7 +85,7 @@ function mapCreateValuesToUiValues(values, options) {
                 values[option.__name] = toArrayMap(values[option.__name]);
             }
         } else if (option.__type === 'JsonString') {
-            if (values[option.__name]) {
+            if (values[option.__name] && !(values[option.__name] instanceof String) && typeof values[option.__name] !== 'string') {
                 values[option.__name] = angular.toJson(values[option.__name], 2);
             }
         } else {


### PR DESCRIPTION
… some cases

Added guard to check if indexCreateSettings is a string, because if it is a string, the angular.toJson method adds backslashes before the quotes.