### PR TITLE
GDB-7587 Current group cluster nodes are not shown when adding a node

### DIFF
--- a/src/js/angular/clustermanagement/controllers.js
+++ b/src/js/angular/clustermanagement/controllers.js
@@ -767,8 +767,8 @@ function AddNodesDialogCtrl($scope, $modalInstance, data, $modal, RemoteLocation
     const clusterModel = angular.copy(data.clusterModel);
     $scope.nodes = [];
 
-    $scope.clusterNodes = clusterModel.locations.filter((location) => clusterConfiguration.nodes.includes(location.rpcAddress));
-    $scope.locations = clusterModel.locations.filter((location) => !$scope.clusterNodes.includes(location));
+    $scope.clusterNodes = clusterModel.nodes.map((node) => ({['rpcAddress']: node.address, ['endpoint']: node.endpoint}));
+    $scope.locations = clusterModel.locations.filter((location) => !clusterConfiguration.nodes.includes(location.rpcAddress));
     $scope.locations.forEach((location) => location.isNew = true);
 
     $scope.addNodeToList = function (location) {

--- a/src/js/angular/clustermanagement/controllers.js
+++ b/src/js/angular/clustermanagement/controllers.js
@@ -767,7 +767,7 @@ function AddNodesDialogCtrl($scope, $modalInstance, data, $modal, RemoteLocation
     const clusterModel = angular.copy(data.clusterModel);
     $scope.nodes = [];
 
-    $scope.clusterNodes = clusterModel.nodes.map((node) => ({['rpcAddress']: node.address, ['endpoint']: node.endpoint}));
+    $scope.clusterNodes = clusterModel.nodes.map((node) => ({rpcAddress: node.address, endpoint: node.endpoint}));
     $scope.locations = clusterModel.locations.filter((location) => !clusterConfiguration.nodes.includes(location.rpcAddress));
     $scope.locations.forEach((location) => location.isNew = true);
 


### PR DESCRIPTION
Since we do not replicate locations, there is a problem when the current leader tries to add a node and does not have the locations of the nodes that are part of the cluster. If they do not exist on the current leader, they are not presented on the Nodes list when adding a node. 

Changed the implementation to use the nodes in the cluster model instead of the locations when creating the nodes list.