### PR TITLE
GDB-7537: User Guide crashes on step 47 when returning to SPARQL editor

### DIFF
--- a/src/js/angular/guides/guide-utils.js
+++ b/src/js/angular/guides/guide-utils.js
@@ -294,6 +294,38 @@ const GuideUtils = (function () {
         return angular.isFunction(elementSelector) ? elementSelector() : elementSelector;
     };
 
+    /**
+     * Executes a sparql query.
+     * @param {*} $location - the locations service.
+     * @param {*} $route
+     * @param {string} query - sparql query to be executed.
+     * @param {boolean} reload - if true sparql page will be loaded before execution of query.
+     * @return {Promise<unknown>}
+     */
+    const executeSparqlQuery = ($location, $route, query, reload = false) => new Promise((resolve, reject) => {
+        if (reload) {
+            $location.url('/sparql');
+            $route.reload();
+            waitFor(getSparqlEditorSelector())
+                .then(() => {
+                    waitFor('.no-query-run')
+                        .then(() => {
+                            window.editor.setValue(query);
+                            clickOnGuideElement('runSparqlQuery')()
+                                .then(() => resolve())
+                                .catch((error) => reject(error));
+                        })
+                        .catch((error) => reject(error));
+                })
+                .catch((error) => reject(error));
+        } else {
+            window.editor.setValue(query);
+            clickOnGuideElement('runSparqlQuery')()
+                .then(() => resolve())
+                .catch((error) => reject(error));
+        }
+    });
+
     return {
         GUIDES_LIST_URL,
         GUIDES_DOWNLOAD_URL,
@@ -323,7 +355,8 @@ const GuideUtils = (function () {
         isChecked,
         isGuideElementChecked,
         defaultInitPreviousStep,
-        getElementSelector
+        getElementSelector,
+        executeSparqlQuery
     };
 })();
 

--- a/src/js/angular/guides/steps/complex/execute-sparql-query/plugin.js
+++ b/src/js/angular/guides/steps/complex/execute-sparql-query/plugin.js
@@ -76,15 +76,9 @@ PluginRegistry.add('guide.step', [
                                 window.editor.setValue(defaultQuery);
                                 resolve();
                             } else {
-                                if ('/sparql' !== $location.url()) {
-                                    $location.url('/sparql');
-                                    $route.reload();
-                                }
-                                GuideUtils.waitFor(GuideUtils.getSparqlEditorSelector(), 3)
-                                    .then(() => {
-                                        window.editor.setValue(queries[index - 1]);
-                                        resolve();
-                                    })
+                                const haveToReload = '/sparql' !== $location.url();
+                                GuideUtils.executeSparqlQuery($location, $route, query, haveToReload)
+                                    .then(() => resolve())
                                     .catch((error) => reject(error));
                             }
                         }),
@@ -135,13 +129,8 @@ PluginRegistry.add('guide.step', [
                         canBePaused: false,
                         initPreviousStep: (services, stepId) => new Promise((resolve, reject) => {
                             if ('/sparql' !== $location.url()) {
-                                $location.url('/sparql');
-                                $route.reload();
-                                GuideUtils.waitFor(GuideUtils.getSparqlEditorSelector())
-                                    .then(() => {
-                                        window.editor.setValue(query);
-                                        GuideUtils.clickOnGuideElement('runSparqlQuery')().then(() => resolve()).catch((error) => reject(error));
-                                    })
+                                GuideUtils.executeSparqlQuery($location, $route, query, true)
+                                    .then(() => resolve())
                                     .catch((error) => reject(error));
                             } else {
                                 const previousStep = services.ShepherdService.getPreviousStepFromHistory(stepId);

--- a/src/js/angular/guides/tour-lib-services/shepherd.service.js
+++ b/src/js/angular/guides/tour-lib-services/shepherd.service.js
@@ -322,7 +322,8 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
         if (step.options.attachTo) {
             GuideUtils.waitFor(step.options.attachTo.element, step.options.maxWaitTime)
                 .then(() => guide.show(stepIndex))
-                .catch(() => {
+                .catch((error) => {
+                    console.log(error);
                     toastr.error($translate.instant('guide.start.unexpected.error.message'));
                 });
         } else {
@@ -542,7 +543,8 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
                                     guide.show(nextStep.id);
                                 }
                             })
-                            .catch(() => {
+                            .catch((error) => {
+                                console.log(error);
                                 toastr.error($translate.instant('guide.unexpected.error.message'));
                                 this._cancelGuide(guide, false);
                             });
@@ -553,7 +555,8 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
                     currentStep.hide();
                     guide.show(nextStep.id);
                 })
-                .catch(() => {
+                .catch((error) => {
+                    console.log(error);
                     toastr.error($translate.instant('guide.unexpected.error.message'));
                     this._cancelGuide(guide, false);
                 });
@@ -584,7 +587,8 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
                 if (angular.isFunction(currentStepDescription.onNextClick)) {
                     const onNextResult = currentStepDescription.onNextClick(guide, currentStepDescription);
                     if (onNextResult instanceof Promise) {
-                        onNextResult.catch(() => {
+                        onNextResult.catch((error) => {
+                            console.log(error);
                             toastr.error($translate.instant('guide.unexpected.error.message'));
                             this._cancelGuide(guide, false);
                         });


### PR DESCRIPTION
What?

 User guides crashes when return to step which have got a query executed.

Why?

 When a guide is active and "/sparql" view is loaded/reloaded a new query tab is opened. When a guide goes to step "execute-sparql-query" the guide functionality set the query before new tab is opened, runs the query and wait for specific result, but executed query is wrong so result is wrong and the guide crashes.

How?

 Added waiting for no result text element which is shown when new tab is opened. When new tab is opened sets the query and execute it.