### PR TITLE
GDB-6815_Resource_view_on_mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ failing tests.
 There are two options for running the tests. One is a headless execution and the second is through
 the Cypress's dashboard application. Follow the steps described below: 
 * Ensure a GraphDB instance is running on `localhost:7200`. One can be run by executing 
-`docker-compose up` in the `graphdb-workbench/test-cypress` folder. 
+`docker-compose up` in the `graphdb-workbench/test-cypress` folder. Check path directory which is set with **-Dgraphdb.workbench.importDirectory** property when server is started. The folder with this path have to contains all files from "fixture/graphdb-import" 
+
 * In `graphdb-workbench` folder execute `npm run start` to build and run the workbench web 
 application. In result it is published and served by webpack's web dev server.
 * In terminal, go in `graphdb-workbench/test-cypress` folder and choose one of the options below: 

--- a/src/css/explore.css
+++ b/src/css/explore.css
@@ -14,3 +14,9 @@
 .autocomplete-toast a, .autocomplete-toast a:hover {
     color: #fff;
 }
+
+@media screen and (max-width: 768px) {
+    .page {
+        padding-right: 20px;
+    }
+}

--- a/src/css/new-sparql.css
+++ b/src/css/new-sparql.css
@@ -164,3 +164,9 @@ a[aria-expanded = true].query-has-error span {
     position: absolute;
     right: 0;
 }
+
+@media only screen and (max-width:768px) {
+    #sparql-content {
+        width: fit-content;
+    }
+}

--- a/src/css/workbench-custom.css
+++ b/src/css/workbench-custom.css
@@ -373,3 +373,7 @@
 .text-left {
     text-align: left;
 }
+
+.fit-content {
+    width: fit-content;
+}

