### PR TITLE
Feature/gdb 8479 replace old yasr component with new yasgui

### DIFF
--- a/src/css/similarity.css
+++ b/src/css/similarity.css
@@ -7,11 +7,3 @@
     display: block;
     margin: 0 auto;
 }
-
-.yasr .dataTables_filter {
-    display: none;
-}
-
-.yasr-container {
-    margin-top: 10px;
-}

--- a/src/js/angular/rest/sparql.rest.service.js
+++ b/src/js/angular/rest/sparql.rest.service.js
@@ -14,7 +14,8 @@ function SparqlRestService($http) {
         addKnownPrefixes,
         editSavedQuery,
         deleteSavedQuery,
-        addNewSavedQuery
+        addNewSavedQuery,
+        getQueryResult
     };
 
     /**
@@ -113,5 +114,14 @@ function SparqlRestService($http) {
 
     function addKnownPrefixes(prefixes) {
         return $http.post(`${SPARQL_ENDPOINT}/add-known-prefixes`, prefixes);
+    }
+
+    function getQueryResult(repositoryId, sendData, accept) {
+        return $http.get(`repositories/${repositoryId}`, {
+            params: sendData,
+            headers: {
+                Accept: accept
+            }
+        });
     }
 }

--- a/src/js/angular/similarity/app.js
+++ b/src/js/angular/similarity/app.js
@@ -7,6 +7,7 @@ import 'angular/similarity/controllers/create-index.controller';
 import 'angular/core/directives/queryeditor/sparql-tab.directive';
 import 'angular/core/directives/queryeditor/query-editor.controller';
 import 'angular/core/directives/queryeditor/query-editor.directive';
+import 'angular/core/directives/yasgui-component/yasgui-component.directive';
 
 angular.module('graphdb.framework.similarity', [
     'graphdb.framework.core.controllers',
@@ -16,5 +17,6 @@ angular.module('graphdb.framework.similarity', [
     'graphdb.framework.similarity.controllers.list',
     'graphdb.framework.core.directives.queryeditor.controllers',
     'graphdb.framework.core.directives.queryeditor.sparqltab',
-    'graphdb.framework.core.directives.queryeditor.queryeditor'
+    'graphdb.framework.core.directives.queryeditor.queryeditor',
+    'graphdb.framework.core.directives.yasgui-component'
 ]);

--- a/src/js/angular/similarity/controllers/similarity-list.controller.js
+++ b/src/js/angular/similarity/controllers/similarity-list.controller.js
@@ -25,7 +25,8 @@ SimilarityCtrl.$inject = [
     'AutocompleteRestService',
     'productInfo',
     'RDF4JRepositoriesRestService',
-    '$translate'
+    '$translate',
+    'SparqlRestService'
 ];
 
 function SimilarityCtrl(
@@ -41,10 +42,12 @@ function SimilarityCtrl(
     AutocompleteRestService,
     productInfo,
     RDF4JRepositoriesRestService,
-    $translate) {
+    $translate,
+    SparqlRestService) {
 
     const PREFIX = 'http://www.ontotext.com/graphdb/similarity/';
     const PREFIX_PREDICATION = 'http://www.ontotext.com/graphdb/similarity/psi/';
+    const acceptContent = 'application/x-sparqlstar-results+json, application/sparql-results+json;q=0.9, */*;q=0.8';
     const PREFIX_INSTANCE = PREFIX + 'instance/';
     const ANY_PREDICATE = PREFIX_PREDICATION + 'any';
     $scope.pluginName = 'similarity';
