### PR TITLE
GDB-6402 The visual graph can display non-existent data

### DIFF
--- a/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -2025,9 +2025,9 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
 
         if (newNodes.length === 0) {
             if (isStartNode) {
-                toastr.info('This node has no visible connections. Check your Graph Settings if you expect such.');
+                toastr.info('This node either does not exist or has no visible connections. Check your Graph Settings if you expect such.');
             } else if (linksFound.length === 0) {
-                toastr.info('This node has no other visible connections. Check your Graph Settings if you expect such.');
+                toastr.info('This node either does not exist or has no visible connections. Check your Graph Settings if you expect such.');
             }
 
             graph.addAndMatchLinks(linksFound);


### PR DESCRIPTION
Visual graph visualizes all valid IRIs by design, no matter if they are actually existing in the repository.  If they are not existing, then a pop-up message shows. The message is now changed to:
This node either does not exist or has no visible connections. Check your Graph Settings if you expect such. Thus it is more descriptive.