### PR TITLE
GDB-7489: User Guide break when the user clicks outside info panel

### DIFF
--- a/src/pages/rdfClassHierarchyInfo.html
+++ b/src/pages/rdfClassHierarchyInfo.html
@@ -149,6 +149,7 @@
                 onopen="onopen"
                 onclose="onclose"
                 ps-side="right"
+                ps-click-outside="false"
 				ps-custom-height="calc(100vh - 55px)"
 				ps-size="25vw">
             <div class="break-word-alt p-1">


### PR DESCRIPTION
Switched off auto close pageslide component when click outside panel.