### PR TITLE
GDB-7292 fixes and improvements

### DIFF
--- a/src/js/angular/core/directives.js
+++ b/src/js/angular/core/directives.js
@@ -258,9 +258,9 @@ function multiRequired() {
 
 const SEARCH_DISPLAY_TYPE = {table: 'table', visual: 'visual'};
 
-searchResourceInput.$inject = ['$location', 'toastr', 'ClassInstanceDetailsService', 'AutocompleteRestService', '$rootScope', '$q', '$sce', 'LocalStorageAdapter', 'LSKeys', '$repositories', '$translate'];
+searchResourceInput.$inject = ['$location', 'toastr', 'ClassInstanceDetailsService', 'AutocompleteRestService', '$rootScope', '$q', '$sce', 'LocalStorageAdapter', 'LSKeys', '$repositories', '$translate', 'GuidesService'];
 
-function searchResourceInput($location, toastr, ClassInstanceDetailsService, AutocompleteRestService, $rootScope, $q, $sce, LocalStorageAdapter, LSKeys, $repositories, $translate) {
+function searchResourceInput($location, toastr, ClassInstanceDetailsService, AutocompleteRestService, $rootScope, $q, $sce, LocalStorageAdapter, LSKeys, $repositories, $translate, GuidesService) {
     return {
         restrict: 'EA',
         scope: {
@@ -540,6 +540,9 @@ function searchResourceInput($location, toastr, ClassInstanceDetailsService, Aut
             $scope.onKeyDown = function (event) {
                 if (event.keyCode === 13) {
                     event.preventDefault();
+                    if (GuidesService.isActive()) {
+                        return;
+                    }
                     if ($scope.uriValidation !== 'false') {
                         if (element.autoCompleteStatus) {
                             $scope.checkIfValidAndSearchEvent(event);

--- a/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -21,9 +21,9 @@ angular
         $tooltipProvider.options({appendToBody: true});
     }]);
 
-GraphsVisualizationsCtrl.$inject = ["$scope", "$rootScope", "$repositories", "$licenseService", "toastr", "$timeout", "$http", "ClassInstanceDetailsService", "AutocompleteRestService", "$q", "$location", "$jwtAuth", "UiScrollService", "ModalService", "$modal", "$window", "LocalStorageAdapter", "LSKeys", "SavedGraphsRestService", "GraphConfigRestService", "RDF4JRepositoriesRestService", "$translate"];
+GraphsVisualizationsCtrl.$inject = ["$scope", "$rootScope", "$repositories", "$licenseService", "toastr", "$timeout", "$http", "ClassInstanceDetailsService", "AutocompleteRestService", "$q", "$location", "$jwtAuth", "UiScrollService", "ModalService", "$modal", "$window", "LocalStorageAdapter", "LSKeys", "SavedGraphsRestService", "GraphConfigRestService", "RDF4JRepositoriesRestService", "$translate", "GuidesService"];
 
-function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseService, toastr, $timeout, $http, ClassInstanceDetailsService, AutocompleteRestService, $q, $location, $jwtAuth, UiScrollService, ModalService, $modal, $window, LocalStorageAdapter, LSKeys, SavedGraphsRestService, GraphConfigRestService, RDF4JRepositoriesRestService, $translate) {
+function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseService, toastr, $timeout, $http, ClassInstanceDetailsService, AutocompleteRestService, $q, $location, $jwtAuth, UiScrollService, ModalService, $modal, $window, LocalStorageAdapter, LSKeys, SavedGraphsRestService, GraphConfigRestService, RDF4JRepositoriesRestService, $translate, GuidesService) {
 
     $scope.languageChanged = false;
     $scope.propertiesObj = {};
@@ -1658,6 +1658,10 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
 
 
         function dragstarted(d) {
+            if (GuidesService.isActive()) {
+                // disable dragging if a guide is active.
+                return;
+            }
             if (d3.event.sourceEvent.button === 0) {
                 d.fixedBeforeDrag = d.fixed;
                 d.isBeingDragged = true;
@@ -1815,6 +1819,10 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
         });
 
         function panAndZoomed() {
+            if (GuidesService.isActive()) {
+                // disable zooming if a guide is active.
+                return;
+            }
             transformValues = "translate(" + d3.event.translate + ") scale(" + d3.event.scale + ")";
             container.attr("transform", transformValues);
         }
@@ -2993,9 +3001,13 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
 
     // event for capturing left and right arrows used for rotation
     $('body').on("keydown", function (event) {
-        if (event.target.nodeName === 'input' || !$scope.nodeSelected) {
-            // don't do anything when the target is an input field or no node is selected
-        } else if (event.keyCode === 37) {
+
+        if (GuidesService.isActive() || event.target.nodeName === 'input' || !$scope.nodeSelected) {
+            // don't do anything when the target is an input field or no node is selected or a guide is active.
+            return;
+        }
+
+       if (event.keyCode === 37) {
             // left arrow rotates left
             $scope.rotate(true);
         } else if (event.keyCode === 39) {

--- a/src/js/angular/guides/guide-utils.js
+++ b/src/js/angular/guides/guide-utils.js
@@ -77,13 +77,18 @@ const GuideUtils = (function () {
      * Returns a function that returns a promise that will resolve when the D3 library force layout
      * settles (reaches an alpha value below the given threshold) or when the maximum wait time
      * passes. Useful in 'beforeShowPromise' of a step.
+     * @param elementSelector - a node selector.
      * @param scope scope where the d3alpha property is set
      * @param timeoutInSeconds maximum wait time for the alpha value to settle, the default is 2 seconds
      * @param alphaThreshold alpha value threshold, the default is 0.02
      * @returns {function(): Promise<unknown>}
      */
-    const awaitAlphaDropD3 = function (scope, timeoutInSeconds = 2, alphaThreshold = 0.02) {
+    const awaitAlphaDropD3 = function (elementSelector, scope, timeoutInSeconds = 2, alphaThreshold = 0.02) {
         return () => new Promise(function(resolve) {
+            if (isVisible(elementSelector)) {
+                resolve();
+                return;
+            }
             setTimeout(() => {
                 let iteration = timeoutInSeconds * 1000;
                 const waitTime = 100;

--- a/src/js/angular/guides/steps/complex/import-rdf-file/plugin.js
+++ b/src/js/angular/guides/steps/complex/import-rdf-file/plugin.js
@@ -14,7 +14,7 @@ PluginRegistry.add('guide.step', [
                     }, options)
                 },
                 {
-                    guideBlockName: 'read-only-element',
+                    guideBlockName: 'clickable-element',
                     options: angular.extend({}, {
                         title: 'guide.step_plugin.import_rdf_file.title',
                         content: 'guide.step_plugin.import_rdf_file.content',

--- a/src/js/angular/guides/steps/complex/visual-graph/plugin.js
+++ b/src/js/angular/guides/steps/complex/visual-graph/plugin.js
@@ -54,6 +54,7 @@ PluginRegistry.add('guide.step', [
         getSteps: (options, services) => {
             const GuideUtils = services.GuideUtils;
             const $rootScope = services.$rootScope;
+            const elementSelector = `.node-wrapper[id^="${options.iri}"] circle`;
             return [
                 {
                     guideBlockName: 'clickable-element',
@@ -61,16 +62,21 @@ PluginRegistry.add('guide.step', [
                         title: 'guide.step_plugin.visual-graph-expand.title',
                         content: 'guide.step_plugin.visual-graph-expand.content',
                         url: '/graphs-visualizations',
-                        elementSelector: `.node-wrapper[id^="${options.iri}"] circle`,
+                        canBePaused: false,
+                        elementSelector,
                         advanceOn: {
                             selector: `.node-wrapper[id^="${options.iri}"] circle`,
                             event: 'dblclick'
                         },
-                        onNextClick: (guide, step) => {
-                            GuideUtils.graphVizExpandNode(step.elementSelector);
-                            guide.next();
+                        onNextClick: (guide, stepDescription) => {
+                            GuideUtils.graphVizExpandNode(stepDescription.elementSelector);
+                            guide.getCurrentStep().hide();
+                            GuideUtils.awaitAlphaDropD3(null, $rootScope)()
+                                .then(() => {
+                                    guide.next();
+                                });
                         },
-                        beforeShowPromise: GuideUtils.awaitAlphaDropD3($rootScope)
+                        beforeShowPromise: GuideUtils.awaitAlphaDropD3(elementSelector, $rootScope)
                     }, options)
                 }
             ];
@@ -81,6 +87,7 @@ PluginRegistry.add('guide.step', [
         getSteps: (options, services) => {
             const GuideUtils = services.GuideUtils;
             const $rootScope = services.$rootScope;
+            const elementSelector = `.node-wrapper[id^="${options.iri}"] circle`;
             const steps = [
                 {
                     guideBlockName: 'clickable-element',
@@ -88,7 +95,8 @@ PluginRegistry.add('guide.step', [
                         title: 'guide.step_plugin.visual-graph-properties.title',
                         content: 'guide.step_plugin.visual-graph-properties.content',
                         url: '/graphs-visualizations',
-                        elementSelector: `.node-wrapper[id^="${options.iri}"] circle`,
+                        elementSelector,
+                        canBePaused: false,
                         advanceOn: {
                             selector: `.node-wrapper[id^="${options.iri}"] circle`,
                             event: 'click'
@@ -97,7 +105,7 @@ PluginRegistry.add('guide.step', [
                             GuideUtils.graphVizShowNodeInfo(step.elementSelector);
                             guide.next();
                         },
-                        beforeShowPromise: GuideUtils.awaitAlphaDropD3($rootScope)
+                        beforeShowPromise: GuideUtils.awaitAlphaDropD3(elementSelector, $rootScope)
                     }, options)
                 },
                 {
@@ -106,7 +114,8 @@ PluginRegistry.add('guide.step', [
                         title: 'guide.step_plugin.visual-graph-properties-side-panel.title',
                         content: 'guide.step_plugin.visual-graph-properties-side-panel.content',
                         url: '/graphs-visualizations',
-                        elementSelector: '.rdf-info-side-panel',
+                        elementSelector: '.rdf-side-panel-content',
+                        canBePaused: false,
                         placement: 'left',
                         beforeShowPromise: GuideUtils.deferredShow(500)
                     }, options)
@@ -127,6 +136,7 @@ PluginRegistry.add('guide.step', [
                             title: 'guide.step_plugin.visual-graph-properties-focus' + translationIdSuffix + '.title',
                             content: 'guide.step_plugin.visual-graph-properties-focus' + translationIdSuffix + '.content',
                             url: '/graphs-visualizations',
+                            canBePaused: false,
                             elementSelector: GuideUtils.getGuideElementSelector('graph-visualization-node-info-' + focusProperty.property),
                             focusProperty: focusProperty.property,
                             extraContent: focusProperty.message
@@ -141,6 +151,7 @@ PluginRegistry.add('guide.step', [
                     title: 'guide.step_plugin.visual-graph-properties-side-panel-close.title',
                     content: 'guide.step_plugin.visual-graph-properties-side-panel-close.content',
                     url: '/graphs-visualizations',
+                    canBePaused: false,
                     elementSelector: GuideUtils.getGuideElementSelector('close-info-panel'),
                     advanceOn: {
                         selector: GuideUtils.getGuideElementSelector('close-info-panel'),
@@ -160,6 +171,7 @@ PluginRegistry.add('guide.step', [
         getSteps: (options, services) => {
             const GuideUtils = services.GuideUtils;
             const $rootScope = services.$rootScope;
+            const elementSelector = `.link-wrapper[id^="${options.fromIri}>${options.toIri}"]`;
             return [
                 {
                     guideBlockName: 'read-only-element',
@@ -167,9 +179,10 @@ PluginRegistry.add('guide.step', [
                         title: 'guide.step_plugin.visual-graph-link-focus.title',
                         content: 'guide.step_plugin.visual-graph-link-focus.content',
                         url: '/graphs-visualizations',
+                        canBePaused: false,
                         extraPadding: 40,
-                        elementSelector: `.link-wrapper[id^="${options.fromIri}>${options.toIri}"]`,
-                        beforeShowPromise: GuideUtils.awaitAlphaDropD3($rootScope)
+                        elementSelector,
+                        beforeShowPromise: GuideUtils.awaitAlphaDropD3(elementSelector, $rootScope)
                     }, options)
                 }
             ];
@@ -180,6 +193,7 @@ PluginRegistry.add('guide.step', [
         getSteps: (options, services) => {
             const GuideUtils = services.GuideUtils;
             const $rootScope = services.$rootScope;
+            const elementSelector = `.node-wrapper[id^="${options.iri}"] circle`;
             return [
                 {
                     guideBlockName: 'read-only-element',
@@ -187,9 +201,10 @@ PluginRegistry.add('guide.step', [
                         title: 'guide.step_plugin.visual-graph-node-focus.title',
                         content: 'guide.step_plugin.visual-graph-node-focus.content',
                         url: '/graphs-visualizations',
+                        canBePaused: false,
                         extraPadding: 10,
-                        elementSelector: `.node-wrapper[id^="${options.iri}"] circle`,
-                        beforeShowPromise: GuideUtils.awaitAlphaDropD3($rootScope)
+                        elementSelector,
+                        beforeShowPromise: GuideUtils.awaitAlphaDropD3(elementSelector, $rootScope)
                     }, options)
                 }
             ];

--- a/src/js/angular/guides/tour-lib-services/shepherd.service.js
+++ b/src/js/angular/guides/tour-lib-services/shepherd.service.js
@@ -143,7 +143,11 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
     }
 
     this.isActive = () => {
-        return Shepherd.activeTour;
+        if (!Shepherd.activeTour) {
+            return false;
+        }
+        const paused = LocalStorageAdapter.get(GUIDE_PAUSE);
+        return paused && paused === 'false';
     };
 
     this.getGuideId = () => {

--- a/src/pages/graphs-visualizations.html
+++ b/src/pages/graphs-visualizations.html
@@ -218,6 +218,7 @@
         onopen="onopen"
         onclose="onclose"
         ps-side="right"
+        ps-click-outside="false"
         ps-custom-height="calc(100vh - 55px)"
         ps-size="{{pageslideExpanded ? '80vw' : '25vw'}}">
     <div class="rdf-side-panel-content break-word-alt p-1 pt-2">


### PR DESCRIPTION
GDB-7310 - Fixes import rdf file. Button was not clickable. GDB-7312 - Disabling keyboard events, zoom and dragging of a node when a guide is active. Disabling search when fill "Search RDF resources" input and press "Enter" button when a guide is active. GDB-7312 - Fixes issue with buttons of visual graph toolbar.

Additional work:
  - fixes isActive function of ShepherService
  - added check if node is visible in awaitAlphaDropD3 function.