### PR TITLE
Refactoring jdbc and sparql-templates views

### DIFF
--- a/src/js/angular/core/directives/yasgui-component/templates/yasgui-component.html
+++ b/src/js/angular/core/directives/yasgui-component/templates/yasgui-component.html
@@ -1,6 +1,7 @@
 <link href="css/lib/ontotext-yasgui-web-component.css?v=[AIV]{version}[/AIV]" rel="stylesheet">
 
 <ontotext-yasgui
+    class="{{classToApply}}"
     ng-custom-element
     ngce-prop-config="ontotextYasguiConfig"
     ngce-prop-saved_query_config="savedQueryConfig"

--- a/src/js/angular/core/directives/yasgui-component/yasgui-component-directive.util.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component-directive.util.js
@@ -15,3 +15,19 @@ export const YasguiComponentDirectiveUtil = (function () {
         getOntotextYasguiElement
     };
 })();
+
+export const DISABLE_YASQE_BUTTONS_CONFIGURATION = [
+    {
+        name: 'createSavedQuery',
+        visible: false
+    }, {
+        name: 'showSavedQueries',
+        visible: false
+    }, {
+        name: 'shareQuery',
+        visible: false
+    }, {
+        name: 'includeInferredStatements',
+        visible: false
+    }
+];

--- a/src/js/angular/jdbc/app.js
+++ b/src/js/angular/jdbc/app.js
@@ -7,6 +7,7 @@ import 'angular/rest/jdbc.rest.service';
 import 'angular/core/directives/queryeditor/sparql-tab.directive';
 import 'angular/core/directives/queryeditor/query-editor.controller';
 import 'angular/core/directives/queryeditor/query-editor.directive';
