### PR TITLE
GDB-8232: executing a saved query from the welcome page

### DIFF
--- a/src/js/angular/core/directives/queryeditor/query-editor.directive.js
+++ b/src/js/angular/core/directives/queryeditor/query-editor.directive.js
@@ -847,13 +847,22 @@ function queryEditorDirective($timeout, $location, toastr, $repositories, Sparql
                         warning: true
                     }).result
                         .then(function () {
-                            scope.runQuery(false);
+                            autoExecuteQuery(true);
+                        }, function () {
+                            autoExecuteQuery(false);
                         });
                 } else {
                     scope.runQuery(false);
                 }
             }
         }
+
+        const autoExecuteQuery = (execute) => {
+            $location.search('execute', null);
+            if (execute) {
+                scope.runQuery(false);
+            }
+        };
 
         function loadQueryIntoExistingOrNewTab(query, infer, sameAs) {
             const tabId = scope.getExistingTabId(query);


### PR DESCRIPTION
## What
When I execute a query from "Saved SPARQL queries" in Welcome page, then "sparql" page is loaded with the query and a confirm dialog is opened. When the dialog is closed no matter how: "Yes", "Cancel" or "x" button and refresh the page dialog is opened again.

## Why
When execute a saved query is from Welcome page the url that triggers "sparql" view be opened contains a parameter "execute". This parameter triggers the opening of a confirmation dialog.

## How
Added code that removes "execute" parameter from the url when dialog is closed.