### PR TITLE
GDB-7337: Implements click on main menu plugin

### DIFF
--- a/src/js/angular/autocomplete/plugin.js
+++ b/src/js/angular/autocomplete/plugin.js
@@ -11,7 +11,7 @@ PluginRegistry.add('route', {
 
 PluginRegistry.add('main.menu', {
     'items': [
-        {label: 'Setup', labelKey: 'menu.setup.label', href: '#', order: 5, role: 'IS_AUTHENTICATED_FULLY', icon: "icon-settings"},
-        {label: 'Autocomplete', labelKey: 'menu.autocomplete.label', href: 'autocomplete', order: 40, parent: 'Setup', role: "IS_AUTHENTICATED_FULLY"}
+        {label: 'Setup', labelKey: 'menu.setup.label', href: '#', order: 5, role: 'IS_AUTHENTICATED_FULLY', icon: "icon-settings", guideSelector: 'menu-setup'},
+        {label: 'Autocomplete', labelKey: 'menu.autocomplete.label', href: 'autocomplete', order: 40, parent: 'Setup', role: "IS_AUTHENTICATED_FULLY", guideSelector: 'sub-menu-autocomplete'}
     ]
 });

--- a/src/js/angular/clustermanagement/plugin.js
+++ b/src/js/angular/clustermanagement/plugin.js
@@ -18,7 +18,8 @@ PluginRegistry.add('main.menu', {
         href: 'cluster',
         order: 20,
         role: 'ROLE_ADMIN',
-        parent: 'Setup'
+        parent: 'Setup',
+        guideSelector: 'sub-menu-cluster'
     }]
 });
 

--- a/src/js/angular/core/services.js
+++ b/src/js/angular/core/services.js
@@ -72,6 +72,7 @@ function MenuItemsProvider() {
             role: item.role,
             editions: item.editions,
             icon: item.icon,
+            guideSelector: item.guideSelector,
             children: children
         };
     };

--- a/src/js/angular/explore/plugin.js
+++ b/src/js/angular/explore/plugin.js
@@ -33,6 +33,7 @@ PluginRegistry.add('main.menu', {
         href: '#',
         order: 1,
         role: 'IS_AUTHENTICATED_FULLY',
-        icon: "icon-data"
+        icon: "icon-data",
+        guideSelector: 'menu-explore'
     }]
 });

--- a/src/js/angular/export/plugin.js
+++ b/src/js/angular/export/plugin.js
@@ -17,7 +17,8 @@ PluginRegistry.add('main.menu', {
             href: '#',
             order: 1,
             role: 'IS_AUTHENTICATED_FULLY',
-            icon: 'icon-data'
+            icon: 'icon-data',
+            guideSelector: 'menu-explore'
         },
         {
             label: 'Graphs overview',
@@ -25,7 +26,8 @@ PluginRegistry.add('main.menu', {
             href: 'graphs',
             order: 0,
             role: 'IS_AUTHENTICATED_FULLY',
-            parent: 'Explore'
+            parent: 'Explore',
+            guideSelector: 'sub-menu-graph-overview'
         }
     ]
 });

--- a/src/js/angular/externalsync/plugin.js
+++ b/src/js/angular/externalsync/plugin.js
@@ -17,7 +17,8 @@ PluginRegistry.add('main.menu', {
             href: '#',
             order: 5,
             role: 'IS_AUTHENTICATED_FULLY',
-            icon: 'icon-settings'
+            icon: 'icon-settings',
+            guideSelector: 'menu-setup'
         },
         {
             label: 'Connectors',
@@ -25,7 +26,8 @@ PluginRegistry.add('main.menu', {
             href: 'connectors',
             order: 10,
             parent: 'Setup',
-            role: 'IS_AUTHENTICATED_FULLY'
+            role: 'IS_AUTHENTICATED_FULLY',
+            guideSelector: 'sub-menu-connectors'
         }
     ]
 });

