### PR TITLE
GDB-7614: Interactive guides page fails

### DIFF
--- a/src/pages/home.html
+++ b/src/pages/home.html
@@ -17,7 +17,7 @@
                     </div>
                 </div>
                 <div class="card-block">
-                    <a href="/guides" class="btn btn-lg btn-primary">{{'take.me.to.guides' | translate}}</a>
+                    <a href="guides" class="btn btn-lg btn-primary">{{'take.me.to.guides' | translate}}</a>
                     <a href="#" class="btn btn-lg btn-outline-secondary decline-tutorial" ng-click="declineTutorial()">{{'hide.panel' | translate}}</a>
                     <div class="btn-toolbar pull-right" role="toolbar" aria-label="Toolbar with button groups">
                         <div class="btn-group" role="group" aria-label="First group">


### PR DESCRIPTION
When GraphDB is behind a reverse proxy and there is a context path the Interactive guides page will fail to load.