### PR TITLE
GDB-8005 Fix translation labels generation in ontop create view

### DIFF
--- a/src/js/angular/repositories/ontop-repo.directive.js
+++ b/src/js/angular/repositories/ontop-repo.directive.js
@@ -270,7 +270,7 @@ function ontopRepoDirective($modal, RepositoriesRestService, toastr, Upload, $tr
             if (field === 'port' && $scope.selectedDriver.portRequired) {
                 field = 'portIfRequired';
             }
-            return $scope.repoTooltips.ontop[field];
+            return $translate.instant('repoTooltips.ontop.' + field);
         };
 
         $scope.editOntopRepo = function () {


### PR DESCRIPTION
## What
When creating ontop repository, tooltips for some fields are not shown and console is full of errors

## Why
The generation of the keys for the tooltip labels is wrong the function throws an error

## How
- fix the function which generates tooltip translation labels' keys