--- a/src/js/angular/graphexplore/plugin.js
+++ b/src/js/angular/graphexplore/plugin.js
@@ -57,19 +57,22 @@ PluginRegistry.add('main.menu', {
             href: '#',
             order: 1,
             role: 'IS_AUTHENTICATED_FULLY',
-            icon: 'icon-data'
+            icon: 'icon-data',
+            guideSelector: 'menu-explore'
         }, {
             label: 'Class relationships',
             labelKey: 'menu.class.relationships.label',
             href: 'relationships',
             order: 2,
-            parent: 'Explore'
+            parent: 'Explore',
+            guideSelector: 'sub-menu-class-relationships'
         }, {
             label: 'Class hierarchy',
             labelKey: 'menu.class.hierarchy.label',
             href: 'hierarchy',
             order: 1,
-            parent: 'Explore'
+            parent: 'Explore',
+            guideSelector: 'menu-class-hierarchy'
         }, {
             label: 'Visual graph',
             labelKey: 'visual.graph.label',
@@ -79,7 +82,8 @@ PluginRegistry.add('main.menu', {
             children: [{
                 href: 'graphs-visualizations/config/save',
                 children: []
-            }]
+            }],
+            guideSelector: 'sub-menu-visual-graph'
         }
     ]
 });

--- a/src/js/angular/guides/guide-utils.js
+++ b/src/js/angular/guides/guide-utils.js
@@ -9,13 +9,18 @@ const GuideUtils = (function () {
             });
     }
 
+    const clickOnGuideElement = function (elementSelector, postSelector) {
+        return GuideUtils.clickOnElement(GuideUtils.getGuideElementSelector(elementSelector, postSelector));
+    }
+
     /**
      * Waits element to be present.
      * @param selector - selector of element looking for.
+     * @param checkVisibility - if true will wait to become visible. Default value is true
      * @param timeoutInSeconds - max time to waite in second. Default value is 1 second.
      * @returns {Promise}
      */
