### PR TITLE
GDB-7891 yasr download results in different format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "^0.0.2-TR18",
+                "ontotext-yasgui-web-component": "^0.0.2-TR19",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -9905,9 +9905,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR18",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR18.tgz",
-            "integrity": "sha512-N3Y1xPIusJwDWLAeKzgmaNw1mosP482d4e2Ffs1KOUe0sXm2/susnPbVyCTRN8ABuiMxCrf2tXg28dmbyBeEnA==",
+            "version": "0.0.2-TR19",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR19.tgz",
+            "integrity": "sha512-PAQsLAxfrxBKVyE2kUhnknvHXlG8oxgMYuqMgzik3itpsO0Ec0mYxifso5uHp3RrstNQuwm/bv5RK56ijtbrUg==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24267,9 +24267,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR18",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR18.tgz",
-            "integrity": "sha512-N3Y1xPIusJwDWLAeKzgmaNw1mosP482d4e2Ffs1KOUe0sXm2/susnPbVyCTRN8ABuiMxCrf2tXg28dmbyBeEnA==",
+            "version": "0.0.2-TR19",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR19.tgz",
+            "integrity": "sha512-PAQsLAxfrxBKVyE2kUhnknvHXlG8oxgMYuqMgzik3itpsO0Ec0mYxifso5uHp3RrstNQuwm/bv5RK56ijtbrUg==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "^0.0.2-TR18",
+        "ontotext-yasgui-web-component": "^0.0.2-TR19",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/src/js/angular/core/directives/queryeditor/templates/query-editor.html
+++ b/src/js/angular/core/directives/queryeditor/templates/query-editor.html
@@ -1,3 +1,6 @@
+<link href="css/lib/yasr.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+<link href="css/yasr.custom.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+
 <div id="sparql-content" class="fit-content-on-mobile">
     <div ng-hide="viewMode == 'editor'"
          ng-class="orientationViewMode ? 'row' : viewMode == 'yasr' ? 'col-xs-12' : 'col-xs-6'" ng-style="noPadding">

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -170,7 +170,7 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
     /**
      * Handles the ontotext-yasgui component output events.
      *
-     * @param {TYPE: string, payload: any}$event - the event fired from ontotext-yasgui component
+     * @param {EventData}$event - the event fired from ontotext-yasgui component
      */
     $scope.output = ($event) => {
         const yasguiOutputModel = toYasguiOutputModel($event);
@@ -307,22 +307,16 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
     // ================================
     // =     Setup output handlers    =
     // ================================
-    outputHandlers.set('downloadAs', downloadAsHandler);
-
     function downloadAsHandler(downloadAsEvent) {
         const handler = downloadAsPluginNameToEventHandler.get(downloadAsEvent.pluginName);
         if (handler) {
             handler(downloadAsEvent);
         }
     }
-
+    outputHandlers.set('downloadAs', downloadAsHandler);
     // ================================
     // =   Setup download handlers    =
     // ================================
-
-    downloadAsPluginNameToEventHandler.set('response', downloadCurrentResults);
-    downloadAsPluginNameToEventHandler.set('extended_table', downloadThroughServer);
-
     function downloadCurrentResults(downloadAsEvent) {
         if ("application/sparql-results+json" === downloadAsEvent.contentType) {
             ontoElement.getEmbeddedResultAsJson()
@@ -337,6 +331,7 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
                 });
         }
     }
+    downloadAsPluginNameToEventHandler.set('response', downloadCurrentResults);
 
     function getFileTimePrefix() {
         const now = new Date();
@@ -348,12 +343,12 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
         const infer = downloadAsEvent.infer;
         const sameAs = downloadAsEvent.sameAs;
         const accept = downloadAsEvent.contentType;
-        const authToken = localStorage.getItem('com.ontotext.graphdb.auth') || '';
+        const authToken = $jwtAuth.getAuthToken() || '';
 
         // TODO change it
         // Simple cross-browser download with a form
         const $wbDownload = $('#wb-download');
-        $wbDownload.attr('action', 'repositories/' + $repositories.getActiveRepository());
+        $wbDownload.attr('action', getQueryEndpoint());
         $('#wb-download-query').val(query);
         $('#wb-download-infer').val(infer);
         $('#wb-download-sameAs').val(sameAs);
@@ -361,6 +356,7 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
         $('#wb-download-accept').val(accept);
         $wbDownload.submit();
     }
