### PR TITLE
GDB-8369 Cherry pick GDB-8369 into 2.2

### DIFF
--- a/src/js/angular/clustermanagement/controllers.js
+++ b/src/js/angular/clustermanagement/controllers.js
@@ -241,9 +241,7 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
                 })
                 .catch((error) => {
                     const failMessage = $translate.instant('cluster_management.delete_cluster_dialog.notifications.fail_delete');
-                    const failedNodesList = Object.keys(error.data)
-                        .reduce((message, key) => message += `<div>${key} - ${error.data[key]}</div>`, '');
-                    toastr.error(failedNodesList, failMessage, {allowHtml: true});
+                    handleErrors(error.data, error.status, failMessage);
                 })
                 .finally(() => {
                     $scope.setLoader(false);
@@ -325,7 +323,7 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
                 })
                 .catch((error) => {
                     const failMessageTitle = $translate.instant('cluster_management.cluster_page.notifications.add_nodes_fail');
-                    handleAddRemoveErrors(error.data, error.status, failMessageTitle);
+                    handleErrors(error.data, error.status, failMessageTitle);
                 })
                 .finally(() => {
                     $scope.setLoader(false);
@@ -361,7 +359,7 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
                 })
                 .catch((error) => {
                     const failMessageTitle = $translate.instant('cluster_management.cluster_page.notifications.remove_nodes_fail');
-                    handleAddRemoveErrors(error.data, error.status, failMessageTitle);
+                    handleErrors(error.data, error.status, failMessageTitle);
                 })
                 .finally(() => {
                     $scope.setLoader(false);
@@ -375,7 +373,7 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
         $scope.getClusterConfiguration();
     }
 
-    function handleAddRemoveErrors(data, status, title) {
+    function handleErrors(data, status, title) {
         let failMessage = data.message || data;
 
         if (status === 400 && Array.isArray(data)) {


### PR DESCRIPTION
… (#968)

* GDB-8369 Ascertaining whether the error is a 403 and calls getError(error.data, error.status) if it is

* GDB-8369 use handleAddRemoveErrors() to reformat the message

* GDB-8369 Rename handleAddRemoveErrors() to handleErrors()

(cherry picked from commit 8b6fc50ab52a3ee9a500438ca95e28bd23c73ca1)