### PR TITLE
GDB-7610: Plugins view gives periodic errors in the console

### DIFF
--- a/src/js/angular/plugins/controllers.js
+++ b/src/js/angular/plugins/controllers.js
@@ -35,7 +35,6 @@ function PluginsCtrl($scope, $interval, toastr, $repositories, $licenseService, 
             PluginsRestService.getPlugins($scope.getActiveRepository())
                 .success(function (data) {
                     $scope.plugins = $scope.buildPluginsArray(data.results.bindings);
-                    $scope.matchedElements = [];
                     if (angular.isDefined($scope.plugins)) {
                         $scope.displayedPlugins = $scope.plugins;
                     }
@@ -116,6 +115,7 @@ function PluginsCtrl($scope, $interval, toastr, $repositories, $licenseService, 
     };
 
     $scope.filterResults = function () {
+        $scope.matchedElements = [];
         angular.forEach($scope.plugins, function (item) {
             if (item.name.indexOf($scope.searchPlugins) !== -1) {
                 $scope.matchedElements.push(item);
@@ -124,7 +124,6 @@ function PluginsCtrl($scope, $interval, toastr, $repositories, $licenseService, 
     };
 
     $scope.onPluginsSearch = function () {
-        $scope.matchedElements = [];
         $scope.filterResults();
     };
 


### PR DESCRIPTION
What?
 There is "Error: [ngRepeat:dupes] Duplicates in a repeater are not allowed..." in console when plugin page is opened.

Why?

Periodically plugin controller refreshes available plugins and filter them. All plugins which match search term are pushed to "matchedElements" array, but this array not cleaned before used it, this caused duplicate error.

How?

The array is cleared before add plugins to it.