### PR TITLE
GDB-7948 Fix monitoring view bar-chart colors

### DIFF
--- a/src/css/jmx.css
+++ b/src/css/jmx.css
@@ -49,3 +49,7 @@
   white-space: nowrap;
   margin: 0 4px;
 }
+
+.nv-multiBarHorizontalChart .nv-bar {
+  fill-opacity: 0.5;
+}


### PR DESCRIPTION
## What
Colors for disk storage chart are a bit different from others

## Why
The fill-opacity style is different for some reason

## How
- add a css rule to set the fill-opacity to 0.5 as other charts