### PR TITLE
GDB-8395: Workbench throwing console warnings for invalid JSON

### DIFF
--- a/src/js/angular/core/directives/queryeditor/query-editor.directive.js
+++ b/src/js/angular/core/directives/queryeditor/query-editor.directive.js
@@ -70,6 +70,7 @@ function queryEditorDirective($timeout, $location, toastr, $repositories, Sparql
 
         scope.sparqlQueryErrorInfo = undefined;
         scope.fullErrorMessage = false;
+        scope.queryEditorIsReady = false;
 
         scope.showFullErrorMessage = function (fullErrorMessage) {
             scope.fullErrorMessage = fullErrorMessage;
@@ -85,6 +86,7 @@ function queryEditorDirective($timeout, $location, toastr, $repositories, Sparql
 
         $timeout(function () {
             drawQueryEditor(scope);
+            scope.queryEditorIsReady = true;
         }, 150);
     }
 
@@ -194,7 +196,6 @@ function queryEditorDirective($timeout, $location, toastr, $repositories, Sparql
             scope.currentQuery.query = window.editor.getValue();
             scope.currentQuery.queryType = window.editor.getQueryType();
         });
-
 
         function selectTab(id) {
             $timeout(function () {

--- a/src/js/angular/core/directives/queryeditor/templates/query-editor.html
+++ b/src/js/angular/core/directives/queryeditor/templates/query-editor.html
@@ -70,7 +70,7 @@
                 <textarea ng-model="query" id="query" rows="16" cols="100" guide-selector="inputQuery"></textarea>
 
                 <div id="yasqe_buttons_mocked" style="display: none"></div>
-                <div id="yasqe_buttons" ng-hide="notoolbar">
+                <div id="yasqe_buttons" ng-hide="notoolbar" ng-if="queryEditorIsReady">
                     <div id="buttons">
                         <button class="btn btn-link" id="wb-sparql-saveQuery"
                                 ng-show="!notoolbarSaved && isUser()"
@@ -121,6 +121,7 @@
                 </div>
                 <div id="runButton" ng-hide="norun">
                     <button id="wb-sparql-runQuery" class="btn btn-primary" ng-disabled="queryIsRunning"
+                            ng-if="queryEditorIsReady"
                             ng-click="runQuery(false, $event.shiftKey ? 'explain' : ($event.altKey ? 'gpt' : ''))"
                             guide-selector="runSparqlQuery">
                         {{runButtonName | translate}}

--- a/test-cypress/integration/sparql/sparql-error-handling.spec.js
+++ b/test-cypress/integration/sparql/sparql-error-handling.spec.js
@@ -4,7 +4,7 @@ const LONG_ERROR_MESSAGE = "Lorem ipsum dolor sit amet, consectetur adipisicing 
 const MAX_VISIBLE_ERROR_CHARACTERS = 160;
 const SHORTEN_PART_OFF_ERROR_MESSAGE = LONG_ERROR_MESSAGE.substring(0, MAX_VISIBLE_ERROR_CHARACTERS);
 const SHORT_ERROR_MESSAGE = LONG_ERROR_MESSAGE.substring(0, MAX_VISIBLE_ERROR_CHARACTERS - 1);
-describe.skip('Error handling', () => {
+describe('Error handling', () => {
     let repositoryId;
 
     beforeEach(() => {
@@ -19,7 +19,7 @@ describe.skip('Error handling', () => {
     });
 
     it('should show all error message if message length is short', () => {
-        stubErrorResponse(400, SHORT_ERROR_MESSAGE);
+        stubErrorResponse(repositoryId, 400, SHORT_ERROR_MESSAGE);
         // When I open sparql editor page
         // Then I should see no query has been executed
         SparqlSteps.getNoQueryRunInfo().should('be.visible');
@@ -36,7 +36,7 @@ describe.skip('Error handling', () => {
     });
 
     it('should show shorten error message if message length is long', () => {
-        stubErrorResponse(400, LONG_ERROR_MESSAGE);
+        stubErrorResponse(repositoryId, 400, LONG_ERROR_MESSAGE);
         // When I open sparql editor page
         // Then I should see no query has been executed
         SparqlSteps.getNoQueryRunInfo().should('be.visible');
@@ -71,10 +71,10 @@ describe.skip('Error handling', () => {
         SparqlSteps.getShowLessExceptionMessage().should('not.exist');
     });
 
-    const stubErrorResponse = (statusCode, errorMessage) => {
-        cy.intercept('POST', '/repositories/' + repositoryId, {
+    const stubErrorResponse = (repositoryId, statusCode, errorMessage) => {
+        cy.intercept('POST', `/repositories/${repositoryId}`, {
             statusCode,
             body: errorMessage
-        }).as('queryResultStub');
+        }).as('queryErrorResultStub');
     };
 });

--- a/test-cypress/integration/sparql/sparql-error-handling.spec.js
+++ b/test-cypress/integration/sparql/sparql-error-handling.spec.js
@@ -1,4 +1,5 @@
 import SparqlSteps from "../../steps/sparql-steps";
+import {QueryStubs} from "../../stubs/query-stubs";
 
 const LONG_ERROR_MESSAGE = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 const MAX_VISIBLE_ERROR_CHARACTERS = 160;
@@ -19,7 +20,7 @@ describe('Error handling', () => {
     });
 
     it('should show all error message if message length is short', () => {
-        stubErrorResponse(repositoryId, 400, SHORT_ERROR_MESSAGE);
+        QueryStubs.stubQueryErrorResponse(repositoryId, 400, SHORT_ERROR_MESSAGE);
         // When I open sparql editor page
         // Then I should see no query has been executed
         SparqlSteps.getNoQueryRunInfo().should('be.visible');
@@ -36,7 +37,7 @@ describe('Error handling', () => {
     });
 
     it('should show shorten error message if message length is long', () => {
-        stubErrorResponse(repositoryId, 400, LONG_ERROR_MESSAGE);
+        QueryStubs.stubQueryErrorResponse(repositoryId, 400, LONG_ERROR_MESSAGE);
         // When I open sparql editor page
         // Then I should see no query has been executed
         SparqlSteps.getNoQueryRunInfo().should('be.visible');
@@ -70,11 +71,4 @@ describe('Error handling', () => {
         // and don't see the button "Show less exception message",
         SparqlSteps.getShowLessExceptionMessage().should('not.exist');
     });
-
-    const stubErrorResponse = (repositoryId, statusCode, errorMessage) => {
-        cy.intercept('POST', `/repositories/${repositoryId}`, {
-            statusCode,
-            body: errorMessage
-        }).as('queryErrorResultStub');
-    };
 });

--- a/test-cypress/stubs/query-stubs.js
+++ b/test-cypress/stubs/query-stubs.js
@@ -6,4 +6,11 @@ export class QueryStubs {
     static stubQueryResponse(url, fixture, alias, withDelay = 0) {
         cy.intercept(url, {fixture, delay: withDelay}).as(alias);
     }
+
+    static stubQueryErrorResponse(repositoryId, statusCode, errorMessage) {
+        cy.intercept('POST', `/repositories/${repositoryId}`, {
+            statusCode,
+            body: errorMessage
+        }).as('queryErrorResultStub');
+    }
 }

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -14,7 +14,6 @@ function replaceVersion(content) {
 }
 
 module.exports = {
-    devtool: 'source-map',
     entry: {
         vendor: './src/vendor.js',
         main: './src/main.js',
@@ -111,16 +110,12 @@ module.exports = {
                 transform: replaceVersion
             },
             {
-                from: 'src/guides',
-                to: 'guides'
-            },
-            {
                 from: 'src/i18n',
                 to: 'i18n'
             },
             {
                 from: 'src/js/angular/repositories/templates',
-                to: 'js/angular/repositories/templates',
+                to: 'js/angular/repositories/templates'
             },
             {
                 from: 'src/js/angular/autocomplete/templates',

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -11,6 +11,7 @@ const portThere = 7200;
 
 module.exports = merge(commonConfig, {
     mode: 'development',
+    devtool: 'source-map',
     output: {
         filename: '[name].bundle.js',
         chunkFilename: '[name].bundle.js',

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -9,7 +9,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = merge(commonConfig, {
     mode: 'production',
-    devtool: '(none)',
     performance: {
         maxEntrypointSize: 990000,
         maxAssetSize: 990000,

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -9,6 +9,14 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = merge(commonConfig, {
     mode: 'production',
+    devtool: '(none)',
+    performance: {
+        maxEntrypointSize: 990000,
+        maxAssetSize: 990000,
+        assetFilter: function(assetFilename) {
+            return !assetFilename.endsWith('swagger-ui.js');
+        }
+    },
     output: {
         filename: '[name].[contentHash].bundle.js',
         chunkFilename: '[name].[contentHash].bundle.js',


### PR DESCRIPTION
## What
- There was a warning message:
```
unable to locate 'src/guides' at '/home/boyan/Git/graphdb-workbench/src/guides'
```
when open a page of workbench.
- There was a warning message:
```
     DevTools failed to load source map: Could not load content for http://localhost:7200/main.35e30fd1f1326e91ed6c.bundle.js.map: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```
in the Chrome console when opens a page in production.

## Why
- There was legacy configuration of webpack copy plugin from "user interactive guide" functionality.
- During the build process sources are skipped but there are references to the sources into minified files. At the end of every one file has something like "//# sourceMappingURL=184.ed3e402118e64c17a70b.bundle.js.map". This causes Chrome to try loading the source file.

## How
- Removes the legacy configuration.
- Disable devtool on production. After I turned off "devtool" warning messages appeared, informs that assets and entrypoint are big. That's why performance configuration is added. It configured max size of entry points or assets, that can be deployed. The file "swagger-ui.js" is skipped because is too big (2.8MB).

Additional work:
## What
 The test "sparql-error-handling.spec.js" is failing randomly.

## Why
There is a Null Pointer Exception (NPE) occurring with the following error message: "TypeError: Cannot read properties of undefined (reading 'getQueryMode')". This exception is caused by attempting to access the 'getQueryMode' function of Yasqe (window.editor) before it is initialized.

## How
The issue arises when the Cypress test finds the Run button and attempts to click on it. However, sometimes the button becomes visible before Yasqe (window.editor) is fully initialized. During the execution of the 'run query' function, there is a logic check for the query mode that calls the 'getQueryMode' function of Yasqe (window.editor.getQueryMode()). Since the editor is not yet initialized, the exception is thrown due to the undefined property access.

To resolve this issue, it is necessary to ensure that the Yasqe editor is fully initialized before attempting to access its functions or properties, such as 'getQueryMode'.

## How
In the file "query-editor.directive.js," a new boolean flag called "queryEditorIsReady" has been added. This flag is set to true when the query editor is fully prepared, including the creation and overriding of editor functions.

When the "queryEditorIsReady" flag is true, the container that contains various buttons like "Run," "Infer," and "Same as.." is created and displayed accordingly. This ensures that the container and its buttons are only generated and shown when the query editor is fully ready for interaction.