### PR TITLE
GDB-7061 Fix failing cypress tests in repositories spec

### DIFF
--- a/src/js/angular/core/directives/languageselector/language-selector.directive.js
+++ b/src/js/angular/core/directives/languageselector/language-selector.directive.js
@@ -40,6 +40,9 @@ function languageSelector($translate, LocalStorageAdapter, LSKeys, $languageServ
             };
 
             $scope.getLanguageTooltip = function (lang) {
+                if (!lang || !$scope.selectedLang) {
+                    return '';
+                }
                 if ($scope.selectedLang.key !== lang.key) {
                     return $translate.instant('change.language.tooltip', {}, undefined, lang.key) + ' ' + lang.name;
                 } else {

--- a/src/js/angular/core/services/repositories.service.js
+++ b/src/js/angular/core/services/repositories.service.js
@@ -136,12 +136,12 @@ repositories.service('$repositories', ['$http', 'toastr', '$rootScope', '$timeou
             if (!quick) {
                 this.locationsShouldReload = true;
             }
-            LocationsRestService.getActiveLocation().then(
+            return LocationsRestService.getActiveLocation().then(
                 function (res) {
                     if (res.data) {
                         const location = res.data;
                         if (location.active) {
-                            RepositoriesRestService.getRepositories().then(function (result) {
+                            return RepositoriesRestService.getRepositories().then(function (result) {
                                     that.location = location;
                                     Object.entries(result.data).forEach(([key, value]) => {
                                         that.clearLocationErrorMsg(key);
@@ -156,7 +156,7 @@ repositories.service('$repositories', ['$http', 'toastr', '$rootScope', '$timeou
                                     if (successCallback) {
                                         successCallback();
                                     }
-                                },
+                                }).catch(
                                 function (err) {
                                     loadingDone(err);
                                     if (errorCallback) {
@@ -176,7 +176,7 @@ repositories.service('$repositories', ['$http', 'toastr', '$rootScope', '$timeou
                     }
                     $rootScope.globalLocation = that.location;
                     $rootScope.globalRepositories = that.getRepositories();
-                },
+                }).catch(
                 function (err) {
                     loadingDone(err);
                     if (errorCallback) {
@@ -187,15 +187,14 @@ repositories.service('$repositories', ['$http', 'toastr', '$rootScope', '$timeou
 
         let locationsRequestPromise;
 
-        this.getLocations = function () {
-            if (that.locationsShouldReload) {
+        this.getLocations = function (abortRequestPromise) {
+            if (this.locationsShouldReload || locationsRequestPromise) {
                 if (!locationsRequestPromise) {
                     this.locationsShouldReload = false;
                     this.locations = [this.location];
-                    const that = this;
-                    locationsRequestPromise = LocationsRestService.getLocations()
+                    locationsRequestPromise = LocationsRestService.getLocations(abortRequestPromise)
                         .then((data) => {
-                            this.locations = data.data;
+                            that.locations = data.data;
                             return this.locations;
                         })
                         .catch(function () {
@@ -212,14 +211,9 @@ repositories.service('$repositories', ['$http', 'toastr', '$rootScope', '$timeou
                 return locationsRequestPromise;
             }
 
-            // if request is in progress, return its promise, else return a promise and resolve it with locations
-            if (locationsRequestPromise) {
-                return locationsRequestPromise;
-            } else {
-                const deferred = $q.defer();
-                deferred.resolve(this.locations);
-                return deferred.promise;
-            }
+            const deferred = $q.defer();
+            deferred.resolve(this.locations);
+            return deferred.promise;
         };
 
 

--- a/src/js/angular/rest/locations.rest.service.js
+++ b/src/js/angular/rest/locations.rest.service.js
@@ -20,8 +20,8 @@ function LocationsRestService($http) {
         getLocationRpcAddress
     };
 
-    function getLocations() {
-        return $http.get(LOCATIONS_ENDPOINT);
+    function getLocations(abortRequestPromise) {
+        return $http.get(LOCATIONS_ENDPOINT, {timeout: abortRequestPromise ? abortRequestPromise.promise : null});
     }
 
     function addLocation(data) {

--- a/test-cypress/integration/repository/repositories.spec.js
+++ b/test-cypress/integration/repository/repositories.spec.js
@@ -41,8 +41,11 @@ describe('Repositories', () => {
 
     beforeEach(() => {
         repositoryId = 'repo-' + Date.now();
+        cy.intercept('/rest/locations').as('getLocations');
 
         cy.visit('/repository');
+        waitLoader();
+        cy.wait('@getLocations');
         cy.window();
 
         waitUntilRepositoriesPageIsLoaded();
@@ -166,7 +169,7 @@ describe('Repositories', () => {
             .and('contain', 'Repository ID cannot be empty');
     });
 
-    it.skip('should allow creation of repositories with custom settings', () => {
+    it('should allow creation of repositories with custom settings', () => {
         const repoTitle = 'Repo title for ' + repositoryId;
 
         createRepository();
@@ -214,7 +217,7 @@ describe('Repositories', () => {
         getRepositoryContextIndexCheckbox().should('be.checked');
     });
 
-    it.skip('should allow to switch between repositories', () => {
+    it('should allow to switch between repositories', () => {
         const secondRepoId = 'second-repo-' + Date.now();
         createRepository();
         chooseRepositoryType(GDB_REPOSITORY_TYPE);
@@ -222,6 +225,7 @@ describe('Repositories', () => {
 
         typeRepositoryId(repositoryId);
         saveRepository();
+        cy.wait('@getLocations');
 
         createRepository();
         chooseRepositoryType(GDB_REPOSITORY_TYPE);
@@ -275,6 +279,7 @@ describe('Repositories', () => {
         // The currently selected repository is kept in local storage
         cy.visit('/repository');
         cy.window();
+
         // Should automatically select the default repository
         getRepositoriesDropdown()
             .find('.active-repository')
@@ -286,7 +291,7 @@ describe('Repositories', () => {
             });
     });
 
-    it.skip('should allow to edit existing repository', () => {
+    it('should allow to edit existing repository', () => {
         const newTitle = 'Title edit';
 
         createRepository();
@@ -296,7 +301,7 @@ describe('Repositories', () => {
         typeRepositoryId(repositoryId);
         typeRepositoryTitle('Title');
         saveRepository();
-
+        cy.wait('@getLocations');
         editRepository(repositoryId);
 
         // Some fields should be disabled
@@ -312,7 +317,7 @@ describe('Repositories', () => {
                 confirmModal();
                 waitLoader();
             });
-
+        cy.wait('@getLocations');
         // See the title is rendered in the repositories list
         getRepositoryFromList(repositoryId).should('contain', newTitle);
 
@@ -323,14 +328,14 @@ describe('Repositories', () => {
         getRepositoryContextIndexCheckbox().should('be.checked');
     });
 
-    it.skip('should allow to delete existing repository', () => {
+    it('should allow to delete existing repository', () => {
         createRepository();
         chooseRepositoryType(GDB_REPOSITORY_TYPE);
         cy.url().should('include', '/repository/create/');
 
         typeRepositoryId(repositoryId);
         saveRepository();
-
+        cy.wait('@getLocations');
         selectRepoFromDropdown(repositoryId);
 
         getRepositoryFromList(repositoryId)
@@ -607,7 +612,7 @@ describe('Repositories', () => {
         compareDriverDownloadUrl('https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads');
     });
 
-    it.skip('should restart an existing repository', () => {
+    it('should restart an existing repository', () => {
 
         createRepository();
         chooseRepositoryType(GDB_REPOSITORY_TYPE);
@@ -673,7 +678,7 @@ describe('Repositories', () => {
         assertRepositoryStatus(repositoryId, "RUNNING");
     });
 
-    it.skip('should create SHACL repo and test shapes validation', () => {
+    it('should create SHACL repo and test shapes validation', () => {
         //Prepare repository by enabling SHACL
         createRepository();
         chooseRepositoryType(GDB_REPOSITORY_TYPE);

--- a/test-cypress/package.json
+++ b/test-cypress/package.json
@@ -24,6 +24,7 @@
         "cypress": "^7.3.0",
         "cypress-failed-log": "^2.5.1",
         "cypress-localstorage-commands": "^1.4.4",
+        "cypress-terminal-report": "^4.0.1",
         "cypress-wait-until": "^1.7.1"
     },
     "bin": {

--- a/test-cypress/plugins/index.js
+++ b/test-cypress/plugins/index.js
@@ -17,4 +17,13 @@ module.exports = (on, config) => {
     on('task', {
         failed: require('cypress-failed-log/src/failed')()
     });
+
+    require('cypress-terminal-report/src/installLogsPrinter')(on, {
+        logToFilesOnAfterRun: true,
+        printLogsToConsole: 'onFail',
+        outputRoot: config.projectRoot + '/logs/',
+        outputTarget: {
+            'cypress-logs|txt': 'txt'
+        }
+    });
 };

--- a/test-cypress/support/index.js
+++ b/test-cypress/support/index.js
@@ -24,3 +24,5 @@ import './commands';
 Cypress.env('modifierKey', Cypress.platform === 'darwin' ? '{cmd}' : '{ctrl}');
 
 require('cypress-failed-log');
+require('cypress-terminal-report/src/installLogsCollector')();
+

--- a/test/repositories/controllers.spec.js
+++ b/test/repositories/controllers.spec.js
@@ -188,14 +188,15 @@ describe('==> Repository module controllers tests', function () {
             let toastr;
             let createController;
             let $translate;
+            let $q;
 
-            beforeEach(angular.mock.inject(function (_toastr_, _$repositories_, _$httpBackend_, _$controller_, $rootScope, _$translate_) {
+            beforeEach(angular.mock.inject(function (_toastr_, _$repositories_, _$httpBackend_, _$controller_, $rootScope, _$translate_, _$q_) {
                 toastr = _toastr_;
                 $repositories = _$repositories_;
                 $httpBackend = _$httpBackend_;
                 $controller = _$controller_;
                 $translate = _$translate_;
-
+                $q = _$q_;
                 $translate.instant = function (key) {
                     return bundle[key];
                 };
@@ -282,9 +283,11 @@ describe('==> Repository module controllers tests', function () {
                 $scope.repositoryInfo = {};
                 $httpBackend.expectPOST('rest/repositories', {}).respond(200, '');
                 var init = false;
-                $repositories.init = function (callback) {
+                $repositories.init = function () {
                     init = true;
-                    callback();
+                    const deferred = $q.defer();
+                    deferred.resolve();
+                    return deferred.promise;
                 };
                 $scope.createRepoHttp();
                 $httpBackend.flush();
@@ -365,13 +368,15 @@ describe('==> Repository module controllers tests', function () {
             repositoriesMock = {
                 hasActiveLocation: function () {
                     return false;
-                }, init: function (callback) {
+                }, init: function () {
                     init = true;
-                    callback();
+                    const deferred = $q.defer();
+                    deferred.resolve();
+                    return deferred.promise;
                 },
                 getLocations: function () {
                     const deferred = $q.defer();
-                    deferred.resolve([{uri: '', local: true}]);
+                    deferred.resolve([{uri: '', label: 'Local', local: true}]);
                     return deferred.promise;
                 }
             };


### PR DESCRIPTION
 - the problem is that when navigating away from a page, the currently running requests are forcefully aborted, but the http client promises remain unresolved/unrejected
 - passed a timeout promise to the locations request which is resolved on repositories' page destroy handler, which causes the request to fail and reject the promises
 - also added cypress-terminal-report and configured it to also log the console on failed tests
 - also fixed a problem with a NPE in the language selector directive which became clear after adding the report plugin