### PR TITLE
GDB-7642: The browser's Back button doesn't return the user back to the SPARQL view

### DIFF
--- a/src/js/angular/explore/controllers.js
+++ b/src/js/angular/explore/controllers.js
@@ -199,6 +199,9 @@ function ExploreCtrl($scope, $http, $location, toastr, $routeParams, $repositori
         }
         // Remember the role in the URL so the URL is stable and leads back to the same view
         $location.search('role', $scope.role);
+        // Changing the URL parameters adds a history entry in the browser history, and this causes incorrect behavior of the browser's back button functionality.
+        // To resolve this issue, we replace the current URL without adding a new history entry.
+        $location.replace();
         // wait for principal request if it has not finished and then fetch graph
         Promise.resolve(principalRequestPromise)
             .then(() => getGraph());


### PR DESCRIPTION
## What
When the 'Resource' view is open, after clicking on a resource link in the SPARQL view result table and then clicking on the browser back button, the 'Resource' view is reloaded instead of returning the user back to the SPARQL view.

## Why
When the page is loaded, the URL is changed. It is modified with the 'role' URL parameter being added to it. The page has buttons that change the value of this parameter when clicked on. The modification of the parameter causes the browser to add a new history entry for every modification of the URL. As a result, when the user clicks on the back button, they are returned to the same page instead of the page they came from.

## How
Removes the last history entry from the browser history after every modification of the URL.