### PR TITLE
GDB-6990 Fix cluster legend text being cut

### DIFF
--- a/src/css/clustermanagement.css
+++ b/src/css/clustermanagement.css
@@ -83,12 +83,16 @@ path.link {
   color: black;
 }
 
+.legend-group .label-wrapper {
+  overflow: visible;
+}
+
 .toggle-legend-btn {
   position: absolute;
   bottom: 0;
 }
 
-#legend-nodes-group.hidden {
+.legend-group.hidden {
   visibility: hidden;
 }
 

--- a/src/js/angular/clustermanagement/cluster-drawing.service.js
+++ b/src/js/angular/clustermanagement/cluster-drawing.service.js
@@ -96,6 +96,7 @@ function addHostnameToNodes(nodeElements, nodeRadius, isLegend) {
             .attr('x', -nodeRadius)
             .attr('width', nodeRadius * 2)
             .attr('height', 10)
+            .attr('class', 'label-wrapper')
             .append('xhtml:div')
             .attr('class', 'id id-host');
     } else {

--- a/src/js/angular/clustermanagement/directives.js
+++ b/src/js/angular/clustermanagement/directives.js
@@ -100,7 +100,7 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
                     if (legendNodesGroup) {
                         legendNodesGroup.remove();
                     }
-                    legendNodesGroup = svg.append('g').attr('id', 'legend-nodes-group').classed('hidden', !scope.showLegend);
+                    createLegendGroup();
                     createClusterLegend();
                 }
 
@@ -136,7 +136,13 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
 
                     linksGroup = svg.append('g').attr('id', 'links-group');
                     nodesGroup = svg.append('g').attr('id', 'nodes-group');
-                    legendNodesGroup = svg.append('g').attr('id', 'legend-nodes-group').classed('hidden', !scope.showLegend);
+                    createLegendGroup();
+                }
+
+                function createLegendGroup() {
+                    legendNodesGroup = svg.append('g').attr('id', 'legend-group')
+                        .classed('hidden', !scope.showLegend)
+                        .classed('legend-group', true);
                 }
 
                 let tooltipElement;
@@ -265,6 +271,7 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
                             .attr('x', 5)
                             .attr('width', linkWidth - 10)
                             .attr('height', 10)
+                            .attr('class', 'label-wrapper')
                             .append('xhtml:div')
                             .attr('class', 'id id-host')
                             .style("font-size", "9px")


### PR DESCRIPTION
 - since the labels are inside an foreignObject with set height, it would not show overflowing text
 - set overflow to visible for foreign objects inside legend