### PR TITLE
GDB-7954: Add pagination control to all yasr plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "^0.0.2-TR20",
+                "ontotext-yasgui-web-component": "^0.0.2-TR21",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -9905,9 +9905,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR20",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR20.tgz",
-            "integrity": "sha512-UMK9AkSLWB6pn6sU/+oG1EEzzDbJa7RQqogG9j4LGx4BZZs/qdxh/1MzAQzkqTPVGvbxGcP5kqxSkzGfdE8eoA==",
+            "version": "0.0.2-TR21",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR21.tgz",
+            "integrity": "sha512-Z6J/p9RvbmkFDG3xq66GJjEq/pmoHyLwX2RSq4K5jlgwXJ1wIJjqaQZfBOVKWPtnAY5xkGaetA8EqYsXXAMfVQ==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24267,9 +24267,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR20",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR20.tgz",
-            "integrity": "sha512-UMK9AkSLWB6pn6sU/+oG1EEzzDbJa7RQqogG9j4LGx4BZZs/qdxh/1MzAQzkqTPVGvbxGcP5kqxSkzGfdE8eoA==",
+            "version": "0.0.2-TR21",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR21.tgz",
+            "integrity": "sha512-Z6J/p9RvbmkFDG3xq66GJjEq/pmoHyLwX2RSq4K5jlgwXJ1wIJjqaQZfBOVKWPtnAY5xkGaetA8EqYsXXAMfVQ==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "^0.0.2-TR20",
+        "ontotext-yasgui-web-component": "^0.0.2-TR21",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -266,13 +266,13 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
         });
     };
 
-    function setPrefixes(namespacesResponse) {
+    const setPrefixes = (namespacesResponse) => {
         const usedPrefixes = {};
         namespacesResponse.data.results.bindings.forEach(function (e) {
             usedPrefixes[e.prefix.value] = e.namespace.value;
         });
         $scope.prefixes = usedPrefixes;
-    }
+    };
 
     // Initialization and bootstrap
     function init() {
@@ -298,7 +298,7 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
      * request and the request object can be altered here, and it will be sent with these changes.
      * @param {object} queryResponseEvent - the event payload containing the query and the request object.
      */
-    function queryHandler(queryResponseEvent) {
+    const queryHandler = (queryResponseEvent) => {
         updateRequestHeaders(queryResponseEvent.request);
         changeEndpointByQueryType(queryResponseEvent.queryMode, queryResponseEvent.request);
         const pageNumber = queryResponseEvent.request._data['pageNumber'] ? parseInt(queryResponseEvent.request._data['pageNumber']) : undefined;
@@ -309,7 +309,7 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
             queryResponseEvent.request._data['offset'] = (pageNumber - 1) * (pageSize -1);
             queryResponseEvent.request._data['limit'] = pageSize;
         }
-    }
+    };
     outputHandlers.set(EventDataType.QUERY, queryHandler);
 
     /**
@@ -317,16 +317,16 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
      * count query request and the request object can be altered here, and it will be sent with these changes.
      * @param {object} countQueryResponseEvent - the event payload containing the query and the request object.
      */
-    function countQueryResponseHandler(countQueryResponseEvent) {
+    const countQueryResponseHandler = (countQueryResponseEvent) => {
         updateRequestHeaders(countQueryResponseEvent.request);
         changeEndpointByQueryType(countQueryResponseEvent.queryMode, countQueryResponseEvent.request);
         countQueryResponseEvent.request._data['pageSize'] = undefined;
         countQueryResponseEvent.request._data['pageNumber'] = undefined;
         countQueryResponseEvent.request._data['count'] = 1;
-    }
+    };
     outputHandlers.set(EventDataType.COUNT_QUERY, countQueryResponseHandler);
 
-    function extractTotalElements(countResponse) {
+    const extractTotalElements = (countResponse) => {
         if (!countResponse || !countResponse.body) {
             return -1;
         }
@@ -350,7 +350,7 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
             }
         }
         return -1;
-    }
+    };
 
     /**
      * Handles the "countQueryResponse" event emitted by the ontotext-yasgui. The event is fired immediately after receiving the
@@ -358,21 +358,21 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
      * contain "totalElements".
      * @param {object} countQueryResponseEvent - the event payload containing the response of count query.
      */
-    function extractTotalElementsHandler(countQueryResponseEvent) {
+    const extractTotalElementsHandler = (countQueryResponseEvent) => {
         const countResponse = countQueryResponseEvent.response;
         countQueryResponseEvent.response.body.totalElements = extractTotalElements(countResponse);
-    }
+    };
     outputHandlers.set(EventDataType.COUNT_QUERY_RESPONSE, extractTotalElementsHandler);
 
-    function downloadAsHandler(downloadAsEvent) {
+    const downloadAsHandler = (downloadAsEvent) => {
         const handler = downloadAsPluginNameToEventHandler.get(downloadAsEvent.pluginName);
         if (handler) {
             handler(downloadAsEvent);
         }
-    }
+    };
     outputHandlers.set(EventDataType.DOWNLOAD_AS, downloadAsHandler);
 
-    function notificationMessageHandler(notificationMessageEvent) {
+    const notificationMessageHandler = (notificationMessageEvent) => {
         if (NotificationMessageType.SUCCESS === notificationMessageEvent.messageType) {
             toastr.success(notificationMessageEvent.message);
         } else if (NotificationMessageType.WARNING === notificationMessageEvent.messageType) {
@@ -380,12 +380,12 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
         } else if (NotificationMessageType.ERROR === notificationMessageEvent.messageType) {
             toastr.error(notificationMessageEvent.message);
         }
-    }
+    };
     outputHandlers.set(EventDataType.NOTIFICATION_MESSAGE, notificationMessageHandler);
     // ================================
     // =   Setup download handlers    =
     // ================================
