### PR TITLE
GDB-7311: Added enable autocomplete index

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1608,5 +1608,7 @@
     "all": "all",
     "clear.tooltip": "Clear",
     "repo.page.location.label": "Location",
-    "repo.page.location.input.field.tooltip": "The location where to create repository. The default is the local one."
+    "repo.page.location.input.field.tooltip": "The location where to create repository. The default is the local one.",
+    "guide.step_plugin.enable-autocomplete.title": "",
+    "guide.step_plugin.enable-autocomplete.content": "Click checkbox that enables the index"
 }

--- a/src/js/angular/guides/guide-utils.js
+++ b/src/js/angular/guides/guide-utils.js
@@ -28,12 +28,18 @@ const GuideUtils = (function () {
                 try {
                     let element = document.querySelector(selector);
                     if (element != null) {
+                        if (!checkVisibility || angular.element(element).is(':visible')) {
                             clearInterval(elementExist);
-                        if (angular.element(element).is(':visible')) {
-                            resolve(element);
+                            setTimeout(() => {
+                                resolve(angular.element(element));
+                            }, 0)
                         } else {
+                            iteration -= waitTime;
+                            if (iteration < 0) {
+                                clearInterval(elementExist);
                                 console.log('Element is not visible: ' + selector);
                                 reject();
+                            }
                         }
                     } else {
                         iteration -= waitTime;

--- a/src/js/angular/guides/guides.service.js
+++ b/src/js/angular/guides/guides.service.js
@@ -144,6 +144,7 @@ function GuidesService($http, $rootScope, $translate, ShepherdService) {
     this.guideResumeSubscription = undefined;
     this.languageChangeSubscription = undefined;
     this.guideCancelSubscription = undefined;
+    this.guideRepositoryUrl = '';
 
     this.init = () => {
         this._subscribeToGuideResumed();
@@ -176,6 +177,7 @@ function GuidesService($http, $rootScope, $translate, ShepherdService) {
                 }
             });
     }
+
 
     /**
      * Cancel the currently started guide if any.
@@ -213,7 +215,7 @@ function GuidesService($http, $rootScope, $translate, ShepherdService) {
      */
     this.loadGuide = (guideFileName) => {
         return new Promise(resolve => {
-            $http.get(`guides/${guideFileName}`)
+            $http.get(`${this.guideRepositoryUrl}/guides/${guideFileName}`)
                 .success(function (data) {
                     resolve(data);
                 });
@@ -238,7 +240,7 @@ function GuidesService($http, $rootScope, $translate, ShepherdService) {
      */
     this.getGuides = () => {
         return new Promise(resolve => {
-            $http.get(`guides/guides.json`)
+            $http.get(`${this.guideRepositoryUrl}/guides/guides.json`)
                 .success(function (data) {
                     resolve(data);
                 });
@@ -251,7 +253,7 @@ function GuidesService($http, $rootScope, $translate, ShepherdService) {
      */
     this.getTranslation = () => {
         return new Promise(resolve => {
-            $http.get(`guides/i18n/locale-${$translate.use()}.json`)
+            $http.get(`${this.guideRepositoryUrl}/guides/i18n/locale-${$translate.use()}.json`)
                 .success(function (data) {
                     resolve(data);
                 });
@@ -301,7 +303,8 @@ function GuidesService($http, $rootScope, $translate, ShepherdService) {
      *       maxWaitTime: number,
      *       canBePaused: boolean,
      *       onNextClick: function
-     *       onPreviousClick: function
+     *       onPreviousClick: function,
+     *       beforeShowPromise: function
      *     }
      * </pre>
      *
@@ -365,6 +368,10 @@ function GuidesService($http, $rootScope, $translate, ShepherdService) {
      *     <li>
      *         <b>onPreviousClick</b> - function which will be executed when previous button is clicked.
      *     </li>
+     *     <li>
+     *         <b>beforeShowPromise</b> - a function that returns a promise. When the promise resolves, the rest of the show code for the step will execute.
+     *         Default implementation is wait <code>maxWaitTime</code> element with <code>elementSelector</code> to be visible.
+     *     </li>
      * </ul>
      * @private
      */
@@ -418,7 +425,7 @@ function GuidesService($http, $rootScope, $translate, ShepherdService) {
                 if (!!predefinedStepDescription.getSteps) {
                     steps = steps.concat(this._getSteps(angular.copy(predefinedStepDescription.getSteps(options, GuideUtils)), parentOptions));
                 } else if (!!predefinedStepDescription.getStep) {
-                    steps.push(angular.copy(predefinedStepDescription.getStep(options)));
+                    steps.push(angular.copy(predefinedStepDescription.getStep(options, GuideUtils)));
                 } else {
                     steps = steps.concat(this._getSteps(angular.copy(predefinedStepDescription, predefinedStepDescription.options), parentOptions));
                 }

--- a/src/js/angular/guides/steps/complex/enable-autocomplete/plugin.js
+++ b/src/js/angular/guides/steps/complex/enable-autocomplete/plugin.js
@@ -1,0 +1,31 @@
+PluginRegistry.add('guide.step', [
+    {
+        'guideBlockName': 'enable-autocomplete',
+        'getSteps': (options, GuideUtils) => [
+            {
+                'guideBlockName': 'click-main-menu',
+                'options': angular.extend({}, {
+                    'label': 'menu_setup_autocomplete',
+                    'parentMenuSelector': 'menu-setup',
+                    'menuSelector': 'sub-menu-autocomplete'
+                }, options)
+            }, {
+                'guideBlockName': 'clickable-element',
+                'options': angular.extend({}, {
+                    'title': 'guide.step_plugin.enable-autocomplete.title',
+                    'content': 'guide.step_plugin.enable-autocomplete.content',
+                    'url': '/autocomplete',
+                    'elementSelector': GuideUtils.getGuideElementSelector('autocompleteCheckbox'),
+                    'onNextClick': () => {
+                        GuideUtils.waitFor(GuideUtils.getGuideElementSelector('autocompleteCheckbox', ' input'), 3, false)
+                            .then(autocompleteCheckbox => {
+                                if (!autocompleteCheckbox.is(':checked')) {
+                                    GuideUtils.clickOnGuideElement('autocompleteCheckbox')();
+                                }
+                            });
+                    }
+                }, options)
+            }
+        ]
+    }
+]);

--- a/src/js/angular/guides/steps/core/plugin.js
+++ b/src/js/angular/guides/steps/core/plugin.js
@@ -11,32 +11,64 @@ const BASIC_STEP = {
     'onPreviousClick': undefined
 };
 
+/**
+ * This function will be call before show a step. Step will shown after promise is resolve. It waits element of step to be visible on the page.
+ * @param maxWaitTime
+ * @param GuideUtils
+ * @param elementSelector
+ * @returns {function(): *}
+ */
+const beforeShowPromise = (GuideUtils, elementSelector, maxWaitTime) => {
+    return () => {
+        return GuideUtils.waitFor(elementSelector, maxWaitTime);
+    }
+}
+
 PluginRegistry.add('guide.step', [
     {
         'guideBlockName': 'clickable-element',
-        'getStep': (options) => {
+        'getStep': (options, GuideUtils) => {
             const notOverridable = {
                 'type': 'clickable',
             };
-            return angular.extend({}, BASIC_STEP, options, notOverridable);
+
+            const stepDescription = angular.extend({}, BASIC_STEP, {
+                'advanceOn': {
+                    selector: options.elementSelector,
+                    event: 'click'
+                },
+            }, options, notOverridable);
+
+            if (!stepDescription.beforeShowPromise) {
+                stepDescription.beforeShowPromise = beforeShowPromise(GuideUtils, stepDescription.elementSelector, stepDescription.maxWaitTime);
+            }
+            return stepDescription;
         }
     },
     {
         'guideBlockName': 'read-only-element',
-        'getStep': (options) => {
+        'getStep': (options, GuideUtils) => {
             const notOverridable = {
                 'type': 'readonly',
             };
-            return angular.extend({}, BASIC_STEP, options, notOverridable);
+            const stepDescription = angular.extend({}, BASIC_STEP, options, notOverridable);
+            if (!stepDescription.beforeShowPromise) {
+                stepDescription.beforeShowPromise = beforeShowPromise(GuideUtils, stepDescription.elementSelector, stepDescription.maxWaitTime);
+            }
+            return stepDescription;
         }
     },
     {
         'guideBlockName': 'input-element',
-        'getStep': (options) => {
+        'getStep': (options, GuideUtils) => {
             const notOverridable = {
                 'type': 'readonly',
             };
-            return angular.extend({}, BASIC_STEP, options, notOverridable);
+            const stepDescription = angular.extend({}, BASIC_STEP, options, notOverridable);
+            if (!stepDescription.beforeShowPromise) {
+                stepDescription.beforeShowPromise = beforeShowPromise(GuideUtils, stepDescription.elementSelector, stepDescription.maxWaitTime);
+            }
+            return stepDescription;
         }
     }
 ]);

--- a/src/pages/autocomplete.html
+++ b/src/pages/autocomplete.html
@@ -34,7 +34,12 @@
 		<div ng-if="pluginFound && !getDegradedReason()">
             <div class="lead mb-1" id="toggleIndex">
 				<span class="autocomplete-header">{{'autocomplete.for.repo' | translate}} <strong>{{getActiveRepository()}}</strong> {{'is.label' | translate}} <span class="tag {{autocompleteEnabled ? 'tag-primary' : 'tag-default'}}">{{autocompleteEnabled ? 'common.on.btn' : 'common.off.btn' | translate}}</span></span>
-				<span tooltip="{{'click.to' | translate}} {{autocompleteEnabled ? 'disable.label' : 'enable.label' | translate}} {{'autocomplete.sentence.end' | translate}}" tooltip-placement="top" tooltip-trigger="mouseenter" ng-click="toggleAutocomplete()" class="switch autocomplete-switch enable-autocomplete-switch">
+				<span tooltip="{{'click.to' | translate}} {{autocompleteEnabled ? 'disable.label' : 'enable.label' | translate}} {{'autocomplete.sentence.end' | translate}}"
+                      tooltip-placement="top"
+                      tooltip-trigger="mouseenter"
+                      ng-click="toggleAutocomplete()"
+                      guide-selector="autocompleteCheckbox"
+                      class="switch autocomplete-switch enable-autocomplete-switch">
                     <input type="checkbox" class="switch" ng-checked="autocompleteEnabled"/>
                     <label for="toggleIndex"></label>
                 </span>


### PR DESCRIPTION
WHAT:
 Added 'enable-autocomplete' guide plugin.

WHY:
It can used as part of guides.

HOW:
Registers 'enable-autocomplete' plugin to 'guide.step' plugins.

Additional changes:
	Refactor function _pauseGuide of ShepherdService.
	Symplify implementations of functions "_getPreviousButtonAction" and "_getNextButtonAction".
	Added support if elemen of a step is clickable and user click on it guide will show next step automatically.