--- a/src/css/yasr.custom.css
+++ b/src/css/yasr.custom.css
@@ -100,7 +100,6 @@
 .yasr .uri-cell {
   display: inline;
   word-break: normal !important;
-  word-wrap: normal !important;
 }
 
 .yasr .triple-cell {

--- a/src/js/angular/core/directives/queryeditor/query-editor.directive.js
+++ b/src/js/angular/core/directives/queryeditor/query-editor.directive.js
@@ -4,6 +4,7 @@ import 'angular/externalsync/controllers';
 import YASQE from 'lib/yasqe.bundled';
 import YASR from 'lib/yasr.bundled';
 import {decodeHTML} from "../../../../../app";
+import {YasrUtils} from "../../../utils/yasr-utils";
 
 angular
     .module('graphdb.framework.core.directives.queryeditor.queryeditor', [
@@ -48,6 +49,10 @@ function queryEditorDirective($timeout, $location, toastr, $repositories, Sparql
         scope.nostatus = attrs.hasOwnProperty('nostatus');
         // Doesn't show the run button
         scope.norun = attrs.hasOwnProperty('norun');
+
+        scope.enableColumnResizingOnWindowWidth = attrs.hasOwnProperty('enableColumnResizingOnWindowWidth');
+
+
         // Name of the Run button in the editor
         scope.runButtonName = 'query.editor.run.btn';
         if (attrs.runButtonName) {
@@ -541,11 +546,21 @@ function queryEditorDirective($timeout, $location, toastr, $repositories, Sparql
         });
 
         function initYasr() {
-            yasr = YASR(document.getElementById("yasr"), { // eslint-disable-line new-cap
+            scope.$on('$destroy', function () {
+                if (yasr) {
+                    yasr.destroy();
+                }
+            });
+
+            const yasrOptions = { // eslint-disable-line new-cap
                 getUsedPrefixes: {}, // initially blank, populated when we fetch the namespaces
                 persistency: false,
                 locale: $languageService.getLanguage()
-            });
+            };
+            if (scope.enableColumnResizingOnWindowWidth) {
+                yasrOptions.pluginsOptions = YasrUtils.getYasrConfiguration();
+            }
+            yasr = YASR(document.getElementById("yasr"), yasrOptions);
             window.yasr = yasr;
             yasr.afterCopy = afterCopy;
             yasr.getQueryResultsAsFormat = function (downloadFormat) {

--- a/src/js/angular/explore/controllers.js
+++ b/src/js/angular/explore/controllers.js
@@ -2,6 +2,7 @@ import 'angular/utils/file-types';
 import YASR from 'lib/yasr.bundled';
 import {saveAs} from 'lib/FileSaver-patch';
 import {decodeHTML} from "../../../app";
+import {YasrUtils} from "../utils/yasr-utils";
 
 const modules = [
     'ngCookies',
@@ -96,12 +97,18 @@ function ExploreCtrl($scope, $http, $location, toastr, $routeParams, $repositori
                         data.results.bindings.forEach(function (e) {
                             $scope.usedPrefixes[e.prefix.value] = e.namespace.value;
                         });
+                        $scope.$on('$destroy', function () {
+                            if (yasr) {
+                                yasr.destroy();
+                            }
+                        });
                         yasr = YASR(document.getElementById('yasr'), { // eslint-disable-line new-cap
                             //this way, the URLs in the results are prettified using the defined prefixes
                             getUsedPrefixes: $scope.usedPrefixes,
                             persistency: false,
                             hideHeader: true,
-                            locale: $languageService.getLanguage()
+                            locale: $languageService.getLanguage(),
+                            pluginsOptions: YasrUtils.getYasrConfiguration()
                         });
                         $scope.loadResource();
                     }).error(function (data) {

--- a/src/js/angular/similarity/controllers/similarity-list.controller.js
+++ b/src/js/angular/similarity/controllers/similarity-list.controller.js
@@ -1,5 +1,6 @@
 import YASR from 'lib/yasr.bundled';
 import {decodeHTML} from "../../../../app";
+import {YasrUtils} from "../../utils/yasr-utils";
 
 angular
     .module('graphdb.framework.similarity.controllers.list', [])
@@ -107,11 +108,17 @@ function SimilarityCtrl($scope, $interval, toastr, $repositories, $licenseServic
                     data.results.bindings.forEach(function (e) {
                         $scope.usedPrefixes[e.prefix.value] = e.namespace.value;
                     });
+                    $scope.$on('$destroy', function () {
+                        if (yasr) {
+                            yasr.destroy();
+                        }
+                    });
                     yasr = YASR(document.getElementById('yasr'), { // eslint-disable-line new-cap
                         //this way, the URLs in the results are prettified using the defined prefixes
                         getUsedPrefixes: $scope.usedPrefixes,
                         persistency: false,
-                        hideHeader: true
+                        hideHeader: true,
+                        pluginsOptions: YasrUtils.getYasrConfiguration()
                     });
                 }).error(function (data) {
                     toastr.error(getError(data), $translate.instant('get.namespaces.error.msg'));

--- a/src/js/angular/utils/yasr-utils.js
+++ b/src/js/angular/utils/yasr-utils.js
@@ -1,0 +1,29 @@
+// This is table plugin configuration constant.
+// It holds default value of window width when column resizing will be enabled.
+const DEFAULT_ENABLE_COLUMN_RESIZING_ON_WINDOW_WIDTH = 768;
+
+const YasrUtils = (function () {
+
+    const getYasrConfiguration = function (configuartion) {
+        const defaultConfiguration = {
+            table: getDefaultTablePluginConfiguration()
+        };
+
+        return angular.extend({}, defaultConfiguration, configuartion);
+    };
+
+    const getDefaultTablePluginConfiguration = function () {
+        return {
+            enableColumnResizingOnWindowWidth: DEFAULT_ENABLE_COLUMN_RESIZING_ON_WINDOW_WIDTH
+        };
+    };
+
+    return {
+        getYasrConfiguration,
+        getDefaultTablePluginConfiguration
+    };
+})();
+
+export {
+    YasrUtils
+};

--- a/src/js/lib/yasr.bundled.js
+++ b/src/js/lib/yasr.bundled.js
@@ -54121,7 +54121,7 @@ module.exports={
         "spec": ">=1.4.1 <2.0.0",
         "type": "range"
       },
-      "/home/sava/IntellijProjects/YASR-Ontotext"
+      "/home/boyan/Git/YASR-Ontotext"
     ]
   ],
   "_from": "yasgui-utils@>=1.4.1 <2.0.0",
@@ -54155,7 +54155,7 @@ module.exports={
   "_shasum": "2bcfc5a315688de3ae6057883d9ae342b205f267",
   "_shrinkwrap": null,
   "_spec": "yasgui-utils@^1.4.1",
-  "_where": "/home/sava/IntellijProjects/YASR-Ontotext",
+  "_where": "/home/boyan/Git/YASR-Ontotext",
   "author": {
     "name": "Laurens Rietveld"
   },
@@ -54165,12 +54165,20 @@ module.exports={
   "dependencies": {
     "store": "^2.0.4"
   },
+  "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
   "description": "Utils for YASGUI libs",
   "devDependencies": {},
   "directories": {},
   "dist": {
     "shasum": "2bcfc5a315688de3ae6057883d9ae342b205f267",
-    "tarball": "https://registry.npmjs.org/yasgui-utils/-/yasgui-utils-1.6.7.tgz"
+    "tarball": "https://registry.npmjs.org/yasgui-utils/-/yasgui-utils-1.6.7.tgz",
+    "integrity": "sha512-w9BnalJg330lZhljHn0j6Ta6jyQTJL8nbhjyeDj4Z9PrX7GLrgcwq7CO7uP6Keq86L1XjpUgUU6JAmTlmkXj6w==",
+    "signatures": [
+      {
+        "keyid": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+        "sig": "MEUCIQChXn8SW+Xzp3hIj8sCOEzZO7ohF5kxjzHo5OmcJ1XO/wIgcBFbqGmN4Iyiw9ptQjoCz57rpREAGaXlYIf2o+zj68I="
+      }
+    ]
   },
   "gitHead": "6031b1cb732d390b29cd5376dceb9a9d665bbd11",
   "homepage": "https://github.com/YASGUI/Utils",
@@ -54536,7 +54544,15 @@ var root = module.exports = function(yasr) {
     yasr.translate = require('./translate.js')(yasr.options.locale);
 
 	var container = $("<div class='booleanResult'></div>");
-	var draw = function() {
+	var plugin = {
+		id: 'boolean',
+		name: null,//don't need to set this: we don't show it in the selection widget anyway, so don't need a human-friendly name
+		hideFromSelection: true,
+		getPriority: 1,
+	}
+	plugin.options = $.extend(true, {}, yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {});
+
+	plugin.draw = function() {
 		container.empty().appendTo(yasr.resultsContainer);
 		var booleanVal = yasr.results.getBoolean();
 		
@@ -54558,21 +54574,11 @@ var root = module.exports = function(yasr) {
 		
 		$("<span></span>").text(textVal).appendTo(container);
 	};
-	
 
-	var canHandleResults = function(){return yasr.results.getBoolean && (yasr.results.getBoolean() === true || yasr.results.getBoolean() == false);};
+	plugin.canHandleResults = function(){return yasr.results.getBoolean && (yasr.results.getBoolean() === true || yasr.results.getBoolean() == false);};
 
-	
-	
-	return {
-		name: null,//don't need to set this: we don't show it in the selection widget anyway, so don't need a human-friendly name
-		draw: draw,
-		hideFromSelection: true,
-		getPriority: 1,
-		canHandleResults: canHandleResults
-	}
+	return plugin;
 };
-
 
 root.version = {
 	"YASR-boolean" : require("../package.json").version,
@@ -54599,7 +54605,15 @@ var root = module.exports = function(yasr) {
     yasr.translate = require('./translate.js')(yasr.options.locale);
 
 	var container = $("<div class='booleanBootResult'></div>");
-	var draw = function() {
+	const plugin = {
+		id: 'booleanBootstrap',
+		name: null,//don't need to set this: we don't show it in the selection widget anyway, so don't need a human-friendly name
+		hideFromSelection: true,
+		getPriority: 3,
+	}
+	plugin.options = $.extend(true, {}, yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {});
+
+	plugin.draw = function() {
 		container.empty().appendTo(yasr.resultsContainer);
 		var booleanVal = yasr.results.getBoolean();
 		
@@ -54615,21 +54629,11 @@ var root = module.exports = function(yasr) {
 			
 		alert.appendTo(container);
 	};
-	
 
-	var canHandleResults = function(){return yasr.results.getBoolean && (yasr.results.getBoolean() === true || yasr.results.getBoolean() == false);};
+	plugin.canHandleResults = function(){return yasr.results.getBoolean && (yasr.results.getBoolean() === true || yasr.results.getBoolean() == false);};
 
-	
-	
-	return {
-		name: null,//don't need to set this: we don't show it in the selection widget anyway, so don't need a human-friendly name
-		draw: draw,
-		hideFromSelection: true,
-		getPriority: 3,
-		canHandleResults: canHandleResults
-	}
+	return plugin;
 };
-
 
 root.version = {
 	"YASR-boolean" : require("../package.json").version,
@@ -54752,8 +54756,17 @@ var root = module.exports = function(yasr) {
     yasr.translate = require('./translate.js')(yasr.options.locale);
 
 	var $container = $("<div class='errorResult'></div>");
-	var options = $.extend(true, {}, root.defaults);
-	
+
+	const plugin = {
+		id: 'error',
+		name: null,//don't need to set this: we don't show it in the selection widget anyway, so don't need a human-friendly name
+		getPriority: 20,
+		hideFromSelection: true,
+	}
+
+	const customOptions = yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {};
+	var options = plugin.options = $.extend(true, {}, root.defaults, customOptions);
+
 	var getTryBtn = function(){
 		var $tryBtn = null;
 		if (options.tryQueryLink) {
@@ -54768,7 +54781,7 @@ var root = module.exports = function(yasr) {
 		return $tryBtn;
 	}
 	
-	var draw = function() {
+	plugin.draw = function() {
 		var error = yasr.results.getException();
 		$container.empty().appendTo(yasr.resultsContainer);
 		var $header = $("<div>", {class:'errorHeader'}).appendTo($container);
@@ -54807,17 +54820,9 @@ var root = module.exports = function(yasr) {
 		}
 		
 	};
-	
-	
-	var  canHandleResults = function(yasr){return yasr.results.getException() || false;};
-	
-	return {
-		name: null,//don't need to set this: we don't show it in the selection widget anyway, so don't need a human-friendly name
-		draw: draw,
-		getPriority: 20,
-		hideFromSelection: true,
-		canHandleResults: canHandleResults,
-	}
+
+	plugin.canHandleResults = function(yasr){return yasr.results.getException() || false;};
+	return plugin;
 };
 
 /**
@@ -55552,8 +55557,6 @@ console = console || {"log":function(){}};//make sure any console statements don
 
 require('./jquery/extendJquery.js');
 
-
-
 /**
  * Main YASR constructor
  * 
@@ -55564,8 +55567,6 @@ require('./jquery/extendJquery.js');
  * @return {doc} YASR document
  */
 var root = module.exports = function(parent, options, queryResults) {
-
-
 	var yasr = {};
 	yasr.options = $.extend(true, {}, root.defaults, options);
 	yasr.container = $(parent).find(".yasr");
@@ -56023,6 +56024,18 @@ var root = module.exports = function(parent, options, queryResults) {
 		yasr.setResponse(queryResults);
 	} 
 	yasr.updateHeader();
+
+	const resizeEvent = 'resize.' + new Date().getTime();
+	$(window).on(resizeEvent, yasr.draw);
+
+	yasr.destroy = function () {
+		$(window).off(resizeEvent);
+		for (const plugin in yasr.plugins) {
+			if ($.isFunction(plugin.destroy)) {
+				plugin.destroy();
+			}
+		}
+	}
 	return yasr;
 };
 
@@ -56606,9 +56619,16 @@ var root = module.exports = function(yasr) {
     // load and register the translation service providing the locale config
     yasr.translate = require('./translate.js')(yasr.options.locale);
 
-	var plugin = {};
-	var options = $.extend(true, {}, root.defaults);
-	
+	var plugin = {
+		id: 'pivot',
+		name: "Pivot Table",
+		nameLabel: 'yasr.pivot.pivot_table',
+		getPriority: 4,
+	};
+
+	const customOptions = yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {};
+	var options = plugin.options = $.extend(true, {}, root.defaults, customOptions);
+
 	if (options.useD3Chart) {
 		try {
 			// Don't load d3 here, use the global one
@@ -56619,9 +56639,7 @@ var root = module.exports = function(yasr) {
 		}
 		if ($.pivotUtilities.d3_renderers) $.extend(true,  $.pivotUtilities.renderers, $.pivotUtilities.d3_renderers);
 	}
-	
-	
-	
+
 	var $pivotWrapper;
 	var mergeLabelPostfix = null;
 	var getShownVariables = function() {
@@ -56644,7 +56662,6 @@ var root = module.exports = function(yasr) {
 	};
 	
 	var formatForPivot = function(callback) {
-		
 		var vars = getShownVariables();
 		var usedPrefixes = null;
 		if (yasr.options.getUsedPrefixes) {
@@ -56695,7 +56712,8 @@ var root = module.exports = function(yasr) {
 		}
 		return settings;
 	};
-	var draw = function() {
+
+	plugin.draw = function() {
 		var doDraw = function() {
 			var onRefresh = function(pivotObj) {
 				if (persistencyId) {
@@ -56777,11 +56795,12 @@ var root = module.exports = function(yasr) {
 			doDraw();
 		}
 	};
-	var canHandleResults = function(){
+
+	plugin.canHandleResults = function(){
 		return yasr.results && yasr.results.getVariables && yasr.results.getVariables() && yasr.results.getVariables().length > 0;
 	};
 	
-	var getDownloadInfo =  function() {
+	plugin.getDownloadInfo =  function() {
 		if (!yasr.results) return null;
 		var svgEl = yasr.resultsContainer.find('.pvtRendererArea svg');
 		if (svgEl.length > 0) {
@@ -56816,7 +56835,8 @@ var root = module.exports = function(yasr) {
 		} 
 		
 	};
-	var getEmbedHtml = function() {
+
+	plugin.getEmbedHtml = function() {
 		if (!yasr.results) return null;
 		
 		var svgEl = yasr.resultsContainer.find('.pvtRendererArea svg')
@@ -56833,19 +56853,9 @@ var root = module.exports = function(yasr) {
 		//don't use jquery, so we can easily influence indentation
 		return '<div style="width: 800px; height: 600px;">\n' + htmlString + '\n</div>';
 	};
-	return {
-		getDownloadInfo: getDownloadInfo,
-		getEmbedHtml: getEmbedHtml,
-		options: options,
-		draw: draw,
-		name: "Pivot Table",
-		nameLabel: 'yasr.pivot.pivot_table',
-		canHandleResults: canHandleResults,
-		getPriority: 4,
-	}
+
+	return plugin;
 };
-
-
 
 root.defaults = {
 	mergeLabelsWithUris: false,
@@ -56878,16 +56888,24 @@ var root = module.exports = function(yasr) {
     // load and register the translation service providing the locale config
     yasr.translate = require('./translate.js')(yasr.options.locale);
 
-	var plugin = {};
-	var options = $.extend(true, {}, root.defaults);
+	const plugin = {
+		id: 'rawResponse',
+		name: "Raw Response",
+		nameLabel: 'yasr.name.raw_response',
+		getPriority: 2,
+	}
+
+	const customOptions = yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {};
+	var options = plugin.options = $.extend(true, {}, root.defaults, customOptions);
 	var cm = null;
-	var draw = function() {
+
+	plugin.draw = function() {
 		var cmOptions = options.CodeMirror;
 		cmOptions.value = yasr.results.getShortOriginalResponse(options.limit);
 		
 		var mode = yasr.results.getType();
 		if (mode) {
-			if (mode == "json") {
+			if (mode === "json") {
 				mode = {name: "javascript", json: true};
 			}
 			cmOptions.mode = mode;
@@ -56903,17 +56921,17 @@ var root = module.exports = function(yasr) {
 		cm.on('unfold', function() {
 			cm.refresh();
 		});
-		
 	};
-	var canHandleResults = function(){
+
+	plugin.canHandleResults = function(){
 		if (!yasr.results) return false;
 		if (!yasr.results.getOriginalResponseAsString) return false;
 		var response = yasr.results.getOriginalResponseAsString();
-		if ((!response || response.length == 0) && yasr.results.getException()) return false;//in this case, show exception instead, as we have nothing to show anyway
+		if ((!response || response.length === 0) && yasr.results.getException()) return false;//in this case, show exception instead, as we have nothing to show anyway
 		return true;
 	};
-	
-	var getDownloadInfo = function() {
+
+	plugin.getDownloadInfo = function() {
 		if (!yasr.results) return null;
 		var contentType = yasr.results.getOriginalContentType();
 		var type = yasr.results.getType();
@@ -56925,18 +56943,8 @@ var root = module.exports = function(yasr) {
 		};
 	};
 	
-	return {
-		draw: draw,
-		name: "Raw Response",
-		nameLabel: 'yasr.name.raw_response',
-		canHandleResults: canHandleResults,
-		getPriority: 2,
-		getDownloadInfo: getDownloadInfo,
-		
-	}
+	return plugin;
 };
-
-
 
 root.defaults = {
 	CodeMirror: {
@@ -56946,7 +56954,7 @@ root.defaults = {
 	    foldGutter: true,
 	    gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
 	},
-	limit: 100
+	limit: 1000
 };
 
 root.version = {
@@ -56982,11 +56990,14 @@ var root = module.exports = function(yasr) {
 
 	var table = null;
 	var plugin = {
+		id: 'table',
 		name: "Table",
 		nameLabel: 'yasr.table',
 		getPriority: 10,
 	};
-	var options = plugin.options = $.extend(true, {}, root.defaults);
+
+	const customOptions = yasr.options.pluginsOptions ? yasr.options.pluginsOptions[plugin.id] : {};
+	var options = plugin.options = $.extend(true, {}, root.defaults, customOptions);
 	var tableLengthPersistencyId = (options.persistency? yasr.getPersistencyId(options.persistency.tableLength): null);
 
 	var getRows = function() {
@@ -57090,7 +57101,7 @@ var root = module.exports = function(yasr) {
 		// hideOrShowDatatablesControls();
 		addAdditionalEvents();
 	};
-	
+
 	plugin.draw = function() {
 		table = $('<table cellpadding="0" cellspacing="0" border="0" class="resultsTable table stripe hover table-bordered fixedCellWidth"></table>');
 		$(yasr.resultsContainer).html(table);
@@ -57109,11 +57120,12 @@ var root = module.exports = function(yasr) {
 		
 		
 		drawSvgIcons();
-		
-		addEvents();
-		
-		//finally, make the columns dragable:
-		table.colResizable();
+
+		if (!options.enableColumnResizingOnWindowWidth || options.enableColumnResizingOnWindowWidth <= $(window).width()) {
+			addEvents();
+			//finally, make the columns dragable:
+			table.colResizable();
+		}
 		//and: make sure the height of the resize handlers matches the height of the table header
 		var thHeight = table.find('thead').outerHeight();
 		$(yasr.resultsContainer).find('.JCLRgrip').height(table.find('thead').outerHeight());

--- a/src/pages/explore.html
+++ b/src/pages/explore.html
@@ -1,6 +1,6 @@
 <link href="css/explore.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 <div core-errors></div>
-<div class="page" ng-show="getActiveRepository()">
+<div class="page fit-content" ng-show="getActiveRepository()">
     <div class="resource-info" ng-if="!isTripleResource()">
         <div class="thumb" ng-show="{{details.img}}">
             <a href="{{details.img}}"><img ng-src="{{details.img}}" alt="details image"/></a>
@@ -102,7 +102,7 @@
         </ul>
     </div>
 
-    <div id="yasr">
+    <div id="yasr" class="explore">
         <!--<pagination class="nav navbar-right" ng-show="allResultsCount > pageSize" total-items="allResultsCount" items-per-page="pageSize" ng-model="page" ng-change="changePagination()" direction-links="false" boundary-links="true" max-size="5" rotate="true"></pagination>-->
         <div class="yasr" id="yasr-inner">
             <div class='yasr_results' guide-selector="yasrResults"></div>

--- a/src/pages/jdbc-create.html
+++ b/src/pages/jdbc-create.html
@@ -8,7 +8,7 @@
 
 <link href="css/jdbc.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 
-<div class="container-fluid">
+<div class="container-fluid fit-content">
     <h1>
         {{title}}
         <span class="btn btn-link"
@@ -129,7 +129,7 @@
                 <br/>
                 <query-editor nostorage notabs notoolbar-saved notoolbar-copy nostatus nocount norun
                               notoolbar-inference
-                              notoolbar-same-as callback-on-change="updateDirty">
+                              notoolbar-same-as callback-on-change="updateDirty" enable-column-resizing-on-window-width>
                 </query-editor>
             </div>
         </div>

--- a/src/pages/similarity-indexes.html
+++ b/src/pages/similarity-indexes.html
@@ -1,6 +1,6 @@
 <link href="css/similarity.css?v=[AIV]{version}[/AIV]" rel='stylesheet' type='text/css'/>
 
-<div class="container-fluid">
+<div class="container-fluid fit-content">
 
 	<h1>
 		{{title}}

--- a/src/pages/sparql-template-create.html
+++ b/src/pages/sparql-template-create.html
@@ -8,7 +8,7 @@
 
 <link href="css/jdbc.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 
-<div class="container-fluid">
+<div class="container-fluid fit-content">
     <h1>
         {{title}}
         <span class="btn btn-link"

--- a/src/pages/sparql.html
+++ b/src/pages/sparql.html
@@ -44,7 +44,7 @@
     <query-editor
             ng-show="getActiveRepositoryNoError()"
             ng-keyup="saveQueryToLocal(currentQuery)"
-            nocount="{{skipCountQuery}}">
+            nocount="{{skipCountQuery}}" enable-column-resizing-on-window-width>
     </query-editor>
     <form id="wb-download" method="GET" action="" target="_self">
         <input id="wb-download-query" name="query" type="hidden"/>

--- a/src/vendor.js
+++ b/src/vendor.js
@@ -3,7 +3,7 @@ import 'angular-toastr/dist/angular-toastr.min.css';
 import 'font-awesome/css/font-awesome.min.css';
 import './css/lib/animate/animate.css';
 import 'shepherd.js/dist/css/shepherd.css';
-import './css/shepherd-custom.css'
+import './css/shepherd-custom.css';
 
 import 'jquery';
 import 'lib/angularjs/1.3.8/angular.js';


### PR DESCRIPTION
GDB-6815: Resource view on mobile

What?
 There was wrong calculation of table size when page is loaded on mobile.

Why?
 "colResizable-1.4.js" library is used for column size calculation. It don't do its job properly on mobile.

How?

 - Added functionality to switch off column resizing when screen width is small. Affected pages are:
  - explore
  - create jdbc
  - similarity, create similarity
  - SPARQL query
  - SPARQL template create