### PR TITLE
GDB-8252 Fix displaying of additional Ontop properties

### DIFF
--- a/src/js/angular/repositories/controllers.js
+++ b/src/js/angular/repositories/controllers.js
@@ -44,7 +44,9 @@ const parseMemberParamIfNeeded = function (param) {
 };
 
 const convertAdditionalPropertiesParamIfNeeded = function (params) {
-    if (params.additionalProperties && params.additionalProperties.value) {
+    const values = params && params.additionalProperties && params.additionalProperties.value;
+
+    if (values && values instanceof Object) {
         const values = params.additionalProperties.value;
         const valuesAsStrings = Object.keys(values).map((key) => `${key}=${values[key]}`);
         params.additionalProperties.value = valuesAsStrings.join('\n');

--- a/src/js/angular/repositories/controllers.js
+++ b/src/js/angular/repositories/controllers.js
@@ -43,6 +43,14 @@ const parseMemberParamIfNeeded = function (param) {
     }
 };
 
+const convertAdditionalPropertiesParamIfNeeded = function (params) {
+    if (params.additionalProperties && params.additionalProperties.value) {
+        const values = params.additionalProperties.value;
+        const valuesAsStrings = Object.keys(values).map((key) => `${key}=${values[key]}`);
+        params.additionalProperties.value = valuesAsStrings.join('\n');
+    }
+};
+
 const getShaclOptionsClass = function () {
     const optionsModule = document.getElementById('shaclOptions');
 
@@ -574,6 +582,7 @@ function AddRepositoryCtrl($scope, toastr, $repositories, $location, $timeout, U
             $scope.repositoryInfo.type = data.type;
             parseNumberParamsIfNeeded($scope.repositoryInfo.params);
             parseMemberParamIfNeeded($scope.repositoryInfo.params);
+            convertAdditionalPropertiesParamIfNeeded($scope.repositoryInfo.params);
             $scope.loader = false;
             // The clean way is the "autofocus" attribute and we use it but it doesn't seem to
             // work in all browsers because of the way dynamic content is handled so give it another
@@ -809,6 +818,7 @@ function EditRepositoryCtrl($scope, $routeParams, toastr, $repositories, $locati
                     $scope.repositoryInfo = data;
                     $scope.setRepositoryType(data.type);
                     parseNumberParamsIfNeeded($scope.repositoryInfo.params);
+                    convertAdditionalPropertiesParamIfNeeded($scope.repositoryInfo.params);
                     $scope.repositoryInfo.saveId = $scope.saveRepoId;
                     $scope.loader = false;
                 })

--- a/src/js/angular/repositories/ontop-repo.directive.js
+++ b/src/js/angular/repositories/ontop-repo.directive.js
@@ -112,7 +112,7 @@ function ontopRepoDirective($uibModal, RepositoriesRestService, toastr, Upload, 
 
         $scope.isReadOnly = function (labelName) {
             return labelName === 'driverClass' || labelName === 'url';
-        }
+        };
 
         $scope.editFile = function(file) {
             const modalInstance = $uibModal.open({

--- a/test-cypress/integration/repository/repositories.spec.js
+++ b/test-cypress/integration/repository/repositories.spec.js
@@ -66,7 +66,7 @@ describe('Repositories', () => {
     }
 
     it('create repository page should list available repository types options', () => {
-        let expectedRepoTypes = ['GraphDB Repository', 'Ontop Virtual SPARQL', 'FedX Virtual SPARQL'];
+        const expectedRepoTypes = ['GraphDB Repository', 'Ontop Virtual SPARQL', 'FedX Virtual SPARQL'];
         createRepository();
         cy.url().should('include', '/repository/create');
 
@@ -241,7 +241,7 @@ describe('Repositories', () => {
 
         // Wait for redirection to previous '/repository'
         cy.waitUntil(() =>
-                cy.url().then(url => url === (Cypress.config('baseUrl') + '/repository')));
+                cy.url().then((url) => url === (Cypress.config('baseUrl') + '/repository')));
 
         // Connect to the first repo via the connection icon
         // Note: Not using within() because the whole row will be re-rendered & detached
@@ -465,7 +465,7 @@ describe('Repositories', () => {
                     additionalProperties: {
                         "label": "Additional Ontop/JDBC properties",
                         "name": "additionalProperties",
-                        "value": ""
+                        "value": "prop1=value1\nprop2=value2"
                     }
                 }
             };
@@ -477,6 +477,12 @@ describe('Repositories', () => {
             });
 
             cy.reload(); //refresh page as the virtual repo is not visible in the UI when created with the request
+
+            editRepository(virtualRepoName);
+
+            // Additional Ontop Properties field should be visible and populated correctly
+            getAdditionalPropertiesTextArea().should('be.visible');
+            getAdditionalPropertiesTextArea().should('have.value', 'prop2=value2\nprop1=value1');
 
             //Check workbench restricted sections when connected to an Ontop repository
             selectRepoFromDropdown(virtualRepoName);
@@ -694,8 +700,8 @@ describe('Repositories', () => {
             getRepositoryFromList(repositoryId)
                 .should('be.visible')
                 .find('.repository-status .text-secondary')
-                .then($el => $el)
-                .then($el => $el && $el.text() === status));
+                .then(($el) => $el)
+                .then(($el) => $el && $el.text() === status));
     }
 
     function getRepositoriesList() {
@@ -793,6 +799,10 @@ describe('Repositories', () => {
 
     function getRepositoryRulesetMenu() {
         return getRepositoryCreateForm().find('#ruleset');
+    }
+
+    function getAdditionalPropertiesTextArea() {
+        return getRepositoryCreateForm().find('#additionalProperties');
     }
 
     function getRepositoryDisableSameAsCheckbox() {
@@ -905,7 +915,7 @@ describe('Repositories', () => {
         return cy.get('#ontop-content');
     }
 
-    function getDatabaseDriver(){
+    function getDatabaseDriver() {
         return cy.get('#driverType');
     }
 
@@ -953,13 +963,13 @@ describe('Repositories', () => {
         compareDriverDownloadUrl(downloadLink);
     }
 
-    function compareDriverDownloadUrl(expectedUrl){
+    function compareDriverDownloadUrl(expectedUrl) {
         cy.get('.uri')
             .should('be.visible')
             .and('have.attr', 'href', expectedUrl);
     }
 
-    function getSHACLRepositoryCheckbox(){
+    function getSHACLRepositoryCheckbox() {
         return cy.get('#isShacl');
     }
 });


### PR DESCRIPTION
## What
Upon editing a repository, the additional Onto properties are not displayed correct. Instead, [object Object] is shown in the text area.

## Why
The server returns an object which is not parsed and is set in the textbox. The initial talk was for the UI to receive a string so there is no need to parse it, but this has changed.

## How
- added function to convert additional properties values to string