+import 'angular/core/directives/yasgui-component/yasgui-component.directive';
 
 const modules = [
     'toastr',
@@ -17,8 +18,8 @@ const modules = [
     'graphdb.framework.rest.jdbc.service',
     'graphdb.framework.core.directives.queryeditor.controllers',
     'graphdb.framework.core.directives.queryeditor.sparqltab',
-    'graphdb.framework.core.directives.queryeditor.queryeditor'
-
+    'graphdb.framework.core.directives.queryeditor.queryeditor',
+    'graphdb.framework.core.directives.yasgui-component'
 ];
 
 angular.module('graphdb.framework.jdbc', modules);

--- a/src/js/angular/sparql-editor/app.js
+++ b/src/js/angular/sparql-editor/app.js
@@ -1,10 +1,8 @@
 import 'angular/sparql-editor/controllers';
-import 'angular/sparql-editor/share-query-link.service';
 import 'angular/core/directives/yasgui-component/yasgui-component.directive';
 
 const modules = [
     'ui.bootstrap',
-    'graphdb.framework.sparql-editor.share-query.service',
     'graphdb.framework.sparql-editor.controllers',
     'graphdb.framework.core.directives.yasgui-component'
 ];

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -27,8 +27,7 @@ SparqlEditorCtrl.$inject = [
     '$repositories',
     'toastr',
     '$translate',
-    'SparqlRestService',
-    'ShareQueryLinkService'];
+    'SparqlRestService'];
 
 function SparqlEditorCtrl($scope,
                           $q,
@@ -37,8 +36,7 @@ function SparqlEditorCtrl($scope,
                           $repositories,
                           toastr,
                           $translate,
-                          SparqlRestService,
-                          ShareQueryLinkService) {
+                          SparqlRestService) {
     this.repository = '';
 
     $scope.yasguiConfig = undefined;

--- a/src/js/angular/sparql-template/app.js
+++ b/src/js/angular/sparql-template/app.js
@@ -8,6 +8,7 @@ import 'angular/core/directives/queryeditor/sparql-tab.directive';
 import 'angular/core/directives/queryeditor/query-editor.controller';
 import 'angular/core/directives/queryeditor/query-editor.directive';
 import 'angular/utils/uri-utils';
+import 'angular/core/directives/yasgui-component/yasgui-component.directive';
 
 const modules = [
     'toastr',
@@ -19,7 +20,8 @@ const modules = [
     'graphdb.framework.core.directives.queryeditor.controllers',
     'graphdb.framework.core.directives.queryeditor.sparqltab',
     'graphdb.framework.core.directives.queryeditor.queryeditor',
-    'graphdb.framework.utils.uriutils'
+    'graphdb.framework.utils.uriutils',
+    'graphdb.framework.core.directives.yasgui-component'
 ];
 
 angular.module('graphdb.framework.sparql-template', modules);

--- a/src/pages/jdbc-create.html
+++ b/src/pages/jdbc-create.html
@@ -52,13 +52,9 @@
                 <div>
                     <!-- First tab -->
                     <div class="tab-pane" ng-show="activeTab === 1">
-                        <ontotext-yasgui
-                            class="pt-1"
-                            ng-custom-element
-                            ngce-prop-config="config"
-                            ngce-prop-language="language"
-                            ngce-on-output="output($event)">
-                        </ontotext-yasgui>
+
+                        <yasgui-component id="query-editor" class="pt-1" yasgui-config="yasguiConfig" query-changed="setDirty()"></yasgui-component>
+
                         <div ng-if="!jdbcConfigurationInfo.isValidQuery"
                              class="idError alert alert-danger invalid-query"
                              translate="jdbc.invalid.query">

--- a/src/pages/sparql-template-create.html
+++ b/src/pages/sparql-template-create.html
@@ -40,13 +40,9 @@
                          translate="sparql.template.iri.constraint">
                     </div>
                 </div>
-                <ontotext-yasgui
-                    class="pt-1"
-                    ng-custom-element
-                    ngce-prop-config="config"
-                    ngce-prop-language="language"
-                    ngce-on-output="output($event)">
-                </ontotext-yasgui>
+
+                <yasgui-component id="query-editor" class="pt-1" yasgui-config="yasguiConfig" query-changed="markDirty()"></yasgui-component>
+
                 <div ng-if="!sparqlTemplateInfo.isValidQuery"
                      class="idError alert alert-danger  invalid-query"
                      translate="sparql.template.query.invalid">

--- a/test-cypress/integration/explore/similarity.spec.js
+++ b/test-cypress/integration/explore/similarity.spec.js
@@ -192,7 +192,7 @@ describe('Similarity screen validation', () => {
         });
     });
 
-    it.only('Disable and enable similarity plugin', () => {
+    it('Disable and enable similarity plugin', () => {
         const disableSimilarityPlugin = 'INSERT DATA { <u:a> <http://www.ontotext.com/owlim/system#stopplugin> \'similarity\' . }';
         initRepository();
         cy.presetRepository(repositoryId);

--- a/test-cypress/integration/setup/jdbc-create.spec.js
+++ b/test-cypress/integration/setup/jdbc-create.spec.js
@@ -230,7 +230,7 @@ describe('JDBC configuration', () => {
         ModalDialogSteps.verifyUrlChangedConfirmation('You have unsaved changes. Are you sure that you want to exit?');
     });
 
-    it.only('should display confirm message when the configuration query data is changed', () => {
+    it('should display confirm message when the configuration query data is changed', () => {
         // When I open the create JDBC configuration page,
         // type and change the query,
         YasqeSteps.writeInEditor("Some changes");

--- a/test-cypress/integration/sparql-editor/yasr/table-plugin.spec.js
+++ b/test-cypress/integration/sparql-editor/yasr/table-plugin.spec.js
@@ -23,7 +23,7 @@ describe('Yasr Table plugin', () => {
 
     describe('Results formatting', () => {
 
-        it.only('Should all resource be formatted with short uri when results are of type uri', {
+        it('Should all resource be formatted with short uri when results are of type uri', {
             retries: {
                 runMode: 1,
                 openMode: 0

--- a/test-cypress/steps/setup/jdbc-create-steps.js
+++ b/test-cypress/steps/setup/jdbc-create-steps.js
@@ -3,9 +3,6 @@ export class JdbcCreateSteps {
     static visit(jdbcConfigurationName) {
         cy.visit(`/jdbc/configuration/create${jdbcConfigurationName ? '?name=' + jdbcConfigurationName : ''}`);
         cy.get('.ontotext-yasgui').should('be.visible');
-        // When page is loaded the component is initializes twice, because of angular. The problem will be fixed
-        // when all yasgui logic is extracted into a directive.
-        cy.wait(1000);
     }
 
     static verifyUrl() {

--- a/test-cypress/steps/setup/sparql-create-update-steps.js
+++ b/test-cypress/steps/setup/sparql-create-update-steps.js
@@ -2,9 +2,6 @@ export class SparqlCreateUpdateSteps {
     static visit(templateId) {
         cy.visit(`/sparql-template/create${templateId ? '?templateID=' + templateId : ''}`);
         cy.get('.ontotext-yasgui').should('be.visible');
-        // When page is loaded the component is initializes twice, because of angular. The problem will be fixed
-        // when all yasgui logic is extracted into a directive.
-        cy.wait(1000);
     }
 
     static verifyUrl() {

--- a/test-cypress/support/repository-commands.js
+++ b/test-cypress/support/repository-commands.js
@@ -21,7 +21,12 @@ Cypress.Commands.add('createRepository', (options = {}) => {
 Cypress.Commands.add('deleteRepository', (id) => {
     // Note: Going through /rest/repositories because it would not fail if the repo is missing
     const url = REPOSITORIES_URL + id;
-    cy.request('DELETE', url)
+    cy.request({
+            method: 'DELETE',
+            url: url,
+        // Prevent Cypress from failing the test on non-2xx status codes
+            failOnStatusCode: false
+        })
         .then((response) => {
             cy.waitUntil(() => response && response.status === 200);
         });


### PR DESCRIPTION
Refactoring jdbc templates

## What
- Change sparql template view to use yasgui directive instead component directly.
- Change jdbc template view to use yasgui directive instead component directly.

## Why
The Yasgui directive was introduced that wrap most of needed configurations of ontotext-yasgui-we-component

## How
- Change the templates and the controllers to use the directive.

Additional work:
- added flag "failOnStatusCode" to delete repository command. It prevents the tests to failed if something is wrong if repository can't delete. This method is used after each test, it is not part of the test, it just should clean backend server after the test.
- Extends yasgui-component.directive.js
- Moves visual button configuration to the view from the directive.