### PR TITLE
GDB-7146 Fix showing wrong user when login

### DIFF
--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -407,12 +407,14 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         $repositories.setRepository(repository);
     };
 
-    // Using $q.when to proper set values in view
-    $q.when($jwtAuth.getPrincipal())
-        .then((principal) => {
-            $scope.principal = principal;
-            $scope.isIgnoreSharedQueries = principal && principal.appSettings.IGNORE_SHARED_QUERIES;
-        });
+    function setPrincipal() {
+        // Using $q.when to proper set values in view
+        $q.when($jwtAuth.getPrincipal())
+            .then((principal) => {
+                $scope.principal = principal;
+                $scope.isIgnoreSharedQueries = principal && principal.appSettings.IGNORE_SHARED_QUERIES;
+            });
+    }
 
     $scope.logout = function () {
         $jwtAuth.clearAuthentication();
@@ -787,6 +789,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
                 $rootScope.redirectToLogin();
             }
         } else {
+            setPrincipal();
             $licenseService.checkLicenseStatus();
             $scope.getSavedQueries();
         }


### PR DESCRIPTION
## What?
When you switch users in the workbench, the username in the status bar is not changed until refresh.

## Why?
The problem is that for the status bar, the security principal is fetched only once and cached, thus showing the same user when switching without closing the tab.

## How?
Wrapped fetching of the security principal in a function which is now called on every `securityInit` event trigger. This event is emitted on security initialization which might change the principal.