### PR TITLE
Class hierarchy issues

### DIFF
--- a/src/js/angular/guides/steps/complex/class-hierarchy/plugin.js
+++ b/src/js/angular/guides/steps/complex/class-hierarchy/plugin.js
@@ -30,8 +30,8 @@ PluginRegistry.add('guide.step', [
                         content: '',
                         extraContent: options.introExtraContent,
                         url: '/hierarchy',
-                        elementSelector: '#classChart',
-                        placement: 'top'
+                        elementSelector: '#classChart #main-group',
+                        placement: 'left'
                     }, options)
                 });
             }
@@ -44,6 +44,7 @@ PluginRegistry.add('guide.step', [
                         options: angular.extend({}, {
                             content: 'guide.step_plugin.class_hierarchy_zoom.content',
                             url: '/hierarchy',
+                            placement: 'left',
                             elementSelector: selector,
                             onNextClick: (guide, step) => {
                                 GuideUtils.classHierarchyZoom(step.elementSelector);
@@ -58,6 +59,8 @@ PluginRegistry.add('guide.step', [
                                 content: '',
                                 extraContent: zoomIri.postExtraContent,
                                 url: '/hierarchy',
+                                placement: 'left',
+                                beforeShowPromise: GuideUtils.deferredShow(800),
                                 elementSelector: selector
                             }, options)
                         });

--- a/src/js/angular/guides/steps/complex/table-graph/plugin.js
+++ b/src/js/angular/guides/steps/complex/table-graph/plugin.js
@@ -23,7 +23,7 @@ PluginRegistry.add('guide.step', [
                     options: angular.extend({}, {
                         content: 'guide.step_plugin.table-graph-overview',
                         scrollToHandler: GuideUtils.scrollToTop,
-                        elementSelector: GuideUtils.getSparqlResultsSelector(),
+                        elementSelector: GuideUtils.getSparqlResultsSelector() + ' tbody',
                         placement: 'top'
                     }, options)
                 }
@@ -96,7 +96,7 @@ PluginRegistry.add('guide.step', [
                         steps.push({
                             guideBlockName: 'read-only-element',
                             options: angular.extend({}, {
-                                elementSelector: GuideUtils.getSparqlResultsSelector()
+                                elementSelector: GuideUtils.getSparqlResultsSelector() + ' tbody'
                             }, angular.extend({}, options, subStep))
                         });
                     }


### PR DESCRIPTION
Fixed GDB-7471. Changed position of the steps to be on left class hierarchy side.

Fixed GDB-7474. The selector of the step pointed the header of the table with query results. There is not enough space for the dialog that's why it is shown under the table header row. The selector is changed to points to the body of the table.