-    const waitFor = function (selector, timeoutInSeconds) {
+    const waitFor = function (selector, timeoutInSeconds, checkVisibility = true) {
         return new Promise(function (resolve, reject) {
             let iteration = timeoutInSeconds * 1000 | 1000;
             const waitTime = 100;
@@ -23,12 +28,12 @@ const GuideUtils = (function () {
                 try {
                     let element = document.querySelector(selector);
                     if (element != null) {
-                        clearInterval(elementExist);
+                            clearInterval(elementExist);
                         if (angular.element(element).is(':visible')) {
                             resolve(element);
                         } else {
-                            console.log('Element is not visible: ' + selector);
-                            reject();
+                                console.log('Element is not visible: ' + selector);
+                                reject();
                         }
                     } else {
                         iteration -= waitTime;
@@ -46,9 +51,26 @@ const GuideUtils = (function () {
             }, waitTime);
         });
     };
+
+    const isVisible = function (selector) {
+        const element = document.querySelector(selector);
+        return element && angular.element(element).is(':visible');
+    }
+
+    const isGuideElementVisible = function (guideSelectorValue) {
+        return this.isVisible(getGuideElementSelector(guideSelectorValue));
+    }
+
+    const getGuideElementSelector = function (guideSelectorValue, postSelector) {
+        return `[guide-selector="${guideSelectorValue}"]${postSelector ? postSelector : ''}`
+    }
     return {
         waitFor,
-        clickOnElement
+        clickOnElement,
+        clickOnGuideElement,
+        getGuideElementSelector,
+        isVisible,
+        isGuideElementVisible
     };
 })();
 

--- a/src/js/angular/guides/steps/complex/main-menu/plugin.js
+++ b/src/js/angular/guides/steps/complex/main-menu/plugin.js
@@ -1,0 +1,56 @@
+PluginRegistry.add('guide.step', [
+    {
+        'guideBlockName': 'click-main-menu',
+        'getSteps': (options, GuideUtils) => {
+            const steps = [];
+            const isSubmenu = options.hasOwnProperty('parentMenuSelector');
+            if (isSubmenu) {
+                steps.push({
+                    'guideBlockName': 'clickable-element',
+                    'options': angular.extend({}, {
+                        'title': 'guide.step_plugin.click-main-menu.' + options.label + '.main-menu.title',
+                        'content': 'guide.step_plugin.click-main-menu.' + options.label + '.main-menu.content',
+                        'elementSelector': GuideUtils.getGuideElementSelector(options.parentMenuSelector),
+                        // Open main menu if is not open
+                        'onNextClick': () => {
+                            // first we check if sub menu is not visible this mean that parent menu is not open.
+                            if (!GuideUtils.isGuideElementVisible(options.menuSelector)) {
+                                // If is not open then triggers click event on it.
+                                GuideUtils.clickOnGuideElement(options.parentMenuSelector, ' div')();
+                            }
+                        },
+                        // Close main menu if is open
+                        'onPreviousClick': () => {
+                            // first we check if sub menu is visible this mean that parent menu is open.
+                            if (GuideUtils.isGuideElementVisible(options.menuSelector)) {
+                                // If is open then triggers click event on it.
+                                GuideUtils.clickOnGuideElement(options.parentMenuSelector, ' div')();
+                            }
+                        }
+                    }, options)
+                });
+            }
+            steps.push({
+                'guideBlockName': 'clickable-element',
+                'options': angular.extend({}, {
+                    'title': 'guide.step_plugin.click-main-menu.' + options.label + '.menu.title',
+                    'content': 'guide.step_plugin.click-main-menu.' + options.label + '.menu.content',
+                    'elementSelector': GuideUtils.getGuideElementSelector(options.menuSelector),
+                    'placement': 'left',
+                    'onNextClick': () => {
+                        GuideUtils.clickOnGuideElement(options.menuSelector, ' a')()
+                    },
+                    'onPreviousClick': () => {
+                        // first we check if sub menu is not visible this mean that parent menu is not open.
+                        if (!GuideUtils.isGuideElementVisible(options.menuSelector)) {
+                            // If is not open then triggers click event on it.
+                            GuideUtils.clickOnGuideElement(options.parentMenuSelector, ' div')();
+                        }
+                    },
+                    'canBePaused': !isSubmenu
+                }, options)
+            });
+            return steps;
+        }
+    }
+]);

--- a/src/js/angular/guides/steps/core/plugin.js
+++ b/src/js/angular/guides/steps/core/plugin.js
@@ -1,9 +1,9 @@
 const BASIC_STEP = {
     'title': '',
     'content': '',
-    'elementSelector': '',
+    'elementSelector': undefined,
     'placement': 'bottom',
-    'url': '',
+    'url': undefined,
     'type': 'read-only-element',
     'maxWaitTime': 3,
     'canBePaused': true,
@@ -15,25 +15,28 @@ PluginRegistry.add('guide.step', [
     {
         'guideBlockName': 'clickable-element',
         'getStep': (options) => {
-            return angular.extend({}, BASIC_STEP, options, {
-                'type': 'clickable'
-            });
+            const notOverridable = {
+                'type': 'clickable',
+            };
+            return angular.extend({}, BASIC_STEP, options, notOverridable);
         }
     },
     {
         'guideBlockName': 'read-only-element',
         'getStep': (options) => {
-            return angular.extend({}, BASIC_STEP, options, {
+            const notOverridable = {
                 'type': 'readonly',
-            });
+            };
+            return angular.extend({}, BASIC_STEP, options, notOverridable);
         }
     },
     {
         'guideBlockName': 'input-element',
         'getStep': (options) => {
-            return angular.extend({}, BASIC_STEP, options, {
-                'type': 'input',
-            });
+            const notOverridable = {
+                'type': 'readonly',
+            };
+            return angular.extend({}, BASIC_STEP, options, notOverridable);
         }
     }
 ]);

--- a/src/js/angular/import/plugin.js
+++ b/src/js/angular/import/plugin.js
@@ -18,7 +18,8 @@ PluginRegistry.add('main.menu', {
             href: 'import',
             order: 0,
             role: 'IS_AUTHENTICATED_FULLY',
-            icon: 'icon-import'
+            icon: 'icon-import',
+            guideSelector: 'menu-import'
         }
     ]
 });

--- a/src/js/angular/jdbc/plugin.js
+++ b/src/js/angular/jdbc/plugin.js
@@ -1,13 +1,13 @@
 PluginRegistry.add('route', [
     {
-    'url': '/jdbc',
-    'module': 'graphdb.framework.jdbc',
-    'path': 'jdbc/app',
-    'chunk': 'jdbc',
-    'controller': 'JdbcListCtrl',
-    'templateUrl': 'pages/jdbc.html',
-    'title': 'view.jdbc.title',
-    'helpInfo': 'view.jdbc.helpInfo'
+        'url': '/jdbc',
+        'module': 'graphdb.framework.jdbc',
+        'path': 'jdbc/app',
+        'chunk': 'jdbc',
+        'controller': 'JdbcListCtrl',
+        'templateUrl': 'pages/jdbc.html',
+        'title': 'view.jdbc.title',
+        'helpInfo': 'view.jdbc.helpInfo'
     },
     {
         'url': '/jdbc/configuration/create',
@@ -19,11 +19,11 @@ PluginRegistry.add('route', [
         'title': 'view.jdbc.create.title',
         'helpInfo': 'view.jdbc.create.helpInfo'
     }
-    ]);
+]);
 
 PluginRegistry.add('main.menu', {
     'items': [
-        {label: 'Setup', labelKey: 'menu.setup.label', href: '#', order: 5, role: 'IS_AUTHENTICATED_FULLY', icon: "icon-settings"},
-        {label: 'JDBC', labelKey: 'menu.jdbc.label', href: 'jdbc', order: 50, parent: 'Setup', role: "IS_AUTHENTICATED_FULLY"}
+        {label: 'Setup', labelKey: 'menu.setup.label', href: '#', order: 5, role: 'IS_AUTHENTICATED_FULLY', icon: "icon-settings", guideSelector: 'menu-setup'},
+        {label: 'JDBC', labelKey: 'menu.jdbc.label', href: 'jdbc', order: 50, parent: 'Setup', role: "IS_AUTHENTICATED_FULLY", guideSelector: 'sub-menu-jdbs'}
     ]
 });

--- a/src/js/angular/namespaces/plugin.js
+++ b/src/js/angular/namespaces/plugin.js
@@ -17,13 +17,15 @@ PluginRegistry.add('main.menu', {
             href: '#',
             order: 5,
             role: 'IS_AUTHENTICATED_FULLY',
-            icon: "icon-settings"
+            icon: "icon-settings",
+            guideSelector: 'menu-setup'
         }, {
             label: 'Namespaces',
             labelKey: 'menu.namespaces.label',
             href: 'namespaces',
             order: 30,
-            parent: 'Setup'
+            parent: 'Setup',
+            guideSelector: 'sub-menu-namespaces'
         }
     ]
 });