-    function downloadCurrentResults(downloadAsEvent) {
+    const downloadCurrentResults = (downloadAsEvent) => {
         if ("application/sparql-results+json" === downloadAsEvent.contentType) {
             ontoElement.getEmbeddedResultAsJson()
                 .then((response) => {
@@ -398,15 +398,15 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
                     downloadAsFile(`${getFileTimePrefix()}_queryResults.csv`, downloadAsEvent.contentType, response);
                 });
         }
-    }
+    };
     downloadAsPluginNameToEventHandler.set('response', downloadCurrentResults);
 
-    function getFileTimePrefix() {
+    const getFileTimePrefix = () => {
         const now = new Date();
         return `${now.toLocaleDateString($scope.language)}_${now.toLocaleTimeString($scope.language)}`;
-    }
+    };
 
-    function downloadThroughServer(downloadAsEvent) {
+    const downloadThroughServer = (downloadAsEvent) => {
         const query = downloadAsEvent.query;
         const infer = downloadAsEvent.infer;
         const sameAs = downloadAsEvent.sameAs;
@@ -423,7 +423,7 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
         $('#wb-auth-token').val(authToken);
         $('#wb-download-accept').val(accept);
         $wbDownload.submit();
-    }
+    };
     downloadAsPluginNameToEventHandler.set(YasrPluginName.EXTENDED_TABLE, downloadThroughServer);
 
     init();

--- a/src/js/angular/utils/yasgui-utils.js
+++ b/src/js/angular/utils/yasgui-utils.js
@@ -1,24 +1,6 @@
 import {EventData} from "../../../models/ontotext-yasgui/event-data";
 import {EventDataType} from "../../../models/ontotext-yasgui/event-data-type";
 
