### PR TITLE
GDB-8453: Rename & Fix Workbench link from "Developer Hub"

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -615,7 +615,7 @@
     "menu.system.information.label": "System information",
     "menu.rest.api.label": "REST API",
     "menu.documentation.label": "Documentation",
-    "menu.developer.hub.label": "Developer Hub",
+    "menu.tutorials.label": "Tutorials",
     "menu.support.label": "Support",
     "menu.guides.label": "Interactive guides",
     "menu.plugins.label": "Plugins",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -615,7 +615,7 @@
     "menu.system.information.label": "Informations sur le système",
     "menu.rest.api.label": "API REST",
     "menu.documentation.label": "Documentation",
-    "menu.developer.hub.label": "Carrefour des développeurs",
+    "menu.tutorials.label": "Tutoriels",
     "menu.support.label": "Support",
     "menu.guides.label": "Guides interactifs",
     "menu.plugins.label": "Plugins",

--- a/src/js/angular/stats/plugin.js
+++ b/src/js/angular/stats/plugin.js
@@ -61,13 +61,13 @@ PluginRegistry.add('main.menu', {
             },
             guideSelector: 'sub-menu-documentation'
         }, {
-            label: 'Developer Hub',
-            labelKey: 'menu.developer.hub.label',
+            label: 'Tutorials',
+            labelKey: 'menu.tutorials.label',
             order: 3,
             parent: 'Help',
             icon: 'icon-external',
             hrefFun: function (productInfo) {
-                return DOCUMENTATION_URL + productInfo.productShortVersion + '/devhub/';
+                return DOCUMENTATION_URL + productInfo.productShortVersion + '/tutorials.html';
             },
             guideSelector: 'sub-menu-developer-hub'
         }, {

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -615,7 +615,7 @@
     "menu.system.information.label": "System information",
     "menu.rest.api.label": "REST API",
     "menu.documentation.label": "Documentation",
-    "menu.developer.hub.label": "Developer Hub",
+    "menu.tutorials.label": "Tutorials",
     "menu.support.label": "Support",
     "menu.guides.label": "Interactive guides",
     "menu.plugins.label": "Plugins",

--- a/test-cypress/integration/sparql/main.menu.spec.js
+++ b/test-cypress/integration/sparql/main.menu.spec.js
@@ -141,9 +141,9 @@ describe('Main menu tests', function () {
                         externalRedirect: 'https://graphdb.ontotext.com/documentation/'
                     },
                     {
-                        name: 'Developer Hub',
+                        name: 'Tutorials',
                         visible: false,
-                        externalRedirect: '/devhub/'
+                        externalRedirect: '/tutorials.html'
                     },
                     {
                         name: 'Support',


### PR DESCRIPTION
## What
- The link's title "Developer Hub" has been changed to "Tutorials";
- The link's href has been changed to refer to 'https://graphdb.ontotext.com/documentation/<major.minor>/tutorials.html'.

## Why
As of version 10.2, including the current 10.3 build, the 'Developer Hub' link refers to a section of the documentation that no longer exists. ## How
- The label has been renamed;
- The href has been changed;