### PR TITLE
GDB-6446-Clear-Repository-with-enabled-History-Plugin-should-show-app…

### DIFF
--- a/src/js/angular/export/controllers.js
+++ b/src/js/angular/export/controllers.js
@@ -293,7 +293,12 @@ exportCtrl.controller('ExportCtrl',
                                     $scope.getGraphs();
                                 }, function (err) {
                                     $scope.deleting['*'] = false;
-                                    toastr.error('Failed to clear repository ' + $repositories.getActiveRepository(), err);
+                                    if (err.data && err.data.includes("Clearing all statements in the repository is" +
+                                        " incompatible with collecting history.")) {
+                                        toastr.error(err.data);
+                                    } else {
+                                        toastr.error('Failed to clear repository ' + $repositories.getActiveRepository(), err);
+                                    }
                                 });
                         }, 100);
                     });

--- a/src/js/angular/export/controllers.js
+++ b/src/js/angular/export/controllers.js
@@ -293,8 +293,8 @@ exportCtrl.controller('ExportCtrl',
                                     $scope.getGraphs();
                                 }, function (err) {
                                     $scope.deleting['*'] = false;
-                                    if (err.data && err.data.includes("Clearing all statements in the repository is" +
-                                        " incompatible with collecting history.")) {
+                                    if (typeof err.data == "string" && err.data.indexOf("Clearing all statements in the " +
+                                        "repository is incompatible with collecting history") > -1) {
                                         toastr.error(err.data);
                                     } else {
                                         toastr.error('Failed to clear repository ' + $repositories.getActiveRepository(), err);


### PR DESCRIPTION
…ropriate-error-message-at-the-workbench

Added error message when trying to clear the whole repository through with the use of the Clear Repository button. If the history plugin is enabled and this forbids the deleting of the repo - a message has to occur to guide the user