@@ -74,19 +77,13 @@ function SimilarityCtrl(
     // =========================
     // Public functions
     // =========================
-    // loads similarity indexes
     $scope.loadSimilarityIndexes = () => {
         if (!$scope.isGraphDBRepository || !$scope.pluginIsActive) {
             return;
         }
         SimilarityRestService.getIndexes()
-            .success(function (data) {
-                $scope.similarityIndexes = mapIndexesResponseToSimilarityIndex(data);
-            })
-            .error(function (data) {
-                const msg = getError(data);
-                toastr.error(msg, $translate.instant('similarity.could.not.get.indexes.error'));
-            });
+            .success((data) => $scope.similarityIndexes = mapIndexesResponseToSimilarityIndex(data))
+            .error((error) => toastr.error(getError(error), $translate.instant('similarity.could.not.get.indexes.error')));
     };
 
     $scope.reloadSimilarityIndexes = () => {
@@ -121,67 +118,13 @@ function SimilarityCtrl(
     };
 
     $scope.performSearch = (similarityIndex, uri, searchType, resultType, parameters) => {
-
         toggleOntoLoader(true);
-
-        // this is either the search term or the iri for the subject
-        let termOrSubject = uri;
-
-        $scope.lastSearch = new SimilaritySearch();
-        $scope.lastSearch.type = searchType;
-
-        if (SimilaritySearchType.isSearchEntityPredicateType(searchType)) {
-            termOrSubject = $scope.psiSubject;
-            $scope.lastSearch.predicate = uri;
-        }
-
-        if (SimilaritySearchType.isSearchTermType(searchType)) {
-            termOrSubject = literalForQuery(termOrSubject);
-        } else {
-            termOrSubject = iriForQuery(termOrSubject);
-        }
-
-        $scope.lastSearch.termOrSubject = termOrSubject;
-
-        const headers = {Accept: 'application/x-sparqlstar-results+json, application/sparql-results+json;q=0.9, */*;q=0.8'};
-        let sparqlQuery;
-        if (SimilaritySearchType.isSearchAnalogicalType(searchType)) {
-            sparqlQuery = ($scope.selectedSimilarityIndex.analogicalQuery) ? $scope.selectedSimilarityIndex.analogicalQuery : $scope.searchQueries['analogical'];
-        } else {
-            sparqlQuery = ($scope.selectedSimilarityIndex.searchQuery) ? $scope.selectedSimilarityIndex.searchQuery : $scope.searchQueries[$scope.selectedSimilarityIndex.type];
-        }
-        const sendData = {
-            query: sparqlQuery,
-            $index: iriForQuery(PREFIX_INSTANCE + similarityIndex.name),
-            $query: termOrSubject,
-            $searchType: iriForQuery(($scope.selectedSimilarityIndex.isTextType() ? PREFIX : PREFIX_PREDICATION) + (SimilaritySearchType.isSearchEntityPredicateType(searchType) ? SimilaritySearchType.SEARCH_ENTITY : searchType)),
-            $resultType: iriForQuery($scope.selectedSimilarityIndex.isTextType() ? PREFIX + resultType : PREFIX_PREDICATION + SimilarityResultType.ENTITY_RESULT),
-            $parameters: literalForQuery(parameters)
-        };
-
-        if (SimilaritySearchType.isSearchEntityPredicateType(searchType)) {
-            sendData.$psiPredicate = $scope.lastSearch.predicate ? iriForQuery($scope.lastSearch.predicate) : iriForQuery(ANY_PREDICATE);
-        }
-
-        if (SimilaritySearchType.isSearchAnalogicalType(searchType)) {
-            $scope.searchSubject = uri;
-            sendData.$givenSubject = iriForQuery($scope.analogicalSubject);
-            sendData.$givenObject = iriForQuery($scope.analogicalObject);
-            sendData.$searchSubject = iriForQuery(uri);
-        }
-
-        $.ajax({
-            method: 'GET',
-            url: 'repositories/' + $repositories.getActiveRepository(),
-            data: sendData,
-            headers: headers
-        }).done(function (data, textStatus, jqXhrOrErrorString) {
-            toggleOntoLoader(false);
-            yasr.setResponse(data, textStatus, jqXhrOrErrorString);
-        }).fail(function (data) {
-            toastr.error(getError(data), $translate.instant('similarity.get.resource.error'));
-            toggleOntoLoader(false);
-        });
+        updateLastSearch(searchType, uri);
+        const sendData = buildSendData(similarityIndex, uri, searchType, resultType, parameters);
+        SparqlRestService.getQueryResult($repositories.getActiveRepository(), sendData, acceptContent)
+            .then((response) => setSimilarityResponse(response))
+            .catch((error) => toastr.error(getError(error.data), $translate.instant('similarity.get.resource.error')))
+            .finally(() => toggleOntoLoader(false));
     };
 
     $scope.viewSearchQuery = () => {
@@ -213,9 +156,7 @@ function SimilarityCtrl(
             templateUrl: 'pages/viewQuery.html',
             controller: 'ViewQueryCtrl',
             resolve: {
-                query: function () {
-                    return replacedQuery;
-                }
+                query: () => replacedQuery
             }
         });
     };
@@ -228,11 +169,8 @@ function SimilarityCtrl(
         }).result
             .then(function () {
                 SimilarityRestService.deleteIndex(similarityIndex)
-                    .then(function () {
-                        $scope.loadSimilarityIndexes();
-                    }, function (err) {
-                        toastr.error(getError(err));
-                    });
+                    .then(() => $scope.loadSimilarityIndexes())
+                    .catch((err) => toastr.error(getError(err)));
             });
     };
 
