### PR TITLE
GDB-7527-Missing label in Visual graph

### DIFF
--- a/src/pages/graphs-visualizations.html
+++ b/src/pages/graphs-visualizations.html
@@ -365,7 +365,7 @@
                             <div class="checkbox">
                                 <label tooltip="{{'sidepanel.show.preferred.predicates.links.only.tooltip' | translate}}">
                                     <input type="checkbox" class="show-preferred-predicates-only" ng-model="settings['preferredPredicatesOnly']">
-                                    {{'sidepanel.show.preferred.predicates' | translate}}
+                                    {{'sidepanel.show.preferred.predicates.only' | translate}}
                                 </label>
                             </div>
                         </div>


### PR DESCRIPTION
Fixed sidepanel.show.preferred.predicates to sidepanel.show.preferred.predicates.only in graphs-visualizations.html so it can be properly translated.