### PR TITLE
GDB-8085: implement update query flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "^0.0.2-TR30",
+                "ontotext-yasgui-web-component": "^0.0.2-TR31",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -9904,9 +9904,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR30",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR30.tgz",
-            "integrity": "sha512-qPXbau/cD1aUZJr4KoAh/K0CZJcev1KUqGIqDX9uidhMljqs3mO2y1OX6n8qRTaD6HH2QVCNx/5B84c+mGCerg==",
+            "version": "0.0.2-TR31",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR31.tgz",
+            "integrity": "sha512-g9C5g/rFOVTX5koyVZKkWWGHGc4RVoY7PudLBgmgEf5usndpuI4Kh5xL2Hmpb0lyqB11wjyDugT1mwPlxKxuoQ==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24266,9 +24266,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR30",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR30.tgz",
-            "integrity": "sha512-qPXbau/cD1aUZJr4KoAh/K0CZJcev1KUqGIqDX9uidhMljqs3mO2y1OX6n8qRTaD6HH2QVCNx/5B84c+mGCerg==",
+            "version": "0.0.2-TR31",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR31.tgz",
+            "integrity": "sha512-g9C5g/rFOVTX5koyVZKkWWGHGc4RVoY7PudLBgmgEf5usndpuI4Kh5xL2Hmpb0lyqB11wjyDugT1mwPlxKxuoQ==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "^0.0.2-TR30",
+        "ontotext-yasgui-web-component": "^0.0.2-TR31",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/src/js/angular/utils/yasgui-utils.js
+++ b/src/js/angular/utils/yasgui-utils.js
@@ -5,6 +5,7 @@ import {CountQueryResponseEvent} from "../../../models/ontotext-yasgui/count-que
 import {CountQueryRequestEvent} from "../../../models/ontotext-yasgui/count-query-request-event";
 import {DownloadAsEvent} from "../../../models/ontotext-yasgui/download-as-event";
 import {NotificationMessageEvent} from "../../../models/ontotext-yasgui/notification-message-event";
