### PR TITLE
GDB-7271:Implement guide services

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
         "lodash": "^4.17.21",
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
-        "oclazyload": "^1.1.0"
+        "oclazyload": "^1.1.0",
+        "shepherd.js": "^10.0.1"
     },
     "resolutions": {
         "minimist": "^1.2.5"

--- a/src/css/shepherd-custom.css
+++ b/src/css/shepherd-custom.css
@@ -1,0 +1,22 @@
+.btn-primary.shepherd-button:hover {
+    background-color: #d0460d;
+}
+
+.btn-primary.shepherd-button[disabled]{
+    opacity: 0.5;
+}
+
+.btn-secondary.shepherd-button:hover {
+    background-color: #dcdcdc;
+    color: #003663;
+}
+
+.guide-dialog.shepherd-element {
+    margin: 12px !important;
+}
+
+.shepherd-text {
+    text-align: center;
+    min-height: 60px;
+    margin-top: 10px;
+}

--- a/src/js/angular/guides/directives.js
+++ b/src/js/angular/guides/directives.js
@@ -1,0 +1,9 @@
+/**
+ * Used from guide functionality for easy selection of elements where popover dialog will be appear.
+ * Example of usage:
+ * <a href="" guide-selector="some-unique-string">
+ *     ...
+ * </a>
+ * Usage of directive will keep guide safety if someone change link from example to be button or something else, the guide will continue to working.
+ */
+angular.module('graphdb.framework.guides.directives', []).directive('guideSelector', function() {return {}});

--- a/src/js/angular/guides/guide-utils.js
+++ b/src/js/angular/guides/guide-utils.js
@@ -1,0 +1,57 @@
+const GuideUtils = (function () {
+
+    const clickOnElement = function (elementSelector) {
+        return () => waitFor(elementSelector)
+            .then(element => {
+                element.click();
+            }).catch(() => {
+                // nothing to do element is not visible or clickable
+            });
+    }
+
+    /**
+     * Waits element to be present.
+     * @param selector - selector of element looking for.
+     * @param timeoutInSeconds - max time to waite in second. Default value is 1 second.
+     * @returns {Promise}
+     */
+    const waitFor = function (selector, timeoutInSeconds) {
+        return new Promise(function (resolve, reject) {
+            let iteration = timeoutInSeconds * 1000 | 1000;
+            const waitTime = 100;
+            const elementExist = setInterval(() => {
+                try {
+                    let element = document.querySelector(selector);
+                    if (element != null) {
+                        clearInterval(elementExist);
+                        if (angular.element(element).is(':visible')) {
+                            resolve(element);
+                        } else {
+                            console.log('Element is not visible: ' + selector);
+                            reject();
+                        }
+                    } else {
+                        iteration -= waitTime;
+                        if (iteration < 0) {
+                            clearInterval(elementExist);
+                            console.log('Element is not found: ' + selector);
+                        }
+                    }
+                } catch (error) {
+                    clearInterval(elementExist);
+                    console.log('Error when processing selector: ' + selector);
+                    console.log(error);
+                    reject();
+                }
+            }, waitTime);
+        });
+    };
+    return {
+        waitFor,
+        clickOnElement
+    };
+})();
+
+export {
+    GuideUtils
+};

--- a/src/js/angular/guides/guides.service.js
+++ b/src/js/angular/guides/guides.service.js
@@ -1,0 +1,452 @@
+import 'angular/utils/local-storage-adapter';
+import 'angular/guides/tour-lib-services/shepherd.service';
+import {GuideUtils} from "./guide-utils";
+
+const modules = [
+    'graphdb.framework.guides.shepherd.services'
+];
+
+angular
+    .module('graphdb.framework.guides.services', modules)
+    .service('GuidesService', GuidesService);
+
+
+GuidesService.$inject = ['$http', '$rootScope', '$translate', 'ShepherdService'];
+
+/**
+ * Service for interaction with guide functionality. A guide is described as sequence of steps.
+ * A step can have one or more other steps. Everyone step is implemented as plugin with name 'guide.step'.
+ * There is two kind of steps:
+ * <ul>
+ *     <li>Core steps</li>
+ *     <li>Complex step</li>
+ * </ul>
+ *
+ * A core step is smallest step which describes a interaction with Workbench. For example the step "Click on button Import from main menu".
+ * The description of such step is in format JSON object:
+ *
+ * <pre>
+ *     {
+ *       title: string,
+ *       content: string,
+ *       elementSelector: string,
+ *       url: string,
+ *       placement: string,
+ *       type: string,
+ *       maxWaitTime: number,
+ *       canBePaused: boolean,
+ *       forceReload: boolean,
+ *       onNextClick: function
+ *     }
+ * </pre>
+ *
+ * <ul>
+ *     <li>
+ *         <b>title</b> - the title of the step. It will be shown as header of popover dialog;
+ *     </li>
+ *     <li>
+ *         <b>content</b> - the content of the step. It will be shown as content of popover dialog;
+ *     </li>
+ *     <li>
+ *         <b>elementSelector</b> - the selector of the element where popover dialog will be placed.
+ *     </li>
+ *     <li>
+ *         <b>url</b> - the url of the page where the element is present;
+ *     </li>
+ *     <li>
+ *         <b>placement</b> - where popover dialog to be placed. Possible values:
+ *         <ul>
+ *           <li>auto</li>
+ *           <li>auto-start</li>
+ *           <li>auto-end</li>
+ *           <li>top</li>
+ *           <li>top-start</li>
+ *           <li>top-end</li>
+ *           <li>bottom</li>
+ *           <li>bottom-start</li>
+ *           <li>bottom-end</li>
+ *           <li>right</li>
+ *           <li>right-start</li>
+ *           <li>right-end</li>
+ *           <li>left</li>
+ *           <li>left-start</li>
+ *           <li>left-end</li>
+ *         </ul>
+ *     </li>
+ *     <li><b>type</b> - the type of step. Possible values:
+ *       <ul>
+ *           <li>
+ *               <b>clickable-element</b> - the element is clickable like link, button... Client of workbench can click on this element.
+ *           </li>
+ *           <li>
+ *               <b>read-only-element</b> - the element is readable. Client of workbench can only read this component.
+ *           </li>
+ *           <li>
+ *               <b>input-element</b> - the element is some kind ot input like text, text area ... . Client of workbench can enter data in the element.
+ *           </li>
+ *        </ul>
+ *     </li>
+ *     <li>
+ *         <b>maxWaitTime</b> - some element need more time to be present on the page. This is the max waiting time element to be visible
+ *         on the page. Default value is 3 second.
+ *     </li>
+ *     <li>
+ *         <b>canBePaused</b> - some element need user interaction with some other element on the page before appear. Step which uses such
+ *         element can be persist when guide is paused. For example if step is "Click on sub menu "Repositories" of menu "Setup""
+ *     </li>
+ *     <li><b>forceReload</b> - if true will reload page no matter that step is on same page.
+ *     <li>
+ *         <b>onNextClick</b> - function which will be executed when nexButton is clicked. Usual it implements click on the element of the step.
+ * </ul>
+ * The core steps are the steps passed to some tour library services. Currently we use {@see ShepherdService}. They are created from plugins
+ * described in guides/steps/core directory. Format of a such plugin is:
+ * <pre>
+ *     {
+ *         guideBlockName: string,
+ *         getStep: function
+ *     }
+ * </pre>
+ *
+ * <ul>
+ *     <li>
+ *         <b>guideBlockName</b> - unique name of the plugin.
+ *     </li>
+ *     <li>
+ *         <b>getStep</b> - function which returns a json which describe a core step.
+ *     </li>
+ * </ul>
+ *
+ *
+ * A complex step is a sequence of steps described an action. Fro example click on sub menu. First have to click on main-menu and
+ * after that on sub menu. They are created from plugins described in guides/steps/complex directory. Format of a such plugin is:
+ * {
+ *     guideBlockName: string,
+ *     getSteps: function
+ * }
+ *
+ * <ul>
+ *     <li>
+ *         <b>guideBlockName</b> - unique name of the plugin.
+ *     </li>
+ *     <li>
+ *         <b>getSteps</b> function which returns a json array with description of other complex plugins or core steps.
+ *     </li>
+ * </ul>
+ *
+ * @param $http - the http client.
+ * @param $rootScope - the rootScope.
+ * @param $translate - the translation service.
+ * @param ShepherdService - service (wrapper) of library  <a href="https://shepherdjs.dev/docs/">shepherd</a>.
+ * @constructor
+ */
+function GuidesService($http, $rootScope, $translate, ShepherdService) {
+
+    this.guideResumeSubscription = undefined;
+    this.languageChangeSubscription = undefined;
+    this.guideCancelSubscription = undefined;
+
+    this.init = () => {
+        this._subscribeToGuideResumed();
+        this._subscribeToGuideCancel();
+        this._subscribeToGuidePause();
+    };
+
+    /**
+     * Creates a guide and start it from <code>startStepId</code>. Steps of starting guids are:
+     * <ol>
+     *     <li>Cancels currently ran guid if any;</li>
+     *     <li>Loads guide description from <code>guideFileName</code>;</li>
+     *     <li>Converts complex step sequence to core steps sequence;</li>
+     *     <li>Starts guide from step with id <code>startStepId.</code>
+     * </ol>
+     * @param guideFileName - path to guide description file.
+     * @param startStepId
+     */
+    this.startGuide = (guideFileName, startStepId) => {
+        this.cancelGuide();
+        this.loadGuide(guideFileName)
+            .then(guide => {
+                return this._toStepsDescriptions(guide);
+            })
+            .then(stepsDescriptions => {
+                if (!!startStepId) {
+                    ShepherdService.resumeGuide(guideFileName, stepsDescriptions, startStepId);
+                } else {
+                    ShepherdService.startGuide(guideFileName, stepsDescriptions, startStepId);
+                }
+            });
+    }
+
+    /**
+     * Cancel the currently started guide if any.
+     */
+    this.cancelGuide = () => {
+        ShepherdService.cancel();
+    }
+
+    /**
+     * Fetches guide description with name <code>guideFileName</code> from the server.
+     *
+     * @param guideFileName - path to guide description file.
+     * @returns {Promise<[]>} - array with steps descriptions. Format of steps description:
+     *
+     * <pre>
+     *     {
+     *       tutorialName: string,
+     *       options: {
+     *          ......
+     *          },
+     *          steps: [
+     *          ...
+     *          ]
+     *        }
+     * </pre>
+     *
+     * <ul>
+     *     <li>
+     *         <b>guideName</b> - guide name (optional).
+     *     </li>
+     *     <li>
+     *         <b>options</b> - global options of the guide.
+     *     </li>
+     * </ul>
+     */
+    this.loadGuide = (guideFileName) => {
+        return new Promise(resolve => {
+            $http.get(`guides/${guideFileName}`)
+                .success(function (data) {
+                    resolve(data);
+                });
+        });
+    }
+
+    /**
+     * Fetches list with all available guides.
+     * @returns {Promise<[]>} array with guides descriptions. A guide description have to be:
+     * <pre>
+     *     {
+     *         name: string,
+     *         title: string,
+     *         guideFileName: string
+     *     }
+     * </pre>
+     *  <ul>
+     *      <li><b>name</b> - name of a guide, it have to be unique;</li>
+     *      <li><b>title</b> - title of a guide. It will be shown in the pages;</li>
+     *      <li><b>guideFileName</b> - path to guide description file.</li>
+     *  </ul>
+     */
+    this.getGuides = () => {
+        return new Promise(resolve => {
+            $http.get(`guides/guides.json`)
+                .success(function (data) {
+                    resolve(data);
+                });
+        });
+    }
+
+    /**
+     * Fetches guide translation file for locale <code>locale</code>.
+     * @returns {Promise<{}>}
+     */
+    this.getTranslation = () => {
+        return new Promise(resolve => {
+            $http.get(`guides/i18n/locale-${$translate.use()}.json`)
+                .success(function (data) {
+                    resolve(data);
+                });
+        });
+    }
+
+    /**
+     * Converts guide steps (array with complex steps) to array with core steps.
+     * @param guide - a guide description:
+     *
+     * <pre>
+     *     {
+     *       tutorialName: string,
+     *       options: {
+     *       ....
+     *       },
+     *       steps: [
+     *         {
+     *           guideBlockName: string,
+     *           options: {
+     *             fileName: string
+     *          }
+     *          ...
+     *          ]
+     *        }
+     * </pre>
+     *  <ul>
+     *      <li>
+     *          <b>guideBlockName</b> - unique name of the plugin.
+     *      </li>
+     *      <li>
+     *         <b>options</b> - options of the steps. For example the name of the rdf file which have to be imported.
+     *     </li>
+     *  </ul>
+     *
+     * @returns arrays with core steps extracted from all 'guide.step' plugins registered in <code>data</code>. Format of a step
+     * description is:
+     *
+     * <pre>
+     *     {
+     *       title: string,
+     *       content: string,
+     *       elementSelector: string,
+     *       url: string,
+     *       placement: string,
+     *       type: string,
+     *       maxWaitTime: number,
+     *       canBePaused: boolean,
+     *       onNextClick: function
+     *       onPreviousClick: function
+     *     }
+     * </pre>
+     *
+     * <ul>
+     *     <li>
+     *         <b>title</b> - the title of the step. It will be shown as header of popover dialog;
+     *     </li>
+     *     <li>
+     *         <b>content</b> - the content of the step. It will be shown as content of popover dialog;
+     *     </li>
+     *     <li>
+     *         <b>elementSelector</b> - the selector of the element where popover dialog will be placed.
+     *     </li>
+     *     <li>
+     *         <b>url</b> - the url of the page where the element is present;
+     *     </li>
+     *     <li>
+     *         <b>placement</b> - where popover dialog to be placed. Possible values:
+     *         <ul>
+     *           <li>auto</li>
+     *           <li>auto-start</li>
+     *           <li>auto-end</li>
+     *           <li>top</li>
+     *           <li>top-start</li>
+     *           <li>top-end</li>
+     *           <li>bottom</li>
+     *           <li>bottom-start</li>
+     *           <li>bottom-end</li>
+     *           <li>right</li>
+     *           <li>right-start</li>
+     *           <li>right-end</li>
+     *           <li>left</li>
+     *           <li>left-start</li>
+     *           <li>left-end</li>
+     *         </ul>
+     *     </li>
+     *     <li><b>type</b> - the type of step. Possible values:
+     *       <ul>
+     *           <li>
+     *               <b>clickable-element</b> - the element is clickable like link, button... Client of workbench can click on this element.
+     *           </li>
+     *           <li>
+     *               <b>read-only-element</b> - the element is readable. Client of workbench can only read this component.
+     *           </li>
+     *           <li>
+     *               <b>input-element</b> - the element is some kind ot input like text, text area ... . Client of workbench can enter data in the element.
+     *           </li>
+     *        </ul>
+     *     </li>
+     *     <li>
+     *         <b>maxWaitTime</b> - some element need more time to be present on the page. This is the max waiting time element to be visible
+     *         on the page. Default value is 3 second.
+     *     </li>
+     *     <li>
+     *         <b>canBePaused</b> - some element need user interaction with some other element on the page before appear. Step which uses such
+     *         element can be persist when guide is paused. For example if step is "Click on sub menu "Repositories" of menu "Setup""
+     *     </li>
+     *     <li>
+     *         <b>onNextClick</b> - function which will be executed when nex button is clicked.
+     *     </li>
+     *     <li>
+     *         <b>onPreviousClick</b> - function which will be executed when previous button is clicked.
+     *     </li>
+     * </ul>
+     * @private
+     */
+    this._toStepsDescriptions = (guide) => {
+        if (!guide) {
+            return [];
+        }
+        let coreSteps = [];
+        guide.steps.forEach(step => {
+            coreSteps = coreSteps.concat(this._getSteps(step, guide.options));
+        });
+
+        // Add id to everyone step
+        for (let index = 0; index < coreSteps.length; index++) {
+            coreSteps[index].id = index;
+        }
+        return coreSteps;
+    }
+
+    /**
+     * Converts a complex step to array with core steps.
+     * @param complexStep - a complex or core step description. Format of the description is:
+     * <pre>
+     *     {
+     *         guideBlockName: string,
+     *         options: {}
+     *     }
+     * </pre>
+     *  <ul>
+     *      <li>
+     *          <b>guideBlockName</b> - unique name of the plugin.
+     *      </li>
+     *      <li>
+     *         <b>options</b> - options of the steps. For example the name of the rdf file which have to be imported.
+     *     </li>
+     *  </ul>
+     * @param parentOptions - options passed from parent.
+     * @returns {*[]} - an array with core steps.
+     * @private
+     */
+    this._getSteps = (complexStep, parentOptions) => {
+        let steps = [];
+        if (angular.isArray(complexStep)) {
+            complexStep.forEach(stepDescription => {
+                steps = steps.concat(this._getSteps(stepDescription, angular.extend({}, complexStep.options, parentOptions)));
+            });
+        } else {
+            const predefinedStepDescription = PluginRegistry.get('guide.step').find((predefinedStep => predefinedStep.guideBlockName === complexStep.guideBlockName));
+            if (predefinedStepDescription) {
+                const options = angular.extend({}, predefinedStepDescription.options, complexStep.options, parentOptions);
+                if (!!predefinedStepDescription.getSteps) {
+                    steps = steps.concat(this._getSteps(angular.copy(predefinedStepDescription.getSteps(options, GuideUtils)), parentOptions));
+                } else if (!!predefinedStepDescription.getStep) {
+                    steps.push(angular.copy(predefinedStepDescription.getStep(options)));
+                } else {
+                    steps = steps.concat(this._getSteps(angular.copy(predefinedStepDescription, predefinedStepDescription.options), parentOptions));
+                }
+            }
+        }
+        return steps;
+    }
+
+    /**
+     * Subscribes to guide resume event. When event occurred the guide will be start from the step where the guide was paused.
+     *
+     * @private
+     */
+    this._subscribeToGuideResumed = () => {
+        if (!this.guideResumeSubscription) {
+            this.guideResumeSubscription = $rootScope.$on('guideResume', () => {
+                const guideFileName = ShepherdService.getGuideFileName();
+                const currentStepId = ShepherdService.getCurrentStepId();
+                this.startGuide(guideFileName, currentStepId);
+            });
+        }
+    };
+
+    this._subscribeToGuideCancel = () => {
+        ShepherdService.subscribeToGuideCancel(() => $rootScope.$broadcast('guideReset'));
+    }
+
+    this._subscribeToGuidePause = () => {
+        ShepherdService.subscribeToGuidePause(() => $rootScope.$broadcast('guidePaused'));
+    }
+}

--- a/src/js/angular/guides/steps/core/plugin.js
+++ b/src/js/angular/guides/steps/core/plugin.js
@@ -1,0 +1,39 @@
+const BASIC_STEP = {
+    'title': '',
+    'content': '',
+    'elementSelector': '',
+    'placement': 'bottom',
+    'url': '',
+    'type': 'read-only-element',
+    'maxWaitTime': 3,
+    'canBePaused': true,
+    'onNextClick': undefined,
+    'onPreviousClick': undefined
+};
+
+PluginRegistry.add('guide.step', [
+    {
+        'guideBlockName': 'clickable-element',
+        'getStep': (options) => {
+            return angular.extend({}, BASIC_STEP, options, {
+                'type': 'clickable'
+            });
+        }
+    },
+    {
+        'guideBlockName': 'read-only-element',
+        'getStep': (options) => {
+            return angular.extend({}, BASIC_STEP, options, {
+                'type': 'readonly',
+            });
+        }
+    },
+    {
+        'guideBlockName': 'input-element',
+        'getStep': (options) => {
+            return angular.extend({}, BASIC_STEP, options, {
+                'type': 'input',
+            });
+        }
+    }
+]);

--- a/src/js/angular/guides/tour-lib-services/shepherd.service.js
+++ b/src/js/angular/guides/tour-lib-services/shepherd.service.js
@@ -1,0 +1,532 @@
+import {GuideUtils} from "../guide-utils";
+import Shepherd from "shepherd.js";
+
+export const GUIDE_NAME = 'shepherd.guide_name';
+export const GUIDE_CURRENT_STEP_ID ='shepherd.guide.current.step.id';
+export const GUIDE_PAUSE = 'shepherd.guide.pause';
+
+const modules = ['graphdb.framework.utils.localstorageadapter'];
+
+angular
+    .module('graphdb.framework.guides.shepherd.services', modules)
+    .service('ShepherdService', ShepherdService);
+/**
+ * Service (wrapper) of library  <a href="https://shepherdjs.dev/docs/">shepherd</a>.
+ * @param $location
+ * @param $translate
+ * @param LocalStorageAdapter
+ * @constructor
+ */
+ShepherdService.$inject = ['$location', '$translate', 'LocalStorageAdapter'];
+
+function ShepherdService($location, $translate, LocalStorageAdapter) {
+    this.guideCancelSubscription = undefined;
+    this.onPause = () => {};
+    this.onCancel = () => {};
+
+    /**
+     * Creates and starts a guide.
+     * @param guideFileName - path to guide description file.
+     * @param stepsDescriptions - array with core steps. Format of a step is:
+     * <pre>
+     *     {
+     *       title: string,
+     *       content: string,
+     *       elementSelector: string,
+     *       url: string,
+     *       placement: string,
+     *       type: string,
+     *       maxWaitTime: number,
+     *       canBePaused: boolean,
+     *       onNextClick: function,
+     *       onPreviousClick: function
+     *     }
+     * </pre>
+     *
+     * <ul>
+     *     <li>
+     *         <b>title</b> - the title of the step. It will be shown as header of popover dialog;
+     *     </li>
+     *     <li>
+     *         <b>content</b> - the content of the step. It will be shown as content of popover dialog;
+     *     </li>
+     *     <li>
+     *         <b>elementSelector</b> - the selector of the element where popover dialog will be placed.
+     *     </li>
+     *     <li>
+     *         <b>url</b> - the url of the page where the element is present;
+     *     </li>
+     *     <li>
+     *         <b>placement</b> - where popover dialog to be placed. Possible values:
+     *         <ul>
+     *           <li>auto</li>
+     *           <li>auto-start</li>
+     *           <li>auto-end</li>
+     *           <li>top</li>
+     *           <li>top-start</li>
+     *           <li>top-end</li>
+     *           <li>bottom</li>
+     *           <li>bottom-start</li>
+     *           <li>bottom-end</li>
+     *           <li>right</li>
+     *           <li>right-start</li>
+     *           <li>right-end</li>
+     *           <li>left</li>
+     *           <li>left-start</li>
+     *           <li>left-end</li>
+     *         </ul>
+     *     </li>
+     *     <li><b>type</b> - the type of step. Possible values:
+     *       <ul>
+     *           <li>
+     *               <b>clickable-element</b> - the element is clickable like link, button... Client of workbench can click on this element.
+     *           </li>
+     *           <li>
+     *               <b>read-only-element</b> - the element is readable. Client of workbench can only read this component.
+     *           </li>
+     *           <li>
+     *               <b>input-element</b> - the element is some kind ot input like text, text area ... . Client of workbench can enter data in the element.
+     *           </li>
+     *        </ul>
+     *     </li>
+     *     <li>
+     *         <b>maxWaitTime</b> - some element need more time to be present on the page. This is the max waiting time element to be visible
+     *         on the page. Default value is 3 second.
+     *     </li>
+     *     <li>
+     *         <b>canBePaused</b> - some element need user interaction with some other element on the page before appear. Step which uses such
+     *         element can be persist when guide is paused. For example if step is "Click on sub menu "Repositories" of menu "Setup""
+     *     </li>
+     *     <li>
+     *         <b>onNextClick</b> - function which will be executed when nex button is clicked.
+     *     </li>
+     *     <li>
+     *         <b>onPreviousClick</b> - function which will be executed when previous button is clicked.
+     *     </li>
+     *
+     * </ul>
+     * @param startStepId - start step id.
+     */
+    this.startGuide = (guideFileName, stepsDescriptions, startStepId) => {
+        if (!stepsDescriptions) {
+            return;
+        }
+        const guide = this._createGuide(guideFileName)
+        this._addGuideSteps(guide, stepsDescriptions);
+        this._startGuide(guide, startStepId);
+    }
+
+    /**
+     * Starts guide from the step where it was paused.
+     */
+    this.resumeGuide = (guideFileName, stepsDescriptions, startStepId) => {
+        LocalStorageAdapter.set(GUIDE_PAUSE, false);
+        this.startGuide(guideFileName, stepsDescriptions, startStepId);
+    }
+
+    /**
+     * Cancels currently started guide if any.
+     */
+    this.cancel = () => {
+        const activeGuide = Shepherd.activeTour;
+        if (activeGuide) {
+            activeGuide.cancel();
+        }
+    }
+
+    this.getGuideFileName = () => {
+        return LocalStorageAdapter.get(GUIDE_NAME);
+    }
+
+    this.getCurrentStepId = () => {
+        return LocalStorageAdapter.get(GUIDE_CURRENT_STEP_ID);
+    }
+
+    this.subscribeToGuideCancel = (oncancel) => {
+        if (angular.isFunction(oncancel)) {
+            this.onCancel = oncancel;
+        }
+    }
+
+    this.subscribeToGuidePause = (onPause) => {
+        if (angular.isFunction(onPause)) {
+            this.onPause = onPause;
+        }
+    }
+
+    /**
+     * Creates a guide.
+     * @param guideFileName - path to guide description name.
+     * @returns {Shepherd.Tour} - created guide.
+     */
+    this._createGuide = (guideFileName) => {
+        this._subscribeToGuideCanceled();
+        return new Shepherd.Tour({
+            name: guideFileName,
+            useModalOverlay: true,
+            defaultStepOptions: {
+                classes: 'shadow-md bg-purple-dark',
+                scrollTo: true
+            }
+        });
+    }
+
+    /**
+     * Transforms <code>stepsDescriptions</code> to Shepherd Tour steps and add it to <code>guide<code>.
+     * @param guide - the guide.
+     * @param stepsDescriptions - array with steps descriptions. The format of a description is:
+     *
+     * <pre>
+     *     {
+     *       title: string,
+     *       content: string,
+     *       elementSelector: string,
+     *       url: string,
+     *       placement: string,
+     *       type: string,
+     *       maxWaitTime: number,
+     *       canBePaused: boolean,
+     *       onNextClick: function,
+     *       onPreviousClick: function
+     *     }
+     * </pre>
+     *
+     * <ul>
+     *     <li>
+     *         <b>title</b> - the title of the step. It will be shown as header of popover dialog;
+     *     </li>
+     *     <li>
+     *         <b>content</b> - the content of the step. It will be shown as content of popover dialog;
+     *     </li>
+     *     <li>
+     *         <b>elementSelector</b> - the selector of the element where popover dialog will be placed.
+     *     </li>
+     *     <li>
+     *         <b>url</b> - the url of the page where the element is present;
+     *     </li>
+     *     <li>
+     *         <b>placement</b> - where popover dialog to be placed. Possible values:
+     *         <ul>
+     *           <li>auto</li>
+     *           <li>auto-start</li>
+     *           <li>auto-end</li>
+     *           <li>top</li>
+     *           <li>top-start</li>
+     *           <li>top-end</li>
+     *           <li>bottom</li>
+     *           <li>bottom-start</li>
+     *           <li>bottom-end</li>
+     *           <li>right</li>
+     *           <li>right-start</li>
+     *           <li>right-end</li>
+     *           <li>left</li>
+     *           <li>left-start</li>
+     *           <li>left-end</li>
+     *         </ul>
+     *     </li>
+     *     <li><b>type</b> - the type of step. Possible values:
+     *       <ul>
+     *           <li>
+     *               <b>clickable-element</b> - the element is clickable like link, button... Client of workbench can click on this element.
+     *           </li>
+     *           <li>
+     *               <b>read-only-element</b> - the element is readable. Client of workbench can only read this component.
+     *           </li>
+     *           <li>
+     *               <b>input-element</b> - the element is some kind ot input like text, text area ... . Client of workbench can enter data in the element.
+     *           </li>
+     *        </ul>
+     *     </li>
+     *     <li>
+     *         <b>maxWaitTime</b> - some element need more time to be present on the page. This is the max waiting time element to be visible
+     *         on the page. Default value is 3 second.
+     *     </li>
+     *     <li>
+     *         <b>canBePaused</b> - some element need user interaction with some other element on the page before appear. Step which uses such
+     *         element can be persist when guide is paused. For example if step is "Click on sub menu "Repositories" of menu "Setup""
+     *     </li>
+     *     <li>
+     *         <b>onNextClick</b> - function which will be executed when nex button is clicked.
+     *     </li>
+     *      <li>
+     *         <b>onPreviousClick</b> - function which will be executed when previous button is clicked.
+     *     </li>
+     * </ul>
+     */
+    this._addGuideSteps = (guide, stepsDescriptions) => {
+        // Check if stepsDescriptions is not empty. This mean there is first step. The first step has not previous one.
+        if (stepsDescriptions.length > 0) {
+            guide.addStep(this._getFirstStep(guide, stepsDescriptions));
+        }
+
+        // Chek if stepsDescriptions has more than 2 elements. This mean there are middle steps. The middle steps have previous and next steps.
+        if (stepsDescriptions.length > 2) {
+            // Process all steps without first and last one.
+            for (let index = 1; index < stepsDescriptions.length - 1; index++) {
+                guide.addStep(this._getMiddleStep(guide, stepsDescriptions, index));
+            }
+        }
+
+        // Check if stepsDescriptions more than 1 element, this mean that we have process last step. The last step has no next step.
+        if (stepsDescriptions.length > 1) {
+            guide.addStep(this._getLastStep(guide, stepsDescriptions));
+        }
+    }
+
+    /**
+     * Starts <code>guide</code> from <code>startStepId</code>
+     * @param guide - the guid to be started.
+     * @param startStepId - star step id. If it is not present the <code>guide</code> will be started from beginning.
+     * @private
+     */
+    this._startGuide = (guide, startStepId) => {
+        const stepIndex = guide.steps.findIndex((value => value.options.id === startStepId));
+        const step = guide.steps[stepIndex > -1 ? stepIndex : 0];
+        const url = step.options.url;
+        if (!!url) {
+            $location.path(url);
+        }
+
+        GuideUtils.waitFor(step.options.attachTo.element, step.options.maxWaitTime)
+            .then(() => guide.show(stepIndex))
+            .catch(() => guide.cancel());
+    }
+
+    this._subscribeToGuideCanceled = () => {
+        if (!this.guideCancelSubscription) {
+            this.guideCancelSubscription = Shepherd.on('cancel', () => {
+                this._clearLocaleStorage();
+                if (this.onCancel) {
+                    this.onCancel();
+                }
+            });
+        }
+    }
+
+    /**
+     * Creates first step from <code>stepsDescriptions</code>.
+     * @param guide - the guide.
+     * @param stepsDescriptions - array with descriptions of steps.
+     * @returns the first step.
+     * @private
+     */
+    this._getFirstStep = function (guide, stepsDescriptions) {
+        const nextStepDescription = stepsDescriptions.length > 1 ? stepsDescriptions[1] : undefined;
+        return this._toGuideStep(guide, undefined, stepsDescriptions[0], nextStepDescription);
+    }
+
+    /**
+     * Creates middle step from <code>stepsDescriptions</code>.
+     * @param guide - the guide.
+     * @param stepsDescriptions - array with descriptions of steps.
+     * @param indexOfProcessedStep - index of step which have to be created.
+     * @returns the created step.
+     * @private
+     */
+    this._getMiddleStep = (guide, stepsDescriptions, indexOfProcessedStep) => {
+        return this._toGuideStep(guide, stepsDescriptions[indexOfProcessedStep - 1], stepsDescriptions[indexOfProcessedStep], stepsDescriptions[indexOfProcessedStep + 1]);
+    }
+
+    /**
+     * Creates last step from <code>stepsDescriptions</code>.
+     * @param guide - the guide.
+     * @param stepsDescriptions - array with descriptions of steps.
+     * @returns the last step.
+     * @private
+     */
+    this._getLastStep = (guide, stepsDescriptions) => {
+        return this._toGuideStep(guide, stepsDescriptions[stepsDescriptions.length - 2], stepsDescriptions[stepsDescriptions.length - 1]);
+    }
+
+    /**
+     * Converts <code>currentStepDescription</code> to Shepherd Tour step.
+     * @param guide - the guide.
+     * @param previousStepDescription - the previous step description.
+     * @param currentStepDescription - processed step description.
+     * @param nextStepDescription - the next step description.
+     * @returns created step.
+     * @private
+     */
+    this._toGuideStep = (guide, previousStepDescription, currentStepDescription, nextStepDescription) => {
+        const step = this._toBaseGuideStep($translate, currentStepDescription, () => this._updateLocalStorage());
+        const buttons = [];
+        if (previousStepDescription) {
+            buttons.push(this._getPreviousButton(guide, previousStepDescription, currentStepDescription));
+        }
+        if (!!nextStepDescription) {
+            buttons.push(this._getNextButton(guide, currentStepDescription, nextStepDescription));
+        }
+        buttons.push(this._getPauseButton(guide));
+        step.buttons = buttons;
+        return step;
+    }
+
+    this._getPauseButton = (guide) => {
+        return this._getButton($translate.instant('guide.button.pause'), () => this._pauseGuide(guide), true);
+    }
+
+    /**
+     * Pauses current ran guide.
+     */
+    this._pauseGuide = (guide) => {
+        guide.hide();
+        this._saveStep(this._getStepWhichCanBePaused(Shepherd.activeTour));
+        LocalStorageAdapter.set(GUIDE_PAUSE, true);
+        if (this.onPause()) {
+            this.onPause();
+        }
+    }
+
+    this._getStepWhichCanBePaused = (tour) => {
+        const currentStep = tour.getCurrentStep();
+        if (currentStep) {
+            if (currentStep.options.canBePaused) {
+                return currentStep;
+            }
+            tour.back();
+            tour.hide();
+            const previousStep = tour.getCurrentStep();
+            // checks if ids are equal this mean first step is reached.
+            if (currentStep.id === previousStep.id) {
+                return currentStep;
+            } else {
+                return this._getStepWhichCanBePaused(tour);
+            }
+        }
+    }
+
+    /**
+     * Creates a previous button.
+     * @param guide - the guide.
+     * @param previousStepDescription - previous step description.
+     * @param currentStepDescription - processed step description.
+     * @returns created step.
+     * @private
+     */
+    this._getPreviousButton = (guide, previousStepDescription, currentStepDescription) => {
+        const text = $translate.instant('guide.button.previous');
+        const action = this._getPreviousButtonAction(guide, previousStepDescription, currentStepDescription);
+        return this._getButton(text, action);
+    }
+
+    this._getPreviousButtonAction = (guide, previousStepDescription, currentStepDescription) => {
+        return () => {
+            if ('clickable' === previousStepDescription.type && angular.isFunction(previousStepDescription.onPreviousClick)) {
+                previousStepDescription.onPreviousClick();
+            } else if (previousStepDescription.forceReload || previousStepDescription.url && previousStepDescription.url !== currentStepDescription.url) {
+                $location.path(previousStepDescription.url);
+            }
+            GuideUtils.waitFor(previousStepDescription.elementSelector, previousStepDescription.maxWaitTime)
+                .then(() => guide.back())
+                .catch(() => guide.cancel());
+        }
+    }
+
+    /**
+     * Creates a next button.
+     * @param guide - the guide.
+     * @param currentStepDescription - processed step description.
+     * @param nextStepDescription - next step description.
+     * @returns created step.
+     * @private
+     */
+    this._getNextButton = (guide, currentStepDescription, nextStepDescription) => {
+        const text = $translate.instant('guide.button.next');
+        const action = _getNextButtonAction(guide, currentStepDescription, nextStepDescription);
+        return this._getButton(text, action);
+    }
+
+    const _getNextButtonAction = (guide, currentStepDescription, nextStepDescription) => {
+        return () => {
+            if ('clickable' === currentStepDescription.type && angular.isFunction(currentStepDescription.onNextClick)) {
+                currentStepDescription.onNextClick();
+            } else if (nextStepDescription.forceReload || nextStepDescription.url && nextStepDescription.url !== currentStepDescription.url) {
+                $location.path(nextStepDescription.url);
+            }
+            GuideUtils.waitFor(nextStepDescription.elementSelector, nextStepDescription.maxWaitTime)
+                .then(() => guide.next())
+                .catch(() => guide.cancel());
+        }
+    }
+
+    /**
+     * Updates guide related values into local store.
+     * @private
+     */
+    this._updateLocalStorage = () => {
+        const activeTour = Shepherd.activeTour;
+        if (!activeTour) {
+            return;
+        }
+        this._saveStep(activeTour.getCurrentStep());
+    }
+
+    this._saveStep = (step) => {
+        if (!!step) {
+            LocalStorageAdapter.set(GUIDE_NAME, step.tour.options.name);
+            LocalStorageAdapter.set(GUIDE_CURRENT_STEP_ID, step.options.id);
+        }
+    }
+
+    /**
+     * Remove all related data to a guid from local store.
+     * @private
+     */
+    this._clearLocaleStorage = () => {
+        LocalStorageAdapter.remove(GUIDE_NAME);
+        LocalStorageAdapter.remove(GUIDE_PAUSE);
+        LocalStorageAdapter.remove(GUIDE_CURRENT_STEP_ID);
+    };
+
+    /**
+     * Creates a Shepherd Tour step and fill it with base properties from <code>stepDescription</code>.
+     * @param $translate
+     * @param stepDescription - step description. The format of a description is:
+     * @param onShow - function which will be executed when popup dialog shown.
+     * @returns created step.
+     * @private
+     */
+    this._toBaseGuideStep = ($translate, stepDescription, onShow) => {
+        return {
+            id: stepDescription.id,
+            title: $translate.instant(stepDescription.title, stepDescription),
+            text: $translate.instant(stepDescription.content, stepDescription),
+            url: stepDescription.url,
+            maxWaitTime: stepDescription.maxWaitTime,
+            cancelIcon: {enabled: true},
+            attachTo: {
+                element: stepDescription.elementSelector,
+                on: stepDescription.placement
+            },
+            modalOverlayOpeningPadding: 0,
+            modalOverlayOpeningRadius: 0,
+            canBePaused: stepDescription.canBePaused,
+            classes: 'guide-dialog',
+            when: {
+                show: () => {
+                    onShow();
+                }
+            }
+        };
+    }
+
+    /**
+     * Created a base button.
+     * @param text - the text of button.
+     * @param isSecondary - if true will be styled as secondary button.
+     * @param action - to be executed when button is clicked.
+     * @returns created button.
+     */
+    this._getButton = (text, action, isSecondary) => {
+        const button = {
+            text: text,
+            classes: isSecondary ? 'btn-lg btn-secondary' : 'btn-lg btn-primary'
+        };
+
+        button.action = () => {
+            action();
+        }
+
+        return button;
+    }
+}

--- a/src/vendor.js
+++ b/src/vendor.js
@@ -2,6 +2,8 @@ import 'lib/bootstrap/bootstrap.min.css';
 import 'angular-toastr/dist/angular-toastr.min.css';
 import 'font-awesome/css/font-awesome.min.css';
 import './css/lib/animate/animate.css';
+import 'shepherd.js/dist/css/shepherd.css';
+import './css/shepherd-custom.css'
 
 import 'jquery';
 import 'lib/angularjs/1.3.8/angular.js';


### PR DESCRIPTION
WHAT:

     Added base services of guide functionality
WHY:

	We would like to create guides that helps our client to investigate what can do with GraphDB.
HOW:

	Adds lib shephred (https://shepherdjs.dev/docs/). We will use it to create guides.
	Implements ShepherdService to wrapp shephred library.
	Implements GuidesService with base functionality.
	Implements a directive guideSelector which will be used to mark dom elements that the guides used.