### PR TITLE
GDB-7786 Introduce share query action

### DIFF
--- a/src/js/angular/rest/mappers/saved-query-mapper.js
+++ b/src/js/angular/rest/mappers/saved-query-mapper.js
@@ -1,3 +1,12 @@
+export const buildQueryModel = (query, queryName, owner, isPublic) => {
+    return {
+        queryName: queryName,
+        query: query,
+        owner: owner,
+        isPublic: isPublic
+    };
+};
+
 /**
  * Maps a saved queries response to array with saved queries model objects.
  * @param {object} response object having data[] property
@@ -5,12 +14,9 @@
  */
 export const savedQueriesResponseMapper = (response) => {
     if (response && response.data) {
-        return response.data.map((savedQuery) => ({
-                queryName: savedQuery.name,
-                query: savedQuery.body,
-                owner: savedQuery.owner,
-                isPublic: savedQuery.shared
-            })
+        return response.data.map((savedQuery) => (
+                buildQueryModel(savedQuery.body, savedQuery.name, savedQuery.owner, savedQuery.shared)
+            )
         );
     }
     return [];
@@ -29,7 +35,7 @@ export const savedQueryResponseMapper = (response) => {
     return null;
 };
 
-export const savedQueryPayloadFromEvent = (event) => {
+export const queryPayloadFromEvent = (event) => {
     return {
         name: event.detail.queryName,
         body: event.detail.query,

--- a/src/js/angular/sparql-editor/share-query-link.service.js
+++ b/src/js/angular/sparql-editor/share-query-link.service.js
@@ -21,9 +21,10 @@ function ShareQueryLinkService() {
     function createShareQueryLink(queryData) {
         return getBaseUrl() + '?' + $.param({
             name: queryData.name,
-            infer: queryData.inference,
-            sameAs: queryData.sameAs,
-            query: window.editor.getValue()
+            query: queryData.body,
+            // TODO: pass these from the component as well
+            infer: queryData.inference || true,
+            sameAs: queryData.sameAs || true
         });
     }
 

--- a/src/js/angular/utils/route-constants.js
+++ b/src/js/angular/utils/route-constants.js
@@ -1,5 +1,9 @@
 export const RouteConstants = {
     'savedQueryName': 'savedQueryName',
     'savedQueryOwner': 'owner',
-    'query': 'query'
+    'query': 'query',
+    // same as savedQueryName but for shared queries - this is how WB handles it
+    'name': 'name',
+    // same as savedQueryOwner but for shared queries - this is how WB handles it
+    'owner': 'owner'
 };

--- a/src/pages/sparql-editor.html
+++ b/src/pages/sparql-editor.html
@@ -11,7 +11,8 @@
         ngce-on-update_saved_query="updateSavedQuery($event)"
         ngce-on-delete_saved_query="deleteSavedQuery($event)"
         ngce-on-share_saved_query="shareSavedQuery($event)"
-        ngce-on-saved_query_share_link_copied="savedQueryShareLinkCopied()"
+        ngce-on-share_query="shareQuery($event)"
+        ngce-on-query_share_link_copied="queryShareLinkCopied()"
         ngce-on-load_saved_queries="loadSavedQueries($event)">
     </ontotext-yasgui>
 </div>

--- a/test-cypress/integration/sparql-editor/actions/share-query.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/share-query.spec.js
@@ -1,0 +1,78 @@
+import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
+import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
+import {ApplicationSteps} from "../../../steps/application-steps";
+import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
+import {DEFAULT_QUERY} from "../../../steps/yasgui/saved-query";
+import {ShareSavedQueryDialog} from "../../../steps/yasgui/share-saved-query-dialog";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+
+describe('Share query', () => {
+
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'sparql-editor-' + Date.now();
+        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        QueryStubs.stubDefaultQueryResponse(repositoryId);
+
+        SparqlEditorSteps.visitSparqlEditorPage();
+        YasguiSteps.getYasgui().should('be.visible');
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should be able to get shareable link for current query', () => {
+        // When I click on share query action
+        YasqeSteps.shareQuery();
+        // Then I expect a dialog with the shareable link to appear
+        ShareSavedQueryDialog.getDialog().should('be.visible');
+        ShareSavedQueryDialog.getDialogTitle().should('contain', 'Copy URL to clipboard');
+        ShareSavedQueryDialog.getShareLink().then((shareLink) => {
+            expect(shareLink).to.have.string(`/sparql-editor?name=Unnamed&query=select%20*%20where%20%7B%20%20%0A%20%3Fs%20%3Fp%20%3Fo%20.%20%0A%20%7D%20limit%20100&infer=true&sameAs=true`);
+        });
+        // When I cancel operation
+        ShareSavedQueryDialog.closeDialog();
+        // Then I expect that the dialog should be closed
+        ShareSavedQueryDialog.getDialog().should('not.exist');
+        // And I click the copy button
+        YasqeSteps.shareQuery();
+        ShareSavedQueryDialog.getDialog().should('be.visible');
+        ShareSavedQueryDialog.copyLink();
+        // Then I expect that the share link is copied in the clipboard
+        ShareSavedQueryDialog.getDialog().should('not.exist');
+        ApplicationSteps.getSuccessNotifications().should('be.visible');
+    });
+
+    it('Should be able to open a share link in a new editor tab', () => {
+        // Given I have opened the sparql editor
+        YasguiSteps.getTabs().should('have.length', 1);
+        // When I get the shareable link for current query
+        YasqeSteps.shareQuery();
+        ShareSavedQueryDialog.getDialog().should('be.visible');
+        // And I open the link
+        ShareSavedQueryDialog.getShareLink().then((shareLink) => {
+            cy.visit(shareLink);
+            // Then I expect that the sparql view should be opened
+            // And the saved query will be loaded in the editor
+            YasguiSteps.getTabs().should('have.length', 1);
+            YasguiSteps.getCurrentTab().should('contain', 'Unnamed');
+            YasguiSteps.getTabQuery(0).should('contain', DEFAULT_QUERY);
+            // TODO: And the infer should be active
+            // TODO: And the expand results should be active
+            // When I open the other tab
+            // TODO: the next step appears to be flaky with the element is detached error
+            // YasguiSteps.openTab(0);
+            // YasguiSteps.getCurrentTab().should('contain', 'Unnamed');
+            // // And I open the share link again
+            // cy.visit(shareLink);
+            // // Then I expect that the previously opened tab to be selected instead of opening a new one
+            // YasguiSteps.getTabs().should('have.length', 2);
+            // YasguiSteps.getCurrentTab().should('contain', savedQueryName);
+            // YasguiSteps.getTabQuery(0).should('contain', DEFAULT_QUERY);
+        });
+    });
+});

--- a/test-cypress/steps/yasgui/share-saved-query-dialog.js
+++ b/test-cypress/steps/yasgui/share-saved-query-dialog.js
@@ -3,6 +3,10 @@ export class ShareSavedQueryDialog {
         return cy.get('.share-saved-query-dialog');
     }
 
+    static getDialogTitle() {
+        return this.getDialog().find('.dialog-title');
+    }
+
     static getShareLinkField() {
         return this.getDialog().find('#shareLink');
     }
@@ -13,5 +17,9 @@ export class ShareSavedQueryDialog {
 
     static copyLink() {
         this.getDialog().find('.copy-button').click();
+    }
+
+    static closeDialog() {
+        this.getDialog().find('.cancel-button').click();
     }
 }

--- a/test-cypress/steps/yasgui/yasqe-steps.js
+++ b/test-cypress/steps/yasgui/yasqe-steps.js
@@ -38,4 +38,12 @@ export class YasqeSteps {
     static expandResultsOverSameAs() {
         this.getExpandResultsOverSameAsButton().click();
     }
+
+    static getShareQueryButton() {
+        return cy.get('.yasqe_shareQueryButton');
+    }
+
+    static shareQuery() {
+        this.getShareQueryButton().click();
+    }
 }


### PR DESCRIPTION
## What
Allow the client to get a shareable link for the currently opened query and open it.

## Why
The WB has this feature.

## How
* Introduced the share query action in the editor and handling the events from it.
* Implemented resolver for the shared query url parameters allowing to open and init a sparql editor tab based on these parameters.
* Implemented tests.