### PR TITLE
GDB-7785 Introduce ability to open shared saved query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "^0.0.2-TR8",
+                "ontotext-yasgui-web-component": "^0.0.2-TR9",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -10048,9 +10048,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR8",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR8.tgz",
-            "integrity": "sha512-rRSFa/I6be9WdfYLom/q8J6R2fjqxPKYaBEfhSg5xIT9KOtrSFnfOoiXbDEaoX3pAWaJHUHHfyR/3QmpmxUlOw==",
+            "version": "0.0.2-TR9",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR9.tgz",
+            "integrity": "sha512-mCf3qzf65aFj5MCz8853Zh+rXGJxbGuWSMDJJNurUS1jLNnnm3L/QdwazWkmJr5dxcunpv2UH1DzIr9v3Kb6mA==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24562,9 +24562,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR8",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR8.tgz",
-            "integrity": "sha512-rRSFa/I6be9WdfYLom/q8J6R2fjqxPKYaBEfhSg5xIT9KOtrSFnfOoiXbDEaoX3pAWaJHUHHfyR/3QmpmxUlOw==",
+            "version": "0.0.2-TR9",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR9.tgz",
+            "integrity": "sha512-mCf3qzf65aFj5MCz8853Zh+rXGJxbGuWSMDJJNurUS1jLNnnm3L/QdwazWkmJr5dxcunpv2UH1DzIr9v3Kb6mA==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "^0.0.2-TR8",
+        "ontotext-yasgui-web-component": "^0.0.2-TR9",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/src/js/angular/rest/mappers/saved-query-mapper.js
+++ b/src/js/angular/rest/mappers/saved-query-mapper.js
@@ -1,6 +1,11 @@
+/**
+ * Maps a saved queries response to array with saved queries model objects.
+ * @param {object} response object having data[] property
+ * @return {*[]|*} an array with saved query model objects.
+ */
 export const savedQueriesResponseMapper = (response) => {
-    if (response) {
-        return response.map((savedQuery) => ({
+    if (response && response.data) {
+        return response.data.map((savedQuery) => ({
                 queryName: savedQuery.name,
                 query: savedQuery.body,
                 owner: savedQuery.owner,
@@ -9,6 +14,19 @@ export const savedQueriesResponseMapper = (response) => {
         );
     }
     return [];
+};
+
+/**
+ * Maps a saved query response to a saved query model object.
+ * @param {object} response object having data[] property.
+ * @return {object|null} a saved query model object or null.
+ */
+export const savedQueryResponseMapper = (response) => {
+    const mapped = savedQueriesResponseMapper(response);
+    if (mapped.length) {
+        return mapped[0];
+    }
+    return null;
 };
 
 export const savedQueryPayloadFromEvent = (event) => {

--- a/test-cypress/integration/sparql-editor/saved-query/share-query.spec.js
+++ b/test-cypress/integration/sparql-editor/saved-query/share-query.spec.js
@@ -2,7 +2,7 @@ import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
 import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
 import {ApplicationSteps} from "../../../steps/application-steps";
 import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
-import {SavedQuery} from "../../../steps/yasgui/saved-query";
+import {DEFAULT_QUERY, SavedQuery} from "../../../steps/yasgui/saved-query";
 import {SavedQueriesDialog} from "../../../steps/yasgui/saved-queries-dialog";
 import {ShareSavedQueryDialog} from "../../../steps/yasgui/share-saved-query-dialog";
 
@@ -34,8 +34,8 @@ describe('Share saved queries', () => {
         SavedQueriesDialog.shareQueryByName(savedQueryName);
         // Then I expect that share query dialog will be opened
         ShareSavedQueryDialog.getDialog().should('be.visible');
-        ShareSavedQueryDialog.getShareLink().then(($el) => {
-            expect($el.val()).to.have.string(`/sparql-editor?savedQueryName=${encodeURIComponent(savedQueryName)}`);
+        ShareSavedQueryDialog.getShareLink().then((shareLink) => {
+            expect(shareLink).to.have.string(`/sparql-editor?savedQueryName=${encodeURIComponent(savedQueryName)}`);
         });
         // When I click copy button
         ShareSavedQueryDialog.copyLink();
@@ -44,7 +44,35 @@ describe('Share saved queries', () => {
         ApplicationSteps.getSuccessNotifications().should('be.visible');
     });
 
-    it.skip('Should be able to open a saved query through a share link', () => {
-
+    it('Should be able to open a share link in a new editor tab', () => {
+        // Given I have created a query
+        YasguiSteps.getTabs().should('have.length', 1);
+        const savedQueryName = SavedQuery.generateQueryName();
+        SavedQuery.create(savedQueryName);
+        // When I get the shareable link for the query
+        YasguiSteps.showSavedQueries();
+        SavedQueriesDialog.shareQueryByName(savedQueryName);
+        ShareSavedQueryDialog.getDialog().should('be.visible');
+        // And I open the link
+        ShareSavedQueryDialog.getShareLink().then((shareLink) => {
+            cy.visit(shareLink);
+            // Then I expect that the sparql view should be opened
+            // And the saved query will be loaded in the editor
+            YasguiSteps.getTabs().should('have.length', 2);
+            YasguiSteps.getCurrentTab().should('contain', savedQueryName);
+            YasguiSteps.getTabQuery(0).should('contain', DEFAULT_QUERY);
+            // TODO: And the infer should be active
+            // TODO: And the expand results should be active
+            // When I open the other tab
+            // TODO: the next step appears to be flaky with the element is detached error
+            // YasguiSteps.openTab(0);
+            // YasguiSteps.getCurrentTab().should('contain', 'Unnamed');
+            // // And I open the share link again
+            // cy.visit(shareLink);
+            // // Then I expect that the previously opened tab to be selected instead of opening a new one
+            // YasguiSteps.getTabs().should('have.length', 2);
+            // YasguiSteps.getCurrentTab().should('contain', savedQueryName);
+            // YasguiSteps.getTabQuery(0).should('contain', DEFAULT_QUERY);
+        });
     });
 });

--- a/test-cypress/steps/yasgui/saved-query.js
+++ b/test-cypress/steps/yasgui/saved-query.js
@@ -2,7 +2,7 @@ import {YasguiSteps} from "./yasgui-steps";
 import {SaveQueryDialog} from "./save-query-dialog";
 import {ApplicationSteps} from "../application-steps";
 
-const DEFAULT_QUERY = 'select *';
+export const DEFAULT_QUERY = 'select *';
 
 export class SavedQuery {
 

--- a/test-cypress/steps/yasgui/share-saved-query-dialog.js
+++ b/test-cypress/steps/yasgui/share-saved-query-dialog.js
@@ -3,8 +3,12 @@ export class ShareSavedQueryDialog {
         return cy.get('.share-saved-query-dialog');
     }
 
-    static getShareLink() {
+    static getShareLinkField() {
         return this.getDialog().find('#shareLink');
+    }
+
+    static getShareLink() {
+        return this.getShareLinkField().invoke('val');
     }
 
     static copyLink() {

--- a/test-cypress/steps/yasgui/yasgui-steps.js
+++ b/test-cypress/steps/yasgui/yasgui-steps.js
@@ -20,6 +20,10 @@ export class YasguiSteps {
         return cy.get('.tab.active');
     }
 
+    static openTab(index) {
+        this.getTabs().eq(index).click();
+    }
+
     static getTabQuery(tabIndex) {
         return cy.get('.yasqe .CodeMirror').then((el) => {
             return el[tabIndex].CodeMirror.getValue();


### PR DESCRIPTION
## What
Allow the client to open a query model in a new or existing tab depending on if there is already existing tab with the same name and query.

## Why
The client would needs to open a shared query in editor tab, be it a new or existing one.

## How
* Analyze the url parameters and if there is a savedQueryName parameter then try to load the saved query and open it in the editor.
* Implemented tests.