### PR TITLE
Gdb 8332 missing options to add remove cluster nodes

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -103,7 +103,7 @@
             "loader_message": "Deleting cluster",
             "notifications": {
                 "success_delete": "Cluster deleted successfully",
-                "success_delete_partial": "Not all nodes are deleted",
+                "success_delete_partial": "Not all nodes were deleted",
                 "fail_delete": "Can not delete cluster"
             }
         },

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -103,7 +103,7 @@
             "loader_message": "Suppression d'un cluster",
             "notifications": {
                 "success_delete": "Cluster supprimé avec succès",
-                "success_delete_partial": "Tous les nœuds ne sont pas supprimés",
+                "success_delete_partial": "Tous les nœuds n'ont pas été supprimés",
                 "fail_delete": "Impossible de supprimer le cluster"
             }
         },

--- a/src/js/angular/clustermanagement/controllers.js
+++ b/src/js/angular/clustermanagement/controllers.js
@@ -29,8 +29,7 @@ export const NodeState = {
     NO_CONNECTION: 'NO_CONNECTION',
     READ_ONLY: 'READ_ONLY',
     RESTRICTED: 'RESTRICTED',
-    NO_CLUSTER: 'NO_CLUSTER',
-    DELETED: 'Cluster was deleted on this node.'
+    NO_CLUSTER: 'NO_CLUSTER'
 };
 export const LinkState = {
     IN_SYNC: 'IN_SYNC',
@@ -56,6 +55,7 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
     $scope.childContext = {};
 
     $scope.shouldShowClusterSettingsPanel = false;
+    const DELETED_ON_NODE_MESSAGE = 'Cluster was deleted on this node.';
     $scope.onopen = $scope.onclose = () => angular.noop();
 
     $scope.toggleSidePanel = () => {
@@ -226,7 +226,7 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
             $scope.setLoader(true, loaderMessage);
             ClusterRestService.deleteCluster(forceDelete)
                 .then((response) => {
-                    const allNodesDeleted = Object.values(response.data).every((nodeState) => nodeState === NodeState.DELETED);
+                    const allNodesDeleted = Object.values(response.data).every((resultMsg) => resultMsg === DELETED_ON_NODE_MESSAGE);
                     if (allNodesDeleted) {
                         const successMessage = $translate.instant('cluster_management.delete_cluster_dialog.notifications.success_delete');
                         toastr.success(successMessage);

--- a/src/js/angular/clustermanagement/controllers.js
+++ b/src/js/angular/clustermanagement/controllers.js
@@ -30,7 +30,7 @@ export const NodeState = {
     READ_ONLY: 'READ_ONLY',
     RESTRICTED: 'RESTRICTED',
     NO_CLUSTER: 'NO_CLUSTER',
-    DELETED: 'DELETED'
+    DELETED: 'Cluster was deleted on this node.'
 };
 export const LinkState = {
     IN_SYNC: 'IN_SYNC',

--- a/src/js/angular/clustermanagement/controllers.js
+++ b/src/js/angular/clustermanagement/controllers.js
@@ -235,7 +235,7 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
                             'cluster_management.delete_cluster_dialog.notifications.success_delete_partial');
                         const failedNodesList = Object.keys(response.data)
                             .reduce((message, key) => message += `<div>${key} - ${response.data[key]}</div>`, '');
-                        toastr.success(failedNodesList, successMessage, {allowHtml: true});
+                        toastr.warning(failedNodesList, successMessage, {allowHtml: true});
                     }
                     $scope.getClusterConfiguration();
                 })

--- a/src/pages/cluster-management/clusterInfo.html
+++ b/src/pages/cluster-management/clusterInfo.html
@@ -29,12 +29,12 @@
                 tooltip-placement="bottom">
             <span class="icon-trash"></span> {{'cluster_management.buttons.delete_cluster' | translate}}
         </button>
-        <button type="button" class="btn btn-primary add-node-btn" ng-if="currentNode.nodeState === NodeState.LEADER"
+        <button type="button" class="btn btn-primary add-node-btn" ng-if="currentLeader"
                 ng-click="showAddNodeToClusterDialog()"
                 gdb-tooltip="{{'cluster_management.buttons.add_nodes_btn_tooltip' | translate}}" tooltip-placement="bottom">
             <span class="icon-plus"></span> {{'cluster_management.buttons.add_nodes_btn' | translate}}
         </button>
-        <button type="button" class="btn btn-secondary remove-node-btn mr-2" ng-if="currentNode.nodeState === NodeState.LEADER"
+        <button type="button" class="btn btn-secondary remove-node-btn mr-2" ng-if="currentLeader"
                 ng-click="showRemoveNodesFromClusterDialog()"
                 gdb-tooltip="{{'cluster_management.buttons.remove_nodes_btn_tooltip' | translate}}" tooltip-placement="bottom">
             <span class="icon-minus"></span> {{'cluster_management.buttons.remove_nodes_btn' | translate}}

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -103,7 +103,7 @@
             "loader_message": "Deleting cluster",
             "notifications": {
                 "success_delete": "Cluster deleted successfully",
-                "success_delete_partial": "Not all nodes are deleted",
+                "success_delete_partial": "Not all nodes were deleted",
                 "fail_delete": "Can not delete cluster"
             }
         },


### PR DESCRIPTION
Changed the DELETED message to the one in backend. Also changed the evaluation if add or remove node buttons should appear from currentNode.nodeState === NodeState.LEADER -> currentLeader, because leader is needed to process this request.