### PR TITLE
GDB-8020: stop execution of query

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "^0.0.2-TR23",
+        "ontotext-yasgui-web-component": "^0.0.2-TR24",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -49,7 +49,8 @@ function SparqlEditorCtrl($scope, $location, $jwtAuth, $repositories, toastr, $t
                 },
                 prefixes: $scope.prefixes,
                 pageSize: 1000,
-                maxPersistentResponseSize: 500000
+                maxPersistentResponseSize: 500000,
+                isVirtualRepository: $repositories.isActiveRepoOntopType()
             };
         }
     };


### PR DESCRIPTION
## What
Stops execution of a query when:
- try to execute explain plan query for update query;
- try to execute update query on virtual repository

## Why
- Explain plan query can be executed only for construct or select queries;
- Virtual repository can't be updated.

## How
- Adds isVirtualRepository to ontotext-yasgui-web-component configuration.
- Updates version of ontotext-yasgui-web-component. Then new version supports this new requirements.
