### PR TITLE
GDB-7306-Add/remove FTS indexes after repo config restart.

### DIFF
--- a/src/js/angular/repositories/controllers.js
+++ b/src/js/angular/repositories/controllers.js
@@ -849,7 +849,7 @@ function EditRepositoryCtrl($scope, $routeParams, toastr, $repositories, $locati
                 toastr.success($translate.instant('edit.repo.success.msg', {saveId: $scope.repositoryInfo.saveId}));
                 $repositories.init().finally(() => $scope.goBackToPreviousLocation());
                 if ($scope.repositoryInfo.saveId === $scope.repositoryInfo.id && $scope.repositoryInfo.restartRequested) {
-                    $repositories.restartRepository($scope.repositoryInfo.id);
+                    $repositories.restartRepository($scope.repositoryInfo);
                 }
             }).error(function (data) {
             const msg = getError(data);


### PR DESCRIPTION
Changed in controllers.js, $scope.editRepoHttp = function (), passing the repo as object as it was passing only its id.