### PR TITLE
Refactors copy resource link success message.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "^0.0.2-TR19",
+                "ontotext-yasgui-web-component": "^0.0.2-TR20",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -9905,9 +9905,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR19",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR19.tgz",
-            "integrity": "sha512-PAQsLAxfrxBKVyE2kUhnknvHXlG8oxgMYuqMgzik3itpsO0Ec0mYxifso5uHp3RrstNQuwm/bv5RK56ijtbrUg==",
+            "version": "0.0.2-TR20",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR20.tgz",
+            "integrity": "sha512-UMK9AkSLWB6pn6sU/+oG1EEzzDbJa7RQqogG9j4LGx4BZZs/qdxh/1MzAQzkqTPVGvbxGcP5kqxSkzGfdE8eoA==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24267,9 +24267,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR19",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR19.tgz",
-            "integrity": "sha512-PAQsLAxfrxBKVyE2kUhnknvHXlG8oxgMYuqMgzik3itpsO0Ec0mYxifso5uHp3RrstNQuwm/bv5RK56ijtbrUg==",
+            "version": "0.0.2-TR20",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR20.tgz",
+            "integrity": "sha512-UMK9AkSLWB6pn6sU/+oG1EEzzDbJa7RQqogG9j4LGx4BZZs/qdxh/1MzAQzkqTPVGvbxGcP5kqxSkzGfdE8eoA==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "^0.0.2-TR19",
+        "ontotext-yasgui-web-component": "^0.0.2-TR20",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -7,6 +7,9 @@ import {
 import {RouteConstants} from "../utils/route-constants";
 import {QueryMode} from "../utils/query-types";
 import {downloadAsFile, toYasguiOutputModel} from "../utils/yasgui-utils";
+import {YasrPluginName} from "../../../models/ontotext-yasgui/yasr-plugin-name";
+import {EventDataType} from "../../../models/ontotext-yasgui/event-data-type";
+import {NotificationMessageType} from "../../../models/ontotext-yasgui/notification-message-type";
 
 angular
     .module('graphdb.framework.sparql-editor.controllers', ['ui.bootstrap'])
@@ -83,16 +86,6 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
     $scope.createSavedQuery = (event) => {
         const payload = queryPayloadFromEvent(event);
         SparqlRestService.addNewSavedQuery(payload).then(() => queryCreatedHandler(payload)).catch(querySaveErrorHandler);
-    };
-
-    $scope.notify = (notification) => {
-        if ("success" === notification.detail.type) {
-            toastr.success(notification.detail.message);
-        } else if ("warning" === notification.detail.type) {
-            toastr.warning(notification.detail.message);
-        } else if ("error" === notification.detail.type) {
-            toastr.error(notification.detail.message);
-        }
     };
 
     /**
@@ -313,7 +306,18 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
             handler(downloadAsEvent);
         }
     }
-    outputHandlers.set('downloadAs', downloadAsHandler);
+    outputHandlers.set(EventDataType.DOWNLOAD_AS, downloadAsHandler);
+
+    function notificationMessageHandler(notificationMessageEvent) {
+        if (NotificationMessageType.SUCCESS === notificationMessageEvent.messageType) {
+            toastr.success(notificationMessageEvent.message);
+        } else if (NotificationMessageType.WARNING === notificationMessageEvent.messageType) {
+            toastr.warning(notificationMessageEvent.message);
+        } else if (NotificationMessageType.ERROR === notificationMessageEvent.messageType) {
+            toastr.error(notificationMessageEvent.message);
+        }
+    }
+    outputHandlers.set(EventDataType.NOTIFICATION_MESSAGE, notificationMessageHandler);
     // ================================
     // =   Setup download handlers    =
     // ================================
@@ -356,7 +360,7 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
         $('#wb-download-accept').val(accept);
         $wbDownload.submit();
     }
-    downloadAsPluginNameToEventHandler.set('extended_table', downloadThroughServer);
+    downloadAsPluginNameToEventHandler.set(YasrPluginName.EXTENDED_TABLE, downloadThroughServer);
 
     init();
 }

--- a/src/js/angular/utils/yasgui-utils.js
+++ b/src/js/angular/utils/yasgui-utils.js
@@ -1,8 +1,13 @@
+import {EventData} from "../../../models/ontotext-yasgui/event-data";
+import {EventDataType} from "../../../models/ontotext-yasgui/event-data-type";
+
 export const toYasguiOutputModel = ($event) => {
     const eventData = toEventData($event);
     switch (eventData.TYPE) {
-        case "downloadAs":
+        case EventDataType.DOWNLOAD_AS:
             return buildDownloadAsModel(eventData);
+        case EventDataType.NOTIFICATION_MESSAGE:
+            return buildNotificationMessageModel(eventData);
         default:
             return eventData;
     }
@@ -19,12 +24,14 @@ export const buildDownloadAsModel = (eventData) => {
     };
 };
 
-export class EventData {
-    constructor(TYPE, payload) {
-        this.TYPE = TYPE;
-        this.payload = payload;
-    }
-}
+export const buildNotificationMessageModel = (eventData) => {
+    return {
+        TYPE: eventData.TYPE,
+        message: eventData.payload.message,
+        code: eventData.payload.code,
+        messageType: eventData.payload.messageType
+    };
+};
 
 export const toEventData = ($event) => {
     return new EventData($event.detail.TYPE, $event.detail.payload);

--- a/src/models/ontotext-yasgui/event-data-type.js
+++ b/src/models/ontotext-yasgui/event-data-type.js
@@ -1,0 +1,12 @@
+/**
+ * Holds all possible values of {@see EventData} types.
+ */
+export class EventDataType {
+    static get DOWNLOAD_AS() {
+        return 'downloadAs';
+    }
+
+    static get NOTIFICATION_MESSAGE() {
+        return 'notificationMessage';
+    }
+}

--- a/src/models/ontotext-yasgui/event-data.js
+++ b/src/models/ontotext-yasgui/event-data.js
@@ -1,0 +1,9 @@
+/**
+ * Model of all events fired by "ontotext-yasgui".
+ */
+export class EventData {
+    constructor(TYPE, payload) {
+        this.TYPE = TYPE;
+        this.payload = payload;
+    }
+}

--- a/src/models/ontotext-yasgui/notification-message-type.js
+++ b/src/models/ontotext-yasgui/notification-message-type.js
@@ -1,0 +1,16 @@
+/**
+ * Holds all possible notification message types fired by "ontotext-yasgui".
+ */
+export class NotificationMessageType {
+    static get SUCCESS() {
+        return 'success';
+    }
+
+    static get WARNING() {
+        return 'warning';
+    }
+
+    static get ERROR() {
+        return 'error';
+    }
+}

--- a/src/models/ontotext-yasgui/yasr-plugin-name.js
+++ b/src/models/ontotext-yasgui/yasr-plugin-name.js
@@ -1,0 +1,16 @@
+/**
+ * Holds all yasr plugin names.
+ */
+export class YasrPluginName {
+    static get EXTENDED_TABLE() {
+        return 'extended_table';
+    }
+
+    static get RAW_RESPONSE() {
+        return 'response';
+    }
+
+    static get TABLE() {
+        return 'table';
+    }
+}

--- a/src/pages/sparql-editor.html
+++ b/src/pages/sparql-editor.html
@@ -14,7 +14,6 @@
         ngce-on-share_query="shareQuery($event)"
         ngce-on-query_share_link_copied="queryShareLinkCopied()"
         ngce-on-load_saved_queries="loadSavedQueries($event)"
-        ngce-on-notify="notify($event)"
         ngce-on-output="output($event)">
     </ontotext-yasgui>
 


### PR DESCRIPTION
## What
Changes implementation of notification when an url of result link is copied into clipboard.

## Why
There is a new implementation of event fired by "ontotext-yasgui" when an url link is copied.
## How
Updates the version of "ontotext-yasgui". Register a notification event handler in "ontotext-yasgui" output event emitter.
Additional work:
Added models for:
- EventData - event data model for all events fired by "ontotext-yasgui";
- EventDataType - describes all possible events which can be fired by "ontotext-yasgui";
- NotificationMessageType - describes all possible notification message types: "success", "warning", "error";
- YasrPluginName - describes the names of yasr plugins.