### PR TITLE
GDB-8129: Long IRIs are cut from the SPARQL results view

### DIFF
--- a/src/css/yasr.custom.css
+++ b/src/css/yasr.custom.css
@@ -99,12 +99,13 @@
 
 .yasr .uri-cell {
     display: inline;
-    word-break: normal !important;
-    word-wrap: break-word !important;
+    word-break: break-word !important;
+    overflow-wrap: break-word !important;
 }
 
 .yasr .literal-cell {
-    word-wrap: break-word !important;
+    word-break: normal !important;
+    overflow-wrap: break-word !important;
     -webkit-hyphens: auto;
     -moz-hyphens: auto;
     hyphens: auto;


### PR DESCRIPTION
## What
When data of a result cell is IRI that contains a long word. For example "http://example.com/foobarbaz/meeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeow/123", then the data is cut at the end.

## Why
There was style that prevent browser to cut long words.

## How
Changed styling of cells with IRI data.