--- a/src/js/angular/plugins/plugin.js
+++ b/src/js/angular/plugins/plugin.js
@@ -17,7 +17,8 @@ PluginRegistry.add('main.menu', {
             href: '#',
             order: 5,
             role: 'IS_AUTHENTICATED_FULLY',
-            icon: "icon-settings"
+            icon: "icon-settings",
+            guideSelector: 'menu-setup'
         },
         {
             label: 'Plugins',
@@ -25,7 +26,8 @@ PluginRegistry.add('main.menu', {
             href: 'plugins',
             order: 25,
             parent: 'Setup',
-            role: "IS_AUTHENTICATED_FULLY"
+            role: "IS_AUTHENTICATED_FULLY",
+            guideSelector: 'sub-menu-plugins'
         }
     ]
 });

--- a/src/js/angular/queries/plugin.js
+++ b/src/js/angular/queries/plugin.js
@@ -18,13 +18,15 @@ PluginRegistry.add('main.menu', {
             order: 3,
             // Changed to role user as now users can monitor their own queries
             role: 'ROLE_USER',
-            icon: 'icon-monitoring'
+            icon: 'icon-monitoring',
+            guideSelector: 'menu-monitor'
         }, {
             label: 'Queries and Updates',
             labelKey: 'menu.queries.and.updates.label',
             href: 'monitor/queries',
             order: 1,
-            parent: 'Monitor'
+            parent: 'Monitor',
+            guideSelector: 'sub-menu-queries-and-updates'
         }
     ]
 });

--- a/src/js/angular/rdfrank/plugin.js
+++ b/src/js/angular/rdfrank/plugin.js
@@ -17,7 +17,8 @@ PluginRegistry.add('main.menu', {
             href: '#',
             order: 5,
             role: 'IS_AUTHENTICATED_FULLY',
-            icon: 'icon-settings'
+            icon: 'icon-settings',
+            guideSelector: 'menu-setup'
         },
         {
             label: 'RDF Rank',
@@ -25,7 +26,8 @@ PluginRegistry.add('main.menu', {
             href: 'rdfrank',
             order: 45,
             parent: 'Setup',
-            role: 'IS_AUTHENTICATED_FULLY'
+            role: 'IS_AUTHENTICATED_FULLY',
+            guideSelector: 'sub-menu-rdf-rank'
         }
     ]
 });

--- a/src/js/angular/repositories/plugin.js
+++ b/src/js/angular/repositories/plugin.js
@@ -43,7 +43,8 @@ PluginRegistry.add('main.menu', {
             href: '#',
             order: 5,
             role: 'IS_AUTHENTICATED_FULLY',
-            icon: 'icon-settings'
+            icon: 'icon-settings',
+            guideSelector: 'menu-setup'
         },
         {
             label: 'Repositories',
@@ -55,7 +56,8 @@ PluginRegistry.add('main.menu', {
             children: [{
                 href: 'repository/create',
                 children: []
-            }]
+            }],
+            guideSelector: 'sub-menu-repositories'
         }
     ]
 });

