### PR TITLE
GDB-8043 Reformat the message of error 431 when trying to download json result of a very large query

### DIFF
--- a/src/js/angular/core/directives/queryeditor/query-editor.directive.js
+++ b/src/js/angular/core/directives/queryeditor/query-editor.directive.js
@@ -616,7 +616,11 @@ function queryEditorDirective($timeout, $location, toastr, $repositories, Sparql
                         // data is received as blob
                         res.data.text()
                             .then((message) => {
-                                toastr.error(message, $translate.instant('common.error'));
+                                if (res.status === 431) {
+                                    toastr.error(res.statusText, $translate.instant('common.error'));
+                                } else {
+                                    toastr.error(message, $translate.instant('common.error'));
+                                }
                             });
                     });
                 } else {


### PR DESCRIPTION
GDB-8043: reformat the message of error 431 when trying to download json result of a very large query