### PR TITLE
GDB-8023: extends ontotext-yasgui notification handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "^0.0.2-TR22",
+                "ontotext-yasgui-web-component": "^0.0.2-TR23",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -9904,9 +9904,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR22",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR22.tgz",
-            "integrity": "sha512-KEyQUGtNXA/CuBlbDeDNVgAWPd7Bl5l14FotFHWuwzIje4qTkPNxVwN8KFZe3YyaD1ksAzpANTTR3oi7toTmVg==",
+            "version": "0.0.2-TR23",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR23.tgz",
+            "integrity": "sha512-PPiiZ7LYc+3PsQo2ujrWkS9qvyHdwMB7VEM7XxlXvAaUG0Ttj0Rt+cmHO/k6fvOutRFavdO5hA2Ujv00lFICOw==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24266,9 +24266,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR22",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR22.tgz",
-            "integrity": "sha512-KEyQUGtNXA/CuBlbDeDNVgAWPd7Bl5l14FotFHWuwzIje4qTkPNxVwN8KFZe3YyaD1ksAzpANTTR3oi7toTmVg==",
+            "version": "0.0.2-TR23",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR23.tgz",
+            "integrity": "sha512-PPiiZ7LYc+3PsQo2ujrWkS9qvyHdwMB7VEM7XxlXvAaUG0Ttj0Rt+cmHO/k6fvOutRFavdO5hA2Ujv00lFICOw==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "^0.0.2-TR22",
+        "ontotext-yasgui-web-component": "^0.0.2-TR23",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -1,4 +1,4 @@
-import {isNumber, merge} from "lodash";
+import {isFunction, merge} from "lodash";
 import {
     savedQueriesResponseMapper,
     queryPayloadFromEvent,
@@ -9,7 +9,6 @@ import {QueryMode} from "../utils/query-types";
 import {downloadAsFile, toYasguiOutputModel} from "../utils/yasgui-utils";
 import {YasrPluginName} from "../../../models/ontotext-yasgui/yasr-plugin-name";
 import {EventDataType} from "../../../models/ontotext-yasgui/event-data-type";
-import {NotificationMessageType} from "../../../models/ontotext-yasgui/notification-message-type";
 
 angular
     .module('graphdb.framework.sparql-editor.controllers', ['ui.bootstrap'])
@@ -385,14 +384,9 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
      * @param {NotificationMessageEvent} notificationMessageEvent - the "ontotext-yasgui-web-component" event.
      */
     const notificationMessageHandler = (notificationMessageEvent) => {
-        if (NotificationMessageType.SUCCESS === notificationMessageEvent.messageType) {
-            toastr.success(notificationMessageEvent.message);
-        } else if (NotificationMessageType.WARNING === notificationMessageEvent.messageType) {
-            toastr.warning(notificationMessageEvent.message);
-        } else if (NotificationMessageType.ERROR === notificationMessageEvent.messageType) {
-            toastr.error(notificationMessageEvent.message);
-        } else if (NotificationMessageType.INFO === notificationMessageEvent.messageType) {
-            toastr.info(notificationMessageEvent.message);
+        const notifyFunction = toastr[notificationMessageEvent.messageType];
+        if (isFunction(notifyFunction)) {
+            notifyFunction(notificationMessageEvent.message);
         }
     };
     outputHandlers.set(EventDataType.NOTIFICATION_MESSAGE, notificationMessageHandler);

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -391,6 +391,8 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
             toastr.warning(notificationMessageEvent.message);
         } else if (NotificationMessageType.ERROR === notificationMessageEvent.messageType) {
             toastr.error(notificationMessageEvent.message);
+        } else if (NotificationMessageType.INFO === notificationMessageEvent.messageType) {
+            toastr.info(notificationMessageEvent.message);
         }
     };
     outputHandlers.set(EventDataType.NOTIFICATION_MESSAGE, notificationMessageHandler);

--- a/src/models/ontotext-yasgui/notification-message-type.js
+++ b/src/models/ontotext-yasgui/notification-message-type.js
@@ -4,5 +4,6 @@
 export const NotificationMessageType = {
     'SUCCESS': 'success',
     'WARNING': 'warning',
-    'ERROR': 'error'
+    'ERROR': 'error',
+    'INFO': 'info'
 };


### PR DESCRIPTION
## What
Added a new type "info" of notification messages emitted by ontotext-yasgui-web-component.

## Why
When user try to open a new tab, but query is running, then a notification of type info have to be shown.

## How
Extends "notificationMessageHandler" to support info messages.

Additional work:
Increase version of "ontotext-yasgui-web-component".