### PR TITLE
GDB-7783 integrate the save query action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ coverage/
 # Dev specific
 report/
 cypress/
+test-cypress/logs/
 .downloads

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "^0.0.2-TR2",
+                "ontotext-yasgui-web-component": "^0.0.2-TR3",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -10048,9 +10048,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR2",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR2.tgz",
-            "integrity": "sha512-w42ped240pt6+mOhIpnhCnsVw4cyigZ2tcPo0xaY2h7a62D/QVQm5SNF1vBziXj/4rZuxaQfcy7IH69fgPHkwA==",
+            "version": "0.0.2-TR3",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR3.tgz",
+            "integrity": "sha512-kcYnUzYc23cxDh/75Vmj4wC/7OeqcmmN3P3bSCUTI3syBujPC4CunlusCJInswBkzlNwtGnc2249GvPsDKvTXQ==",
             "dependencies": {
                 "@stencil/core": "^2.20.0",
                 "tippy.js": "^6.3.7"
@@ -24562,9 +24562,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR2",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR2.tgz",
-            "integrity": "sha512-w42ped240pt6+mOhIpnhCnsVw4cyigZ2tcPo0xaY2h7a62D/QVQm5SNF1vBziXj/4rZuxaQfcy7IH69fgPHkwA==",
+            "version": "0.0.2-TR3",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR3.tgz",
+            "integrity": "sha512-kcYnUzYc23cxDh/75Vmj4wC/7OeqcmmN3P3bSCUTI3syBujPC4CunlusCJInswBkzlNwtGnc2249GvPsDKvTXQ==",
             "requires": {
                 "@stencil/core": "^2.20.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "^0.0.2-TR2",
+        "ontotext-yasgui-web-component": "^0.0.2-TR3",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/src/js/angular/rest/sparql.rest.service.js
+++ b/src/js/angular/rest/sparql.rest.service.js
@@ -14,7 +14,7 @@ function SparqlRestService($http) {
         addKnownPrefixes,
         editSavedQuery,
         deleteSavedQuery,
-        addNewSavedQuery,
+        addNewSavedQuery
     };
 
     function getSavedQueries() {
@@ -41,7 +41,20 @@ function SparqlRestService($http) {
         return $http.delete(`${SAVED_QUERIES_ENDPOINT}?name=${encodeURIComponent(savedQueryName)}`);
     }
 
-    function addNewSavedQuery(query) {
-        return $http.post(SAVED_QUERIES_ENDPOINT, query);
+    /**
+     * Creates a new saved query.
+     *
+     * @param {object} payload A payload object in format
+     * <code>
+     *  {
+     *      body: string,
+     *      name: string,
+     *      shared: boolean
+     *  }
+     * </code>
+     * @return {Promise} a promise which resolves with the result of the save query request or an error message.
+     */
+    function addNewSavedQuery(payload) {
+        return $http.post(SAVED_QUERIES_ENDPOINT, payload);
     }
 }

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -1,12 +1,14 @@
+import {merge} from "lodash";
+
 angular
     .module('graphdb.framework.sparql-editor.controllers', ['ui.bootstrap'])
     .controller('SparqlEditorCtrl', SparqlEditorCtrl);
 
-SparqlEditorCtrl.$inject = ['$scope', '$repositories'];
+SparqlEditorCtrl.$inject = ['$scope', '$repositories', 'toastr', '$translate', 'SparqlRestService'];
 
-function SparqlEditorCtrl($scope, $repositories) {
+function SparqlEditorCtrl($scope, $repositories, toastr, $translate, SparqlRestService) {
 
-    this.repository = "";
+    this.repository = '';
 
     $scope.config = undefined;
 
@@ -14,18 +16,44 @@ function SparqlEditorCtrl($scope, $repositories) {
         $scope.configChanged();
     }
 
-    $scope.queryExecuted = function (query) {
-        console.log(query.detail);
-    };
-
     $scope.configChanged = function () {
         const activeRepository = $repositories.getActiveRepository();
         if (activeRepository) {
             $scope.config = {
-                endpoint: "/repositories/test-repo",
+                endpoint: `/repositories/${activeRepository}`,
                 showToolbar: true
             };
         }
+    };
+
+    $scope.queryExecuted = function (query) {
+        console.log(query.detail);
+    };
+
+    $scope.createSavedQuery = function (event) {
+        const payload = {
+            name: event.detail.queryName,
+            body: event.detail.query,
+            shared: event.detail.isPublic
+        };
+        SparqlRestService.addNewSavedQuery(payload).then((res) => {
+            toastr.success($translate.instant('query.editor.save.saved.query.success.msg', {name: payload.name}));
+            $scope.config = merge({}, $scope.config, {
+                savedQuery: {
+                    saveSuccess: true
+                }
+            });
+        }).catch((err) => {
+            const msg = getError(err);
+            const errorMessage = $translate.instant('query.editor.create.saved.query.error');
+            toastr.error(msg, errorMessage);
+            $scope.config = merge({}, $scope.config, {
+                savedQuery: {
+                    saveSuccess: false,
+                    errorMessage: [errorMessage]
+                }
+            });
+        });
     };
 
     $scope.$on('repositoryIsSet', $scope.configChanged);

--- a/src/pages/sparql-editor.html
+++ b/src/pages/sparql-editor.html
@@ -1,9 +1,10 @@
 <div>
-    integrated page
+    <h1>YASGUI integration page</h1>
 
     <ontotext-yasgui
         ng-custom-element
         ngce-prop-config="config"
-        ngce-on-query_executed="queryExecuted($event)">
+        ngce-on-query_executed="queryExecuted($event)"
+        ngce-on-create_saved_query="createSavedQuery($event)">
     </ontotext-yasgui>
 </div>

--- a/test-cypress/integration/sparql-editor/actions/save-query.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/save-query.spec.js
@@ -1,0 +1,81 @@
+import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
+import {YasguiSteps} from "../../../steps/yasgui-steps";
+import {ApplicationSteps} from "../../../steps/application-steps";
+
+describe('Save query', () => {
+
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'sparql-editor-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        cy.intercept(`/repositories/${repositoryId}`, {fixture: '/graphql-editor/default-query-response.json'}).as('getGuides');
+
+        SparqlEditorSteps.visitSparqlEditorPage();
+        YasguiSteps.getYasgui().should('be.visible');
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should be able to edit query and save it', () => {
+        // Given I have opened the sparql editor page
+        YasguiSteps.getCreateSavedQueryButton().should('be.visible');
+        YasguiSteps.createSavedQuery();
+        // When I write a query name
+        YasguiSteps.clearQueryNameField();
+        const savedQueryName = generateQueryName();
+        YasguiSteps.writeQueryName(savedQueryName);
+        YasguiSteps.clearQueryField();
+        YasguiSteps.writeQuery('select *');
+        YasguiSteps.toggleIsPublic();
+        // And I click on save button
+        YasguiSteps.saveQuery();
+        // Then the query should be saved
+        YasguiSteps.getSaveQueryDialog().should('not.exist');
+        ApplicationSteps.getSuccessNotifications().should('be.visible');
+        // TODO: verify that it's save through the saved queries menu when it's ready
+    });
+
+    it('Should prevent saving query with duplicated name', () => {
+        // Given I have opened the sparql editor page
+        YasguiSteps.getCreateSavedQueryButton().should('be.visible');
+        YasguiSteps.createSavedQuery();
+        // When I write a query name
+        YasguiSteps.clearQueryNameField();
+        const savedQueryName = generateQueryName();
+        YasguiSteps.writeQueryName(savedQueryName);
+        YasguiSteps.clearQueryField();
+        YasguiSteps.writeQuery('select *');
+        YasguiSteps.toggleIsPublic();
+        // And I click on save button
+        YasguiSteps.saveQuery();
+        // Then the query should be saved
+        YasguiSteps.getSaveQueryDialog().should('not.exist');
+        ApplicationSteps.getSuccessNotifications().should('be.visible');
+        // When I try to save the query with the same name
+        YasguiSteps.createSavedQuery();
+        YasguiSteps.clearQueryNameField();
+        YasguiSteps.writeQueryName(savedQueryName);
+        YasguiSteps.saveQuery();
+        // Then I expect that dialog will remain open and an error will be visible
+        // TODO: find out why this check fails on Jenkins sometimes with
+        // AssertionError: Timed out retrying after 30000ms: Expected to find element: `.toast-error`, but never found it. Queried from element: <div#toast-container.toast-bottom-right>
+        // ApplicationSteps.getErrorNotifications().should('be.visible');
+        YasguiSteps.getSaveQueryDialog().should('be.visible');
+        YasguiSteps.getErrorsPane().should('contain', 'Error! Cannot create saved query');
+        // When I change the query name
+        YasguiSteps.clearQueryNameField();
+        YasguiSteps.writeQueryName(generateQueryName());
+        YasguiSteps.saveQuery();
+        // Then I should be able to save the query
+        YasguiSteps.getSaveQueryDialog().should('not.exist');
+        ApplicationSteps.getSuccessNotifications().should('be.visible');
+    });
+});
+
+function generateQueryName() {
+    return 'Saved query - ' + Date.now();
+}

--- a/test-cypress/integration/sparql/sparql.menu.spec.js
+++ b/test-cypress/integration/sparql/sparql.menu.spec.js
@@ -688,7 +688,8 @@ describe('SPARQL screen validation', () => {
     });
 
     context('Saved queries & links', () => {
-        beforeEach(() => SparqlSteps.createRepoAndVisit(repositoryId));
+        repositoryId = 'sparql-' + Date.now();
+        beforeEach(() => SparqlSteps.createRepoAndVisit(repositoryId))
 
         const QUERY_FOR_SAVING = 'select (count (*) as ?cnt)\n' +
             'where {\n' +

--- a/test-cypress/steps/application-steps.js
+++ b/test-cypress/steps/application-steps.js
@@ -1,0 +1,23 @@
+export class ApplicationSteps {
+
+    // notifications
+    static getNotifications() {
+        return cy.get('#toast-container');
+    }
+
+    static getSuccessNotifications() {
+        return this.getNotifications().find('.toast-success');
+    }
+
+    static getErrorNotifications() {
+        return this.getNotifications().find('.toast-error');
+    }
+
+    static getInfoNotification() {
+        return this.getNotifications().find('.toast-info');
+    }
+
+    static getWarningNotification() {
+        return this.getNotifications().find('.toast-warning');
+    }
+}

--- a/test-cypress/steps/yasgui-steps.js
+++ b/test-cypress/steps/yasgui-steps.js
@@ -3,4 +3,68 @@ export class YasguiSteps {
     static getYasgui() {
         return cy.get('.yasgui');
     }
+
+    static getCreateSavedQueryButton() {
+        return cy.get('.yasqe_createSavedQueryButton');
+    }
+
+    static createSavedQuery() {
+        this.getCreateSavedQueryButton().click();
+    }
+
+    static getSaveQueryDialog() {
+        return cy.get('.dialog');
+    }
+
+    static closeSaveQueryDialog() {
+        this.getSaveQueryDialog().find('.close-button').click();
+    }
+
+    static cancelSaveQuery() {
+        this.getSaveQueryDialog().find('.cancel-button').click();
+    }
+
+    static getSaveQueryButton() {
+        return this.getSaveQueryDialog().find('.ok-button');
+    }
+
+    static saveQuery() {
+        this.getSaveQueryButton().click();
+    }
+
+    static getQueryField() {
+        return this.getSaveQueryDialog().find('#query');
+    }
+
+    static writeQuery(query) {
+        this.getQueryField().type(query, {parseSpecialCharSequences: false});
+    }
+
+    static clearQueryField() {
+        this.getQueryField().clear();
+    }
+
+    static getQueryNameField() {
+        return this.getSaveQueryDialog().find('#queryName');
+    }
+
+    static writeQueryName(queryName) {
+        this.getQueryNameField().type(queryName);
+    }
+
+    static clearQueryNameField() {
+        this.getQueryNameField().clear();
+    }
+
+    static toggleIsPublic() {
+        this.getSaveQueryDialog().find('#publicQuery').click();
+    }
+
+    static getErrorsPane() {
+        return this.getSaveQueryDialog().find('.alert-danger');
+    }
+
+    static getErrors() {
+        return this.getErrorsPane().find('.error-message');
+    }
 }


### PR DESCRIPTION
## What
Integrate the save query action from the ontotext yasgui component.

## Why
Save query action exists in current implementation in the GDB WB. It allows the user to complete the query name and the query itself, to select if the query will be private or public and save it.

## How
* The ontotext yasgui component now supports the save query action. This changes in this MR are related with the integration of the save action. See also the related branch https://github.com/Ontotext-AD/ontotext-yasgui/pull/39
* Implemented tests.

Additional:
* Install latest ontotext yasgui component version and fix error message show after save query failing request