### PR TITLE
GDB-8085: implement update query flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "^0.0.2-TR25",
+                "ontotext-yasgui-web-component": "^0.0.2-TR27",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -9904,9 +9904,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR25",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR25.tgz",
-            "integrity": "sha512-84EBI8ntI3EsNoMSHKmu+CAN1i6dTdmgYUG0TNm9ug/MwsJraf04gCRBbBE792CZLc2AfRlUFhZrNeZlVpsuRA==",
+            "version": "0.0.2-TR27",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR27.tgz",
+            "integrity": "sha512-zt1wZYXQBgDUlmbdxztNjhs1G6uMqOII0/yXSTu1GOOGSic1b0oc4BFl5V6PZCv/L3Z6A1rxf3snEeEIcMrmRQ==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24266,9 +24266,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR25",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR25.tgz",
-            "integrity": "sha512-84EBI8ntI3EsNoMSHKmu+CAN1i6dTdmgYUG0TNm9ug/MwsJraf04gCRBbBE792CZLc2AfRlUFhZrNeZlVpsuRA==",
+            "version": "0.0.2-TR27",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR27.tgz",
+            "integrity": "sha512-zt1wZYXQBgDUlmbdxztNjhs1G6uMqOII0/yXSTu1GOOGSic1b0oc4BFl5V6PZCv/L3Z6A1rxf3snEeEIcMrmRQ==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "^0.0.2-TR25",
+        "ontotext-yasgui-web-component": "^0.0.2-TR27",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/test-cypress/integration/sparql-editor/actions/exequte-update-query.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/exequte-update-query.spec.js
@@ -1,0 +1,84 @@
+import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
+import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
+import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {TablePluginSteps} from "../../../steps/yasgui/table-plugin-steps";
+
+describe('Execute of update query', () => {
+
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'sparql-editor-' + Date.now();
+        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        QueryStubs.stubDefaultQueryResponse(repositoryId);
+
+        SparqlEditorSteps.visitSparqlEditorPage();
+        YasguiSteps.getYasgui().should('be.visible');
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('should display properly result message info when no one statement is added.', () => {
+        // When I execute insert query which don't change repository statements
+        YasqeSteps.clearEditor();
+        YasqeSteps.writeInEditor(
+                 'PREFIX : <http://bedrock/> ' +
+                         'INSERT { ' +
+                                  ':fred :hasSpouse :wilma. ' +
+                                '} WHERE { ' +
+                                   'rdf:name rdf:label "not_exist_label".' +
+                                '}');
+        YasqeSteps.executeQuery();
+
+        // Then I expect result message info to informs me that statements did not change.
+        TablePluginSteps.getQueryResultInfo().contains('The number of statements did not change.');
+    });
+
+    it('should display properly result message info when insert 2 statements', () => {
+        // When I execute insert query which adds 2 results
+        YasqeSteps.clearEditor();
+        YasqeSteps.writeInEditor(
+                 'PREFIX : <http://bedrock/> ' +
+                         'INSERT DATA { ' +
+                            ':fred :hasSpouse :wilma.' +
+                            ':fred :hasChild :pebbles.' +
+                         '}');
+        YasqeSteps.executeQuery();
+
+        // Then I expect result message info to informs me that 2 statements have been added.
+        TablePluginSteps.getQueryResultInfo().contains('Added 2 statements.');
+    });
+
+    it('should display result message info which describes that two statements are removed', () => {
+        // When I visit a page with "ontotext-yasgui-web-component" in it,
+        // and selected repository has some inserted statements.
+        YasqeSteps.clearEditor();
+        YasqeSteps.writeInEditor(
+            'PREFIX : <http://bedrock/> ' +
+                    'INSERT DATA { ' +
+                         ':fred :hasSpouse :wilma.' +
+                         ':fred :hasChild :pebbles.' +
+                    '}');
+        YasqeSteps.executeQuery();
+        // Wait statements to be inserted.
+        TablePluginSteps.getQueryResultInfo().contains('Added 2 statements.');
+
+        // When I execute delete query which removes 2 results
+        YasqeSteps.clearEditor();
+        YasqeSteps.writeInEditor(
+            'PREFIX : <http://bedrock/> ' +
+                    'DELETE DATA { ' +
+                         ':fred :hasSpouse :wilma.' +
+                         ':fred :hasChild :pebbles.' +
+                    '}');
+        YasqeSteps.executeQuery();
+
+        // Then I expect result message info to informs me that 2 statements have been added.
+        TablePluginSteps.getQueryResultInfo().contains('Removed 2 statements.');
+    });
+});

--- a/test-cypress/steps/yasgui/table-plugin-steps.js
+++ b/test-cypress/steps/yasgui/table-plugin-steps.js
@@ -22,4 +22,8 @@ export class TablePluginSteps {
     static clickOutsideCopyLinkDialog() {
         cy.get('body').click(0, 0);
     }
+
+    static getQueryResultInfo() {
+        return cy.get('.tabPanel.active .yasr_response_chip');
+    }
 }

--- a/test-cypress/steps/yasgui/yasqe-steps.js
+++ b/test-cypress/steps/yasgui/yasqe-steps.js
@@ -11,12 +11,29 @@ export class YasqeSteps {
         return cy.get(".yasqe:visible");
     }
 
+    static getCodeMirror() {
+        return this.getEditor().find('.CodeMirror').then(($el) => {
+            // @ts-ignore
+            return $el[0].CodeMirror;
+        });
+    }
+
     static getExecuteQueryButton() {
         return cy.get('.yasqe_queryButton');
     }
 
     static executeQuery(tabIndex = 0) {
         this.getExecuteQueryButton(tabIndex).eq(tabIndex).click();
+    }
+
+    static clearEditor() {
+        this.getCodeMirror().then((cm) => {
+            cm.getDoc().setValue('');
+        });
+    }
+
+    static writeInEditor(text, parseSpecialCharSequences = false) {
+        this.getEditor().find('textarea').type(text, {force: true, parseSpecialCharSequences});
     }
 
     static getControlBar() {


### PR DESCRIPTION
## What
There is difference between the execution flow of "update" and "select" queries. Implements base functionality of update queries.

## Why
The update queries has not results and YASR have to be not visible. Result info message have to describe how many statements have been affected.

## How
- Updates version of "ontotext-yasgui-web-component".
- Implements callback function "getRepositoryStatementsCount", that returns repository statements count.