### PR TITLE
GDB-8348: setup yasqe mode.

### DIFF
--- a/src/js/angular/sparql-template/controllers.js
+++ b/src/js/angular/sparql-template/controllers.js
@@ -182,7 +182,7 @@ function SparqlTemplateCreateCtrl(
             componentId: 'sparql-template',
             prefixes: prefixes,
             maxPersistentResponseSize: 0,
-            yasqeMode: YasqeMode.PROTECTED,
+            yasqeMode: $scope.canWriteActiveRepo() ? YasqeMode.WRITE : YasqeMode.PROTECTED,
             yasqeAutocomplete: {
                 LocalNamesAutocompleter: (term) => {
                     const canceler = $q.defer();


### PR DESCRIPTION
## What
Open a SPARQL template for edit of editable repository. The query can't be edited.

## Why
Configuration "yasqeMode" of "ontotext-yasgui-web-component" is set to protected without matter if user can edit active repository.

## How
Changed configuration to "write" if user can edit repository otherwise "protected".