--- a/src/js/angular/resources/plugin.js
+++ b/src/js/angular/resources/plugin.js
@@ -17,7 +17,8 @@ PluginRegistry.add('main.menu', {
             href: '#',
             order: 3,
             role: 'ROLE_MONITORING',
-            icon: 'icon-monitoring'
+            icon: 'icon-monitoring',
+            guideSelector: 'menu-monitor'
         }, {
             label: 'Resources',
             labelKey: 'menu.resources.label',
@@ -25,7 +26,8 @@ PluginRegistry.add('main.menu', {
             // Added role requirement here to assert that users cannot see Resources menu item
             role: 'ROLE_MONITORING',
             order: 2,
-            parent: 'Monitor'
+            parent: 'Monitor',
+            guideSelector: 'sub-menu-resources'
         }
     ]
 });

--- a/src/js/angular/security/plugin.js
+++ b/src/js/angular/security/plugin.js
@@ -63,14 +63,16 @@ PluginRegistry.add('main.menu', {
             href: '#',
             order: 5,
             role: 'IS_AUTHENTICATED_FULLY',
-            icon: 'icon-settings'
+            icon: 'icon-settings',
+            guideSelector: 'menu-setup'
         },
         {
             label: 'Users and Access', labelKey: 'menu.users.and.access.label', href: 'users', order: 2, parent: 'Setup', role: 'ROLE_ADMIN',
             children: [{
                 href: 'user/create',
                 children: []
-            }]
+            }],
+            guideSelector: 'sub-menu-user-and-access'
         },
         {
             label: 'My Settings',
@@ -78,7 +80,8 @@ PluginRegistry.add('main.menu', {
             href: 'settings',
             order: 6,
             parent: 'Setup',
-            role: 'ROLE_USER'
+            role: 'ROLE_USER',
+            guideSelector: 'sub-menu-my-settings'
         }
     ]
 });

--- a/src/js/angular/settings/plugin.js
+++ b/src/js/angular/settings/plugin.js
@@ -27,6 +27,7 @@ PluginRegistry.add('main.menu', {
         href: 'license',
         order: 100,
         role: 'ROLE_ADMIN',
-        parent: 'Setup'
+        parent: 'Setup',
+        guideSelector: 'sub-menu-license'
     }]
 });

--- a/src/js/angular/similarity/plugin.js
+++ b/src/js/angular/similarity/plugin.js
@@ -28,7 +28,8 @@ PluginRegistry.add('main.menu', {
             href: '#',
             order: 5,
             role: 'IS_AUTHENTICATED_FULLY',
-            icon: 'icon-settings'
+            icon: 'icon-settings',
+            guideSelector: 'sub-menu-setup'
         },
         {
             label: 'Similarity',
@@ -40,7 +41,8 @@ PluginRegistry.add('main.menu', {
             children: [{
                 href: 'similarity/index/create',
                 children: []
-            }]
+            }],
+            guideSelector: 'sub-menu-similarity'
         }
     ]
 });

--- a/src/js/angular/sparql-template/plugin.js
+++ b/src/js/angular/sparql-template/plugin.js
@@ -23,7 +23,7 @@ PluginRegistry.add('route', [
 
 PluginRegistry.add('main.menu', {
     'items': [
-        {label: 'Setup', labelKey: 'menu.setup.label', href: '#', order: 5, role: 'IS_AUTHENTICATED_FULLY', icon: "icon-settings"},
-        {label: 'SPARQL Templates', labelKey: 'menu.sparql.template.label', href: 'sparql-templates', order: 51, parent: 'Setup', role: "IS_AUTHENTICATED_FULLY"}
+        {label: 'Setup', labelKey: 'menu.setup.label', href: '#', order: 5, role: 'IS_AUTHENTICATED_FULLY', icon: "icon-settings", guideSelector: 'menu-setup'},
+        {label: 'SPARQL Templates', labelKey: 'menu.sparql.template.label', href: 'sparql-templates', order: 51, parent: 'Setup', role: "IS_AUTHENTICATED_FULLY", guideSelector: 'sub-menu-sparql-templates'}
     ]
 });

--- a/src/js/angular/sparql/plugin.js
+++ b/src/js/angular/sparql/plugin.js
@@ -17,7 +17,8 @@ PluginRegistry.add('main.menu', {
             href: 'sparql',
             order: 2,
             role: 'IS_AUTHENTICATED_FULLY',
-            icon: "icon-sparql"
+            icon: "icon-sparql",
+            guideSelector: 'menu-sparql'
         }
     ]
 });