+import {QueryExecutedEvent} from "../../../models/ontotext-yasgui/query-executed-event";
 
 export const toEventData = ($event) => {
     return new EventData($event.detail.TYPE, $event.detail.payload);
@@ -23,6 +24,8 @@ export const toYasguiOutputModel = ($event) => {
             return new CountQueryResponseEvent(eventData);
         case EventDataType.QUERY:
             return new QueryRequestEvent(eventData);
+        case EventDataType.QUERY_EXECUTED:
+            return new QueryExecutedEvent(eventData);
         default:
             return eventData;
     }

--- a/src/js/services/ontotext-yasgui-web-component.service.js
+++ b/src/js/services/ontotext-yasgui-web-component.service.js
@@ -10,6 +10,9 @@ OntotextYasguiWebComponentService.$inject = ['MonitoringRestService', 'RDF4JRepo
 
 function OntotextYasguiWebComponentService(MonitoringRestService, RDF4JRepositoriesRestService, $repositories, toastr, $translate, $location) {
 
+    const supportedLanguages = ['en', 'fr'];
+    let allTranslations;
+
     const onQueryAborted = (req) => {
         if (req) {
             const repository = req.url.substring(req.url.lastIndexOf('/') + 1);
@@ -84,9 +87,20 @@ function OntotextYasguiWebComponentService(MonitoringRestService, RDF4JRepositor
         }
     }
 
+    const getTranslations = () => {
+        if (!this.allTranslations) {
+            this.allTranslations = {}
+            supportedLanguages.forEach((langKey) => {
+                return this.allTranslations[langKey] = $translate.getTranslationTable(langKey);
+            });
+        }
+        return this.allTranslations;
+    }
+
     return {
         onQueryAborted,
         getRepositoryStatementsCount,
-        exploreVisualGraphYasrToolbarElementBuilder
+        exploreVisualGraphYasrToolbarElementBuilder,
+        getTranslations,
     };
 }

--- a/src/models/ontotext-yasgui/before-update-query-result.js
+++ b/src/models/ontotext-yasgui/before-update-query-result.js
@@ -1,0 +1,13 @@
+export class BeforeUpdateQueryResult {
+    constructor(status, messageLabelKey, parameters, mesage) {
+        this.status = status;
+        this.mesage = mesage;
+        this.messageLabelKey = messageLabelKey;
+        this.parameters = parameters;
+    }
+}
+
+export const BeforeUpdateQueryResultStatus = {
+    ERROR: 'error',
+    SUCCESS: 'success'
+};

--- a/src/models/ontotext-yasgui/event-data-type.js
+++ b/src/models/ontotext-yasgui/event-data-type.js
@@ -6,5 +6,6 @@ export const EventDataType = {
     'NOTIFICATION_MESSAGE': 'notificationMessage',
     'QUERY': 'query',
     'COUNT_QUERY': 'countQuery',
-    'COUNT_QUERY_RESPONSE': 'countQueryResponse'
+    'COUNT_QUERY_RESPONSE': 'countQueryResponse',
+    'QUERY_EXECUTED': 'queryExecuted'
 };

--- a/src/models/ontotext-yasgui/query-executed-event.js
+++ b/src/models/ontotext-yasgui/query-executed-event.js
@@ -1,0 +1,15 @@
+/**
+ * Model for event of type {@link EventDataType.QUERY_EXECUTED} emitted by "ontotext-yasgui-web-component".
+ */
+export class QueryExecutedEvent {
+    /**
+     * Constructs the model for {@link EventDataType.QUERY_EXECUTED} event.
+     *
+     * @param {EventData} eventData - event emitted by "ontotext-yasgui-web-component".
+     */
+    constructor(eventData) {
+        this.TYPE = eventData.TYPE;
+        this.duration = eventData.payload.duration;
+        this.tabId = eventData.payload.tabId;
+    }
+}

--- a/test-cypress/integration/sparql-editor/actions/execute-query.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/execute-query.spec.js
@@ -9,7 +9,7 @@ describe('Execute query', () => {
 
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         QueryStubs.stubDefaultQueryResponse(repositoryId);

--- a/test-cypress/integration/sparql-editor/actions/exequte-update-query.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/exequte-update-query.spec.js
@@ -10,7 +10,7 @@ describe('Execute of update query', () => {
 
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         QueryStubs.stubDefaultQueryResponse(repositoryId);

--- a/test-cypress/integration/sparql-editor/actions/expand-results-over-sameas.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/expand-results-over-sameas.spec.js
@@ -9,7 +9,7 @@ describe('Expand results over owl:sameAs', () => {
 
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         cy.intercept(`/repositories/${repositoryId}`, {fixture: '/graphql-editor/default-query-response.json'}).as('query');

--- a/test-cypress/integration/sparql-editor/actions/include-inferred-statements.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/include-inferred-statements.spec.js
@@ -9,7 +9,7 @@ describe('Include inferred statements', () => {
 
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         cy.intercept(`/repositories/${repositoryId}`, {fixture: '/graphql-editor/default-query-response.json'}).as('query');

--- a/test-cypress/integration/sparql-editor/actions/save-query.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/save-query.spec.js
@@ -12,7 +12,7 @@ describe('Save query', () => {
 
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         QueryStubs.stubDefaultQueryResponse(repositoryId);

--- a/test-cypress/integration/sparql-editor/actions/share-query.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/share-query.spec.js
@@ -12,7 +12,7 @@ describe('Share query', () => {
 
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         QueryStubs.stubDefaultQueryResponse(repositoryId);

--- a/test-cypress/integration/sparql-editor/actions/show-saved-queries.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/show-saved-queries.spec.js
@@ -1,6 +1,7 @@
 import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
 import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
 import {SavedQueriesDialog} from "../../../steps/yasgui/saved-queries-dialog";
+import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
 
 describe('Show saved queries', () => {
 
@@ -8,7 +9,7 @@ describe('Show saved queries', () => {
 
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         cy.intercept(`/repositories/${repositoryId}`, {fixture: '/graphql-editor/default-query-response.json'}).as('getGuides');

--- a/test-cypress/integration/sparql-editor/internationalization.spec.js
+++ b/test-cypress/integration/sparql-editor/internationalization.spec.js
@@ -9,7 +9,7 @@ describe('Internationalization of ontotext-yasgui-web-component', () => {
 
     beforeEach(() => {
         const repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         QueryStubs.stubDefaultQueryResponse(repositoryId);

--- a/test-cypress/integration/sparql-editor/lucene-connector.spec.js
+++ b/test-cypress/integration/sparql-editor/lucene-connector.spec.js
@@ -5,13 +5,14 @@ import {ConnectorsStubs} from "../../stubs/yasgui/connectors-stubs";
 import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
 import {ErrorPluginSteps} from "../../steps/yasgui/plugin/error-plugin-steps";
 import {TablePluginSteps} from "../../steps/yasgui/table-plugin-steps";
+import {QueryStubs} from "../../stubs/yasgui/query-stubs";
 
 describe('Connectors - Lucene', () => {
     let repositoryId;
 
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
 

--- a/test-cypress/integration/sparql-editor/lucene-connector.spec.js
+++ b/test-cypress/integration/sparql-editor/lucene-connector.spec.js
@@ -1,0 +1,65 @@
+import {SparqlEditorSteps} from "../../steps/sparql-editor-steps";
+import {YasguiSteps} from "../../steps/yasgui/yasgui-steps";
+import {LuceneConnectorSteps} from "../../steps/lucene-connector-steps";
+import {ConnectorsStubs} from "../../stubs/yasgui/connectors-stubs";
+import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
+import {ErrorPluginSteps} from "../../steps/yasgui/plugin/error-plugin-steps";
+import {TablePluginSteps} from "../../steps/yasgui/table-plugin-steps";
+
+describe('Connectors - Lucene', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'sparql-editor-' + Date.now();
+        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+
+        SparqlEditorSteps.visitSparqlEditorPage();
+        YasguiSteps.getYasgui().should('be.visible');
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('should display error message if connector not supported.', () => {
+        // When I execute connector query which has not supported command.
+        ConnectorsStubs.stubLuceneHasNotSupport();
+        YasqeSteps.clearEditor();
+        YasqeSteps.writeInEditor(LuceneConnectorSteps.getCreateConnectorQuery());
+        YasqeSteps.executeQuery();
+
+        // Then I expect error message to be displayed.
+        ErrorPluginSteps.getErrorPluginBody().contains('No support for lucene-connector, lucene-connector connectors are not supported because the plugin Lucene is not active.');
+    });
+
+    it('should create Lucene connector.', () => {
+        // When I execute create lucene connector query.
+        YasqeSteps.clearEditor();
+        YasqeSteps.writeInEditor(LuceneConnectorSteps.getCreateConnectorQuery());
+        YasqeSteps.executeQuery();
+
+        // Then I expect Lucene connector to be created.
+        TablePluginSteps.getQueryResultInfo().contains('Created connector my_index');
+    });
+
+    it('should delete Lucene connector.', () => {
+        // Given a lucene connector is created.
+        YasqeSteps.clearEditor();
+        YasqeSteps.writeInEditor(LuceneConnectorSteps.getCreateConnectorQuery());
+        YasqeSteps.executeQuery();
+
+        // Then I expect Lucene connector to be created.
+        // This check is used to be sure that connector is created.
+        TablePluginSteps.getQueryResultInfo().contains('Created connector my_index');
+
+        // When I execute delete lucene connector query.
+        YasqeSteps.clearEditor();
+        YasqeSteps.writeInEditor(LuceneConnectorSteps.getDeleteConnectorSteps());
+        YasqeSteps.executeQuery();
+
+        // Then I expect Lucene connector to be created.
+        TablePluginSteps.getQueryResultInfo().contains('Deleted connector my_index');
+    });
+});

--- a/test-cypress/integration/sparql-editor/saved-query/abort-query.spec.js
+++ b/test-cypress/integration/sparql-editor/saved-query/abort-query.spec.js
@@ -1,6 +1,7 @@
 import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
 import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
 import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
+import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
 
 describe('Abort query', () => {
 
@@ -8,7 +9,7 @@ describe('Abort query', () => {
 
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
 

--- a/test-cypress/integration/sparql-editor/saved-query/delete-query.spec.js
+++ b/test-cypress/integration/sparql-editor/saved-query/delete-query.spec.js
@@ -12,7 +12,7 @@ describe('Delete saved queries', () => {
 
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         QueryStubs.stubDefaultQueryResponse(repositoryId);

--- a/test-cypress/integration/sparql-editor/saved-query/edit-query.spec.js
+++ b/test-cypress/integration/sparql-editor/saved-query/edit-query.spec.js
@@ -11,7 +11,7 @@ describe('Edit saved queries', () => {
 
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         QueryStubs.stubDefaultQueryResponse(repositoryId);

--- a/test-cypress/integration/sparql-editor/saved-query/share-query.spec.js
+++ b/test-cypress/integration/sparql-editor/saved-query/share-query.spec.js
@@ -12,7 +12,7 @@ describe('Share saved queries', () => {
 
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         QueryStubs.stubDefaultQueryResponse(repositoryId);

--- a/test-cypress/integration/sparql-editor/sparql-editor.spec.js
+++ b/test-cypress/integration/sparql-editor/sparql-editor.spec.js
@@ -1,11 +1,12 @@
 import {SparqlEditorSteps} from "../../steps/sparql-editor-steps";
 import {YasguiSteps} from "../../steps/yasgui/yasgui-steps";
+import {QueryStubs} from "../../stubs/yasgui/query-stubs";
 
 describe('Default view', () => {
 
     beforeEach(() => {
         const repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         cy.intercept('/repositories/test-repo', {fixture: '/graphql-editor/default-query-response.json'}).as('getGuides');

--- a/test-cypress/integration/sparql-editor/yasgui-tabs.spec.js
+++ b/test-cypress/integration/sparql-editor/yasgui-tabs.spec.js
@@ -3,12 +3,13 @@ import {TabContextMenu, YasguiSteps} from "../../steps/yasgui/yasgui-steps";
 import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
 import {YasrSteps} from "../../steps/yasgui/yasr-steps";
 import {ConfirmationDialogSteps} from "../../steps/yasgui/confirmation-dialog-steps";
+import {QueryStubs} from "../../stubs/yasgui/query-stubs";
 
 describe('Yasgui tabs', () => {
 
     beforeEach(() => {
         const repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         cy.intercept('/repositories/test-repo', {fixture: '/graphql-editor/default-query-response.json'}).as('getGuides');

--- a/test-cypress/integration/sparql-editor/yasr/download-as.spec.js
+++ b/test-cypress/integration/sparql-editor/yasr/download-as.spec.js
@@ -7,7 +7,7 @@ describe('Download results', () => {
     let repositoryId;
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         QueryStubs.stubDefaultQueryResponse(repositoryId);

--- a/test-cypress/integration/sparql-editor/yasr/pagination.spec.js
+++ b/test-cypress/integration/sparql-editor/yasr/pagination.spec.js
@@ -9,7 +9,7 @@ describe('Yasr result pagination', () => {
     let repositoryId;
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         NamespaceStubs.stubGeneratedOntotextNamespacesResponse(repositoryId);

--- a/test-cypress/integration/sparql-editor/yasr/table-plugin.spec.js
+++ b/test-cypress/integration/sparql-editor/yasr/table-plugin.spec.js
@@ -9,7 +9,7 @@ describe('Yasr Table plugin', () => {
     let repositoryId;
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         QueryStubs.stubDefaultQueryResponse(repositoryId);

--- a/test-cypress/integration/sparql-editor/yasr/toolbar/visual-button.spec.js
+++ b/test-cypress/integration/sparql-editor/yasr/toolbar/visual-button.spec.js
@@ -1,12 +1,13 @@
 import {SparqlEditorSteps} from "../../../../steps/sparql-editor-steps";
 import {YasqeSteps} from "../../../../steps/yasgui/yasqe-steps";
 import {YasrSteps} from "../../../../steps/yasgui/yasr-steps";
+import {QueryStubs} from "../../../../stubs/yasgui/query-stubs";
 
 describe('Visual button when user execute a CONSTRUCT query.', () => {
     let repositoryId;
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+        QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         // Given I visit a page with "ontotex-yasgu-web-component" in it.

--- a/test-cypress/steps/lucene-connector-steps.js
+++ b/test-cypress/steps/lucene-connector-steps.js
@@ -1,0 +1,43 @@
+export class LuceneConnectorSteps {
+    static getCreateConnectorQuery() {
+        return `PREFIX luc: <http://www.ontotext.com/connectors/lucene#> ` +
+                `PREFIX luc-index: <http://www.ontotext.com/connectors/lucene/instance#> ` +
+                    `INSERT DATA { ` +
+                        `luc-index:my_index luc:createConnector ''' { ` +
+                            `"types": [` +
+                                `"http://www.ontotext.com/example/wine#Wine"` +
+                            `],` +
+                            `"fields": [` +
+                                `{` +
+                                    `"fieldName": "grape", ` +
+                                    `"propertyChain": [` +
+                                        `"http://www.ontotext.com/example/wine#madeFromGrape", ` +
+                                        `"http://www.w3.org/2000/01/rdf-schema#label"` +
+                                     `]` +
+                                `}, {` +
+                                    `"fieldName": "sugar", ` +
+                                    `"analyzed": false,` +
+                                    `"multivalued": false,` +
+                                    `"propertyChain": [` +
+                                        `"http://www.ontotext.com/example/wine#hasSugar"` +
+                                        `]` +
+                                `}, { ` +
+                                    `"fieldName": "year", ` +
+                                    `"analyzed": false, ` +
+                                    `"propertyChain": [` +
+                                        `"http://www.ontotext.com/example/wine#hasYear"` +
+                                    `]` +
+                                `}` +
+                            `]` +
+                        `}''' ` +
+                `.}`;
+    }
+
+    static getDeleteConnectorSteps() {
+        return `PREFIX luc: <http://www.ontotext.com/connectors/lucene#>` +
+                `PREFIX luc-index: <http://www.ontotext.com/connectors/lucene/instance#>` +
+                `INSERT DATA {` +
+                `  luc-index:my_index luc:dropConnector [] .` +
+                `}`;
+    }
+}

--- a/test-cypress/steps/yasgui/plugin/error-plugin-steps.js
+++ b/test-cypress/steps/yasgui/plugin/error-plugin-steps.js
@@ -1,0 +1,10 @@
+export class ErrorPluginSteps {
+
+    static getErrorPlugin() {
+        return cy.get('.error-response-plugin');
+    }
+
+    static getErrorPluginBody() {
+        return ErrorPluginSteps.getErrorPlugin().find('.error-response-plugin-body');
+    }
+}

--- a/test-cypress/stubs/yasgui/connectors-stubs.js
+++ b/test-cypress/stubs/yasgui/connectors-stubs.js
@@ -1,0 +1,12 @@
+export class ConnectorsStubs {
+
+    static stubLuceneHasNotSupport() {
+        ConnectorsStubs.stubCheckConnector('create', 'lucene-connector', 'Lucene', false);
+    }
+
+    static stubCheckConnector(command, connectorName, pluginName, hasSupport) {
+        cy.intercept(`rest/connectors/check`, (req) => {
+            req.reply({command, connectorName, pluginName, hasSupport});
+        }).as(`query-connector-has-not-support`);
+    }
+}

--- a/test-cypress/stubs/yasgui/query-stubs.js
+++ b/test-cypress/stubs/yasgui/query-stubs.js
@@ -1,4 +1,7 @@
 export class QueryStubs {
+    static stubQueryCountResponse() {
+        cy.intercept('GET', '/rest/monitor/query/count', {body: 0});
+    }
     static stubDefaultQueryResponse(repositoryId, withDelay = 0) {
         QueryStubs.stubQueryResponse(repositoryId, '/graphql-editor/default-query-response.json', withDelay);
     }


### PR DESCRIPTION
## What
Adds visualisation of custom message 'error' or 'success' returned by "beforeUpdateQuery".

## Why
WB has functionality which checks every update queries before execute it. Depends on result the query can be executed or not.

## How
Extends the result of "beforeUpdateQuery" function passed through configuration. The result returns status which can be "error" or "success". Depends on the status, the result message is displayed as error or result info message.