### PR TITLE
GDB-7487: User Guide blocks the workbench if the user double clicks

### DIFF
--- a/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -1545,14 +1545,16 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
 
             const event = d3.event;
             const element = this;
-            if (d3.event.timeStamp - upEventLast < multiClickDelay) {
-                if (virtualClickEventTimer === 1) {
-                    mouseEventTimer = $timeout(function () {
-                        clickedNode(d, element, event);
-                    }, 40 + multiClickDelay - (d3.event.timeStamp - upEventLast));
-                } else if (virtualClickEventTimer === 2) {
-                    // expand node
-                    expandEventHandler(d, 0, element.parentNode);
+            if (!GuidesService.isActive()) {
+                if (d3.event.timeStamp - upEventLast < multiClickDelay) {
+                    if (virtualClickEventTimer === 1) {
+                        mouseEventTimer = $timeout(function () {
+                            clickedNode(d, element, event);
+                        }, 40 + multiClickDelay - (d3.event.timeStamp - upEventLast));
+                    } else if (virtualClickEventTimer === 2) {
+                        // expand node
+                        expandEventHandler(d, 0, element.parentNode);
+                    }
                 }
             }
 

--- a/src/js/angular/guides/guide-utils.js
+++ b/src/js/angular/guides/guide-utils.js
@@ -4,33 +4,33 @@ const GuideUtils = (function () {
 
     const clickOnElement = function (elementSelector) {
         return () => waitFor(elementSelector)
-            .then(element => element.click());
-    }
+            .then((element) => element.click());
+    };
 
     const clickOnGuideElement = function (elementSelector, postSelector) {
         return GuideUtils.clickOnElement(GuideUtils.getGuideElementSelector(elementSelector, postSelector));
-    }
+    };
 
     /**
      * Waits element to be present.
-     * @param selector - selector of element looking for.
-     * @param checkVisibility - if true will wait to become visible. Default value is true
-     * @param timeoutInSeconds - max time to waite in second. Default value is 1 second.
-     * @returns {Promise}
+     * @param {string} selector - selector of element looking for.
+     * @param {number} timeoutInSeconds - max time to waite in second. Default value is 1 second.
+     * @param {boolean} checkVisibility - if true will wait to become visible. Default value is true
+     * @return {Promise}
      */
-    const waitFor = function (selector, timeoutInSeconds, checkVisibility = true) {
+    const waitFor = function (selector, timeoutInSeconds = 1, checkVisibility = true) {
         return new Promise(function (resolve, reject) {
             let iteration = timeoutInSeconds * 1000 | 1000;
             const waitTime = 100;
             const elementExist = setInterval(() => {
                 try {
-                    let element = document.querySelector(selector);
+                    const element = document.querySelector(selector);
                     if (element != null) {
                         if (!checkVisibility || angular.element(element).is(':visible')) {
                             clearInterval(elementExist);
                             setTimeout(() => {
                                 resolve(angular.element(element));
-                            }, 0)
+                            }, 0);
                         } else {
                             iteration -= waitTime;
                             if (iteration < 0) {
@@ -51,7 +51,7 @@ const GuideUtils = (function () {
                     clearInterval(elementExist);
                     console.log('Error when processing selector: ' + selector);
                     console.log(error);
-                    reject();
+                    reject(error);
                 }
             }, waitTime);
         });
@@ -60,25 +60,25 @@ const GuideUtils = (function () {
     const isVisible = function (selector) {
         const element = document.querySelector(selector);
         return element && angular.element(element).is(':visible');
-    }
+    };
 
     const isGuideElementVisible = function (guideSelectorValue) {
-        return this.isVisible(getGuideElementSelector(guideSelectorValue));
-    }
+        return isVisible(getGuideElementSelector(guideSelectorValue));
+    };
 
     const getGuideElementSelector = function (guideSelectorValue, postSelector) {
-        return `[guide-selector="${guideSelectorValue}"] ${postSelector ? postSelector : ''}`
-    }
+        return `[guide-selector="${guideSelectorValue}"] ${postSelector ? postSelector : ''}`;
+    };
 
     /**
      * Returns a function that returns a promise that will resolve when the D3 library force layout
      * settles (reaches an alpha value below the given threshold) or when the maximum wait time
      * passes. Useful in 'beforeShowPromise' of a step.
-     * @param elementSelector - a node selector.
-     * @param scope scope where the d3alpha property is set
-     * @param timeoutInSeconds maximum wait time for the alpha value to settle, the default is 2 seconds
-     * @param alphaThreshold alpha value threshold, the default is 0.02
-     * @returns {function(): Promise<unknown>}
+     * @param {string} elementSelector - a node selector.
+     * @param {*}scope scope where the d3alpha property is set
+     * @param {number} timeoutInSeconds maximum wait time for the alpha value to settle, the default is 2 seconds
+     * @param {number} alphaThreshold alpha value threshold, the default is 0.02
+     * @return {function(): Promise<unknown>}
      */
     const awaitAlphaDropD3 = function (elementSelector, scope, timeoutInSeconds = 2, alphaThreshold = 0.02) {
         return () => new Promise(function(resolve) {
@@ -110,7 +110,7 @@ const GuideUtils = (function () {
 
     /**
      * Expands a graph visualization node by firing a custom event to the visual graph code.
-     * @param elementSelector the node to expand
+     * @param {string} elementSelector the node to expand
      */
     const graphVizExpandNode = function (elementSelector) {
         const element = d3.select(elementSelector);
@@ -120,7 +120,7 @@ const GuideUtils = (function () {
 
     /**
      * Opens the visual graph node info panel by firing a custom event to the visual graph code.
-     * @param elementSelector the node to show the info for
+     * @param {string} elementSelector the node to show the info for
      */
     const graphVizShowNodeInfo = function (elementSelector) {
         const element = d3.select(elementSelector);
@@ -130,7 +130,7 @@ const GuideUtils = (function () {
 
     /**
      * Focuses a class in the class hierarchy view by firing a custom event.
-     * @param elementSelector the node to focus
+     * @param {string} elementSelector the node to focus
      */
     const classHierarchyFocus = function (elementSelector) {
         const element = d3.select(elementSelector);
@@ -140,7 +140,7 @@ const GuideUtils = (function () {
 
     /**
      * Zooms to a class in the class hierarchy view by firing a custom event.
-     * @param elementSelector the node to zoom to
+     * @param {string} elementSelector the node to zoom to
      */
     const classHierarchyZoom = function (elementSelector) {
         const element = d3.select(elementSelector);
@@ -150,11 +150,11 @@ const GuideUtils = (function () {
 
     /**
      * Validates that the provided selector (to a input element) contains the expected user input.
-     * @param elementSelector a selector to an input element
-     * @param expectedInput the expected user input
-     * @param applyInput if true and the input element is empty, the supplied expected user input
+     * @param {*}elementSelector a selector to an input element
+     * @param {*}expectedInput the expected user input
+     * @param {*}applyInput if true and the input element is empty, the supplied expected user input
      * will be entered into the input element; true by default
-     * @returns {boolean} true if the input element is exactly equal to the expected user input,
+     * @return {boolean} true if the input element is exactly equal to the expected user input,
      * false otherwise
      */
     const validateTextInput = function (elementSelector, expectedInput, applyInput = true) {
@@ -172,11 +172,11 @@ const GuideUtils = (function () {
     /**
      * Translates a message, where the message can be a message ID (in most cases) or an object that
      * supplies the translations for each language.
-     * @param $translate the $translation service
-     * @param $interpolate the $interpolate service
-     * @param message the message to translate
-     * @param parameters parameters to pass to the translation service
-     * @returns {*}
+     * @param {*}$translate the $translation service
+     * @param {*}$interpolate the $interpolate service
+     * @param {string} message the message to translate
+     * @param {*}parameters parameters to pass to the translation service
+     * @return {string}
      */
     const translateLocalMessage = ($translate, $interpolate, message, parameters) => {
         const lang = $translate.use();
@@ -196,8 +196,8 @@ const GuideUtils = (function () {
 
     /**
      * Unescape string with HTML Entities: &lt;, &gt; etc.
-     * @param escapedHtml - escaped string. For example: "Click on menu &lt;b&gt;Import&lt;/b&gt;."
-     * @returns {string} - unescaped string. For example: "Click on menu <b>Import</b>."
+     * @param {string} escapedHtml - escaped string. For example: "Click on menu &lt;b&gt;Import&lt;/b&gt;."
+     * @return {string} - unescaped string. For example: "Click on menu <b>Import</b>."
      */
     const unescapeHtml = (escapedHtml) => {
         const div = document.createElement('div');
@@ -207,11 +207,11 @@ const GuideUtils = (function () {
 
     /**
      * Shows a toast with error that advancing to the next step isn't possible.
-     * @param toastr the toast service
-     * @param $translate the translation service
-     * @param $interpolate the interpolation service
-     * @param message the message to show in the toast
-     * @param parameters parameters to pass to the translation service
+     * @param {*}toastr the toast service
+     * @param {*}$translate the translation service
+     * @param {*}$interpolate the interpolation service
+     * @param {string} message the message to show in the toast
+     * @param{*}parameters parameters to pass to the translation service
      */
     const noNextErrorToast = (toastr, $translate, $interpolate, message, parameters) => {
         toastr.error(unescapeHtml(translateLocalMessage($translate, $interpolate, message, parameters)),
@@ -222,8 +222,8 @@ const GuideUtils = (function () {
     /**
      * Returns a function that returns a promise that will resolve when the supplied time passes.
      * Useful in 'beforeShowPromise' of a step to delay things when there is no better way to sync.
-     * @param delay the time to wait in milliseconds
-     * @returns {function(): Promise<unknown>}
+     * @param {number} delay the time to wait in milliseconds
+     * @return {function(): Promise<unknown>}
      */
     const deferredShow = (delay) => {
         return () => new Promise(function (resolve) {
@@ -235,24 +235,24 @@ const GuideUtils = (function () {
 
     const scrollToTop = () => {
         window.scrollTo(0, 0);
-    }
+    };
 
     const removeWhiteSpaces = (value) => {
         return value.replace(/\s+/g, '');
-    }
+    };
 
     /**
      * Constructs a download URL for the downloadable resource described by the provided step's
      * options.
-     * @param options the options of the step
-     * @returns {string} the download URL
+     * @param {*}options the options of the step
+     * @return {string} the download URL
      */
     const toResourceDownloadUrl = (options) => {
         return GUIDES_DOWNLOAD_URL + options.resourcePath + '/' + options.resourceFile;
     };
 
     const getSparqlEditorSelector = (postSelector) => {
-        return getGuideElementSelector('queryEditor', ' .CodeMirror-code', postSelector);
+        return getGuideElementSelector('queryEditor .CodeMirror-code', postSelector);
     };
 
     const getSparqlResultsSelector = (postSelector) => {

--- a/src/js/angular/guides/guides.service.js
+++ b/src/js/angular/guides/guides.service.js
@@ -11,7 +11,7 @@ angular
     .service('GuidesService', GuidesService);
 
 
-GuidesService.$inject = ['$http', '$rootScope', '$translate', '$interpolate', 'ShepherdService', '$repositories', 'toastr', '$location', '$route'];
+GuidesService.$inject = ['$http', '$rootScope', '$translate', '$interpolate', 'ShepherdService', '$repositories', 'toastr', '$location', '$route', '$timeout'];
 
 /**
  * Service for interaction with guide functionality. A guide is described as sequence of steps.
@@ -138,18 +138,19 @@ GuidesService.$inject = ['$http', '$rootScope', '$translate', '$interpolate', 'S
  *     </li>
  * </ul>
  *
- * @param $http - the http client.
- * @param $rootScope - the rootScope.
- * @param $translate - the translation service.
- * @param $interpolate - the interpolation service.
- * @param ShepherdService - service (wrapper) of library  <a href="https://shepherdjs.dev/docs/">shepherd</a>.
- * @param $repositories - the repositories service.
- * @param toastr
- * @param $location
- * @param $route
+ * @param {*} $http - the http client.
+ * @param {*} $rootScope - the rootScope.
+ * @param {*} $translate - the translation service.
+ * @param {*} $interpolate - the interpolation service.
+ * @param {*} ShepherdService - service (wrapper) of library  <a href="https://shepherdjs.dev/docs/">shepherd</a>.
+ * @param {*} $repositories - the repositories service.
+ * @param {*} toastr
+ * @param {*} $location
+ * @param {*} $route
+ * @param {*} $timeout
  * @constructor
  */
-function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdService, $repositories, toastr, $location, $route) {
+function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdService, $repositories, toastr, $location, $route, $timeout) {
 
     this.guideResumeSubscription = undefined;
     this.languageChangeSubscription = undefined;
@@ -169,8 +170,8 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
      *     <li>Converts complex step sequence to core steps sequence;</li>
      *     <li>Starts guide from step with id <code>startStepId.</code>
      * </ol>
-     * @param guide - the guide to start as an object.
-     * @param startStepId
+     * @param {*} guide - the guide to start as an object.
+     * @param {*} startStepId
      */
     this.startGuide = (guide, startStepId) => {
         if (guide && guide.options && guide.options.repositoryIdBase) {
@@ -181,7 +182,7 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
             // - myrepo3 and so on
             const repos = $repositories.getRepositories();
             guide.options.repositoryId = guide.options.repositoryIdBase;
-            for (let i = 2; repos.find(repo => repo.id === guide.options.repositoryId); i++) {
+            for (let i = 2; repos.find((repo) => repo.id === guide.options.repositoryId); i++) {
                 guide.options.repositoryId = guide.options.repositoryIdBase + i;
             }
         }
@@ -204,7 +205,7 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
 
     /**
      * Fetches list with all available guides.
-     * @returns {Promise<[]>} array with guides descriptions. A guide description have to be:
+     * @return {Promise<[]>} array with guides descriptions. A guide description have to be:
      * <pre>
      *     {
      *         name: string,
@@ -219,7 +220,7 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
      *  </ul>
      */
     this.getGuides = () => {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             $http.get(GuideUtils.GUIDES_LIST_URL)
                 .success(function (data) {
                     angular.forEach(data, (guide, index) => {
@@ -232,11 +233,11 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
                     resolve(data);
                 });
         });
-    }
+    };
 
     /**
      * Returns true if a guide is currently active (even if paused).
-     * @returns {*}
+     * @return {boolean}
      */
     this.isActive = () => {
         return ShepherdService.isActive();
@@ -244,7 +245,7 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
 
     /**
      * Converts guide steps (array with complex steps) to array with core steps.
-     * @param guide - a guide description:
+     * @param {*} guide - a guide description:
      *
      * <pre>
      *     {
@@ -271,7 +272,7 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
      *     </li>
      *  </ul>
      *
-     * @returns arrays with core steps extracted from all 'guide.step' plugins registered in <code>data</code>. Format of a step
+     * @return arrays with core steps extracted from all 'guide.step' plugins registered in <code>data</code>. Format of a step
      * description is:
      *
      * <pre>
@@ -359,6 +360,7 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
      *         Default implementation is wait <code>maxWaitTime</code> element with <code>elementSelector</code> to be visible.
      *     </li>
      * </ul>
+     * @return {[]}
      * @private
      */
     this._toStepsDescriptions = (guide) => {
@@ -366,15 +368,15 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
             return [];
         }
         let coreSteps = [];
-        guide.steps.forEach(step => {
+        guide.steps.forEach((step) => {
             coreSteps = coreSteps.concat(this._getSteps(step, guide.options));
         });
         return coreSteps;
-    }
+    };
 
     /**
      * Converts a complex step to array with core steps.
-     * @param complexStep - a complex or core step description. Format of the description is:
+     * @param {*} complexStep - a complex or core step description. Format of the description is:
      * <pre>
      *     {
      *         guideBlockName: string,
@@ -389,24 +391,24 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
      *         <b>options</b> - options of the steps. For example the name of the rdf file which have to be imported.
      *     </li>
      *  </ul>
-     * @param parentOptions - options passed from parent.
-     * @returns {*[]} - an array with core steps.
+     * @param {*}parentOptions - options passed from parent.
+     * @return {*[]} - an array with core steps.
      * @private
      */
     this._getSteps = (complexStep, parentOptions) => {
         let steps = [];
         if (angular.isArray(complexStep)) {
-            complexStep.forEach(stepDescription => {
+            complexStep.forEach((stepDescription) => {
                 steps = steps.concat(this._getSteps(stepDescription, angular.extend({}, complexStep.options, parentOptions)));
             });
         } else {
-            const predefinedStepDescription = PluginRegistry.get('guide.step').find((predefinedStep => predefinedStep.guideBlockName === complexStep.guideBlockName));
+            const predefinedStepDescription = PluginRegistry.get('guide.step').find(((predefinedStep) => predefinedStep.guideBlockName === complexStep.guideBlockName));
             if (predefinedStepDescription) {
                 const options = angular.extend({}, predefinedStepDescription.options, complexStep.options, parentOptions);
-                if (!!predefinedStepDescription.getSteps) {
-                    steps = steps.concat(this._getSteps(angular.copy(predefinedStepDescription.getSteps(options, {$translate, $interpolate, GuideUtils, $rootScope, toastr, $location, $route})), parentOptions));
-                } else if (!!predefinedStepDescription.getStep) {
-                    steps.push(angular.copy(predefinedStepDescription.getStep(options, {GuideUtils, $translate, toastr, $location, $route})));
+                if (predefinedStepDescription.getSteps) {
+                    steps = steps.concat(this._getSteps(angular.copy(predefinedStepDescription.getSteps(options, {$translate, $interpolate, GuideUtils, $rootScope, toastr, $location, $route, $timeout})), parentOptions));
+                } else if (predefinedStepDescription.getStep) {
+                    steps.push(angular.copy(predefinedStepDescription.getStep(options, {GuideUtils, $translate, toastr, $location, $route, $timeout})));
                 } else {
                     steps = steps.concat(this._getSteps(angular.copy(predefinedStepDescription, predefinedStepDescription.options), parentOptions));
                 }
@@ -420,7 +422,7 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
             }
         });
         return steps;
-    }
+    };
 
     /**
      * Subscribes to guide resume event. When event occurred the guide will be start from the step where the guide was paused.
@@ -432,7 +434,7 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
             this.guideResumeSubscription = $rootScope.$on('guideResume', () => {
                 const currentGuideId = ShepherdService.getGuideId();
                 this.getGuides()
-                    .then(guides => {
+                    .then((guides) => {
                         const currentGuide = guides.find((guide) => guide.guideId === currentGuideId);
                         const currentStepId = ShepherdService.getCurrentStepId();
                         this.startGuide(currentGuide, currentStepId);
@@ -443,9 +445,9 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
 
     this._subscribeToGuideCancel = () => {
         ShepherdService.subscribeToGuideCancel(() => $rootScope.$broadcast('guideReset'));
-    }
+    };
 
     this._subscribeToGuidePause = () => {
         ShepherdService.subscribeToGuidePause(() => $rootScope.$broadcast('guidePaused'));
-    }
+    };
 }

--- a/src/js/angular/guides/steps/core/plugin.js
+++ b/src/js/angular/guides/steps/core/plugin.js
@@ -14,11 +14,11 @@ const BASIC_STEP = {
 };
 
 /**
- * This function will be call before show a step. Step will shown after promise is resolve. It waits element of step to be visible on the page.
- * @param maxWaitTime
- * @param services
- * @param elementSelector
- * @returns {function(): *}
+ * This function will be called before show a step. Step will be shown after promise is resolve. It waits element of step to be visible on the page.
+ * @param {*} services
+ * @param {string} elementSelector
+ * @param {number} maxWaitTime
+ * @return {function(): *}
  */
 const beforeShowPromise = (services, elementSelector, maxWaitTime) => {
     return () => {
@@ -29,22 +29,22 @@ const beforeShowPromise = (services, elementSelector, maxWaitTime) => {
                 // throw the error, otherwise guide will continue with the next step.
                 throw error;
             });
-    }
-}
+    };
+};
 
 PluginRegistry.add('guide.step', [
     {
         guideBlockName: 'clickable-element',
         getStep: (options, services) => {
             const notOverridable = {
-                type: 'clickable',
+                type: 'clickable'
             };
 
             const stepDescription = angular.extend({}, BASIC_STEP, {
                 advanceOn: {
                     selector: options.elementSelector,
                     event: 'click'
-                },
+                }
             }, options, notOverridable);
 
             if (!stepDescription.beforeShowPromise) {
@@ -57,7 +57,7 @@ PluginRegistry.add('guide.step', [
         guideBlockName: 'read-only-element',
         getStep: (options, services) => {
             const notOverridable = {
-                type: 'readonly',
+                type: 'readonly'
             };
             const stepDescription = angular.extend({}, BASIC_STEP, options, notOverridable);
             if (!stepDescription.beforeShowPromise) {
@@ -70,7 +70,7 @@ PluginRegistry.add('guide.step', [
         guideBlockName: 'input-element',
         getStep: (options, services) => {
             const notOverridable = {
-                type: 'input',
+                type: 'input'
             };
             const stepDescription = angular.extend({}, BASIC_STEP, options, notOverridable);
             if (!stepDescription.beforeShowPromise) {
@@ -83,7 +83,7 @@ PluginRegistry.add('guide.step', [
         guideBlockName: 'info-message',
         getStep: (options) => {
             const notOverridable = {
-                type: 'readonly',
+                type: 'readonly'
             };
             return angular.extend({}, BASIC_STEP, options, notOverridable);
         }

--- a/src/js/angular/guides/tour-lib-services/shepherd.service.js
+++ b/src/js/angular/guides/tour-lib-services/shepherd.service.js
@@ -30,8 +30,8 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
 
     /**
      * Creates and starts a guide.
-     * @param guideId - a unique ID that identifies the guide.
-     * @param stepsDescriptions - array with core steps. Format of a step is:
+     * @param {string} guideId - a unique ID that identifies the guide.
+     * @param {*} stepsDescriptions - array with core steps. Format of a step is:
      * <pre>
      *     {
      *       title: string,
@@ -114,8 +114,8 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
      *     </li>
      *
      * </ul>
-     * @param startStepId - start step id.
-     * @param clearHistory - if true will clear guide step history.
+     * @param {string} startStepId - start step id.
+     * @param {boolean} clearHistory - if true will clear guide step history.
      */
     this.startGuide = (guideId, stepsDescriptions, startStepId, clearHistory = true) => {
         if (clearHistory) {
@@ -132,6 +132,9 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
 
     /**
      * Starts guide from the step where it was paused.
+     * @param {string} guideId
+     * @param {*} stepsDescriptions
+     * @param {string} startStepId
      */
     this.resumeGuide = (guideId, stepsDescriptions, startStepId) => {
         LocalStorageAdapter.set(GUIDE_PAUSE, false);
@@ -159,7 +162,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
         if (angular.isFunction(oncancel)) {
             this.onCancel = oncancel;
         }
-    }
+    };
 
     this.subscribeToGuidePause = (onPause) => {
         if (angular.isFunction(onPause)) {
@@ -169,8 +172,8 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
 
     /**
      * Creates a guide.
-     * @param guideId - a unique ID that identifies the guide.
-     * @returns {Shepherd.Tour} - created guide.
+     * @param {string} guideId - a unique ID that identifies the guide.
+     * @return {Shepherd.Tour} - created guide.
      */
     this._createGuide = (guideId) => {
         this._subscribeToGuideCanceled();
@@ -188,8 +191,8 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
 
     /**
      * Transforms <code>stepsDescriptions</code> to Shepherd Tour steps and add it to <code>guide<code>.
-     * @param guide - the guide.
-     * @param stepsDescriptions - array with steps descriptions. The format of a description is:
+     * @param {Shepherd.Tour} guide - the guide.
+     * @param {*} stepsDescriptions - array with steps descriptions. The format of a description is:
      *
      * <pre>
      *     {
@@ -283,7 +286,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
             guide.addStep(this._getFirstStep(guide, stepsDescriptions));
         }
 
-        // Chek if stepsDescriptions has more than 2 elements. This mean there are middle steps. The middle steps have previous and next steps.
+        // Check if stepsDescriptions has more than 2 elements. This mean there are middle steps. The middle steps have previous and next steps.
         if (stepsDescriptions.length > 2) {
             // Process all steps without first and last one.
             for (let index = 1; index < stepsDescriptions.length - 1; index++) {
@@ -299,25 +302,25 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
 
     /**
      * Starts <code>guide</code> from <code>startStepId</code>
-     * @param guide - the guid to be started.
-     * @param startStepId - star step id. If it is not present the <code>guide</code> will be started from beginning.
+     * @param {Shepherd.Tour} guide - the guid to be started.
+     * @param {string} startStepId - star step id. If it is not present the <code>guide</code> will be started from beginning.
      * @private
      */
     this._startGuide = (guide, startStepId) => {
         LocalStorageAdapter.remove(GUIDE_PAUSE);
 
-        let stepIndex = guide.steps.findIndex((value => value.options.id === startStepId));
+        let stepIndex = guide.steps.findIndex(((value) => value.options.id === startStepId));
         if (stepIndex < 0) {
             stepIndex = 0;
         }
         const step = guide.steps[stepIndex];
         const url = step.options.url;
-        if (!!url) {
+        if (url) {
             $location.url(url);
             $route.reload();
         }
 
-        if (!!step.options.attachTo) {
+        if (step.options.attachTo) {
             GuideUtils.waitFor(step.options.attachTo.element, step.options.maxWaitTime)
                 .then(() => guide.show(stepIndex))
                 .catch(() => {
@@ -341,9 +344,9 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
 
     /**
      * Creates first step from <code>stepsDescriptions</code>.
-     * @param guide - the guide.
-     * @param stepsDescriptions - array with descriptions of steps.
-     * @returns the first step.
+     * @param {Shepherd.Tour} guide - the guide.
+     * @param {*} stepsDescriptions - array with descriptions of steps.
+     * @return {Shepherd.Step} the first step.
      * @private
      */
     this._getFirstStep = function (guide, stepsDescriptions) {
@@ -353,10 +356,10 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
 
     /**
      * Creates middle step from <code>stepsDescriptions</code>.
-     * @param guide - the guide.
-     * @param stepsDescriptions - array with descriptions of steps.
-     * @param indexOfProcessedStep - index of step which have to be created.
-     * @returns the created step.
+     * @param {Shepherd.Tour} guide - the guide.
+     * @param {*} stepsDescriptions - array with descriptions of steps.
+     * @param {number} indexOfProcessedStep - index of step which have to be created.
+     * @return {Shepherd.Step} the created step.
      * @private
      */
     this._getMiddleStep = (guide, stepsDescriptions, indexOfProcessedStep) => {
@@ -367,7 +370,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
      * Creates last step from <code>stepsDescriptions</code>.
      * @param {Shepherd.Tour} guide - the guide.
      * @param {array} stepsDescriptions - array with descriptions of steps.
-     * @return {{}}the last step.
+     * @return {Shepherd.Step} the last step.
      * @private
      */
     this._getLastStep = (guide, stepsDescriptions) => {
@@ -408,11 +411,11 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
 
     /**
      * Converts <code>currentStepDescription</code> to Shepherd Tour step.
-     * @param guide - the guide.
-     * @param previousStepDescription - the previous step description.
-     * @param currentStepDescription - processed step description.
-     * @param nextStepDescription - the next step description.
-     * @returns created step.
+     * @param {Shepherd.Tour} guide - the guide.
+     * @param {*} previousStepDescription - the previous step description.
+     * @param {*} currentStepDescription - processed step description.
+     * @param {*} nextStepDescription - the next step description.
+     * @return {Shepherd.Step} created step.
      * @private
      */
     this._toGuideStep = (guide, previousStepDescription, currentStepDescription, nextStepDescription) => {
@@ -427,7 +430,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
         }
 
         if (currentStepDescription.skipPoint) {
-            buttons.push(this._getSkipButton(guide, previousStepDescription, currentStepDescription, nextStepDescription));
+            buttons.push(this._getSkipButton(guide));
         }
         step.buttons = buttons;
         return step;
@@ -437,13 +440,13 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
         return this._getButton($translate.instant('pause.btn'), () => this._pauseGuide(guide), true);
     };
 
-    this._getSkipButton = (guide, previousStepDescription, currentStepDescription, nextStepDescription) => {
+    this._getSkipButton = (guide) => {
         return this._getButton($translate.instant('skip.btn'), () => this._skipSteps(guide), true);
     };
 
     this._skipSteps = (guide) => {
         const currentStep = guide.getCurrentStep();
-        const currentStepIndex = guide.steps.findIndex(step => currentStep.id === step.id);
+        const currentStepIndex = guide.steps.findIndex((step) => currentStep.id === step.id);
         this._startGuide(guide, this._getNextSkipPointId(guide.steps, currentStepIndex));
     };
 
@@ -460,10 +463,12 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
 
     /**
      * Pauses current ran guide.
+     * @param {Shepherd.Tour} guide
+     * @private
      */
     this._pauseGuide = (guide) => {
         guide.hide();
-        let step = this._getStepWhichCanBePaused(guide.steps, guide.getCurrentStep().id);
+        const step = this._getStepWhichCanBePaused(guide.steps, guide.getCurrentStep().id);
         this._saveStep(step);
         LocalStorageAdapter.set(GUIDE_PAUSE, true);
 
@@ -484,7 +489,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
     };
 
     this._getStepWhichCanBePaused = (steps, stepId) => {
-        const index = steps.findIndex(step => step.id === stepId);
+        const index = steps.findIndex((step) => step.id === stepId);
         const step = steps[index];
         if (step.options.canBePaused) {
             return step;
@@ -497,13 +502,11 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
 
     /**
      * Creates a previous button.
-     * @param guide - the guide.
-     * @param previousStepDescription - previous step description.
-     * @param currentStepDescription - processed step description.
-     * @returns created step.
+     * @param {Shepherd.Tour} guide - the guide.
+     * @return {*} created button.
      * @private
      */
-    this._getPreviousButton = (guide, previousStepDescription, currentStepDescription) => {
+    this._getPreviousButton = (guide) => {
         const text = $translate.instant('previous.btn');
         const action = this._getPreviousButtonAction(guide);
         return this._getButton(text, action);
@@ -517,7 +520,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
             if (nextStepId === -1) {
                 nextStep = guide.steps.at(0);
             } else {
-                nextStep = guide.steps.find(step => step.options.id === nextStepId);
+                nextStep = guide.steps.find((step) => step.options.id === nextStepId);
             }
 
             const currentStep = guide.getCurrentStep();
@@ -533,7 +536,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
                     .catch(() => {
                         toastr.error($translate.instant('guide.unexpected.error.message'));
                         guide.hide();
-                });
+                    });
                 return;
             } else if (nextStep.options.forceReload || nextStep.options.url && nextStep.options.url !== currentStep.options.url) {
                 $location.path(nextStep.options.url);
@@ -545,10 +548,10 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
 
     /**
      * Creates a next button.
-     * @param guide - the guide.
-     * @param currentStepDescription - processed step description.
-     * @param nextStepDescription - next step description.
-     * @returns created step.
+     * @param {Shepherd.Tour} guide - the guide.
+     * @param {*} currentStepDescription - processed step description.
+     * @param {*} nextStepDescription - next step description.
+     * @return {*} created step.
      * @private
      */
     this._getNextButton = (guide, currentStepDescription, nextStepDescription) => {
@@ -567,7 +570,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
                 if (angular.isFunction(currentStepDescription.onNextClick)) {
                     const onNextResult = currentStepDescription.onNextClick(guide, currentStepDescription);
                     if (onNextResult instanceof Promise) {
-                        onNextResult.catch(error => {
+                        onNextResult.catch(() => {
                             toastr.error($translate.instant('guide.unexpected.error.message'));
                             guide.cancel();
                         });
@@ -592,12 +595,12 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
             return;
         }
         const currentStep = activeTour.getCurrentStep();
-        const currentStepIndex = activeTour.steps.findIndex(step => step.id === currentStep.id);
+        const currentStepIndex = activeTour.steps.findIndex((step) => step.id === currentStep.id);
 
         const lastSavedStepId = this.getCurrentStepId();
-        const lastSavedStepIndex = activeTour.steps.findIndex(step => step.id === lastSavedStepId);
+        const lastSavedStepIndex = activeTour.steps.findIndex((step) => step.id === lastSavedStepId);
 
-        // If current step index is greatest than last saved step index this means that next button was clicked.
+        // If current step index is greater than last saved step index this means that next button was clicked.
         if (currentStepIndex > lastSavedStepIndex) {
             this._addStepToHistory(currentStep);
         } else if (lastSavedStepIndex > currentStepIndex) {
@@ -608,7 +611,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
     };
 
     this._saveStep = (step) => {
-        if (!!step) {
+        if (step) {
             LocalStorageAdapter.set(GUIDE_ID, step.tour.options.name);
             LocalStorageAdapter.set(GUIDE_CURRENT_STEP_ID, step.options.id);
         }
@@ -654,16 +657,18 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
     };
 
     /**
+     *
      * Creates a Shepherd Tour step and fill it with base properties from <code>stepDescription</code>.
-     * @param $translate
-     * @param stepDescription - step description. The format of a description is:
-     * @param onShow - function which will be executed when popup dialog shown.
-     * @returns created step.
+     * @param {Shepherd.Tour} guide
+     * @param {*} $translate
+     * @param {*} stepDescription
+     * @param {function} onShow - function which will be executed when popup dialog shown.
+     * @return {*}
      * @private
      */
     this._toBaseGuideStep = (guide, $translate, stepDescription, onShow) => {
         let attachTo;
-        if (!!stepDescription.elementSelector) {
+        if (stepDescription.elementSelector) {
             attachTo = {
                 element: stepDescription.elementSelector,
                 on: stepDescription.placement
@@ -681,7 +686,10 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
             progress.setAttribute('tooltip-placement', 'bottom');
             progress.setAttribute('tooltip-trigger', 'mouseenter');
             progress.setAttribute('tooltip-append-to-body', 'false');
-            progress.innerText = $translate.instant('guide.block.progress', {n: stepDescription.stepN + 1, nn: stepDescription.stepsTotalN});
+            progress.innerText = $translate.instant('guide.block.progress', {
+                n: stepDescription.stepN + 1,
+                nn: stepDescription.stepsTotalN
+            });
             extraTitle = '&nbsp;&mdash;&nbsp;' + progress.outerHTML;
         }
 
@@ -735,7 +743,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
                 stepDescription.show(guide)();
                 onShow();
                 this._whenStepShow(stepDescription);
-            }
+            };
         }
 
         return () => {
@@ -797,7 +805,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
         switch (stepDescription.type) {
             case 'clickable':
                 iconName = 'focus';
-                iconTooltip = 'mouse'
+                iconTooltip = 'mouse';
                 break;
             case 'input':
                 iconName = 'edit';
@@ -822,10 +830,10 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
 
     /**
      * Created a base button.
-     * @param text - the text of button.
-     * @param isSecondary - if true will be styled as secondary button.
-     * @param action - to be executed when button is clicked.
-     * @returns created button.
+     * @param {string} text - the text of button.
+     * @param {function} action - to be executed when button is clicked.
+     * @param {boolean} isSecondary - if true will be styled as secondary button.
+     * @return {*} created button.
      */
     this._getButton = (text, action, isSecondary) => {
         const button = {


### PR DESCRIPTION
Disabled processing of mouse event on visual graph when guide is started. Added implementation in "visual-graph-expand" "visual-graph-properties" plugins to process those events when guide is started. Additional work:
  Fixed eslint issues.