### PR TITLE
GDB-7021 Fix add remove locations needing page refresh

### DIFF
--- a/src/js/angular/repositories/controllers.js
+++ b/src/js/angular/repositories/controllers.js
@@ -154,7 +154,7 @@ function LocationsAndRepositoriesCtrl($scope, $modal, toastr, $repositories, Mod
 
     //Get locations
     function getLocations() {
-        $repositories.getLocations()
+        return $repositories.getLocations()
             .then((locations) => {
                 $scope.locations = locations;
             })

--- a/src/js/angular/repositories/controllers.js
+++ b/src/js/angular/repositories/controllers.js
@@ -153,11 +153,13 @@ function LocationsAndRepositoriesCtrl($scope, $modal, toastr, $repositories, Mod
     };
 
     //Get locations
-    $repositories.getLocations()
-        .then((locations) => {
-            $scope.locations = locations;
-        })
-        .finally(() => $scope.loader = false);
+    function getLocations() {
+        $repositories.getLocations()
+            .then((locations) => {
+                $scope.locations = locations;
+            })
+            .finally(() => $scope.loader = false);
+    }
 
     $scope.hasActiveLocation = function () {
         return $repositories.hasActiveLocation();
@@ -192,7 +194,7 @@ function LocationsAndRepositoriesCtrl($scope, $modal, toastr, $repositories, Mod
         }).result
             .then(function () {
                 $scope.loader = true;
-                $repositories.deleteLocation(uri).finally(() => $scope.loader = false);
+                $repositories.deleteLocation(uri).finally(() => getLocations());
             });
     };
 
@@ -201,8 +203,7 @@ function LocationsAndRepositoriesCtrl($scope, $modal, toastr, $repositories, Mod
     $scope.addLocationHttp = function (dataAddLocation) {
         $scope.loader = true;
         LocationsRestService.addLocation(dataAddLocation)
-            .success(function (data) {
-                $scope.locations = data;
+            .success(function () {
                 //Reload locations and repositories
                 $repositories.init();
             })
@@ -210,7 +211,7 @@ function LocationsAndRepositoriesCtrl($scope, $modal, toastr, $repositories, Mod
                 const msg = getError(data);
                 toastr.error(msg, $translate.instant('common.error'));
             })
-            .finally(() => $scope.loader = false);
+            .finally(() => getLocations());
     };
 
     $scope.addLocation = function () {
@@ -228,8 +229,7 @@ function LocationsAndRepositoriesCtrl($scope, $modal, toastr, $repositories, Mod
     $scope.editLocationHttp = function (dataEditLocation) {
         $scope.loader = true;
         LocationsRestService.editLocation(dataEditLocation)
-            .success(function (data) {
-                $scope.locations = data;
+            .success(function () {
                 //Reload locations and repositories
                 $repositories.init();
             })
@@ -237,7 +237,7 @@ function LocationsAndRepositoriesCtrl($scope, $modal, toastr, $repositories, Mod
                 const msg = getError(data);
                 toastr.error(msg, $translate.instant('common.error'));
             })
-            .finally(() => $scope.loader = false);
+            .finally(() => getLocations());
     };
 
     $scope.editLocation = function (location) {
@@ -284,7 +284,7 @@ function LocationsAndRepositoriesCtrl($scope, $modal, toastr, $repositories, Mod
         }).result
             .then(function () {
                 $scope.loader = true;
-                $repositories.restartRepository(repository).finally(() => $scope.loader = false);
+                $repositories.restartRepository(repository).finally(() => getLocations());
             });
     };
 
@@ -358,9 +358,11 @@ function LocationsAndRepositoriesCtrl($scope, $modal, toastr, $repositories, Mod
         });
     };
 
+    getLocations();
     const timer = $interval(function () {
         // Update repositories state
         $repositories.initQuick();
+        getLocations();
     }, 5000);
 
     $scope.$on('$destroy', function () {

--- a/test/repositories/controllers.spec.js
+++ b/test/repositories/controllers.spec.js
@@ -101,6 +101,7 @@ describe('==> Repository module controllers tests', function () {
                     test = true
                 };
                 $httpBackend.expectPUT('rest/locations', {}).respond(200, {locations: ['some new location']});
+                $httpBackend.expectGET('rest/locations').respond(200, {locations: ['some new location']});
                 $scope.editLocationHttp({});
                 $httpBackend.flush();
                 expect($scope.locations).toEqual({locations: ['some new location']});
@@ -110,7 +111,6 @@ describe('==> Repository module controllers tests', function () {
 
         describe('$scope.deleteLocation()', function () {
             it('should call $repositories.deleteLocation on modal confirm', function () {
-                $httpBackend.flush();
                 var deleteLocation = '';
                 $repositories.deleteLocation = function (uri) {
                     const deferred = $q.defer();
@@ -119,6 +119,7 @@ describe('==> Repository module controllers tests', function () {
                 };
                 $scope.deleteLocation('uri');
                 modalInstance.close();
+                $httpBackend.flush();
                 expect(deleteLocation).toEqual('uri');
             })
         });


### PR DESCRIPTION
 - when adding/removing locations they are not refetched/reloaded
 - added locations reload in timer function
 - added locations reload to add/remove actions
 - the locations are reloaded in the service only when there is change
 - amended tests to expect another request for locations