+    downloadAsPluginNameToEventHandler.set('extended_table', downloadThroughServer);
 
     init();
 }

--- a/src/js/angular/utils/yasgui-utils.js
+++ b/src/js/angular/utils/yasgui-utils.js
@@ -1,0 +1,29 @@
+export const toYasguiOutputModel = ($event) => {
+    switch ($event.detail.TYPE) {
+        case "downloadAs":
+            return buildDownloadAsModel($event);
+        default:
+            return $event.detail;
+    }
+};
+
+export const buildDownloadAsModel = ($event) => {
+    return {
+        TYPE: $event.detail.TYPE,
+        contentType: $event.detail.payload.value,
+        pluginName: $event.detail.payload.pluginName,
+        query: $event.detail.payload.query,
+        infer: $event.detail.payload.infer,
+        sameAs: $event.detail.payload.sameAs
+    };
+};
+
+export const downloadAsFile = (filename, contentType, content) => {
+    const element = document.createElement('a');
+    element.setAttribute('href', `data:${contentType};charset=utf-8, + ${encodeURIComponent(content)}`);
+    element.setAttribute('download', filename);
+    element.style.display = 'none';
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+};

--- a/src/js/angular/utils/yasgui-utils.js
+++ b/src/js/angular/utils/yasgui-utils.js
@@ -1,21 +1,33 @@
 export const toYasguiOutputModel = ($event) => {
-    switch ($event.detail.TYPE) {
+    const eventData = toEventData($event);
+    switch (eventData.TYPE) {
         case "downloadAs":
-            return buildDownloadAsModel($event);
+            return buildDownloadAsModel(eventData);
         default:
-            return $event.detail;
+            return eventData;
     }
 };
 
-export const buildDownloadAsModel = ($event) => {
+export const buildDownloadAsModel = (eventData) => {
     return {
-        TYPE: $event.detail.TYPE,
-        contentType: $event.detail.payload.value,
-        pluginName: $event.detail.payload.pluginName,
-        query: $event.detail.payload.query,
-        infer: $event.detail.payload.infer,
-        sameAs: $event.detail.payload.sameAs
+        TYPE: eventData.TYPE,
+        contentType: eventData.payload.value,
+        pluginName: eventData.payload.pluginName,
+        query: eventData.payload.query,
+        infer: eventData.payload.infer,
+        sameAs: eventData.payload.sameAs
     };
+};
+
+export class EventData {
+    constructor(TYPE, payload) {
+        this.TYPE = TYPE;
+        this.payload = payload;
+    }
+}
+
+export const toEventData = ($event) => {
+    return new EventData($event.detail.TYPE, $event.detail.payload);
 };
 
 export const downloadAsFile = (filename, contentType, content) => {

--- a/src/main.js
+++ b/src/main.js
@@ -3,5 +3,3 @@ import './css/bootstrap-graphdb-theme-dark-auto.css';
 import './css/workbench-custom.css';
 import './less/core.less';
 import './less/owlim-workbench.less';
-import './css/lib/yasr.css';
-import './css/yasr.custom.css';

--- a/src/pages/explore.html
+++ b/src/pages/explore.html
@@ -1,4 +1,7 @@
 <link href="css/explore.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+<link href="css/lib/yasr.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+<link href="css/yasr.custom.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+
 <div core-errors></div>
 <div class="page fit-content-on-mobile" ng-show="getActiveRepository()">
     <div class="resource-info" ng-if="!isTripleResource()">

--- a/src/pages/sparql-editor.html
+++ b/src/pages/sparql-editor.html
@@ -14,6 +14,15 @@
         ngce-on-share_query="shareQuery($event)"
         ngce-on-query_share_link_copied="queryShareLinkCopied()"
         ngce-on-load_saved_queries="loadSavedQueries($event)"
-        ngce-on-notify="notify($event)">
+        ngce-on-notify="notify($event)"
+        ngce-on-output="output($event)">
     </ontotext-yasgui>
+
+    <form id="wb-download" method="GET" action="" target="_self">
+        <input id="wb-download-query" name="query" type="hidden"/>
+        <input id="wb-download-infer" name="infer" type="hidden"/>
+        <input id="wb-download-sameAs" name="sameAs" type="hidden"/>
+        <input id="wb-download-accept" name="Accept" type="hidden"/>
+        <input id="wb-auth-token" name="authToken" type="hidden"/>
+    </form>
 </div>

--- a/test-cypress/integration/sparql-editor/actions/expand-results-over-sameas.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/expand-results-over-sameas.spec.js
@@ -24,15 +24,15 @@ describe('Expand results over owl:sameAs', () => {
     it('Should be able to toggle expand results parameter', () => {
         // When I open the editor
         // Then I expect that expand results should be enabled by default
-        YasqeSteps.getExpandResultsOverSameAsButton().should('have.attr', 'title', 'Expand results over owl:sameAs: ON');
-        YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-sameas-on');
+        YasqeSteps.getExpandResultsOverSameAsButtonTooltip().should('have.attr', 'data-tooltip', 'Expand results over owl:sameAs: ON');
+        YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-same-as-on');
         YasqeSteps.executeQuery();
         cy.wait('@query').its('request.body').should('contain', 'sameAs=true');
         // When I disable the expand results action
         YasqeSteps.expandResultsOverSameAs();
         // Then I expect that the button state should be changed
-        YasqeSteps.getExpandResultsOverSameAsButton().should('have.attr', 'title', 'Expand results over owl:sameAs: OFF');
-        YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-sameas-off');
+        YasqeSteps.getExpandResultsOverSameAsButtonTooltip().should('have.attr', 'data-tooltip', 'Expand results over owl:sameAs: OFF');
+        YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-same-as-off');
         // And sameAs=false parameter should be sent with the request
         YasqeSteps.executeQuery();
         cy.wait('@query').its('request.body').should('contain', 'sameAs=false');
@@ -40,8 +40,8 @@ describe('Expand results over owl:sameAs', () => {
         // When I disable the include inferred action
         YasqeSteps.includeInferredStatements();
         // Then I expect that sameAs should be disabled too
-        YasqeSteps.getExpandResultsOverSameAsButton().should('have.attr', 'title', 'Expand results over owl:sameAs: OFF');
-        YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-sameas-off');
+        YasqeSteps.getExpandResultsOverSameAsButtonTooltip().should('have.attr', 'data-tooltip', 'Requires \'Include Inferred\'!');
+        YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-same-as-off');
         YasqeSteps.executeQuery();
         cy.wait('@query').its('request.body').should('contain', 'infer=false&sameAs=false');
     });

--- a/test-cypress/integration/sparql-editor/actions/include-inferred-statements.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/include-inferred-statements.spec.js
@@ -24,12 +24,12 @@ describe('Include inferred statements', () => {
     it('Should be able to toggle include inferred statements', () => {
         // When I open the editor
         // Then I expect that include inferred statements should be enabled by default
-        YasqeSteps.getIncludeInferredStatementsButton().should('have.attr', 'title', 'Include inferred data in results: ON');
+        YasqeSteps.getIncludeInferredStatementsButtonTooltip().should('have.attr', 'data-tooltip', 'Include inferred data in results: ON');
         YasqeSteps.getIncludeInferredStatementsButton().should('have.class', 'icon-inferred-on');
         YasqeSteps.executeQuery();
         cy.wait('@query').its('request.body').should('contain', 'infer=true');
         YasqeSteps.includeInferredStatements();
-        YasqeSteps.getIncludeInferredStatementsButton().should('have.attr', 'title', 'Include inferred data in results: OFF');
+        YasqeSteps.getIncludeInferredStatementsButtonTooltip().should('have.attr', 'data-tooltip', 'Include inferred data in results: OFF');
         YasqeSteps.getIncludeInferredStatementsButton().should('have.class', 'icon-inferred-off');
         YasqeSteps.executeQuery();
         cy.wait('@query').its('request.body').should('contain', 'infer=false');

--- a/test-cypress/integration/sparql-editor/yasr/download-as.spec.js
+++ b/test-cypress/integration/sparql-editor/yasr/download-as.spec.js
@@ -1,0 +1,54 @@
+import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
+import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
+import {YasrSteps} from "../../../steps/yasgui/yasr-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+
+describe('Download results', () => {
+    let repositoryId;
+    beforeEach(() => {
+        repositoryId = 'sparql-editor-' + Date.now();
+        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        QueryStubs.stubDefaultQueryResponse(repositoryId);
+        // Given I visit a page with "ontotex-yasgu-web-component" in it.
+        SparqlEditorSteps.visitSparqlEditorPage();
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    describe('DownloadAs button', () => {
+        it('should not be visible if query is not ran', () => {
+            // When yasr has not result
+            // Then download dropdown should not be visible.
+            YasrSteps.getDownloadAsDropdown().should('not.be.visible');
+        });
+
+        it('Should "Download as" dropdown be visible if there is results', () => {
+            // When execute a query witch returns results.
+            YasqeSteps.executeQuery();
+
+            // Then "Download as" dropdown should be visible.
+            YasrSteps.getDownloadAsDropdown().should('be.visible');
+        });
+
+        it('should contains following dropdown option.', () => {
+            // When execute a query witch returns results.
+            YasqeSteps.executeQuery();
+            // And open the download button.
+            YasrSteps.openDownloadAsDropdown();
+
+            // Then expect follow options to be present.
+            YasrSteps.getDownloadAsOption(0).contains('JSON');
+            YasrSteps.getDownloadAsOption(1).contains( 'JSON*');
+            YasrSteps.getDownloadAsOption(2).contains( 'XML');
+            YasrSteps.getDownloadAsOption(3).contains( 'XML*');
+            YasrSteps.getDownloadAsOption(4).contains( 'CSV');
+            YasrSteps.getDownloadAsOption(5).contains( 'TSV');
+            YasrSteps.getDownloadAsOption(6).contains( 'TSV*');
+            YasrSteps.getDownloadAsOption(7).contains( 'Binary RDF Results');
+        });
+    });
+});

--- a/test-cypress/integration/sparql/sparql-language-change.spec.js
+++ b/test-cypress/integration/sparql/sparql-language-change.spec.js
@@ -1,4 +1,5 @@
 import SparqlSteps from '../../steps/sparql-steps';
+import {LanguageSelectorSteps} from "../../steps/language-selector-steps";
 
 describe('YASQE and YASR language change validation', () => {
     let repositoryId;
@@ -10,7 +11,7 @@ describe('YASQE and YASR language change validation', () => {
 
     afterEach(() => {
         // Change the language back to English
-        SparqlSteps.changeLanguage('en');
+        LanguageSelectorSteps.switchToEn();
 
         cy.deleteRepository(repositoryId);
     });
@@ -24,7 +25,7 @@ describe('YASQE and YASR language change validation', () => {
             SparqlSteps.getEditorAndResultsBtn().should('contain', 'Editor and results');
             SparqlSteps.getResultsOnlyBtn().should('contain', 'Results only');
 
-            SparqlSteps.changeLanguage('fr');
+            LanguageSelectorSteps.switchToFr();
 
             // The text in the labels should change
             SparqlSteps.getSparqlQueryUpdateLabel().should('contain', 'Requête et mise à jour SPARQL');

--- a/test-cypress/steps/yasgui/yasqe-steps.js
+++ b/test-cypress/steps/yasgui/yasqe-steps.js
@@ -27,12 +27,20 @@ export class YasqeSteps {
         return cy.get('.yasqe_inferStatementsButton');
     }
 
+    static getIncludeInferredStatementsButtonTooltip() {
+        return this.getIncludeInferredStatementsButton().parent();
+    }
+
     static includeInferredStatements() {
         this.getIncludeInferredStatementsButton().click();
     }
 
     static getExpandResultsOverSameAsButton() {
         return cy.get('.yasqe_expandResultsButton');
+    }
+
+    static getExpandResultsOverSameAsButtonTooltip() {
+        return this.getExpandResultsOverSameAsButton().parent();
     }
 
     static expandResultsOverSameAs() {

--- a/test-cypress/steps/yasgui/yasr-steps.js
+++ b/test-cypress/steps/yasgui/yasr-steps.js
@@ -45,4 +45,16 @@ export class YasrSteps {
     static clickOnCopyResourceLink(rowNumber, cellNumber) {
         this.showSharedResourceLink(rowNumber, cellNumber).realClick();
     }
+
+    static getDownloadAsDropdown() {
+        return this.getYasr().find('ontotext-download-as');
+    }
+
+    static openDownloadAsDropdown() {
+        this.getDownloadAsDropdown().click();
+    }
+
+    static getDownloadAsOption(number) {
+        return this.getDownloadAsDropdown().find('.ontotext-dropdown-menu-item').eq(number);
+    }
 }


### PR DESCRIPTION
What?
Adds a "Download as" dropdown.

Why?
The clients of WB want to download the result of an executed query in different formats.

How?
Updates version of ontotext-yasgui component.
Added handler for downloadAs event and implement download file according downloadAs event data.

Additional work:
Removes 'yasr.css' and './css/yasr.custom.css' from global import.