### PR TITLE
GDB-7185 Use the same binding for the inference select, set inference…

### DIFF
--- a/src/js/angular/explore/controllers.js
+++ b/src/js/angular/explore/controllers.js
@@ -24,6 +24,8 @@ angular
 ExploreCtrl.$inject = ['$scope', '$http', '$location', 'toastr', '$routeParams', '$repositories', 'ClassInstanceDetailsService', 'ModalService', 'RDF4JRepositoriesRestService', 'FileTypes', '$jwtAuth', '$translate', '$languageService', '$q'];
 
 function ExploreCtrl($scope, $http, $location, toastr, $routeParams, $repositories, ClassInstanceDetailsService, ModalService, RDF4JRepositoriesRestService, FileTypes, $jwtAuth, $translate, $languageService, $q) {
+    // Defaults
+    $scope.role = $location.search().role ? $location.search().role : 'subject';
 
     let principalRequestPromise;
     // We need to get sameAs and inference for the current user
@@ -31,7 +33,7 @@ function ExploreCtrl($scope, $http, $location, toastr, $routeParams, $repositori
     $q.when($jwtAuth.getPrincipal())
         .then((principal) => {
             // Get the predefined settings for sameAs and inference per user
-            $scope.inference = principal.appSettings['DEFAULT_INFERENCE'] ? 'all' : 'explicit';
+            $scope.inference = principal.appSettings['DEFAULT_INFERENCE'] && !$scope.role === 'context' ? 'all' : 'explicit';
             $scope.sameAs = principal.appSettings['DEFAULT_INFERENCE'] && principal.appSettings['DEFAULT_SAMEAS'];
         });
 
@@ -59,10 +61,6 @@ function ExploreCtrl($scope, $http, $location, toastr, $routeParams, $repositori
         return localNames;
     };
 
-    // Defaults
-    $scope.role = $location.search().role ? $location.search().role : 'subject';
-    // Fixed inference when we're showing the context tab and a named graph
-    $scope.inferenceNamed = 'explicit';
     $scope.inferences = [
         {id: 'all', title: 'explore.explicit.implicit'},
         {id: 'explicit', title: 'explore.explicit'},
@@ -262,6 +260,9 @@ function ExploreCtrl($scope, $http, $location, toastr, $routeParams, $repositori
 
     $scope.changeRole = function (roleVar) {
         $scope.role = roleVar;
+        if ($scope.role === 'context') {
+            $scope.inference = 'explicit';
+        }
         $scope.exploreResource();
     };
 

--- a/src/pages/explore.html
+++ b/src/pages/explore.html
@@ -45,13 +45,9 @@
     <div class="pull-right">
 
         <label for="inference-select" class="mb-0">
-            <select ng-if="!loading && role !== 'context' && getActiveRepository() !== 'SYSTEM'" id="inference-select"
+            <select id="inference-select"
                     ng-options="inf.id as inf.title | translate for inf in inferences" ng-model="inference"
-                    ng-change="changeInference(inference)" class="form-control form-control-sm"></select>
-            <select ng-if="loading || role === 'context' || getActiveRepository() === 'SYSTEM'" id="inference-select"
-                    ng-options="inf.id as inf.title | translate for inf in inferences" ng-model="inferenceNamed"
-                    class="form-control form-control-sm" disabled>
-            </select>
+                    ng-change="changeInference(inference)" class="form-control form-control-sm" ng-disabled="loading || role === 'context' || getActiveRepository() === 'SYSTEM'"></select>
         </label>
 
         <button type="button" class="btn btn-link" ng-model="sameAs"


### PR DESCRIPTION
Use the same binding for the inference select, set inference to explicit always when role is context. Fixes right inference value being sent when loading resources for a context.