### PR TITLE
GDB-8115: Implement abort query button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "^0.0.2-TR27",
+                "ontotext-yasgui-web-component": "^0.0.2-TR28",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -9904,9 +9904,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR27",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR27.tgz",
-            "integrity": "sha512-zt1wZYXQBgDUlmbdxztNjhs1G6uMqOII0/yXSTu1GOOGSic1b0oc4BFl5V6PZCv/L3Z6A1rxf3snEeEIcMrmRQ==",
+            "version": "0.0.2-TR28",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR28.tgz",
+            "integrity": "sha512-YmsnhzLEPQjXL25li/1iqDF2OPdorejUs4cEu5pBf9DLQqi7YhtFp0EV0tLAELdfSxGrDUGsmYr2c2q1jedFoA==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24266,9 +24266,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR27",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR27.tgz",
-            "integrity": "sha512-zt1wZYXQBgDUlmbdxztNjhs1G6uMqOII0/yXSTu1GOOGSic1b0oc4BFl5V6PZCv/L3Z6A1rxf3snEeEIcMrmRQ==",
+            "version": "0.0.2-TR28",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR28.tgz",
+            "integrity": "sha512-YmsnhzLEPQjXL25li/1iqDF2OPdorejUs4cEu5pBf9DLQqi7YhtFp0EV0tLAELdfSxGrDUGsmYr2c2q1jedFoA==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "^0.0.2-TR27",
+        "ontotext-yasgui-web-component": "^0.0.2-TR28",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -92,7 +92,7 @@ function SparqlEditorCtrl($scope,
                     }
                 },
                 getRepositoryStatementsCount: ontotextYasguiWebComponentService.getRepositoryStatementsCount,
-                onAbortQuery: ontotextYasguiWebComponentService.onAbortQuery
+                onQueryAborted: ontotextYasguiWebComponentService.onQueryAborted
             };
         }
     };

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -10,10 +10,12 @@ import {downloadAsFile, toYasguiOutputModel} from "../utils/yasgui-utils";
 import {YasrPluginName} from "../../../models/ontotext-yasgui/yasr-plugin-name";
 import {EventDataType} from "../../../models/ontotext-yasgui/event-data-type";
 import 'angular/rest/connectors.rest.service';
+import 'services/ontotext-yasgui-web-component.service.js';
 
 const modules = [
     'ui.bootstrap',
-    'graphdb.framework.rest.connectors.service'
+    'graphdb.framework.rest.connectors.service',
+    'graphdb.framework.ontotext-yasgui-web-component'
 ];
 
 angular
@@ -33,7 +35,8 @@ SparqlEditorCtrl.$inject = [
     'ShareQueryLinkService',
     '$languageService',
     'RDF4JRepositoriesRestService',
-    'ConnectorsRestService'];
+    'ConnectorsRestService',
+    'OntotextYasguiWebComponentService'];
 
 function SparqlEditorCtrl($scope,
                           $q,
@@ -46,7 +49,9 @@ function SparqlEditorCtrl($scope,
                           AutocompleteRestService,
                           ShareQueryLinkService,
                           $languageService,
-                          RDF4JRepositoriesRestService, ConnectorsRestService) {
+                          RDF4JRepositoriesRestService,
+                          ConnectorsRestService,
+                          ontotextYasguiWebComponentService) {
     const ontoElement = document.querySelector('ontotext-yasgui');
     const headers = {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -86,23 +91,10 @@ function SparqlEditorCtrl($scope,
                         return autocompleteLocalNames(term, canceler);
                     }
                 },
-                getRepositoryStatementsCount: getRepositoryStatementsCount
+                getRepositoryStatementsCount: ontotextYasguiWebComponentService.getRepositoryStatementsCount,
+                onAbortQuery: ontotextYasguiWebComponentService.onAbortQuery
             };
         }
-    };
-
-    const getRepositoryStatementsCount = () => {
-        // A promise is returned because the $http of  angularjs use HttpPromise and its behavior is different than we expect.
-        // Here is an article that describes the problems AngularJS HttpPromise methods break promise chain {@link https://medium.com/@ExplosionPills/angularjs-httppromise-methods-break-promise-chain-950c85fa1fe7}
-        return RDF4JRepositoriesRestService.getRepositorySize()
-            .then((response) => Promise.resolve(parseInt(response.data)))
-            .catch(function (data) {
-                const params = {
-                    repo: $repositories.getActiveRepository(),
-                    error: getError(data)
-                };
-                toastr.warning($translate.instant('query.editor.repo.size.error', params));
-            });
     };
 
     // =========================

