### PR TITLE
GDB-7145 Fix login form not showing after login expired

### DIFF
--- a/src/js/angular/core/services/jwt-auth.service.js
+++ b/src/js/angular/core/services/jwt-auth.service.js
@@ -123,12 +123,11 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                 });
             };
 
-            let securityConfigRequestPromise;
             this.initSecurity = function () {
                 this.securityInitialized = false;
                 this.auth = localStorage.getItem(this.authStorageName);
 
-                securityConfigRequestPromise = SecurityRestService.getSecurityConfig().then(function (res) {
+                SecurityRestService.getSecurityConfig().then(function (res) {
                     that.securityEnabled = res.data.enabled;
                     that.externalAuth = res.data.hasExternalAuth;
                     that.authImplementation = res.data.authImplementation;
@@ -198,12 +197,16 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                             });
                         }
                     }
-                })
-                    .finally(() => securityConfigRequestPromise = null);
+                });
             };
 
             this.initSecurity();
 
+            this.reinitializeSecurity = function () {
+                if (!this.securityInitialized) {
+                    this.initSecurity();
+                }
+            };
 
             this.isSecurityEnabled = function () {
                 return this.securityEnabled;

--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -109,6 +109,9 @@ securityCtrl.controller('LoginCtrl', ['$scope', '$http', 'toastr', '$jwtAuth', '
         $scope.username = '';
         $scope.password = '';
 
+        // Reinitialize security settings, if failed for some reason
+        $jwtAuth.reinitializeSecurity();
+
         $scope.loginWithOpenID = function() {
             $jwtAuth.loginOpenID();
         };


### PR DESCRIPTION
## What?
The login form is not shown after the login expires.

## Why?
When the login has expired and you load the root of the workbench, the unauthorized interceptor is activated and redirects to /login. This redirect causes an important request to be canceled. The request to /rest/security/all is responsible for setting up security parameters on the workbench. Without those parameters the form is not shown.

## How?
Added a new function to jwtAuth service which checks if the security is initialized and if not, it triggers initialization. Added a call to this new function in the LoginCtrl.