### PR TITLE
GDB-6721 Special characters in the IRI make it non-resolvable from the visual graph

### DIFF
--- a/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -2484,7 +2484,7 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
         $scope.rdfRank = d.rdfRank;
         $scope.nodeIri = d.iri;
         $scope.resourceType = d.isTriple ? 'triple' : 'uri';
-        $scope.encodedIri = d.isTriple ? encodeURI(createTriple(d.iri)) : encodeURI(d.iri);
+        $scope.encodedIri = d.isTriple ? encodeURIComponent(createTriple(d.iri)) : encodeURIComponent(d.iri);
         $scope.showInfoPanel = true;
 
         $scope.rdfsLabel = d.labels[0].label;


### PR DESCRIPTION
Replace encodeURI() with encodeURIComponent() in graphs-visualizatios.controller.js, because encodeURI() does not support special characters like "+", "&", "@" and etc.