### PR TITLE
GDB-7586 SPARQL editor tabs do not encode symbols properly

### DIFF
--- a/src/js/angular/core/directives/queryeditor/sparql-tab.directive.js
+++ b/src/js/angular/core/directives/queryeditor/sparql-tab.directive.js
@@ -136,7 +136,7 @@ function sparqlTabDirective($rootScope, LocalStorageAdapter, LSKeys, ModalServic
     return {
         restrict: 'AE',
         // for some reason when you extract this template in a file and use templateUrl it selects all tabs when editing the tab name, not only the currently selected one
-        template: '<a class="nav-link" role="tab" data-toggle="tab" blur="submit" editable-text="tab.name" e-form="editCurrentlySelectedOnly" ng-click="selectThisTab($event)" ng-dblclick="editCurrentTab()" ><span ng-class="{\'text-muted\': !tab.name}">{{ tab.name || \'sparql.tab.directive.unnamed.tab.title\' | translate}}</span><button type="button" ng-click="deleteTab($event)" class="btn btn-link btn-sm secondary delete-sparql-tab-btn" title="Delete tab"><i class="icon-close"></i></button></a>',
+        template: '<a class="nav-link" role="tab" data-toggle="tab" blur="submit" editable-text="tab.name" e-form="editCurrentlySelectedOnly" ng-click="selectThisTab($event)" ng-dblclick="editCurrentTab()" ><span ng-class="{\'text-muted\': !tab.name}"><span ng-if="tab.name">{{tab.name}}</span><span ng-if="!tab.name">{{\'sparql.tab.directive.unnamed.tab.title\' | translate}}</span></span><button type="button" ng-click="deleteTab($event)" class="btn btn-link btn-sm secondary delete-sparql-tab-btn" title="Delete tab"><i class="icon-close"></i></button></a>',
         replace: true,
         controller: SparqlTabCtrl
     };

--- a/src/js/angular/core/directives/queryeditor/sparql-tab.directive.js
+++ b/src/js/angular/core/directives/queryeditor/sparql-tab.directive.js
@@ -136,7 +136,7 @@ function sparqlTabDirective($rootScope, LocalStorageAdapter, LSKeys, ModalServic
     return {
         restrict: 'AE',
         // for some reason when you extract this template in a file and use templateUrl it selects all tabs when editing the tab name, not only the currently selected one
-        template: '<a class="nav-link" role="tab" data-toggle="tab" blur="submit" editable-text="tab.name" e-form="editCurrentlySelectedOnly" ng-click="selectThisTab($event)" ng-dblclick="editCurrentTab()" ><span ng-class="{\'text-muted\': !tab.name}"><span ng-if="tab.name">{{tab.name}}</span><span ng-if="!tab.name">{{\'sparql.tab.directive.unnamed.tab.title\' | translate}}</span></span><button type="button" ng-click="deleteTab($event)" class="btn btn-link btn-sm secondary delete-sparql-tab-btn" title="Delete tab"><i class="icon-close"></i></button></a>',
+        template: '<a class="nav-link" role="tab" data-toggle="tab" blur="submit" editable-text="tab.name" e-form="editCurrentlySelectedOnly" ng-click="selectThisTab($event)" ng-dblclick="editCurrentTab()" ><span ng-class="{\'text-muted\': !tab.name}">{{ tab.name || (\'sparql.tab.directive.unnamed.tab.title\' | translate)}}</span><button type="button" ng-click="deleteTab($event)" class="btn btn-link btn-sm secondary delete-sparql-tab-btn" title="Delete tab"><i class="icon-close"></i></button></a>',
         replace: true,
         controller: SparqlTabCtrl
     };


### PR DESCRIPTION
* Changes in html template so tab.name could be read and displayed on screen.