### PR TITLE
GDB-8129: Long IRIs are cut from the SPARQL results view

### DIFF
--- a/src/js/lib/yasr.bundled.js
+++ b/src/js/lib/yasr.bundled.js
@@ -57246,7 +57246,12 @@ var root = module.exports = function(yasr) {
 };
 
 var addWorldBreakTagAfterSpecialCharacters = function (text) {
-	return text.replace(/([_:/-](?![_:/-]))/g, "$1<wbr>");
+	// Add wbr tag after "_" or ":" only if they are not followed by "_", ":" or "-".
+	return text.replace(/([_:](?![_:/-]))/g, "$1<wbr>")
+		// Add wbr tag after "/" only if it is not preceded by "<" and not followed by "/", "_", ":" or "-"
+		.replace(/((?<!<)[/](?![_:/-]))/g, "$1<wbr>")
+		// Add wbr tag after "-" only if it is not preceded by "@" followed by characters regardless of the language and not followed by "/", "_", ":" or "-"
+		.replace(/((?<!@\p{L}*)[-](?![_:/-]))/gu, "$1<wbr>");
 };
 
 var addWorldBreakTagBeforeSpecialCharacters = function (text) {

--- a/test-cypress/integration/sparql/sparql-result-formating.spec.js
+++ b/test-cypress/integration/sparql/sparql-result-formating.spec.js
@@ -31,6 +31,9 @@ describe('Formatting of SPARQL result bindings.', () => {
         SparqlSteps.typeQuery('select * where { values (?x ) { ("some text "@en-GB) }}');
         SparqlSteps.executeQuery();
 
+        SparqlSteps.getResultNoUriCell(0, 1).then(function($el) {
+            expect($el.html()).to.eq('"some text "<sup>@en-GB</sup>');
+        });
         // Then I expect break-word is applied,
         SparqlSteps.getResultNoUriCell(0, 1).should('have.css', 'word-wrap', 'break-word');
         // language attribute is applied.


### PR DESCRIPTION
GDB-8129: Long IRIs are cut from the SPARQL results view

## What
When you run a query that returns a result with a language tag, the display of the result is wrong. For example:
 - if some literal has an "en" tag, then "@ensup>" will be displayed;
 - if some literal has an "en-GB" tag, then the html of the literal is "@en-<wbr>GBsup>";

## Why
 Before displaying the results, we insert a <wbr> after special characters (_:/-) to ensure that the result will not be an overflow cell element. The problem occurred because the literals that has language tag contains "/" (an of the special characters which we process). As result the html of the processing literal is "<sup>@en/<wbr>sup>".

## How
Updates yasr.bundled.js.

Additional work:
Updates test to cover described scenarios.