### PR TITLE
GDB-7680: Integrate the ontotext-yasgui component in the workbench

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,11 @@
                 "jquery": "^3.4.1",
                 "jsrsasign": "^10.3.0",
                 "lodash": "^4.17.21",
+                "ng-custom-element": "^2.0.3",
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
+                "ontotext-yasgui-web-component": "^0.0.2-TR-1",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -200,6 +202,18 @@
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
             "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
             "dev": true
+        },
+        "node_modules/@stencil/core": {
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.20.0.tgz",
+            "integrity": "sha512-ka+eOW+dNteXIfLCRipNbbAlBEQjqJ2fkx3fxzlKgnNHEQMdZiuIjlWt63KzvOJStNeuADdQXo89BB1dC2VRUw==",
+            "bin": {
+                "stencil": "bin/stencil"
+            },
+            "engines": {
+                "node": ">=12.10.0",
+                "npm": ">=6.0.0"
+            }
         },
         "node_modules/@types/cookie": {
             "version": "0.4.1",
@@ -9550,6 +9564,11 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
+        "node_modules/ng-custom-element": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/ng-custom-element/-/ng-custom-element-2.0.3.tgz",
+            "integrity": "sha512-V3ajQoe+PjviKb8OXskgFpauLLMuDuYG+8mos6Vu734UEZFGtaQlKZWVNAx9Qyt9S38crOdBwUiFk6bpR+ci4Q=="
+        },
         "node_modules/ng-file-upload": {
             "version": "12.2.13",
             "resolved": "https://registry.npmjs.org/ng-file-upload/-/ng-file-upload-12.2.13.tgz",
@@ -10026,6 +10045,14 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/ontotext-yasgui-web-component": {
+            "version": "0.0.2-TR-1",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR-1.tgz",
+            "integrity": "sha512-3rWcJzMYMitwy6IWNbLntJDX5iLYUV8+3dCF/7SEd33fbuZlxMOLYknWpDG6QOOxX4kCrNYStbgvkVMSg8KrPQ==",
+            "dependencies": {
+                "@stencil/core": "^2.20.0"
             }
         },
         "node_modules/opn": {
@@ -16523,6 +16550,11 @@
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
             "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
             "dev": true
+        },
+        "@stencil/core": {
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.20.0.tgz",
+            "integrity": "sha512-ka+eOW+dNteXIfLCRipNbbAlBEQjqJ2fkx3fxzlKgnNHEQMdZiuIjlWt63KzvOJStNeuADdQXo89BB1dC2VRUw=="
         },
         "@types/cookie": {
             "version": "0.4.1",
@@ -24137,6 +24169,11 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
+        "ng-custom-element": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/ng-custom-element/-/ng-custom-element-2.0.3.tgz",
+            "integrity": "sha512-V3ajQoe+PjviKb8OXskgFpauLLMuDuYG+8mos6Vu734UEZFGtaQlKZWVNAx9Qyt9S38crOdBwUiFk6bpR+ci4Q=="
+        },
         "ng-file-upload": {
             "version": "12.2.13",
             "resolved": "https://registry.npmjs.org/ng-file-upload/-/ng-file-upload-12.2.13.tgz",
@@ -24513,6 +24550,14 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^1.0.0"
+            }
+        },
+        "ontotext-yasgui-web-component": {
+            "version": "0.0.2-TR-1",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR-1.tgz",
+            "integrity": "sha512-3rWcJzMYMitwy6IWNbLntJDX5iLYUV8+3dCF/7SEd33fbuZlxMOLYknWpDG6QOOxX4kCrNYStbgvkVMSg8KrPQ==",
+            "requires": {
+                "@stencil/core": "^2.20.0"
             }
         },
         "opn": {

--- a/package.json
+++ b/package.json
@@ -100,9 +100,11 @@
         "jquery": "^3.4.1",
         "jsrsasign": "^10.3.0",
         "lodash": "^4.17.21",
+        "ng-custom-element": "^2.0.3",
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
+        "ontotext-yasgui-web-component": "^0.0.2-TR-1",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ import 'angular-translate-loader-static-files';
 import 'angular/core/interceptors/unauthorized.interceptor';
 import 'angular/core/directives/rdfresourcesearch/rdf-resource-search.directive';
 import 'angular/core/directives/languageselector/language-selector.directive';
+import {defineCustomElementOntotextYasgui} from 'ontotext-yasgui-web-component/dist/components/index';
 
 // $translate.instant converts <b> from strings to &lt;b&gt
 // and $sce.trustAsHtml could not recognise that this is valid html
@@ -26,7 +27,8 @@ const modules = [
     'graphdb.framework.core.interceptors.unauthorized',
     'graphdb.framework.core.directives.rdfresourcesearch.rdfresourcesearch',
     'graphdb.framework.core.directives.languageselector.languageselector',
-    'graphdb.framework.guides.services'
+    'graphdb.framework.guides.services',
+    'ngCustomElement'
 ];
 
 const providers = [
@@ -42,6 +44,9 @@ const providers = [
 ];
 
 const moduleDefinition = function (productInfo) {
+
+    defineCustomElementOntotextYasgui();
+
     const workbench = angular.module('graphdb.workbench', modules);
 
     workbench.config([...providers,

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1725,5 +1725,8 @@
     "guide.step_plugin.welcome-what.content": "{{translatedGuideDescription}}<p>Let's get started for real now!</p>",
     "guide.confirm.cancel.message": "Are you sure you want to stop the guide?",
     "guide.unexpected.error.message": "The guide was cancelled due to an unexpected error. Please run the guide again and if the problem persists contact the support.",
-    "guide.start.unexpected.error.message": "The guide cannot be started due to an unexpected error. Please try running the guide again and if the problem persists contact the support."
+    "guide.start.unexpected.error.message": "The guide cannot be started due to an unexpected error. Please try running the guide again and if the problem persists contact the support.",
+    "view.sparql-editor.title": "Ontotext Yasgui SPARQL Query & Update",
+    "view.sparql-editor.helpInfo": "The SPARQL Query & Update view is a unified editor for queries and updates. Enter any SPARQL query or update and click Run to execute it. The view also allows you to save queries for future retrieval and execution in the SPARQL editor.",
+    "menu.sparql-editor.label": "Ontotext Yasgui SPARQL"
 }

--- a/src/js/angular/sparql-editor/app.js
+++ b/src/js/angular/sparql-editor/app.js
@@ -1,0 +1,8 @@
+import 'angular/sparql-editor/controllers';
+
+const modules = [
+    'ui.bootstrap',
+    'graphdb.framework.sparql-editor.controllers'
+];
+
+angular.module('graphdb.framework.sparql-editor', modules);

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -1,0 +1,19 @@
+angular
+    .module('graphdb.framework.sparql-editor.controllers', ['ui.bootstrap'])
+    .controller('SparqlEditorCtrl', SparqlEditorCtrl);
+
+SparqlEditorCtrl.$inject = ['$scope'];
+
+function SparqlEditorCtrl($scope) {
+    $scope.config = {
+        yasguiConfig: {
+            requestConfig: {
+                endpoint: "/repositories/test-repo"
+            }
+        }
+    };
+
+    $scope.queryExecuted = function (query) {
+        console.log(query.detail);
+    };
+}

--- a/src/js/angular/sparql-editor/plugin.js
+++ b/src/js/angular/sparql-editor/plugin.js
@@ -1,0 +1,23 @@
+PluginRegistry.add('route', {
+    'url': '/sparql-editor',
+    'module': 'graphdb.framework.sparql-editor',
+    'path': 'sparql-editor/app',
+    'controller': 'SparqlEditorCtrl',
+    'templateUrl': 'pages/sparql-editor.html',
+    'title': 'view.sparql-editor.title',
+    'helpInfo': 'view.sparql-editor.helpInfo'
+});
+
+PluginRegistry.add('main.menu', {
+    'items': [
+        {
+            label: 'SPARQL_EDITOR',
+            labelKey: 'menu.sparql-editor.label',
+            href: 'sparql-editor',
+            order: 2,
+            role: 'IS_AUTHENTICATED_FULLY',
+            icon: "icon-sparql",
+            guideSelector: 'menu-sparql-editor'
+        }
+    ]
+});

--- a/src/pages/sparql-editor.html
+++ b/src/pages/sparql-editor.html
@@ -1,0 +1,9 @@
+<div>
+    integrated page
+
+    <ontotext-yasgui
+        ng-custom-element
+        ngce-prop-config="config"
+        ngce-on-query_executed="queryExecuted($event)">
+    </ontotext-yasgui>
+</div>

--- a/src/vendor.js
+++ b/src/vendor.js
@@ -10,3 +10,4 @@ import 'lib/angularjs/1.3.8/angular.js';
 import 'lib/bootstrap/bootstrap.min';
 import 'angular/core/loading-hint.js';
 import 'bootstrap-switch/dist/js/bootstrap-switch.min';
+import 'ng-custom-element/dist/ng-custom-element.umd';

--- a/test-cypress/fixtures/graphql-editor/default-query-response.json
+++ b/test-cypress/fixtures/graphql-editor/default-query-response.json
@@ -1,0 +1,517 @@
+{
+  "head" : {
+    "vars" : [
+      "s",
+      "p",
+      "o"
+    ]
+  },
+  "results" : {
+    "bindings" : [
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#TransitiveProperty"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#TransitiveProperty"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#domain"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#range"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#equivalentProperty"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#SymmetricProperty"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#equivalentProperty"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#TransitiveProperty"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#equivalentClass"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#SymmetricProperty"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#equivalentClass"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#TransitiveProperty"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://proton.semanticweb.org/protonsys#transitiveOver"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#inverseOf"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#inverseOf"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#SymmetricProperty"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#subject"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#object"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#first"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#List"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#comment"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#label"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#Class"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#Datatype"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#differentFrom"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#differentFrom"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#SymmetricProperty"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#Class"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#Datatype"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#Class"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#Datatype"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#Ontology"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#priorVersion"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        }
+      },
+      {
+        "s" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/TR/2003/CR-owl-guide-20030818/wine"
+        },
+        "p" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "o" : {
+          "type" : "uri",
+          "value" : "http://www.w3.org/2002/07/owl#Ontology"
+        }
+      }
+    ]
+  }
+}

--- a/test-cypress/integration/sparql-editor/sparql-editor.spec.js
+++ b/test-cypress/integration/sparql-editor/sparql-editor.spec.js
@@ -1,0 +1,15 @@
+import {SparqlEditorSteps} from "../../steps/sparql-editor-steps";
+import {YasguiSteps} from "../../steps/yasgui-steps";
+
+describe('Default view', () => {
+
+    beforeEach(() => {
+        cy.intercept('/repositories/test-repo', {fixture: '/graphql-editor/default-query-response.json'}).as('getGuides');
+    });
+
+    it('Should load component with default configuration', () => {
+        SparqlEditorSteps.visitSparqlEditorPage();
+
+        YasguiSteps.getYasgui().should('be.visible');
+    });
+});

--- a/test-cypress/steps/sparql-editor-steps.js
+++ b/test-cypress/steps/sparql-editor-steps.js
@@ -1,0 +1,5 @@
+export class SparqlEditorSteps {
+    static visitSparqlEditorPage() {
+        cy.visit('/sparql-editor');
+    }
+}

--- a/test-cypress/steps/yasgui-steps.js
+++ b/test-cypress/steps/yasgui-steps.js
@@ -1,0 +1,6 @@
+export class YasguiSteps {
+
+    static getYasgui() {
+        return cy.get('.yasgui');
+    }
+}


### PR DESCRIPTION
## What
 * The "ontotext-yasgui-web-component" is integrated in workbench.

## Why
 * As developers we need a page with integrated "ontotext-yasgui-web-component" to start development.

## How
 * Added "ontotext-yasgui-web-component" and "ng-custom-element" modules as project dependence.
 * A new page "sparql-editor" is created and added a menu to open it.