### PR TITLE
GDB-6815: Resource view on mobile

### DIFF
--- a/src/css/yasr.custom.css
+++ b/src/css/yasr.custom.css
@@ -100,6 +100,13 @@
 .yasr .uri-cell {
   display: inline;
   word-break: normal !important;
+  word-wrap: normal !important;
+}
+
+@media screen and (max-width: 768px) {
+    .yasr .uri-cell {
+        word-wrap: break-word !important;
+    }
 }
 
 .yasr .triple-cell {


### PR DESCRIPTION
What?

Text of link in resource view are broken on new line. Why?

Yasr lib added style to break it. When GDB-6815 issue is fixed a style "word-wrap: normal !important;" was removed of yasr cell element. How?

Restored the style and apply it only for mobile. When page is opened on screen with big resolution the columns can be resized and is not needed to break the text.