### PR TITLE
Cherri-pick from 2.2 GDB-8129: Removes wbr tag from cells displayed b…

### DIFF
--- a/src/js/lib/yasr.bundled.js
+++ b/src/js/lib/yasr.bundled.js
@@ -57397,7 +57397,7 @@ var formatLiteralCustom = function(yasr, literalBinding, forHtml) {
 	var stringRepresentation = utils.escapeHtmlEntities(literalBinding.value);
 	var xmlSchemaNs = "http://www.w3.org/2001/XMLSchema#";
 	if ("bnode" === literalBinding.type) {
-		return addWordBreakToLiterals("_:" + stringRepresentation);
+		return "_:" + stringRepresentation;
 	} else if (literalBinding["xml:lang"]) {
 		stringRepresentation = '"' + stringRepresentation + ((forHtml) ? '"<sup>': '"') + '@' + literalBinding["xml:lang"] + ((forHtml) ? '</sup>': '');
 	} else if (literalBinding["lang"]) {

--- a/test-cypress/fixtures/sparql/history-response.json
+++ b/test-cypress/fixtures/sparql/history-response.json
@@ -1,0 +1,522 @@
+{
+    "head": {
+        "vars": [
+            "log",
+            "time",
+            "g",
+            "s",
+            "p",
+            "o",
+            "i"
+        ]
+    },
+    "results": {
+        "bindings": [
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:24:16.352+03:00"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:Kirk"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "urn:name"
+                },
+                "o": {
+                    "type": "literal",
+                    "value": "James Tiberius Kirk"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "false"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:24:02.366+03:00"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:Kirk"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "urn:name"
+                },
+                "o": {
+                    "type": "literal",
+                    "value": "James T. Kirk"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "false"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:24:02.366+03:00"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:Kirk"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "urn:name"
+                },
+                "o": {
+                    "type": "literal",
+                    "value": "James Tiberius Kirk"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:Human"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+                },
+                "o": {
+                    "type": "uri",
+                    "value": "urn:Mammal"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:Commander"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+                },
+                "o": {
+                    "type": "uri",
+                    "value": "urn:StarfleetOfficer"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:Captain"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+                },
+                "o": {
+                    "type": "uri",
+                    "value": "urn:StarfleetOfficer"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:Kirk"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+                },
+                "o": {
+                    "type": "uri",
+                    "value": "urn:Human"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "g": {
+                    "type": "uri",
+                    "value": "http://www.ontotext.com/implicit"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:Kirk"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+                },
+                "o": {
+                    "type": "uri",
+                    "value": "urn:Mammal"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:Kirk"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "urn:dateOfBirth"
+                },
+                "o": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#date",
+                    "type": "literal",
+                    "value": "2233-03-22"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:Kirk"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "urn:name"
+                },
+                "o": {
+                    "type": "literal",
+                    "value": "James T. Kirk"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:Kirk"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "urn:rank"
+                },
+                "o": {
+                    "type": "uri",
+                    "value": "urn:Commander"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "g": {
+                    "type": "uri",
+                    "value": "http://www.ontotext.com/implicit"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:dateOfBirth"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+                },
+                "o": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "g": {
+                    "type": "uri",
+                    "value": "http://www.ontotext.com/implicit"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:dateOfBirth"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+                },
+                "o": {
+                    "type": "uri",
+                    "value": "urn:dateOfBirth"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "g": {
+                    "type": "uri",
+                    "value": "http://www.ontotext.com/implicit"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:name"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+                },
+                "o": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "g": {
+                    "type": "uri",
+                    "value": "http://www.ontotext.com/implicit"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:name"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+                },
+                "o": {
+                    "type": "uri",
+                    "value": "urn:name"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "g": {
+                    "type": "uri",
+                    "value": "http://www.ontotext.com/implicit"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:rank"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+                },
+                "o": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            },
+            {
+                "log": {
+                    "type": "bnode",
+                    "value": "83222b124ff949648bd78ee778d22f601149"
+                },
+                "time": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2023-05-17T12:23:47.811+03:00"
+                },
+                "g": {
+                    "type": "uri",
+                    "value": "http://www.ontotext.com/implicit"
+                },
+                "s": {
+                    "type": "uri",
+                    "value": "urn:rank"
+                },
+                "p": {
+                    "type": "uri",
+                    "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+                },
+                "o": {
+                    "type": "uri",
+                    "value": "urn:rank"
+                },
+                "i": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+                    "type": "literal",
+                    "value": "true"
+                }
+            }
+        ]
+    }
+}

--- a/test-cypress/integration/sparql/sparql-result-formating.spec.js
+++ b/test-cypress/integration/sparql/sparql-result-formating.spec.js
@@ -1,4 +1,5 @@
 import SparqlSteps from "../../steps/sparql-steps";
+import {QueryStubs} from "../../stubs/query-stubs";
 
 describe('Formatting of SPARQL result bindings.', () => {
     let repositoryId;
@@ -68,5 +69,16 @@ describe('Formatting of SPARQL result bindings.', () => {
         // and language attribute is applied.
         SparqlSteps.getResultLiteralCell(0, 1).should('have.attr', 'lang', 'xx');
         SparqlSteps.getResultLiteralCell(0, 1).should('have.css', 'hyphens', 'auto');
+    });
+
+    it('should format bnode', () => {
+        // When I execute a query that returns bnode.
+        QueryStubs.stubSparqlHistoryResponse(repositoryId);
+        SparqlSteps.executeQuery();
+
+        // Then I expect the "_:" prefix of bnode to not be followed by <wbr> tag,
+        SparqlSteps.getResultNoUriCell(0, 1).then(function($el) {
+            expect($el.html()).to.eq('_:83222b124ff949648bd78ee778d22f601149');
+        });
     });
 });

--- a/test-cypress/stubs/query-stubs.js
+++ b/test-cypress/stubs/query-stubs.js
@@ -1,0 +1,9 @@
+export class QueryStubs {
+
+    static stubSparqlHistoryResponse(repositoryId, withDelay = 0) {
+        QueryStubs.stubQueryResponse(`/repositories/${repositoryId}`, '/sparql/history-response.json', 'history-response', withDelay);
+    }
+    static stubQueryResponse(url, fixture, alias, withDelay = 0) {
+        cy.intercept(url, {fixture, delay: withDelay}).as(alias);
+    }
+}


### PR DESCRIPTION
…node type result

## What
If a cell of sparql results table displays value of type bnode, the bnode value is on next line than the prefix "_:".

## Why
 The functionality that process formatting of bnode adds this unwanted tag.

## How
Updates yasr.bundled.js (Removes adding of wbr tag bnode formatting functionality). Additional work:
- add test to cover this case.