### PR TITLE
GDB-7168-WB Download data not working for certain queries

### DIFF
--- a/src/pages/sparql.html
+++ b/src/pages/sparql.html
@@ -46,7 +46,7 @@
             ng-keyup="saveQueryToLocal(currentQuery)"
             nocount="{{skipCountQuery}}">
     </query-editor>
-    <form id="wb-download" method="POST" action="" target="_self">
+    <form id="wb-download" method="GET" action="" target="_self">
         <input id="wb-download-query" name="query" type="hidden"/>
         <input id="wb-download-infer" name="infer" type="hidden"/>
         <input id="wb-download-sameAs" name="sameAs" type="hidden"/>


### PR DESCRIPTION
GDB-7168-WB Download data not working for certain queries - changed POST request method to GET in the download form.