--- a/src/js/angular/stats/plugin.js
+++ b/src/js/angular/stats/plugin.js
@@ -26,26 +26,30 @@ PluginRegistry.add('main.menu', {
             href: '#',
             order: 7,
             role: 'IS_AUTHENTICATED_FULLY',
-            icon: 'icon-settings'
+            icon: 'icon-settings',
+            guideSelector: 'menu-setup'
         }, {
             label: 'Help',
             labelKey: 'menu.help.label',
             href: '#',
             order: 8,
-            icon: 'icon-help'
+            icon: 'icon-help',
+            guideSelector: 'menu-help'
         }, {
             label: 'System information',
             labelKey: 'menu.system.information.label',
             href: 'sysinfo',
             order: 50,
             parent: 'Help',
-            role: 'ROLE_ADMIN'
+            role: 'ROLE_ADMIN',
+            guideSelector: 'sub-menu-system-information'
         }, {
             label: 'REST API',
             labelKey: 'menu.rest.api.label',
             href: 'webapi',
             order: 1,
-            parent: 'Help'
+            parent: 'Help',
+            guideSelector: 'sub-menu-rest-api'
         }, {
             label: 'Documentation',
             labelKey: 'menu.documentation.label',
@@ -54,7 +58,8 @@ PluginRegistry.add('main.menu', {
             icon: 'icon-external',
             hrefFun: function (productInfo) {
                 return DOCUMENTATION_URL + productInfo.productShortVersion + '/';
-            }
+            },
+            guideSelector: 'sub-menu-documentation'
         }, {
             label: 'Developer Hub',
             labelKey: 'menu.developer.hub.label',
@@ -63,7 +68,8 @@ PluginRegistry.add('main.menu', {
             icon: 'icon-external',
             hrefFun: function (productInfo) {
                 return DOCUMENTATION_URL + productInfo.productShortVersion + '/devhub/';
-            }
+            },
+            guideSelector: 'sub-menu-developer-hub'
         }, {
             label: 'Support',
             labelKey: 'menu.support.label',
@@ -72,7 +78,8 @@ PluginRegistry.add('main.menu', {
             icon: 'icon-external',
             hrefFun: function (productInfo) {
                 return DOCUMENTATION_URL + productInfo.productShortVersion + '/support.html';
-            }
+            },
+            guideSelector: 'sub-menu-support'
         }
     ]
 });

--- a/src/template.html
+++ b/src/template.html
@@ -109,7 +109,7 @@
     </li>
     <li ng-repeat="item in menu track by $index" ng-if="hasRole(item.role)"
         ng-class="{open: $index === selected, clicked: clicked && $index === selected}"
-        class="menu-element" ng-click="checkSubMenuPosition($index)">
+        class="menu-element" ng-click="checkSubMenuPosition($index)" guide-selector="{{item.guideSelector}}">
         <div class="menu-element-root" ng-if="item.children.length" ng-click="select($index, $event, clicked);">
             <span ng-class=item.icon class="menu-item-icon"></span>
             <span class="menu-item">{{item.label}}</span>
@@ -124,7 +124,8 @@
             <li ng-repeat="submenu in item.children track by $index"
                 class="sub-menu-item"
                 ng-class="{ active: (isCurrentPath(submenu.href) || isCurrentSubmenuChildPath(submenu)) }"
-                ng-if="checkForWrite(submenu.role, getActiveRepositoryObject()) && checkEdition(submenu.editions)">
+                ng-if="checkForWrite(submenu.role, getActiveRepositoryObject()) && checkEdition(submenu.editions)"
+                guide-selector="{{submenu.guideSelector}}">
                 <a ng-href="{{::submenu.hrefFun ? submenu.hrefFun(productInfo) : submenu.href}}">{{submenu.label}}
                   <span ng-if="submenu.icon" title="{{'open.external.page' | translate}}" ng-class=submenu.icon class="text-muted"></span>
                 </a>


### PR DESCRIPTION
WHAT:

     Added 'click-main-menu' guide plugin.
WHY:

	It can used as part of other guide plugin when have interaction with main menu.
HOW:

	Registers 'click-main-menu' plugin to 'guide.step' plugins.

Additional changes:

   Extends guide service with new functions.
   Added specific guide selector to all menus and sub menus.
   Added html support to popover dialog. Translate service is configured to escape HTML entities as <,> etc. and this breaks processing dialog content as html. Fixed as unescapes escaped characters of translated content.