### PR TITLE
GDB-7629: broken views

### DIFF
--- a/src/css/new-sparql.css
+++ b/src/css/new-sparql.css
@@ -165,8 +165,3 @@ a[aria-expanded = true].query-has-error span {
     right: 0;
 }
 
-@media only screen and (max-width:768px) {
-    #sparql-content {
-        width: fit-content;
-    }
-}

--- a/src/css/workbench-custom.css
+++ b/src/css/workbench-custom.css
@@ -374,6 +374,8 @@
     text-align: left;
 }
 
-.fit-content {
-    width: fit-content;
+@media only screen and (max-width:768px) {
+    .fit-content-on-mobile {
+        width: fit-content;
+    }
 }

--- a/src/js/angular/core/directives/queryeditor/templates/query-editor.html
+++ b/src/js/angular/core/directives/queryeditor/templates/query-editor.html
@@ -1,4 +1,4 @@
-<div id="sparql-content">
+<div id="sparql-content" class="fit-content-on-mobile">
     <div ng-hide="viewMode == 'editor'"
          ng-class="orientationViewMode ? 'row' : viewMode == 'yasr' ? 'col-xs-12' : 'col-xs-6'" ng-style="noPadding">
         <div class="col-xs-12 mb-1" ng-style="noPadding">

--- a/src/pages/explore.html
+++ b/src/pages/explore.html
@@ -1,6 +1,6 @@
 <link href="css/explore.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 <div core-errors></div>
-<div class="page fit-content" ng-show="getActiveRepository()">
+<div class="page fit-content-on-mobile" ng-show="getActiveRepository()">
     <div class="resource-info" ng-if="!isTripleResource()">
         <div class="thumb" ng-show="{{details.img}}">
             <a href="{{details.img}}"><img ng-src="{{details.img}}" alt="details image"/></a>

--- a/src/pages/jdbc-create.html
+++ b/src/pages/jdbc-create.html
@@ -8,7 +8,7 @@
 
 <link href="css/jdbc.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 
-<div class="container-fluid fit-content">
+<div class="container-fluid fit-content-on-mobile">
     <h1>
         {{title}}
         <span class="btn btn-link"

--- a/src/pages/similarity-indexes.html
+++ b/src/pages/similarity-indexes.html
@@ -1,6 +1,6 @@
 <link href="css/similarity.css?v=[AIV]{version}[/AIV]" rel='stylesheet' type='text/css'/>
 
-<div class="container-fluid fit-content">
+<div class="container-fluid">
 
 	<h1>
 		{{title}}

--- a/src/pages/sparql-template-create.html
+++ b/src/pages/sparql-template-create.html
@@ -8,7 +8,7 @@
 
 <link href="css/jdbc.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 
-<div class="container-fluid fit-content">
+<div class="container-fluid fit-content-on-mobile">
     <h1>
         {{title}}
         <span class="btn btn-link"


### PR DESCRIPTION
What?

 Explore, jdbc-create, similarity-indexes, sparql-template-create views are align center

Why?

 With implementation of GDB-6815 issue style "width: fit-content;" was added to the views. This style fixes calculation of views width by ysque libraries, but brokes them when are opened with big resolution.
How?

 Added media query which add the style only for small resolutions.