### PR TITLE
GDB-7501: User Guide can't be rerun if more than one repo exists

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1678,7 +1678,7 @@
     "guide.step_plugin.download-guide-resource.title": "Download guide resources",
     "guide.step_plugin.download-guide-resource.content": "This guide requires a file to be downloaded.<br>Please <a href=\"{{resourceUrl}}\" target=\"_blank\">download {{resourceFile}}</a>.",
     "guide.step_plugin.choose-repository.content": "Click on the repository selection dropdown.",
-    "guide.step_plugin.select-repository.content": "Click on the <b>{{repositoryId}}</b> repository button.",
+    "guide.step_plugin.select-repository.content": "Click on the <b>{{getRepositoryId()}}</b> repository button.",
     "guide.step_plugin.select-repository-plug.content": "Click on the plug icon of the <b>{{repositoryId}}</b> repository.",
     "guide.step_plugin.import_rdf_file.import-file.button.content": "Click on the <b>{{'common.import'|translate}}</b> button.",
     "guide.step_plugin.import_rdf_file.import-settings.import.button.content": "Click on the <b>{{'common.import'|translate}}</b> button.",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1669,7 +1669,7 @@
     "guide.step_plugin.download-guide-resource.title": "Télécharger les ressources du guide",
     "guide.step_plugin.download-guide-resource.content": "Ce guide nécessite le téléchargement d'un fichier.<br>Veuillez <a href=\"{{resourceUrl}}\" target=\"_blank\">télécharger {{resourceFile}}</a>.",
     "guide.step_plugin.choose-repository.content": "Cliquez sur la liste déroulante de sélection du dépôt.",
-    "guide.step_plugin.select-repository.content": "Cliquez sur le bouton de dépôt <b>{{repositoryId}}</b>.",
+    "guide.step_plugin.select-repository.content": "Cliquez sur le bouton de dépôt <b>{{getRepositoryId()}}</b>.",
     "guide.step_plugin.select-repository-plug.content": "Cliquez sur l'icône de prise du dépôt <b>{{repositoryId}}</b>.",
     "guide.step_plugin.import_rdf_file.import-file.button.content": "Cliquez sur le bouton <b>{{'common.import'|translate}}</b>.",
     "guide.step_plugin.import_rdf_file.import-settings.import.button.content": "Cliquez sur le bouton <b>{{'common.import'|translate}}</b>.",

--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -140,7 +140,9 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 
     $('#repositorySelectDropdown').on('hide.bs.dropdown', function (e) {
         if (GuidesService.isActive()) {
-            e.preventDefault();
+            if ($('#repositorySelectDropdown.autoCloseOff').length > 0) {
+                e.preventDefault();
+            }
         }
     });
 
@@ -159,7 +161,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 
     $scope.resumeGuide = function () {
         $rootScope.$broadcast('guideResume');
-    }
+    };
 
     $rootScope.$on('guideReset', function () {
         $scope.guidePaused = false;
@@ -210,7 +212,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 
     $scope.getLocationFromUri = function (location) {
         return $repositories.getLocationFromUri(location);
-    }
+    };
 
     $scope.$on("$locationChangeSuccess", function () {
         $scope.showFooter = $location.url() === '/';
@@ -384,15 +386,15 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 
     $scope.isActiveRepoOntopType = function () {
         return $repositories.isActiveRepoOntopType();
-    }
+    };
 
     $scope.isActiveRepoFedXType = function () {
         return $repositories.isActiveRepoFedXType();
-    }
+    };
 
     $scope.isLicenseValid = function() {
         return $licenseService.isLicenseValid();
-    }
+    };
 
     /**
      *  Sets attrs property in the directive
@@ -493,7 +495,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 
     $scope.isRepoActive = function (repository) {
         return $repositories.isRepoActive(repository);
-    }
+    };
 
     $scope.getRepositorySize = function () {
         $scope.repositorySize = {};
@@ -848,23 +850,23 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 
     $scope.showLicense = function() {
         return $licenseService.showLicense;
-    }
+    };
 
     $scope.getLicense = function() {
         return $licenseService.license;
-    }
+    };
 
     $scope.isLicenseHardcoded = function() {
         return $licenseService.isLicenseHardcoded;
-    }
+    };
 
     $scope.getProductType = function() {
         return $licenseService.productType;
-    }
+    };
 
     $scope.getProductTypeHuman = function() {
         return $licenseService.productTypeHuman;
-    }
+    };
 
 
     $scope.getHumanReadableSeconds = function (s, preciseSeconds) {

--- a/src/js/angular/guides/guide-utils.js
+++ b/src/js/angular/guides/guide-utils.js
@@ -13,12 +13,13 @@ const GuideUtils = (function () {
 
     /**
      * Waits element to be present.
-     * @param {string} selector - selector of element looking for.
+     * @param {string} elementSelector - selector of element looking for.
      * @param {number} timeoutInSeconds - max time to waite in second. Default value is 1 second.
      * @param {boolean} checkVisibility - if true will wait to become visible. Default value is true
      * @return {Promise}
      */
