### PR TITLE
GDB-7011 Fix SPARQL editor error message not showing on hover

### DIFF
--- a/src/js/angular/core/directives/queryeditor/query-editor.directive.js
+++ b/src/js/angular/core/directives/queryeditor/query-editor.directive.js
@@ -149,6 +149,10 @@ function queryEditorDirective($timeout, $location, toastr, $repositories, Sparql
             toastr.error('Cannot execute autocomplete query. ' + getError(data));
         };
 
+        window.editor.on("update", function () {
+            angular.element('.parseErrorIcon').parent().css('z-index', '10');
+        });
+
         window.editor.on("changes", function () {
             angular.element('.CodeMirror-linenumbers').css('width', '1px');
             angular.element('.CodeMirror-sizer').css('margin-left', '0px');


### PR DESCRIPTION
 - the Code Mirror gutter that holds the error icon is below the wrap lines gutter and this prevents the error message to show on icon hover
 - hooked to CM update event and set the error icon gutter z-index to 10, so it is above other gutters