### PR TITLE
GDB-7784 integrate show saved queries action

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "^0.0.2-TR4",
+        "ontotext-yasgui-web-component": "^0.0.2-TR5",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/src/js/angular/rest/mappers/saved-query-response-mapper.js
+++ b/src/js/angular/rest/mappers/saved-query-response-mapper.js
@@ -1,0 +1,12 @@
+export const savedQueriesResponseMapper = (response) => {
+    if (response) {
+        return response.map((savedQuery) => ({
+                queryName: savedQuery.name,
+                query: savedQuery.body,
+                owner: savedQuery.owner,
+                isPublic: savedQuery.shared
+            })
+        );
+    }
+    return [];
+};

--- a/src/js/angular/rest/sparql.rest.service.js
+++ b/src/js/angular/rest/sparql.rest.service.js
@@ -17,6 +17,24 @@ function SparqlRestService($http) {
         addNewSavedQuery
     };
 
+    /**
+     * Fetch saved queries.
+     * @return {Promise} a promise which resolves with the saved queries list result in format
+     * <code>
+     * [
+     *   {
+     *       // the name of the query
+     *       name: string;
+     *       // the query itself
+     *       body: string;
+     *       // the query creator
+     *       owner: string;
+     *       // if the query is public or private
+     *       shared: boolean;
+     *   }
+     * ]
+     * </code>
+     */
     function getSavedQueries() {
         return $http.get(SAVED_QUERIES_ENDPOINT);
     }
@@ -52,7 +70,7 @@ function SparqlRestService($http) {
      *      shared: boolean
      *  }
      * </code>
-     * @return {Promise} a promise which resolves with the result of the save query request or an error message.
+     * @return {Promise} a promise which resolves with the result from the save query request or an error message.
      */
     function addNewSavedQuery(payload) {
         return $http.post(SAVED_QUERIES_ENDPOINT, payload);

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -29,36 +29,6 @@ function SparqlEditorCtrl($scope, $repositories, toastr, $translate, SparqlRestS
         }
     };
 
