### PR TITLE
GDB-8232: Removes all parameters when page is loaded.

### DIFF
--- a/src/js/angular/core/directives/queryeditor/query-editor.directive.js
+++ b/src/js/angular/core/directives/queryeditor/query-editor.directive.js
@@ -867,6 +867,8 @@ function queryEditorDirective($timeout, $location, toastr, $repositories, Sparql
                 }
                 autoexecuteQueryIfRequested();
                 $location.search({});
+                // Replace current URL without adding a new history entry
+                $location.replace();
                 onHandler();
             });
 

--- a/src/js/angular/core/directives/queryeditor/query-editor.directive.js
+++ b/src/js/angular/core/directives/queryeditor/query-editor.directive.js
@@ -847,22 +847,13 @@ function queryEditorDirective($timeout, $location, toastr, $repositories, Sparql
                         warning: true
                     }).result
                         .then(function () {
-                            autoExecuteQuery(true);
-                        }, function () {
-                            autoExecuteQuery(false);
+                            scope.runQuery(false);
                         });
                 } else {
                     scope.runQuery(false);
                 }
             }
         }
-
-        const autoExecuteQuery = (execute) => {
-            $location.search('execute', null);
-            if (execute) {
-                scope.runQuery(false);
-            }
-        };
 
         function loadQueryIntoExistingOrNewTab(query, infer, sameAs) {
             const tabId = scope.getExistingTabId(query);
@@ -875,6 +866,7 @@ function queryEditorDirective($timeout, $location, toastr, $repositories, Sparql
                     scope.currentQuery.sameAs = toBoolean(sameAs);
                 }
                 autoexecuteQueryIfRequested();
+                $location.search({});
                 onHandler();
             });
 

--- a/src/js/angular/sparql/plugin.js
+++ b/src/js/angular/sparql/plugin.js
@@ -6,7 +6,8 @@ PluginRegistry.add('route', {
     'controller': 'QueryEditorCtrl',
     'templateUrl': 'pages/sparql.html',
     'title': 'view.sparql.title',
-    'helpInfo': 'view.sparql.helpInfo'
+    'helpInfo': 'view.sparql.helpInfo',
+    'reloadOnSearch': false,
 });
 
 PluginRegistry.add('main.menu', {

--- a/test-cypress/integration/home/workbench.home.spec.js
+++ b/test-cypress/integration/home/workbench.home.spec.js
@@ -235,10 +235,10 @@ describe('Home screen validation', () => {
             const repositoryId = HomeSteps.createRepo();
             HomeSteps.selectRepo(repositoryId);
 
-            HomeSteps.verifyQueryLink('Add statements', true, '/sparql?savedQueryName=Add%20statements&owner=admin&execute');
-            HomeSteps.verifyQueryLink('Clear graph', true, '/sparql?savedQueryName=Clear%20graph&owner=admin&execute');
-            HomeSteps.verifyQueryLink('Remove statements', true, '/sparql?savedQueryName=Remove%20statements&owner=admin&execute');
-            HomeSteps.verifyQueryLink('SPARQL Select template', false, '/sparql?savedQueryName=SPARQL%20Select%20template&owner=admin&execute');
+            HomeSteps.verifyQueryLink('Add statements', true);
+            HomeSteps.verifyQueryLink('Clear graph', true);
+            HomeSteps.verifyQueryLink('Remove statements', true);
+            HomeSteps.verifyQueryLink('SPARQL Select template', false);
 
             cy.deleteRepository(repositoryId);
         });

--- a/test-cypress/steps/home-steps.js
+++ b/test-cypress/steps/home-steps.js
@@ -40,10 +40,9 @@ class HomeSteps {
             .click({force: true});
     }
 
-    static verifyQueryLink(queryName, modifiesRepoModal, queryURL) {
+    static verifyQueryLink(queryName, modifiesRepoModal) {
         HomeSteps.selectSPARQLQueryToExecute(queryName);
         modifiesRepoModal ? cy.get('.modal-body').should('be.visible') : cy.get('.modal-body').should('not.exist');
-        cy.url().should('eq', Cypress.config("baseUrl") + queryURL);
         HomeSteps.visitAndWaitLoader();
     }
 


### PR DESCRIPTION
## What
When load "sparql" view by "Welcome page saved queries", "Saved queries" or "Get URL to current query" functionality a new tab is opened with filled query. When the tab is closed and page is reloaded, the tab appears again.

## Why
The url of sparql view contains parameters that activates functionality that opens a new tab, loads a query and fill it into the opened tab.

## How
Removes all parameters when page is loaded.