### PR TITLE
GDB-8442 Allow access to cluster view for all authenticated users

### DIFF
--- a/src/css/clustermanagement.css
+++ b/src/css/clustermanagement.css
@@ -17,10 +17,13 @@ path.link {
 }
 
 .cluster-zone.no-cluster {
-  cursor: pointer;
   stroke: black;
   fill: transparent;
   transition: fill 0.2s, stroke 0.2s;
+}
+
+.cluster-zone.no-cluster.has-access {
+    cursor: pointer;
 }
 
 .cluster-zone.no-cluster:hover {

--- a/src/js/angular/clustermanagement/cluster-drawing.service.js
+++ b/src/js/angular/clustermanagement/cluster-drawing.service.js
@@ -37,7 +37,7 @@ export function setCreateClusterZone(hasCluster, clusterZone, translationsMap, h
         textGroup
             .append('text')
             .attr('id', 'no-cluster-label')
-            .text(translationsMap.no_cluster_configured || 'No cluster group configured')
+            .text(translationsMap.no_cluster_configured)
             .attr('y', -50)
             .classed('h2', true)
             .style('text-anchor', "middle");
@@ -45,7 +45,7 @@ export function setCreateClusterZone(hasCluster, clusterZone, translationsMap, h
             textGroup.append('text')
                 .attr('id', 'create-cluster-label')
                 .classed('h3', true)
-                .text(translationsMap.create_cluster_btn || 'Click here to create a cluster')
+                .text(translationsMap.create_cluster_btn)
                 .style('text-anchor', "middle");
         }
         textGroup.append('text')

--- a/src/js/angular/clustermanagement/cluster-drawing.service.js
+++ b/src/js/angular/clustermanagement/cluster-drawing.service.js
@@ -22,10 +22,11 @@ export function createClusterZone(parent) {
     return clusterZone;
 }
 
-export function setCreateClusterZone(hasCluster, clusterZone, translationsMap) {
+export function setCreateClusterZone(hasCluster, clusterZone, translationsMap, hasAccess = false) {
     clusterZone
         .select('.cluster-zone')
-        .classed('no-cluster', !hasCluster);
+        .classed('no-cluster', !hasCluster)
+        .classed('has-access', hasAccess);
 
     if (hasCluster) {
         clusterZone.selectAll('#no-cluster-zone').remove();
@@ -40,11 +41,13 @@ export function setCreateClusterZone(hasCluster, clusterZone, translationsMap) {
             .attr('y', -50)
             .classed('h2', true)
             .style('text-anchor', "middle");
-        textGroup.append('text')
-            .attr('id', 'create-cluster-label')
-            .classed('h3', true)
-            .text(translationsMap.create_cluster_btn || 'Click here to create a cluster')
-            .style('text-anchor', "middle");
+        if (hasAccess ){
+            textGroup.append('text')
+                .attr('id', 'create-cluster-label')
+                .classed('h3', true)
+                .text(translationsMap.create_cluster_btn || 'Click here to create a cluster')
+                .style('text-anchor', "middle");
+        }
         textGroup.append('text')
             .attr('y', 130)
             .attr('class', 'icon-any repo')

--- a/src/js/angular/clustermanagement/controllers.js
+++ b/src/js/angular/clustermanagement/controllers.js
@@ -38,10 +38,10 @@ export const LinkState = {
     NO_CONNECTION: 'NO_CONNECTION'
 };
 
-ClusterManagementCtrl.$inject = ['$scope', '$http', '$q', 'toastr', '$repositories', '$uibModal', '$sce',
+ClusterManagementCtrl.$inject = ['$scope', '$http', '$q', 'toastr', '$repositories', '$uibModal', '$sce', '$jwtAuth',
     '$window', '$interval', 'ModalService', '$timeout', 'ClusterRestService', '$location', '$translate', 'RemoteLocationsService', '$rootScope'];
 
-function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibModal, $sce,
+function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibModal, $sce, $jwtAuth,
     $window, $interval, ModalService, $timeout, ClusterRestService, $location, $translate, RemoteLocationsService, $rootScope) {
     $scope.loader = true;
     $scope.isLeader = false;
@@ -50,6 +50,10 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
     $scope.NodeState = NodeState;
     $scope.leaderChanged = false;
     $scope.currentLeader = null;
+
+    $scope.isAdmin = function () {
+        return $jwtAuth.isAuthenticated() && $jwtAuth.isAdmin();
+    };
 
     // Holds child context
     $scope.childContext = {};
@@ -470,8 +474,8 @@ function CreateClusterCtrl($scope, $uibModalInstance, $timeout, ClusterRestServi
     };
 
     function handleErrors(data, status) {
+        let failMessage;
         delete $scope.preconditionErrors;
-        toastr.error($translate.instant('cluster_management.cluster_page.notifications.create_failed'));
         $scope.errors.splice(0);
         if (status === 412) {
             $scope.preconditionErrors = Object.keys(data).map((key) => `${key} - ${data[key]}`);
@@ -479,7 +483,11 @@ function CreateClusterCtrl($scope, $uibModalInstance, $timeout, ClusterRestServi
             $scope.errors.push(...data);
         } else if (status === 409) {
             $scope.errors.push(data);
+        } else if (data.message || typeof data === 'string'){
+            failMessage = data.message || data;
         }
+        toastr.error(failMessage, $translate.instant('cluster_management.cluster_page.notifications.create_failed'));
+
     }
 
     $scope.isClusterConfigurationValid = () => {

--- a/src/js/angular/clustermanagement/directives.js
+++ b/src/js/angular/clustermanagement/directives.js
@@ -43,6 +43,8 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
         return {
             restrict: 'A',
             link: function (scope, element) {
+                const hasAccess = scope.isAdmin();
+
                 scope.showLegend = false;
                 $rootScope.$on('$translateChangeSuccess', function () {
                     updateTranslations();
@@ -374,9 +376,9 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
                 }
 
                 function setClusterZoneType(hasCluster) {
-                    CDS.setCreateClusterZone(hasCluster, clusterZone, translationsMap);
+                    CDS.setCreateClusterZone(hasCluster, clusterZone, translationsMap, hasAccess);
                     let mouseupCallback;
-                    if (!hasCluster) {
+                    if (!hasCluster && hasAccess) {
                         mouseupCallback = () => {
                             scope.$apply(function () {
                                 scope.showCreateClusterDialog();

--- a/src/js/angular/clustermanagement/plugin.js
+++ b/src/js/angular/clustermanagement/plugin.js
@@ -17,7 +17,7 @@ PluginRegistry.add('main.menu', {
         labelKey: 'menu.cluster.label',
         href: 'cluster',
         order: 20,
-        role: 'ROLE_ADMIN',
+        role: 'ROLE_USER',
         parent: 'Setup',
         guideSelector: 'sub-menu-cluster'
     }]

--- a/src/pages/cluster-management/clusterInfo.html
+++ b/src/pages/cluster-management/clusterInfo.html
@@ -23,22 +23,24 @@
 
 <div class="clearfix mb-2 d-flex" ng-if="!loader && clusterConfiguration">
     <div class="action-buttons">
-        <button type="button" class="btn btn-secondary delete-cluster-btn mr-2"
-                ng-click="showDeleteDialog()"
-                gdb-tooltip="{{'cluster_management.buttons.delete_cluster_tooltip' | translate}}"
-                tooltip-placement="bottom">
-            <span class="icon-trash"></span> {{'cluster_management.buttons.delete_cluster' | translate}}
-        </button>
-        <button type="button" class="btn btn-primary add-node-btn" ng-if="currentLeader"
-                ng-click="showAddNodeToClusterDialog()"
-                gdb-tooltip="{{'cluster_management.buttons.add_nodes_btn_tooltip' | translate}}" tooltip-placement="bottom">
-            <span class="icon-plus"></span> {{'cluster_management.buttons.add_nodes_btn' | translate}}
-        </button>
-        <button type="button" class="btn btn-secondary remove-node-btn mr-2" ng-if="currentLeader"
-                ng-click="showRemoveNodesFromClusterDialog()"
-                gdb-tooltip="{{'cluster_management.buttons.remove_nodes_btn_tooltip' | translate}}" tooltip-placement="bottom">
-            <span class="icon-minus"></span> {{'cluster_management.buttons.remove_nodes_btn' | translate}}
-        </button>
+        <div ng-if="isAdmin()" class="buttons-wrapper">
+            <button type="button" class="btn btn-secondary delete-cluster-btn mr-2"
+                    ng-click="showDeleteDialog()"
+                    gdb-tooltip="{{'cluster_management.buttons.delete_cluster_tooltip' | translate}}"
+                    tooltip-placement="bottom">
+                <span class="icon-trash"></span> {{'cluster_management.buttons.delete_cluster' | translate}}
+            </button>
+            <button type="button" class="btn btn-primary add-node-btn" ng-if="currentLeader"
+                    ng-click="showAddNodeToClusterDialog()"
+                    gdb-tooltip="{{'cluster_management.buttons.add_nodes_btn_tooltip' | translate}}" tooltip-placement="bottom">
+                <span class="icon-plus"></span> {{'cluster_management.buttons.add_nodes_btn' | translate}}
+            </button>
+            <button type="button" class="btn btn-secondary remove-node-btn mr-2" ng-if="currentLeader"
+                    ng-click="showRemoveNodesFromClusterDialog()"
+                    gdb-tooltip="{{'cluster_management.buttons.remove_nodes_btn_tooltip' | translate}}" tooltip-placement="bottom">
+                <span class="icon-minus"></span> {{'cluster_management.buttons.remove_nodes_btn' | translate}}
+            </button>
+        </div>
     </div>
     <button class="btn btn-link"
             ng-click="toggleSidePanel()"
@@ -96,8 +98,8 @@
         <h3 class="hovered-parent">
             {{'cluster_management.cluster_configuration.label' | translate}}
         </h3>
-        <div class="mb-2">
-            <button type="button" class="btn btn-primary delete-cluster-btn"
+        <div class="mb-2" ng-if="isAdmin()">
+            <button type="button" class="btn btn-primary edit-cluster-configuration"
                     ng-if="currentNode.nodeState === NodeState.LEADER"
                     ng-click="showEditConfigurationDialog()"
                     gdb-tooltip="{{'cluster_management.buttons.edit_cluster_tooltip' | translate}}"
@@ -108,7 +110,8 @@
         <div class="datasource mb-1">
             <div class="item clearfix break-word-alt small">
                 {{'cluster_management.cluster_configuration_properties.election_min_timeout' | translate}}
-                <em class="icon-info text-primary" gdb-tooltip="{{'cluster_management.cluster_configuration_properties.election_min_timeout_tooltip' | translate}}"></em>
+                <em class="icon-info text-primary"
+                    gdb-tooltip="{{'cluster_management.cluster_configuration_properties.election_min_timeout_tooltip' | translate}}"></em>
             </div>
             <div class="data-value">
                 <span>{{clusterConfiguration.electionMinTimeout | number}}</span>
@@ -117,7 +120,8 @@
         <div class="datasource mb-1">
             <div class="item clearfix break-word-alt small">
                 {{'cluster_management.cluster_configuration_properties.election_range_timeout' | translate}}
-                <em class="icon-info text-primary" gdb-tooltip="{{'cluster_management.cluster_configuration_properties.election_range_timeout_tooltip' | translate}}"></em>
+                <em class="icon-info text-primary"
+                    gdb-tooltip="{{'cluster_management.cluster_configuration_properties.election_range_timeout_tooltip' | translate}}"></em>
             </div>
             <div class="data-value">
                 <span>{{clusterConfiguration.electionRangeTimeout | number}}</span>
@@ -126,7 +130,8 @@
         <div class="datasource mb-1">
             <div class="item clearfix break-word-alt small">
                 {{'cluster_management.cluster_configuration_properties.heartbeat_interval' | translate}}
-                <em class="icon-info text-primary" gdb-tooltip="{{'cluster_management.cluster_configuration_properties.heartbeat_interval_tooltip' | translate}}"></em>
+                <em class="icon-info text-primary"
+                    gdb-tooltip="{{'cluster_management.cluster_configuration_properties.heartbeat_interval_tooltip' | translate}}"></em>
             </div>
             <div class="data-value">
                 <span>{{clusterConfiguration.heartbeatInterval | number}}</span>
@@ -135,7 +140,8 @@
         <div class="datasource mb-1">
             <div class="item clearfix break-word-alt small">
                 {{'cluster_management.cluster_configuration_properties.message_size_kb' | translate}}
-                <em class="icon-info text-primary" gdb-tooltip="{{'cluster_management.cluster_configuration_properties.message_size_kb_tooltip' | translate}}"></em>
+                <em class="icon-info text-primary"
+                    gdb-tooltip="{{'cluster_management.cluster_configuration_properties.message_size_kb_tooltip' | translate}}"></em>
             </div>
             <div class="data-value">
                 <span>{{clusterConfiguration.messageSizeKB | number}}</span>
@@ -144,7 +150,8 @@
         <div class="datasource mb-1">
             <div class="item clearfix break-word-alt small">
                 {{'cluster_management.cluster_configuration_properties.verification_timeout' | translate}}
-                <em class="icon-info text-primary" gdb-tooltip="{{'cluster_management.cluster_configuration_properties.verification_timeout_tooltip' | translate}}"></em>
+                <em class="icon-info text-primary"
+                    gdb-tooltip="{{'cluster_management.cluster_configuration_properties.verification_timeout_tooltip' | translate}}"></em>
             </div>
             <div class="data-value">
                 <span>{{clusterConfiguration.verificationTimeout | number}}</span>
@@ -154,7 +161,8 @@
         <ul>
             <li ng-repeat="node in clusterModel.nodes">
                 <a class="data-value" href="{{node.endpoint}}" target="_blank">{{node.endpoint}}</a>
-                <div class="small">{{ 'cluster_management.cluster_status.node.rpc_address' | translate }}: <span class="data-value">{{node.address}}</span></div>
+                <div class="small">{{ 'cluster_management.cluster_status.node.rpc_address' | translate }}: <span class="data-value">{{node.address}}</span>
+                </div>
                 <div class="small">{{ 'cluster_management.cluster_status.node.state' | translate }}: <span class="data-value">{{node.nodeState}}</span></div>
             </li>
         </ul>


### PR DESCRIPTION
## What
Allow access to cluster view from the menu or by url to all authenticated users and restrict actions to admin users only

## Why
All authenticated users should have access to the cluster view and only admin users should be able to perform actions

## How
- added a check to see if user has admin access to create a cluster and changed view
- added ng-if to action buttons to hide them is user is not admin
- changed main menu item role to ROLE_USER to allow all authenticated users to see it