-    $scope.queryExecuted = function (query) {
-        console.log(query.detail);
-    };
-
-    $scope.createSavedQuery = function (event) {
-        const payload = {
-            name: event.detail.queryName,
-            body: event.detail.query,
-            shared: event.detail.isPublic
-        };
-        SparqlRestService.addNewSavedQuery(payload).then((res) => {
-            toastr.success($translate.instant('query.editor.save.saved.query.success.msg', {name: payload.name}));
-            $scope.config = merge({}, $scope.config, {
-                savedQuery: {
-                    saveSuccess: true
-                }
-            });
-        }).catch((err) => {
-            const msg = getError(err);
-            const errorMessage = $translate.instant('query.editor.create.saved.query.error');
-            toastr.error(msg, errorMessage);
-            $scope.config = merge({}, $scope.config, {
-                savedQuery: {
-                    saveSuccess: false,
-                    errorMessage: [errorMessage]
-                }
-            });
-        });
-    };
-
     $scope.$on('repositoryIsSet', $scope.configChanged);
     $scope.$on('language-changed', function (event, args) {
         $scope.language = args.locale;

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -1,4 +1,5 @@
 import {merge} from "lodash";
+import {savedQueriesResponseMapper} from "../rest/mappers/saved-query-response-mapper";
 
 angular
     .module('graphdb.framework.sparql-editor.controllers', ['ui.bootstrap'])
@@ -18,7 +19,7 @@ function SparqlEditorCtrl($scope, $repositories, toastr, $translate, SparqlRestS
         $scope.configChanged();
     }
 
-    $scope.configChanged = function () {
+    $scope.configChanged = () => {
         const activeRepository = $repositories.getActiveRepository();
         if (activeRepository) {
             $scope.config = {
@@ -27,6 +28,50 @@ function SparqlEditorCtrl($scope, $repositories, toastr, $translate, SparqlRestS
                 componentId: 'graphdb-workbench-sparql-editor'
             };
         }
+    };
+
+    $scope.queryExecuted = (query) => {
+        console.log(query.detail);
+    };
+
+    $scope.createSavedQuery = (event) => {
+        const payload = {
+            name: event.detail.queryName,
+            body: event.detail.query,
+            shared: event.detail.isPublic
+        };
+        SparqlRestService.addNewSavedQuery(payload).then((res) => {
+            toastr.success($translate.instant('query.editor.save.saved.query.success.msg', {name: payload.name}));
+            $scope.config = merge({}, $scope.config, {
+                savedQuery: {
+                    saveSuccess: true
+                }
+            });
+        }).catch((err) => {
+            const msg = getError(err);
+            const errorMessage = $translate.instant('query.editor.create.saved.query.error');
+            toastr.error(msg, errorMessage);
+            $scope.config = merge({}, $scope.config, {
+                savedQuery: {
+                    saveSuccess: false,
+                    errorMessage: [errorMessage]
+                }
+            });
+        });
+    };
+
+    $scope.loadSavedQueries = () => {
+        SparqlRestService.getSavedQueries().then((res) => {
+            const savedQueries = savedQueriesResponseMapper(res.data);
+            $scope.config = merge({}, $scope.config, {
+                savedQueries: {
+                    data: savedQueries
+                }
+            });
+        }).catch((err) => {
+            const msg = getError(err);
+            toastr.error(msg, $translate.instant('query.editor.get.saved.queries.error'));
+        });
     };
 
     $scope.$on('repositoryIsSet', $scope.configChanged);

--- a/src/pages/sparql-editor.html
+++ b/src/pages/sparql-editor.html
@@ -6,6 +6,7 @@
         ngce-prop-config="config"
         ngce-prop-language="language"
         ngce-on-query_executed="queryExecuted($event)"
-        ngce-on-create_saved_query="createSavedQuery($event)">
+        ngce-on-create_saved_query="createSavedQuery($event)"
+        ngce-on-load_saved_queries="loadSavedQueries($event)">
     </ontotext-yasgui>
 </div>

--- a/test-cypress/integration/sparql-editor/actions/show-saved-queries.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/show-saved-queries.spec.js
@@ -1,0 +1,53 @@
+import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
+import {YasguiSteps} from "../../../steps/yasgui-steps";
+
+describe('Show saved queries', () => {
+
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'sparql-editor-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        cy.intercept(`/repositories/${repositoryId}`, {fixture: '/graphql-editor/default-query-response.json'}).as('getGuides');
+
+        SparqlEditorSteps.visitSparqlEditorPage();
+        YasguiSteps.getYasgui().should('be.visible');
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should open a popup with the saved queries list', () => {
+        // When I click on show saved queries button
+        YasguiSteps.showSavedQueries();
+        // Then I expect that a popup with a saved queries list to be opened
+        YasguiSteps.getSavedQueriesPopup().should('be.visible');
+        YasguiSteps.getSavedQueries().should('have.length.gt', 0);
+    });
+
+    it('Should be able to select a query from the list', () => {
+        // Given I have opened the saved queries popup
+        YasguiSteps.showSavedQueries();
+        YasguiSteps.getSavedQueriesPopup().should('be.visible');
+        // When I select a query from the list
+        YasguiSteps.selectSavedQuery(0);
+        // Then I expect that the popup should be closed
+        YasguiSteps.getSavedQueriesPopup().should('not.exist');
+        // And the query will be populated in a new tab in the yasgui
+        YasguiSteps.getTabs().should('have.length', 2);
+        YasguiSteps.getCurrentTab().should('contain', 'Add statements');
+        YasguiSteps.getTabQuery(1).should('equal', 'PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA\n      {\n      GRAPH <http://example> {\n          <http://example/book1> dc:title "A new book" ;\n                                 dc:creator "A.N.Other" .\n          }\n      }');
+    });
+
+    it('Should be able to close the popup by clicking outside', () => {
+        // Given I have opened the saved queries popup
+        YasguiSteps.showSavedQueries();
+        YasguiSteps.getSavedQueriesPopup().should('be.visible');
+        // When I click outside of the popup
+        cy.get('body').click();
+        // Then the popup should be closed
+        YasguiSteps.getSavedQueriesPopup().should('not.exist');
+    });
+});

--- a/test-cypress/steps/yasgui-steps.js
+++ b/test-cypress/steps/yasgui-steps.js
@@ -1,0 +1,110 @@
+export class YasguiSteps {
+
+    static getYasgui() {
+        return cy.get('.yasgui');
+    }
+
+    static getTabs() {
+        return cy.get('.tab');
+    }
+
+    static getCurrentTab() {
+        return cy.get('.tab.active');
+    }
+
+    static getCreateSavedQueryButton() {
+        return cy.get('.yasqe_createSavedQueryButton');
+    }
+
+    static createSavedQuery() {
+        this.getCreateSavedQueryButton().click();
+    }
+
+    static getSaveQueryDialog() {
+        return cy.get('.dialog');
+    }
+
+    static closeSaveQueryDialog() {
+        this.getSaveQueryDialog().find('.close-button').click();
+    }
+
+    static cancelSaveQuery() {
+        this.getSaveQueryDialog().find('.cancel-button').click();
+    }
+
+    static getSaveQueryButton() {
+        return this.getSaveQueryDialog().find('.ok-button');
+    }
+
+    static saveQuery() {
+        this.getSaveQueryButton().click();
+    }
+
+    static getQueryField() {
+        return this.getSaveQueryDialog().find('#query');
+    }
+
+    static writeQuery(query) {
+        this.getQueryField().type(query, {parseSpecialCharSequences: false});
+    }
+
+    static clearQueryField() {
+        this.getQueryField().clear();
+    }
+
+    static getQueryNameField() {
+        return this.getSaveQueryDialog().find('#queryName');
+    }
+
+    static writeQueryName(queryName) {
+        this.getQueryNameField().type(queryName);
+    }
+
+    static clearQueryNameField() {
+        this.getQueryNameField().clear();
+    }
+
+    static toggleIsPublic() {
+        this.getSaveQueryDialog().find('#publicQuery').click();
+    }
+
+    static getErrorsPane() {
+        return this.getSaveQueryDialog().find('.alert-danger');
+    }
+
+    static getErrors() {
+        return this.getErrorsPane().find('.error-message');
+    }
+
+    static getShowSavedQueriesButton() {
+        return cy.get('.yasqe_showSavedQueriesButton');
+    }
+
+    static showSavedQueries() {
+        this.getShowSavedQueriesButton().click();
+    }
+
+    static getSavedQueriesPopup() {
+        return cy.get('.saved-queries-popup');
+    }
+
+    static getSavedQueries() {
+        return this.getSavedQueriesPopup().find('.saved-query');
+    }
+
+    static verifySavedQueries(data) {
+        this.getSavedQueries().each((el, index) => {
+            cy.wrap(el).should('contain', data[index].queryName);
+        })
+    }
+
+    static selectSavedQuery(index) {
+        this.getSavedQueries().eq(index).find('a').click();
+    }
+
+    static getTabQuery(tabIndex) {
+        return cy.get('.yasqe .CodeMirror').then((el) => {
+            return el[tabIndex].CodeMirror.getValue();
+        });
+    }
+}


### PR DESCRIPTION
## What
Introduce a show saved queries action.

## Why
Save query action exists in current implementation in the GDB WB. It allows the user to load and see the available saved queries then for each query additional actions can be performed, e.g. select, edit, delete.

## How
* Add custom button in the yasqe buttons extension point. The button rises an event for loading of the saved queries. Handling of this event is responsibility of the client who then must set the queries list in the config. Setting the queries in the config triggers the popup to appear.
* Add a saved queries popup which implements the visualization of the saved queries list. Each saved query is represented as a link and can be selected via click which then opens the query in a new yasgui tab. The dialog can be closed via click outside.
* Implemented tests.