-    const waitFor = function (selector, timeoutInSeconds = 1, checkVisibility = true) {
+    const waitFor = function (elementSelector, timeoutInSeconds = 1, checkVisibility = true) {
+        const selector = getElementSelector(elementSelector);
         return new Promise(function (resolve, reject) {
             let iteration = timeoutInSeconds * 1000 | 1000;
             const waitTime = 100;
@@ -289,6 +290,10 @@ const GuideUtils = (function () {
         }
     });
 
+    const getElementSelector = (elementSelector) => {
+        return angular.isFunction(elementSelector) ? elementSelector() : elementSelector;
+    };
+
     return {
         GUIDES_LIST_URL,
         GUIDES_DOWNLOAD_URL,
@@ -317,7 +322,8 @@ const GuideUtils = (function () {
         getSparqlResultsSelectorForRow,
         isChecked,
         isGuideElementChecked,
-        defaultInitPreviousStep
+        defaultInitPreviousStep,
+        getElementSelector
     };
 })();
 

--- a/src/js/angular/guides/guides.service.js
+++ b/src/js/angular/guides/guides.service.js
@@ -399,6 +399,7 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
      * @private
      */
     this._getSteps = (complexStep, parentOptions) => {
+        const services = {$translate, $interpolate, GuideUtils, $rootScope, toastr, $location, $route, $timeout, ShepherdService, $repositories};
         let steps = [];
         if (angular.isArray(complexStep)) {
             complexStep.forEach((stepDescription) => {
@@ -409,9 +410,9 @@ function GuidesService($http, $rootScope, $translate, $interpolate, ShepherdServ
             if (predefinedStepDescription) {
                 const options = angular.extend({}, predefinedStepDescription.options, complexStep.options, parentOptions);
                 if (predefinedStepDescription.getSteps) {
-                    steps = steps.concat(this._getSteps(angular.copy(predefinedStepDescription.getSteps(options, {$translate, $interpolate, GuideUtils, $rootScope, toastr, $location, $route, $timeout, ShepherdService})), parentOptions));
+                    steps = steps.concat(this._getSteps(angular.copy(predefinedStepDescription.getSteps(options, services)), parentOptions));
                 } else if (predefinedStepDescription.getStep) {
-                    steps.push(angular.copy(predefinedStepDescription.getStep(options, {GuideUtils, $translate, toastr, $location, $route, $timeout, ShepherdService})));
+                    steps.push(angular.copy(predefinedStepDescription.getStep(options, services)));
                 } else {
                     steps = steps.concat(this._getSteps(angular.copy(predefinedStepDescription, predefinedStepDescription.options), parentOptions));
                 }

--- a/src/js/angular/guides/steps/complex/select-repository/plugin.js
+++ b/src/js/angular/guides/steps/complex/select-repository/plugin.js
@@ -11,9 +11,8 @@ PluginRegistry.add('guide.step', [
         guideBlockName: 'select-repository-dropdown',
         getSteps: (options, services) => {
             const GuideUtils = services.GuideUtils;
-            const $translate = services.$translate;
-            const $interpolate = services.$interpolate;
             options.mainAction = 'select-repository';
+            options.getRepositoryId = () => getRepositoryName(services, options);
 
             return [{
                 guideBlockName: 'clickable-element',
@@ -26,10 +25,7 @@ PluginRegistry.add('guide.step', [
             }, {
                 guideBlockName: 'clickable-element',
                 options: angular.extend({}, {
-                    content: () => {
-                        const parameters = {repositoryId: getRepositoryName(services, options)};
-                        return `<p>${GuideUtils.translateLocalMessage($translate, $interpolate, 'guide.step_plugin.select-repository.content', parameters)}</p>`;
-                    },
+                    content: 'guide.step_plugin.select-repository.content',
                     elementSelector: () => {
                         return getRepositoryElementSelector(services, options);
                     },

--- a/src/js/angular/guides/tour-lib-services/shepherd.service.js
+++ b/src/js/angular/guides/tour-lib-services/shepherd.service.js
@@ -712,10 +712,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
             extraTitle = '&nbsp;&mdash;&nbsp;' + progress.outerHTML;
         }
 
-        let text;
-        if (angular.isFunction(stepDescription.content)) {
-            text = stepDescription.content;
-        } else {
+        const text = () => {
             const content = this._toParagraph(GuideUtils.translateLocalMessage($translate, $interpolate, stepDescription.content, stepDescription));
 
             let extraContent = '';
@@ -723,8 +720,8 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
                 extraContent = GuideUtils.translateLocalMessage($translate, $interpolate, stepDescription.extraContent, stepDescription);
                 extraContent = this._toParagraph(extraContent, stepDescription.extraContentClass);
             }
-            text = content + extraContent;
-        }
+            return content + extraContent;
+        };
 
         const clickable = stepDescription.type !== 'readonly';
 

--- a/src/js/angular/guides/tour-lib-services/shepherd.service.js
+++ b/src/js/angular/guides/tour-lib-services/shepherd.service.js
@@ -712,12 +712,18 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
             extraTitle = '&nbsp;&mdash;&nbsp;' + progress.outerHTML;
         }
 
-        const content = this._toParagraph(GuideUtils.translateLocalMessage($translate, $interpolate, stepDescription.content, stepDescription));
+        let text;
+        if (angular.isFunction(stepDescription.content)) {
+            text = stepDescription.content;
+        } else {
+            const content = this._toParagraph(GuideUtils.translateLocalMessage($translate, $interpolate, stepDescription.content, stepDescription));
 
-        let extraContent = '';
-        if (stepDescription.extraContent) {
-            extraContent = GuideUtils.translateLocalMessage($translate, $interpolate, stepDescription.extraContent, stepDescription);
-            extraContent = this._toParagraph(extraContent, stepDescription.extraContentClass);
+            let extraContent = '';
+            if (stepDescription.extraContent) {
+                extraContent = GuideUtils.translateLocalMessage($translate, $interpolate, stepDescription.extraContent, stepDescription);
+                extraContent = this._toParagraph(extraContent, stepDescription.extraContentClass);
+            }
+            text = content + extraContent;
         }
 
         const clickable = stepDescription.type !== 'readonly';
@@ -727,7 +733,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
         const step = {
             id: stepDescription.id,
             title: title + extraTitle,
-            text: content + extraContent,
+            text,
             url: stepDescription.url,
             maxWaitTime: stepDescription.maxWaitTime,
             cancelIcon: {enabled: true},


### PR DESCRIPTION
Fixed. 
 - GDB-7538
Additional work:
 - There was a bug when a guide is on step to choose a repository and user click on any menu item of any repository, the dropdown wouldn't close. The problem was that we stop dropdown to be closed when a guide is active, this is because of other bug "GDB-7450: User Guide crashes on repo select step". Fixed, when the step is shown we add a class "autoCloseOff" to dropdown. This class will block closing of dropdown when user click outside dropdown. This class will be removed when user click on "Next" button or some menu item.