@@ -246,14 +184,12 @@ function SimilarityCtrl(
             querySameAs: index.sameAs,
             viewType: index.type,
             indexAnalyzer: index.analyzer
-        }).success(function (query) {
+        }).success((query) => {
             $uibModal.open({
                 templateUrl: 'pages/viewQuery.html',
                 controller: 'ViewQueryCtrl',
                 resolve: {
-                    query: function () {
-                        return query;
-                    }
+                    query: () => query
                 }
             });
         });
@@ -269,13 +205,10 @@ function SimilarityCtrl(
             message: decodeHTML($translate.instant('similarity.rebuild.index.warning', {name: index.name})),
             warning: true
         }).result
-            .then(function () {
+            .then(() => {
                 index.status = SimilarityIndexStatus.REBUILDING;
                 SimilarityRestService.rebuildIndex(index)
-                    .then(function (res) {
-                    }, function (err) {
-                        toastr.error(getError(err));
-                    });
+                    .catch((error) => toastr.error(getError(error)));
             });
     };
 
@@ -304,7 +237,7 @@ function SimilarityCtrl(
     };
 
     $scope.cloneSimilataryIndex = (similarityIndex) => {
-       navigateToEditPage(similarityIndex, true);
+        navigateToEditPage(similarityIndex, true);
     };
 
     $scope.setPsiSubject = (psiSubject) => {
@@ -322,7 +255,6 @@ function SimilarityCtrl(
     // =========================
     // Private functions
     // =========================
-
     const navigateToEditPage = (similarityIndex, isClone = false) => {
         const params = {
             selectQuery: similarityIndex.selectQuery,
@@ -357,12 +289,9 @@ function SimilarityCtrl(
     };
 
     const loadSearchQueries = () => {
-        SimilarityRestService.getSearchQueries().success(function (data) {
-            $scope.searchQueries = data;
-        }).error(function (data) {
-            const msg = getError(data);
-            toastr.error(msg, $translate.instant('similarity.could.not.get.search.queries.error'));
-        });
+        SimilarityRestService.getSearchQueries()
+            .success((data) => $scope.searchQueries = data)
+            .error((data) => toastr.error(getError(data), $translate.instant('similarity.could.not.get.search.queries.error')));
     };
 
     const createYasr = (usedPrefixes) => {
@@ -470,4 +399,67 @@ function SimilarityCtrl(
     // Wait until the active repository object is set, otherwise "canWriteActiveRepo()" may return a wrong result and the "ontotext-yasgui"
     // readOnly configuration may be incorrect.
     const activeRepositoryChangeHandler = $scope.$watch($scope.getActiveRepositoryObject, getActiveRepositoryObjectHandler);
+
+    const buildSendData = (similarityIndex, uri, searchType, resultType, parameters) => {
+        const sendData = {
+            query: buildSparqlQuery($scope.lastSearch.type),
+            $index: iriForQuery(PREFIX_INSTANCE + similarityIndex.name),
+            $query: $scope.lastSearch.termOrSubject,
+            $searchType: iriForQuery(($scope.selectedSimilarityIndex.isTextType() ? PREFIX : PREFIX_PREDICATION) + (SimilaritySearchType.isSearchEntityPredicateType(searchType) ? SimilaritySearchType.SEARCH_ENTITY : searchType)),
+            $resultType: iriForQuery($scope.selectedSimilarityIndex.isTextType() ? PREFIX + resultType : PREFIX_PREDICATION + SimilarityResultType.ENTITY_RESULT),
+            $parameters: literalForQuery(parameters)
+        };
+
+        if (SimilaritySearchType.isSearchEntityPredicateType(searchType)) {
+            sendData.$psiPredicate = $scope.lastSearch.predicate ? iriForQuery($scope.lastSearch.predicate) : iriForQuery(ANY_PREDICATE);
+        }
+
+        if (SimilaritySearchType.isSearchAnalogicalType(searchType)) {
+            $scope.searchSubject = uri;
+            sendData.$givenSubject = iriForQuery($scope.analogicalSubject);
+            sendData.$givenObject = iriForQuery($scope.analogicalObject);
+            sendData.$searchSubject = iriForQuery(uri);
+        }
+        return sendData;
+    };
+
+    const updateLastSearch = (searchType, uri) => {
+        $scope.lastSearch = new SimilaritySearch();
+        $scope.lastSearch.type = searchType;
+
+        if (SimilaritySearchType.isSearchEntityPredicateType(searchType)) {
+            $scope.lastSearch.predicate = uri;
+        }
+
+        $scope.lastSearch.termOrSubject = buildTermOrSubject($scope.lastSearch.type, uri, $scope.psiSubject);
+    };
+
+    const buildSparqlQuery = (searchType) => {
+        let sparqlQuery;
+        if (SimilaritySearchType.isSearchAnalogicalType(searchType)) {
+            sparqlQuery = ($scope.selectedSimilarityIndex.analogicalQuery) ? $scope.selectedSimilarityIndex.analogicalQuery : $scope.searchQueries['analogical'];
+        } else {
+            sparqlQuery = ($scope.selectedSimilarityIndex.searchQuery) ? $scope.selectedSimilarityIndex.searchQuery : $scope.searchQueries[$scope.selectedSimilarityIndex.type];
+        }
+        return sparqlQuery;
+    };
+
+    const buildTermOrSubject = (searchType, uri, psiSubject) => {
+        // this is either the search term or the iri for the subject
+        let termOrSubject = uri;
+
+        if (SimilaritySearchType.isSearchEntityPredicateType(searchType)) {
+            termOrSubject = psiSubject;
+        } else if (SimilaritySearchType.isSearchTermType(searchType)) {
+            termOrSubject = literalForQuery(termOrSubject);
+        } else {
+            termOrSubject = iriForQuery(termOrSubject);
+        }
+        return termOrSubject;
+    };
+
+    const setSimilarityResponse = (response) => {
+        // TODO change old YASR with new one.
+        yasr.setResponse(response.data, response.status, response.statusText);
+    };
 }

--- a/src/pages/similarity-indexes.html
+++ b/src/pages/similarity-indexes.html
@@ -288,13 +288,8 @@
 			<button type="button" class="btn btn-link" ng-click="viewSearchQuery()">{{'view.sparql.query.title' | translate}}</button>
 
 
-			<div class="yasr-container" ng-show="lastSearch">
-				<div id="yasr">
-					<div class="yasr" id="yasr-inner">
-						<div class='yasr_results'></div>
-					</div>
-				</div>
-
+			<div class="yasr-container pt-1" ng-if="lastSearch">
+                <yasgui-component ng-if="!loading" id="query-editor" yasgui-config="yasguiConfig""></yasgui-component>
 				<div id="results-loader" class="ot-loader opacity-hide" onto-loader size="100"></div>
 			</div>
 		</div>

--- a/test-cypress/integration/explore/similarity.spec.js
+++ b/test-cypress/integration/explore/similarity.spec.js
@@ -186,9 +186,8 @@ describe('Similarity screen validation', () => {
             searchIndex('Neal');
 
             // Then I expect search results to be displayed
-            cy.get('.search-results').should('be.visible');
             // And showing 20 results
-            cy.get('.resultsTable tbody tr').should('have.length', 20);
+            YasrSteps.getResults().should('have.length', 20);
         });
     });
 


### PR DESCRIPTION
## What
- Changes rest client of execution of the similarity index queries.
- Reduces big functions to small one.
- Updates similarity indexes view.

## Why
- Makes code easier to read.
- We want to integrate "ontotext-yasgui-web-component" to WB.
## How
- The old implementations of yasr has been replaced with "ontotext-yasgui-web-component".