-export const toYasguiOutputModel = ($event) => {
-    const eventData = toEventData($event);
-    switch (eventData.TYPE) {
-        case EventDataType.DOWNLOAD_AS:
-            return buildDownloadAsModel(eventData);
-        case EventDataType.NOTIFICATION_MESSAGE:
-            return buildNotificationMessageModel(eventData);
-        case EventDataType.COUNT_QUERY:
-            return buildCountQueryModel(eventData);
-        case EventDataType.COUNT_QUERY_RESPONSE:
-            return buildCountQueryResponseModel(eventData);
-        case EventDataType.QUERY:
-            return buildQueryModel(eventData);
-        default:
-            return eventData;
-    }
-};
-
 export const buildCountQueryResponseModel = (eventData) => {
     return {
         TYPE: eventData.TYPE,
@@ -66,6 +48,24 @@ export const buildNotificationMessageModel = (eventData) => {
 
 export const toEventData = ($event) => {
     return new EventData($event.detail.TYPE, $event.detail.payload);
+};
+
+export const toYasguiOutputModel = ($event) => {
+    const eventData = toEventData($event);
+    switch (eventData.TYPE) {
+        case EventDataType.DOWNLOAD_AS:
+            return buildDownloadAsModel(eventData);
+        case EventDataType.NOTIFICATION_MESSAGE:
+            return buildNotificationMessageModel(eventData);
+        case EventDataType.COUNT_QUERY:
+            return buildCountQueryModel(eventData);
+        case EventDataType.COUNT_QUERY_RESPONSE:
+            return buildCountQueryResponseModel(eventData);
+        case EventDataType.QUERY:
+            return buildQueryModel(eventData);
+        default:
+            return eventData;
+    }
 };
 
 export const downloadAsFile = (filename, contentType, content) => {

--- a/src/js/angular/utils/yasgui-utils.js
+++ b/src/js/angular/utils/yasgui-utils.js
@@ -8,9 +8,40 @@ export const toYasguiOutputModel = ($event) => {
             return buildDownloadAsModel(eventData);
         case EventDataType.NOTIFICATION_MESSAGE:
             return buildNotificationMessageModel(eventData);
+        case EventDataType.COUNT_QUERY:
+            return buildCountQueryModel(eventData);
+        case EventDataType.COUNT_QUERY_RESPONSE:
+            return buildCountQueryResponseModel(eventData);
+        case EventDataType.QUERY:
+            return buildQueryModel(eventData);
         default:
             return eventData;
     }
+};
+
+export const buildCountQueryResponseModel = (eventData) => {
+    return {
+        TYPE: eventData.TYPE,
+        response: eventData.payload.response
+    };
+};
+
+export const buildQueryModel = (eventData) => {
+    return {
+        TYPE: eventData.TYPE,
+        query: eventData.payload.query,
+        queryMode: eventData.payload.queryMode,
+        request: eventData.payload.request
+    };
+};
+
+export const buildCountQueryModel = (eventData) => {
+    return {
+        TYPE: eventData.TYPE,
+        query: eventData.payload.query,
+        queryMode: eventData.payload.queryMode,
+        request: eventData.payload.request
+    };
 };
 
 export const buildDownloadAsModel = (eventData) => {

--- a/src/js/angular/utils/yasgui-utils.js
+++ b/src/js/angular/utils/yasgui-utils.js
@@ -1,50 +1,10 @@
 import {EventData} from "../../../models/ontotext-yasgui/event-data";
 import {EventDataType} from "../../../models/ontotext-yasgui/event-data-type";
-
-export const buildCountQueryResponseModel = (eventData) => {
-    return {
-        TYPE: eventData.TYPE,
-        response: eventData.payload.response
-    };
-};
-
-export const buildQueryModel = (eventData) => {
-    return {
-        TYPE: eventData.TYPE,
-        query: eventData.payload.query,
-        queryMode: eventData.payload.queryMode,
-        request: eventData.payload.request
-    };
-};
-
-export const buildCountQueryModel = (eventData) => {
-    return {
-        TYPE: eventData.TYPE,
-        query: eventData.payload.query,
-        queryMode: eventData.payload.queryMode,
-        request: eventData.payload.request
-    };
-};
-
-export const buildDownloadAsModel = (eventData) => {
-    return {
-        TYPE: eventData.TYPE,
-        contentType: eventData.payload.value,
-        pluginName: eventData.payload.pluginName,
-        query: eventData.payload.query,
-        infer: eventData.payload.infer,
-        sameAs: eventData.payload.sameAs
-    };
-};
-
-export const buildNotificationMessageModel = (eventData) => {
-    return {
-        TYPE: eventData.TYPE,
-        message: eventData.payload.message,
-        code: eventData.payload.code,
-        messageType: eventData.payload.messageType
-    };
-};
+import {QueryRequestEvent} from "../../../models/ontotext-yasgui/query-request-event";
+import {CountQueryResponseEvent} from "../../../models/ontotext-yasgui/count-query-response-event";
+import {CountQueryRequestEvent} from "../../../models/ontotext-yasgui/count-query-request-event";
+import {DownloadAsEvent} from "../../../models/ontotext-yasgui/download-as-event";
+import {NotificationMessageEvent} from "../../../models/ontotext-yasgui/notification-message-event";
 
 export const toEventData = ($event) => {
     return new EventData($event.detail.TYPE, $event.detail.payload);
@@ -54,15 +14,15 @@ export const toYasguiOutputModel = ($event) => {
     const eventData = toEventData($event);
     switch (eventData.TYPE) {
         case EventDataType.DOWNLOAD_AS:
-            return buildDownloadAsModel(eventData);
+            return new DownloadAsEvent(eventData);
         case EventDataType.NOTIFICATION_MESSAGE:
-            return buildNotificationMessageModel(eventData);
+            return new NotificationMessageEvent(eventData);
         case EventDataType.COUNT_QUERY:
-            return buildCountQueryModel(eventData);
+            return new CountQueryRequestEvent(eventData);
         case EventDataType.COUNT_QUERY_RESPONSE:
-            return buildCountQueryResponseModel(eventData);
+            return new CountQueryResponseEvent(eventData);
         case EventDataType.QUERY:
-            return buildQueryModel(eventData);
+            return new QueryRequestEvent(eventData);
         default:
             return eventData;
     }

--- a/src/models/ontotext-yasgui/count-query-request-event.js
+++ b/src/models/ontotext-yasgui/count-query-request-event.js
@@ -1,0 +1,29 @@
+/**
+ * Model for event of type {@link EventDataType.COUNT_QUERY} emitted by "ontotext-yasgui-web-component".
+ */
+export class CountQueryRequestEvent {
+
+    /**
+     * Constructs the model for {@link EventDataType.DOWNLOAD_AS} event.
+     *
+     * @param {EventData} eventData - event emitted by "ontotext-yasgui-web-component".
+     */
+    constructor(eventData) {
+        this.TYPE = eventData.TYPE;
+        this.query = eventData.payload.query;
+        this.queryMode = eventData.payload.queryMode;
+        this.request = eventData.payload.request;
+    }
+
+    setPageSize(pageSize) {
+        this.request._data['pageSize'] = pageSize;
+    }
+
+    setPageNumber(pageNumber) {
+        this.request._data['pageNumber'] = pageNumber;
+    }
+
+    setCount(count) {
+        this.request._data['count'] = count;
+    }
+}

--- a/src/models/ontotext-yasgui/count-query-response-event.js
+++ b/src/models/ontotext-yasgui/count-query-response-event.js
@@ -1,0 +1,58 @@
+import {isNumber} from "lodash";
+
+/**
+ * Model for event of type {@link EventDataType.COUNT_QUERY_RESPONSE} emitted by "ontotext-yasgui-web-component".
+ */
+export class CountQueryResponseEvent {
+
+    /**
+     * Constructs the model for {@link EventDataType.COUNT_QUERY_RESPONSE} event.
+     *
+     * @param {EventData} eventData - event emitted by "ontotext-yasgui-web-component".
+     */
+    constructor(eventData) {
+        this.TYPE = eventData.TYPE;
+        this.response = eventData.payload.response;
+    }
+
+    hasResponse() {
+        return this.response && this.response.body;
+    }
+
+    getResponseBody() {
+        if (this.hasResponse()) {
+            return this.response.body;
+        }
+    }
+
+    isResponseNumber() {
+        if (this.hasResponse()) {
+            return isNumber(this.response.body);
+        }
+        return false;
+    }
+
+    isResponseArray() {
+        if (this.hasResponse()) {
+            return Array.isArray(this.response.body);
+        }
+        return false;
+    }
+
+    getBindings() {
+        if (this.hasResponse()) {
+            return this.response.body.results.bindings;
+        }
+    }
+
+    hasBindingResponse() {
+        if (this.hasResponse()) {
+            return this.response.body.results.bindings[0];
+        }
+        return false;
+    }
+
+    setTotalElements(totalElements) {
+        this.response.body.totalElements = totalElements;
+    }
+}

--- a/src/models/ontotext-yasgui/download-as-event.js
+++ b/src/models/ontotext-yasgui/download-as-event.js
@@ -1,0 +1,19 @@
+/**
+ * Model for event of type {@link EventDataType.DOWNLOAD_AS} emitted by "ontotext-yasgui-web-component".
+ */
+export class DownloadAsEvent {
+
+    /**
+     * Constructs the model for {@link EventDataType.DOWNLOAD_AS} event.
+     *
+     * @param {EventData} eventData - event emitted by "ontotext-yasgui-web-component".
+     */
+    constructor(eventData) {
+        this.TYPE = eventData.TYPE;
+        this.contentType = eventData.payload.value;
+        this.pluginName = eventData.payload.pluginName;
+        this.query = eventData.payload.query;
+        this.infer = eventData.payload.infer;
+        this.sameAs = eventData.payload.sameAs;
+    }
+}

--- a/src/models/ontotext-yasgui/event-data-type.js
+++ b/src/models/ontotext-yasgui/event-data-type.js
@@ -3,5 +3,8 @@
  */
 export const EventDataType = {
     'DOWNLOAD_AS': 'downloadAs',
-    'NOTIFICATION_MESSAGE': 'notificationMessage'
+    'NOTIFICATION_MESSAGE': 'notificationMessage',
+    'QUERY': 'query',
+    'COUNT_QUERY': 'countQuery',
+    'COUNT_QUERY_RESPONSE': 'countQueryResponse'
 };

--- a/src/models/ontotext-yasgui/notification-message-event.js
+++ b/src/models/ontotext-yasgui/notification-message-event.js
@@ -1,0 +1,17 @@
+/**
+ * Model for event of type {@link EventDataType.NOTIFICATION_MESSAGE} emitted by "ontotext-yasgui-web-component".
+ */
+export class NotificationMessageEvent {
+
+    /**
+     * Constructs the model for {@link EventDataType.NOTIFICATION_MESSAGE} event.
+     *
+     * @param {EventData} eventData - event emitted by "ontotext-yasgui-web-component".
+     */
+    constructor(eventData) {
+        this.TYPE = eventData.TYPE;
+        this.message = eventData.payload.message;
+        this.code = eventData.payload.code;
+        this.messageType = eventData.payload.messageType;
+    }
+}

--- a/src/models/ontotext-yasgui/query-request-event.js
+++ b/src/models/ontotext-yasgui/query-request-event.js
@@ -1,0 +1,41 @@
+/**
+ * Model for event of type {@link EventDataType.QUERY} emitted by "ontotext-yasgui-web-component".
+ */
+export class QueryRequestEvent {
+
+    /**
+     * Constructs the model for {@link EventDataType.QUERY} event.
+     *
+     * @param {EventData} eventData - event emitted by "ontotext-yasgui-web-component".
+     */
+    constructor(eventData) {
+        this.TYPE = eventData.TYPE;
+        this.query = eventData.payload.query;
+        this.queryMode = eventData.payload.queryMode;
+        this.request = eventData.payload.request;
+    }
+
+    setPageSize(pageSize) {
+        this.request._data['pageSize'] = pageSize;
+    }
+
+    getPageSize() {
+        return this.request._data['pageSize'] ? parseInt(this.request._data['pageSize']) : undefined;
+    }
+
+    setPageNumber(pageNumber) {
+        this.request._data['pageNumber'] = pageNumber;
+    }
+
+    getPageNumber() {
+        return this.request._data['pageNumber'] ? parseInt(this.request._data['pageNumber']) : undefined;
+    }
+
+    setOffset(offset) {
+        this.request._data['offset'] = offset;
+    }
+
+    setLimit(limit) {
+        this.request._data['limit'] = limit;
+    }
+}

--- a/src/pages/sparql-editor.html
+++ b/src/pages/sparql-editor.html
@@ -6,7 +6,6 @@
         ngce-prop-config="config"
         ngce-prop-saved_query_config="savedQueryConfig"
         ngce-prop-language="language"
-        ngce-on-query_executed="queryExecuted($event)"
         ngce-on-create_saved_query="createSavedQuery($event)"
         ngce-on-update_saved_query="updateSavedQuery($event)"
         ngce-on-delete_saved_query="deleteSavedQuery($event)"

--- a/test-cypress/fixtures/namespaces/ontotext-generated-namespace.json
+++ b/test-cypress/fixtures/namespaces/ontotext-generated-namespace.json
@@ -1,0 +1,22 @@
+{
+    "head" : {
+        "vars" : [
+            "prefix",
+            "namespace"
+        ]
+    },
+    "results" : {
+        "bindings" : [
+            {
+                "prefix" : {
+                    "type" : "literal",
+                    "value" : "ontogen"
+                },
+                "namespace" : {
+                    "type" : "literal",
+                    "value" : "http://ontotext-yasgui/generated-yri#"
+                }
+            }
+        ]
+    }
+}

--- a/test-cypress/fixtures/queries/empty-query-response.json
+++ b/test-cypress/fixtures/queries/empty-query-response.json
@@ -1,0 +1,11 @@
+{
+  "head" : {
+    "vars" : [
+      "s",
+      "p"
+    ]
+  },
+  "results" : {
+    "bindings" : [ ]
+  }
+}

--- a/test-cypress/integration/sparql-editor/actions/expand-results-over-sameas.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/expand-results-over-sameas.spec.js
@@ -1,6 +1,7 @@
 import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
 import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
 import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {QueryStubDescription, QueryStubs} from "../../../stubs/yasgui/query-stubs";
 
 describe('Expand results over owl:sameAs', () => {
 
@@ -22,12 +23,16 @@ describe('Expand results over owl:sameAs', () => {
     });
 
     it('Should be able to toggle expand results parameter', () => {
+        const queryDescription = new QueryStubDescription()
+            .setRepositoryId(repositoryId)
+            .setTotalElements(1);
+        QueryStubs.stubQueryResults(queryDescription);
         // When I open the editor
         // Then I expect that expand results should be enabled by default
         YasqeSteps.getExpandResultsOverSameAsButtonTooltip().should('have.attr', 'data-tooltip', 'Expand results over owl:sameAs: ON');
         YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-same-as-on');
         YasqeSteps.executeQuery();
-        cy.wait('@query').its('request.body').should('contain', 'sameAs=true');
+        cy.wait('@query-1_0_1001_1').its('request.body').should('contain', 'sameAs=true');
         // When I disable the expand results action
         YasqeSteps.expandResultsOverSameAs();
         // Then I expect that the button state should be changed
@@ -35,7 +40,7 @@ describe('Expand results over owl:sameAs', () => {
         YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-same-as-off');
         // And sameAs=false parameter should be sent with the request
         YasqeSteps.executeQuery();
-        cy.wait('@query').its('request.body').should('contain', 'sameAs=false');
+        cy.wait('@query-1_0_1001_1').its('request.body').should('contain', 'sameAs=false');
         YasqeSteps.expandResultsOverSameAs();
         // When I disable the include inferred action
         YasqeSteps.includeInferredStatements();
@@ -43,6 +48,6 @@ describe('Expand results over owl:sameAs', () => {
         YasqeSteps.getExpandResultsOverSameAsButtonTooltip().should('have.attr', 'data-tooltip', 'Requires \'Include Inferred\'!');
         YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-same-as-off');
         YasqeSteps.executeQuery();
-        cy.wait('@query').its('request.body').should('contain', 'infer=false&sameAs=false');
+        cy.wait('@query-1_0_1001_1').its('request.body').should('contain', 'infer=false&sameAs=false');
     });
 });

--- a/test-cypress/integration/sparql-editor/actions/include-inferred-statements.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/include-inferred-statements.spec.js
@@ -1,6 +1,7 @@
 import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
 import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
 import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {QueryStubDescription, QueryStubs} from "../../../stubs/yasgui/query-stubs";
 
 describe('Include inferred statements', () => {
 
@@ -22,16 +23,20 @@ describe('Include inferred statements', () => {
     });
 
     it('Should be able to toggle include inferred statements', () => {
+        const queryDescription = new QueryStubDescription()
+            .setRepositoryId(repositoryId)
+            .setTotalElements(1);
+        QueryStubs.stubQueryResults(queryDescription);
         // When I open the editor
         // Then I expect that include inferred statements should be enabled by default
         YasqeSteps.getIncludeInferredStatementsButtonTooltip().should('have.attr', 'data-tooltip', 'Include inferred data in results: ON');
         YasqeSteps.getIncludeInferredStatementsButton().should('have.class', 'icon-inferred-on');
         YasqeSteps.executeQuery();
-        cy.wait('@query').its('request.body').should('contain', 'infer=true');
+        cy.wait('@query-1_0_1001_1').its('request.body').should('contain', 'infer=true');
         YasqeSteps.includeInferredStatements();
         YasqeSteps.getIncludeInferredStatementsButtonTooltip().should('have.attr', 'data-tooltip', 'Include inferred data in results: OFF');
         YasqeSteps.getIncludeInferredStatementsButton().should('have.class', 'icon-inferred-off');
         YasqeSteps.executeQuery();
-        cy.wait('@query').its('request.body').should('contain', 'infer=false');
+        cy.wait('@query-1_0_1001_1').its('request.body').should('contain', 'infer=false');
     });
 });

--- a/test-cypress/integration/sparql-editor/yasr/pagination.spec.js
+++ b/test-cypress/integration/sparql-editor/yasr/pagination.spec.js
@@ -1,0 +1,219 @@
+import {QueryStubDescription, QueryStubs} from "../../../stubs/yasgui/query-stubs";
+import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {YasrSteps} from "../../../steps/yasgui/yasr-steps";
+import {PaginationSteps} from "../../../steps/yasgui/pagination-steps";
+import {NamespaceStubs} from "../../../stubs/namespace-stubs";
+
+describe('Yasr result pagination', () => {
+    let repositoryId;
+    beforeEach(() => {
+        repositoryId = 'sparql-editor-' + Date.now();
+        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        NamespaceStubs.stubGeneratedOntotextNamespacesResponse(repositoryId);
+        // Given: I visit a page with "ontotex-yasgu-web-component" in it.
+        SparqlEditorSteps.visitSparqlEditorPage();
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    describe('Visibility of pagination', () => {
+        it('should not be visible when a tab is open without a query to be executed', () => {
+            // When I visit a page with "ontotext-yasgui" component in it,
+            // and there is not executed query.
+            //Then I expect pagination to not be visible
+            YasrSteps.getPagination().should('not.be.visible');
+        });
+
+        it('should not be visible when there aren\'t results', () => {
+            // When I visit a page with "ontotext-yasgui" component in it,
+            // and execute a query which don't return results
+            QueryStubs.stubEmptyQueryResponse();
+            YasqeSteps.executeQuery();
+
+            //Then I expect pagination to not be visible
+            YasrSteps.getPagination().should('not.be.visible');
+        });
+
+        it('should not be visible when results of query are less than configured page size', () => {
+            // When I visit a page with "ontotext-yasgui" component in it,
+            // and execute a query which returns results less than page size.
+            const queryDescription = new QueryStubDescription()
+                .setRepositoryId(repositoryId)
+                .setTotalElements(3);
+            QueryStubs.stubQueryResults(queryDescription);
+            YasqeSteps.executeQuery();
+
+            // Then I expect pagination to not be visible
+            YasrSteps.getPagination().should('not.be.visible');
+
+            // When I execute a query witch returns results equals to page size.
+            queryDescription
+                .setRepositoryId(repositoryId)
+                .setTotalElements(1000);
+            QueryStubs.stubQueryResults(queryDescription);
+            YasqeSteps.executeQuery();
+
+            // Then I expect pagination to not be visible
+            YasrSteps.getPagination().should('not.be.visible');
+        });
+
+        it('should be visible when results of query are more than configured page size', () => {
+            // When I visit a page with "ontotext-yasgui" component in it,
+            // and execute a query which returns results more than page size.
+            const queryDescription = new QueryStubDescription()
+                .setRepositoryId(repositoryId)
+                .setTotalElements(1150);
+            QueryStubs.stubQueryResults(queryDescription);
+            YasqeSteps.executeQuery();
+
+            // Then I expect pagination to be visible
+            YasrSteps.getPagination().should('be.visible');
+        });
+
+    });
+
+    describe('Pagination behaviour', () => {
+        it('should change page when clink on page number button', () => {
+            // When I visit a page with "ontotext-yasgui" component in it,
+            // and execute a query which returns results more than page size.
+            const queryDescription = new QueryStubDescription()
+                .setRepositoryId(repositoryId)
+                .setTotalElements(1001);
+            QueryStubs.stubQueryResults(queryDescription);
+            YasqeSteps.executeQuery();
+            PaginationSteps.waitPageSelected(1);
+
+            // I expect two pages to be shown in pagination,
+            PaginationSteps.getPageNumberButtons().should('have.length', 2);
+            // and first page to have 1000 results,
+            YasrSteps.getResults().should('have.length', 1000);
+            // and results to be from the first page
+            YasrSteps.getResultLink(0, 2).should('have.text', 'ontogen:page_1-row_1-column_2');
+
+            // When I click on second page button
+            PaginationSteps.clickOnPageNumberButton(2);
+            PaginationSteps.waitPageSelected(2);
+
+            // Then I expect second page to have only one result,
+            YasrSteps.getResults().should('have.length', 1);
+            // and the results to be from the second page
+            YasrSteps.getResultLink(0, 2).should('have.text', 'ontogen:page_2-row_1-column_2');
+        });
+
+        it('should change page when clink on next or previous page button', () => {
+            // When I visit a page with "ontotext-yasgui" component in it,
+            // and execute a query which returns results more than page size.
+            const queryDescription = new QueryStubDescription()
+                .setRepositoryId(repositoryId)
+                .setTotalElements(1002);
+            QueryStubs.stubQueryResults(queryDescription);
+            YasqeSteps.executeQuery();
+            PaginationSteps.waitPageSelected(1);
+
+            // Then I expect two pages to be shown in pagination.
+            PaginationSteps.getPageNumberButtons().should('have.length', 2);
+            // and first page to have 1000 results
+            YasrSteps.getResults().should('have.length', 1000);
+            // and results to be from the first page
+            YasrSteps.getResultLink(0, 2).should('have.text', 'ontogen:page_1-row_1-column_2');
+
+            // When I click on next page button
+            PaginationSteps.clickOnNextPageButton();
+            PaginationSteps.waitPageSelected(2);
+
+            // Then I expect second page to have two results.
+            YasrSteps.getResults().should('have.length', 2);
+            // and the result to be from the second page
+            YasrSteps.getResultLink(0, 2).should('have.text', 'ontogen:page_2-row_1-column_2');
+
+            // When I click on previous button
+            PaginationSteps.clickOnPreviousPageButton();
+            PaginationSteps.waitPageSelected(1);
+
+            // Then I expect first page to have 1000 results,
+            YasrSteps.getResults().should('have.length', 1000);
+            // and the results to be from the first page.
+            YasrSteps.getResultLink(0, 2).should('have.text', 'ontogen:page_1-row_1-column_2');
+        });
+
+        it('should have two more page around selected page', () => {
+            // When I visit a page with "ontotext-yasgui" component in it,
+            // and execute a query which results are on 6 pages.
+            const queryDescription = new QueryStubDescription()
+                .setRepositoryId(repositoryId)
+                .setTotalElements(5001);
+            QueryStubs.stubQueryResults(queryDescription);
+            YasqeSteps.executeQuery();
+            PaginationSteps.waitPageSelected(1);
+
+            PaginationSteps.getPreviousPageButton().should('be.disabled');
+            PaginationSteps.getPageNumberButton(1).should('have.class', 'selected-page');
+            PaginationSteps.getPageNumberButton(2).should('be.visible');
+            PaginationSteps.getPageNumberButton(3).should('be.visible');
+            PaginationSteps.getPageNumberButton(4).should('not.exist');
+            PaginationSteps.getPageNumberButton(4).should('not.exist');
+            PaginationSteps.getPageNumberButton(5).should('not.exist');
+            PaginationSteps.getPageNumberButton(6).should('not.exist');
+            PaginationSteps.getNextPageButton().should('not.be.disabled');
+
+            // When select second page
+            PaginationSteps.clickOnPageNumberButton(2);
+            PaginationSteps.waitPageSelected(2);
+
+            PaginationSteps.getPreviousPageButton().should('not.be.disabled');
+            PaginationSteps.getPageNumberButton(1).should('be.visible');
+            PaginationSteps.getPageNumberButton(2).should('have.class', 'selected-page');
+            PaginationSteps.getPageNumberButton(3).should('be.visible');
+            PaginationSteps.getPageNumberButton(4).should('be.visible');
+            PaginationSteps.getPageNumberButton(5).should('not.exist');
+            PaginationSteps.getPageNumberButton(6).should('not.exist');
+            PaginationSteps.getNextPageButton().should('not.be.disabled');
+
+            // When select third page
+            PaginationSteps.clickOnPageNumberButton(3);
+            PaginationSteps.waitPageSelected(3);
+
+            PaginationSteps.getPreviousPageButton().should('not.be.disabled');
+            PaginationSteps.getPageNumberButton(1).should('be.visible');
+            PaginationSteps.getPageNumberButton(2).should('be.visible');
+            PaginationSteps.getPageNumberButton(3).should('have.class', 'selected-page');
+            PaginationSteps.getPageNumberButton(4).should('be.visible');
+            PaginationSteps.getPageNumberButton(5).should('be.visible');
+            PaginationSteps.getPageNumberButton(6).should('not.exist');
+            PaginationSteps.getNextPageButton().should('not.be.disabled');
+
+            // When select fifth page
+            PaginationSteps.clickOnPageNumberButton(5);
+            PaginationSteps.waitPageSelected(5);
+
+            PaginationSteps.getPreviousPageButton().should('not.be.disabled');
+            PaginationSteps.getPageNumberButton(1).should('not.exist');
+            PaginationSteps.getPageNumberButton(2).should('not.exist');
+            PaginationSteps.getPageNumberButton(3).should('be.visible');
+            PaginationSteps.getPageNumberButton(4).should('be.visible');
+            PaginationSteps.getPageNumberButton(5).should('have.class', 'selected-page');
+            PaginationSteps.getPageNumberButton(6).should('be.visible');
+            PaginationSteps.getPageNumberButton(7).should('not.exist');
+            PaginationSteps.getNextPageButton().should('not.be.disabled');
+
+            // When select last page
+            PaginationSteps.clickOnPageNumberButton(6);
+            PaginationSteps.waitPageSelected(6);
+
+            PaginationSteps.getPreviousPageButton().should('not.be.disabled');
+            PaginationSteps.getPageNumberButton(1).should('not.exist');
+            PaginationSteps.getPageNumberButton(2).should('not.exist');
+            PaginationSteps.getPageNumberButton(3).should('not.exist');
+            PaginationSteps.getPageNumberButton(4).should('be.visible');
+            PaginationSteps.getPageNumberButton(5).should('be.visible');
+            PaginationSteps.getPageNumberButton(6).should('have.class', 'selected-page');
+            PaginationSteps.getPageNumberButton(7).should('not.exist');
+            PaginationSteps.getNextPageButton().should('be.disabled');
+        });
+    });
+});

--- a/test-cypress/steps/yasgui/pagination-steps.js
+++ b/test-cypress/steps/yasgui/pagination-steps.js
@@ -1,0 +1,47 @@
+export class PaginationSteps {
+
+    static getPagination() {
+        return cy.get('.ontotext-pagination');
+    }
+
+    static getPageSelectors() {
+        return PaginationSteps.getPagination().find('.page-selectors');
+    }
+
+    static getPageNumberButtons() {
+        return PaginationSteps.getPageSelectors().find('.page-button');
+    }
+
+    static getNextPageButton() {
+        return PaginationSteps.getPageSelectors().find('.next-button');
+    }
+
+    static getPreviousPageButton() {
+        return PaginationSteps.getPageSelectors().find('.previous-button');
+    }
+
+    static getPageNumberButton(pageNumber) {
+        return PaginationSteps.getPagination().find(`button:contains("${pageNumber}")`);
+    }
+
+    static clickOnPageNumberButton(pageNumber) {
+        PaginationSteps.getPageNumberButton(pageNumber).scrollIntoView().click();
+    }
+
+    static clickOnNextPageButton() {
+        PaginationSteps.getNextPageButton().scrollIntoView().click();
+    }
+
+    static clickOnPreviousPageButton() {
+        PaginationSteps.getPreviousPageButton().scrollIntoView().click();
+    }
+
+    /**
+     * Checks when a page button is selected. When the button is selected this mean that current page is loaded.
+     * Use this method to wait until new page loaded.
+     * @param expectedPage - expected page.
+     */
+    static waitPageSelected(expectedPage) {
+        PaginationSteps.getPageNumberButton(expectedPage).should('have.class', 'selected-page');
+    }
+}

--- a/test-cypress/steps/yasgui/yasr-steps.js
+++ b/test-cypress/steps/yasgui/yasr-steps.js
@@ -27,6 +27,10 @@ export class YasrSteps {
         return this.getResultRow(rowNumber).find('td').eq(cellNumber);
     }
 
+    static getResultLink(rowNumber, cellNumber) {
+        return YasrSteps.getResultCell(rowNumber, cellNumber).find('a');
+    }
+
     static hoverCell(rowNumber, cellNumber) {
         this.getResultCell(rowNumber, cellNumber).realHover();
     }
@@ -56,5 +60,9 @@ export class YasrSteps {
 
     static getDownloadAsOption(number) {
         return this.getDownloadAsDropdown().find('.ontotext-dropdown-menu-item').eq(number);
+    }
+
+    static getPagination() {
+        return YasrSteps.getYasr().find('.ontotext-pagination');
     }
 }

--- a/test-cypress/stubs/namespace-stubs.js
+++ b/test-cypress/stubs/namespace-stubs.js
@@ -1,0 +1,10 @@
+export class NamespaceStubs {
+
+    static stubGeneratedOntotextNamespacesResponse(repositoryId, withDelay = 0) {
+        NamespaceStubs.stubNameSpaceResponse(repositoryId, '/namespaces/ontotext-generated-namespace.json', withDelay);
+    }
+
+    static stubNameSpaceResponse(repositoryId, fixture, withDelay = 0) {
+        cy.intercept(`/repositories/${repositoryId}/namespaces`, {fixture, delay: withDelay}).as(`${repositoryId}-stub-namespaces`);
+    }
+}

--- a/test-cypress/stubs/yasgui/query-stubs.js
+++ b/test-cypress/stubs/yasgui/query-stubs.js
@@ -1,5 +1,242 @@
 export class QueryStubs {
     static stubDefaultQueryResponse(repositoryId, withDelay = 0) {
-        cy.intercept(`/repositories/${repositoryId}`, {fixture: '/graphql-editor/default-query-response.json', delay: withDelay}).as(`${repositoryId}DefaultQuery`);
+        QueryStubs.stubQueryResponse(repositoryId, '/graphql-editor/default-query-response.json', withDelay);
+    }
+
+    static stubEmptyQueryResponse(repositoryId, withDelay = 0) {
+        QueryStubs.stubQueryResponse(repositoryId, '/queries/empty-query-response.json', withDelay);
+    }
+
+    static stubDefaultTripleQueryResponse(repositoryId, withDelay = 0) {
+        QueryStubs.stubQueryResponse(repositoryId, '/queries/default-triple-query-response.json', withDelay);
+    }
+
+    static stubQueryResponse(repositoryId, fixture, withDelay = 0) {
+        cy.intercept(`/repositories/${repositoryId}`, {fixture, delay: withDelay}).as(`${repositoryId}-stub-query`);
+    }
+
+    static stubQueryResults(queryDescription) {
+        const resultType = queryDescription.resultType;
+        const pageSize = queryDescription.pageSize;
+        const totalElements = queryDescription.totalElements;
+        const countQuery = queryDescription.countQuery;
+        const repositoryId = queryDescription.repositoryId;
+
+        const fullyFiledPages = Math.floor(totalElements / pageSize);
+        const elementsForLastPage = totalElements % pageSize;
+        const limit = countQuery ? pageSize + 1 : pageSize;
+
+        // Stubs responses for all fully filled pages.
+        for (let pageNumber = 0; pageNumber < fullyFiledPages; pageNumber++) {
+            const offset = pageNumber * pageSize;
+            let returnElements = pageSize;
+
+            if (QueryStubs.isLastPage(pageNumber, fullyFiledPages)) {
+                // Check if there are more results, if yes the query must return one more result.
+                if (elementsForLastPage > 0 && countQuery) {
+                    returnElements += 1;
+                }
+            } else {
+                if (countQuery) {
+                    // If there are more pages the query must return one more result.
+                    returnElements += 1;
+                }
+            }
+            const page = pageNumber + 1;
+            QueryStubs.stubQueryWithResults(repositoryId, page, offset, limit, returnElements, resultType);
+        }
+
+        // Stubs the last page with.
+        if (elementsForLastPage > 0) {
+            const offset = fullyFiledPages * pageSize;
+            const page = fullyFiledPages + 1;
+            QueryStubs.stubQueryWithResults(repositoryId, page, offset, limit, elementsForLastPage, resultType);
+        }
+
+        QueryStubs.stubTotalQueryCount(repositoryId, totalElements, resultType);
+    }
+
+    static isLastPage(currentPage, allPage) {
+        return allPage - currentPage === 1;
+    }
+
+    static stubQueryWithResults(repositoryId, page, offset, limit, returnResult, resultType) {
+        const result = QueryStubs.createEmptyResponse(resultType);
+        result.results.bindings = QueryStubs.createResults(resultType, page, returnResult);
+        cy.intercept(`/repositories/${repositoryId}`, (req) => {
+            if (req.body.indexOf(`limit=${limit}`) > -1 && req.body.indexOf(`offset=${offset}`) > -1) {
+                req.reply(result);
+            }
+        }).as(`query-${page}_${offset}_${limit}_${returnResult}`);
+    }
+
+    static stubTotalQueryCount(repositoryId, totalElements, resultType, delay = 0) {
+        const result = QueryStubs.createEmptyResponse(resultType);
+        result.results.bindings = [QueryStubs.createTotalResultsCount(resultType, totalElements)];
+        cy.intercept(`/repositories/${repositoryId}`, (req) => {
+            if (req.body.indexOf('count=1') > -1) {
+                req.reply(result);
+            }
+        }).as(`countQuery-${totalElements}`);
+    }
+
+    static createResults(resultType, page, count) {
+        const results = [];
+        for (let index = 0; index < count; index++) {
+            results.push(QueryStubs.createAnResult(resultType, page, index + 1));
+        }
+        return results;
+    }
+
+    static createAnResult(resultType, page, row) {
+        switch (resultType) {
+            case ResultType.URI:
+                return this.createAnUriResult(page, row);
+            case ResultType.TRIPLE:
+                return this.createAnTripleResult(page, row);
+        }
+    }
+
+    static createAnTripleResult(page, row) {
+        return {
+            t : {
+                type : "triple",
+                value : {
+                    s : {
+                        type : "uri",
+                        value : QueryStubs.createAnUri(page, row, 1)
+                    },
+                    p : {
+                        type : "uri",
+                        value : QueryStubs.createAnUri(page, row, 2)
+                    },
+                    o : {
+                        type : "uri",
+                        value : QueryStubs.createAnUri(page, row, 3)
+                    }
+                }
+            }
+        };
+    }
+
+    static createAnUriResult(page, row) {
+        return {
+            s: {
+                type: "uri",
+                value: QueryStubs.createAnUri(page, row, 1)
+            },
+            p: {
+                type: "uri",
+                value: QueryStubs.createAnUri(page, row, 2)
+            },
+            o: {
+                type: "uri",
+                value: QueryStubs.createAnUri(page, row, 3)
+            }
+        };
+    }
+
+    static createAnUri(page, row, column) {
+        return `http://ontotext-yasgui/generated-yri#page_${page}-row_${row}-column_${column}`;
+    }
+
+    static createEmptyResponse(resultType) {
+        switch (resultType) {
+            case ResultType.URI:
+                return QueryStubs.createEmptyUriResponse();
+            case ResultType.TRIPLE:
+                return QueryStubs.createTripleResponse();
+        }
+    }
+
+    static createEmptyUriResponse() {
+        return {
+            head: {
+                vars: ["s", "p", "o"]
+            },
+            results: {
+                bindings: []
+            }
+        };
+    }
+
+    static createTripleResponse() {
+        return {
+            head: {
+                vars: ["t"]
+            },
+            results: {
+                bindings: []
+            }
+        };
+    }
+
+    static createTotalResultsCount(resultType, totalElement) {
+        switch (resultType) {
+            case ResultType.URI:
+                return QueryStubs.createUriTotalResultsCount(totalElement);
+            case ResultType.TRIPLE:
+                return QueryStubs.createTripleTotalResultsCount(totalElement);
+        }
+    }
+
+    static createUriTotalResultsCount(totalElement) {
+        return {
+            s: {
+                type: "uri",
+                value: `${totalElement}`
+            },
+            p: {
+                type: "uri",
+                value: `${totalElement}`
+            },
+            o: {
+                type: "uri",
+                value: `${totalElement}`
+            }
+        };
+    }
+
+    static createTripleTotalResultsCount(totalElement) {
+        return {
+            t: {
+                datatype: "http://www.w3.org/2001/XMLSchema#int",
+                type: "literal",
+                value: `${totalElement}`
+            }
+        };
     }
 }
+
+export class QueryStubDescription {
+    constructor() {
+      this.resultType = ResultType.URI;
+      this.countQuery = true;
+      this.pageSize = 1000;
+    }
+
+    setTotalElements(totalElements) {
+        this.totalElements = totalElements;
+        return this;
+    }
+
+    setCountQuery(countQuery) {
+        this.countQuery = countQuery;
+        return this;
+    }
+
+    setResultType(resultType) {
+        this.resultType = resultType;
+        return this;
+    }
+
+    setRepositoryId(repositoryId) {
+        this.repositoryId = repositoryId;
+        return this;
+    }
+}
+
+export const ResultType = {
+    'URI': 'uri',
+    'TRIPLE': 'triple'
+};


### PR DESCRIPTION
## What
Added pagination to yasr component.

## Why
Some queries returns a lot of results. To show all of it we need a lot of resource and visualization will be slow.

## How
 - Updates "ontotext-yasgui-web-component".
 - Refactoring query event. It is registered in output handlers.