--- a/src/js/services/ontotext-yasgui-web-component.service.js
+++ b/src/js/services/ontotext-yasgui-web-component.service.js
@@ -1,0 +1,38 @@
+const modules = [];
+
+angular
+    .module('graphdb.framework.ontotext-yasgui-web-component', modules)
+    .factory('OntotextYasguiWebComponentService', OntotextYasguiWebComponentService);
+
+OntotextYasguiWebComponentService.$inject = ['MonitoringRestService', 'RDF4JRepositoriesRestService', '$repositories', 'toastr', '$translate'];
+
+function OntotextYasguiWebComponentService(MonitoringRestService, RDF4JRepositoriesRestService, $repositories, toastr, $translate) {
+
+    const onAbortQuery = (req) => {
+        if (req) {
+            const repository = req.url.substring(req.url.lastIndexOf('/') + 1);
+            const currentTrackAlias = req.header['X-GraphDB-Track-Alias'];
+            return MonitoringRestService.deleteQuery(currentTrackAlias, repository)
+                .then(() => Promise.resolve());
+        }
+    };
+
+    const getRepositoryStatementsCount = () => {
+        // A promise is returned because the $http of  angularjs use HttpPromise and its behavior is different than we expect.
+        // Here is an article that describes the problems AngularJS HttpPromise methods break promise chain {@link https://medium.com/@ExplosionPills/angularjs-httppromise-methods-break-promise-chain-950c85fa1fe7}
+        return RDF4JRepositoriesRestService.getRepositorySize()
+            .then((response) => Promise.resolve(parseInt(response.data)))
+            .catch(function (data) {
+                const params = {
+                    repo: $repositories.getActiveRepository(),
+                    error: getError(data)
+                };
+                toastr.warning($translate.instant('query.editor.repo.size.error', params));
+            });
+    };
+
+    return {
+        onAbortQuery,
+        getRepositoryStatementsCount
+    };
+}

--- a/src/js/services/ontotext-yasgui-web-component.service.js
+++ b/src/js/services/ontotext-yasgui-web-component.service.js
@@ -8,7 +8,7 @@ OntotextYasguiWebComponentService.$inject = ['MonitoringRestService', 'RDF4JRepo
 
 function OntotextYasguiWebComponentService(MonitoringRestService, RDF4JRepositoriesRestService, $repositories, toastr, $translate) {
 
-    const onAbortQuery = (req) => {
+    const onQueryAborted = (req) => {
         if (req) {
             const repository = req.url.substring(req.url.lastIndexOf('/') + 1);
             const currentTrackAlias = req.header['X-GraphDB-Track-Alias'];
@@ -32,7 +32,7 @@ function OntotextYasguiWebComponentService(MonitoringRestService, RDF4JRepositor
     };
 
     return {
-        onAbortQuery,
+        onQueryAborted,
         getRepositoryStatementsCount
     };
 }

--- a/test-cypress/integration/sparql-editor/saved-query/abort-query.spec.js
+++ b/test-cypress/integration/sparql-editor/saved-query/abort-query.spec.js
@@ -1,0 +1,58 @@
+import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
+
+describe('Abort query', () => {
+
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'sparql-editor-' + Date.now();
+        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+
+        SparqlEditorSteps.visitSparqlEditorPage();
+        YasguiSteps.getYasgui().should('be.visible');
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('should abort query when click on "Abort query" button.', () => {
+        // When I visit a page with "ontotext-yasgui-web-component" in it,
+        // and execute a query that takes a long time.
+        YasqeSteps.clearEditor();
+        YasqeSteps.writeInEditor(
+            'select (count(*) as ?count) where {?s ?p ?o. ?s1 ?p1 ?o1. ?s2 ?p2 ?o2. ?s3 ?p3 ?o3.}');
+        YasqeSteps.executeQuery();
+
+        // Then I expect to an "Abort query" button to be displayed,
+        YasqeSteps.getAbortQueryButton().should('exist');
+        // and button has text
+        YasqeSteps.getAbortQueryButton().should('have.text', 'Abort query');
+
+        // When I hover over the "Abort button".
+        YasqeSteps.hoverOverAbortQueryButton();
+
+        // Then I expect to see tooltip that describes what happen if click on it.
+        cy.get('div[data-tippy-root]').contains('Click to abort query');
+
+        // When I click on the button.
+        YasqeSteps.getAbortQueryButton().realClick();
+
+        // Then I expect button text to be changed.
+        YasqeSteps.getAbortQueryButton().should('have.text', 'Stop has been requested');
+
+        // When I hover over the "Stop has been requested".
+        YasqeSteps.hoverOverAbortQueryButton();
+
+        // Then I expect to see tooltip that describes what happen if click on it.
+        YasguiSteps.getTooltipRoot().contains('Query was requested to abort and will be terminated on the first I/O operation');
+
+        // When abort query finished.
+        // I expect the button not be visible.
+        YasqeSteps.getAbortQueryButton().should('not.be.visible');
+    });
+});

--- a/test-cypress/steps/yasgui/yasgui-steps.js
+++ b/test-cypress/steps/yasgui/yasgui-steps.js
@@ -170,6 +170,10 @@ export class YasguiSteps {
     static confirmDeleteOperation() {
         this.getDeleteQueryConfirmation().find('.confirm-button').click();
     }
+
+    static getTooltipRoot() {
+        return cy.get('div[data-tippy-root]');
+    }
 }
 
 export class TabContextMenu {

--- a/test-cypress/steps/yasgui/yasqe-steps.js
+++ b/test-cypress/steps/yasgui/yasqe-steps.js
@@ -71,4 +71,16 @@ export class YasqeSteps {
     static shareQuery() {
         this.getShareQueryButton().click();
     }
+
+    static getAbortQueryButton() {
+        return cy.get('.abort-button');
+    }
+
+    static hoverOverAbortQueryButton() {
+        YasqeSteps.getAbortQueryButton().realHover();
+    }
+
+    static getAbortQueryTooltip() {
+        return YasqeSteps.getAbortQueryButton().parent();
+    }
 }


### PR DESCRIPTION
## What
Added ability to abort a query. When the user clicks on "Run" button, an "Abort query" button will be displayed. If the user click on this button, the running query will be aborted.

## Why
WB has such functionality. This functionality will give to the users opportunity to canceled long-running queries.

## How
- Increases "ontotext-yasgui-web-component" version.
- Implements function "onAbortQuery".