### PR TITLE
GDB-7732: Refactoring of query execution.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "^0.0.2-TR40",
+                "ontotext-yasgui-web-component": "0.0.2-TR41",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -10271,9 +10271,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR9",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR9.tgz",
-            "integrity": "sha512-mCf3qzf65aFj5MCz8853Zh+rXGJxbGuWSMDJJNurUS1jLNnnm3L/QdwazWkmJr5dxcunpv2UH1DzIr9v3Kb6mA==",
+            "version": "0.0.2-TR41",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR41.tgz",
+            "integrity": "sha512-Bslq5Gxo/JFX4Vm0Vzitvk2COOOlirgtOPDtdKWKxqYTWsF5Am82aPiJOifDxG37QFQ2XNetkuJUApwQnAPlMg==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -25102,9 +25102,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR9",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR9.tgz",
-            "integrity": "sha512-mCf3qzf65aFj5MCz8853Zh+rXGJxbGuWSMDJJNurUS1jLNnnm3L/QdwazWkmJr5dxcunpv2UH1DzIr9v3Kb6mA==",
+            "version": "0.0.2-TR41",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR41.tgz",
+            "integrity": "sha512-Bslq5Gxo/JFX4Vm0Vzitvk2COOOlirgtOPDtdKWKxqYTWsF5Am82aPiJOifDxG37QFQ2XNetkuJUApwQnAPlMg==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "^0.0.2-TR38",
+                "ontotext-yasgui-web-component": "^0.0.2-TR40",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -10271,9 +10271,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR38",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR38.tgz",
-            "integrity": "sha512-gxj/MZv5dLg5LZSjoL0TL5Ea7OkEK4BaPD2HyAmIDhf2C8dDJGUU/zT4FSTjUrLCN7xxP0UhoWZzRsOa+2iTdA==",
+            "version": "0.0.2-TR9",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR9.tgz",
+            "integrity": "sha512-mCf3qzf65aFj5MCz8853Zh+rXGJxbGuWSMDJJNurUS1jLNnnm3L/QdwazWkmJr5dxcunpv2UH1DzIr9v3Kb6mA==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -25102,9 +25102,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "0.0.2-TR38",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR38.tgz",
-            "integrity": "sha512-gxj/MZv5dLg5LZSjoL0TL5Ea7OkEK4BaPD2HyAmIDhf2C8dDJGUU/zT4FSTjUrLCN7xxP0UhoWZzRsOa+2iTdA==",
+            "version": "0.0.2-TR9",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-0.0.2-TR9.tgz",
+            "integrity": "sha512-mCf3qzf65aFj5MCz8853Zh+rXGJxbGuWSMDJJNurUS1jLNnnm3L/QdwazWkmJr5dxcunpv2UH1DzIr9v3Kb6mA==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "^0.0.2-TR38",
+        "ontotext-yasgui-web-component": "^0.0.2-TR40",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "^0.0.2-TR40",
+        "ontotext-yasgui-web-component": "0.0.2-TR41",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/src/css/create-similarity-index.css
+++ b/src/css/create-similarity-index.css
@@ -1,0 +1,3 @@
+#query-editor .yasr .yasr_header {
+    margin-bottom: 0;
+}

--- a/src/js/angular/core/directives/yasgui-component/yasgui-component-directive.util.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component-directive.util.js
@@ -12,7 +12,7 @@ export const YasguiComponentDirectiveUtil = (function () {
 
     return {
         getOntotextYasguiElementController,
-        getOntotextYasguiElement
+        getOntotextYasguiElement,
     };
 })();
 
@@ -48,21 +48,30 @@ export class YasqeButtonsBuilder {
     build() {
         return [
             {
-                name: 'createSavedQuery',
+                name: YasqeButtonName.CREATE_SAVED_QUERY,
                 visible: this.createSavedQueryVisibility
             }, {
-                name: 'showSavedQueries',
+                name: YasqeButtonName.SHOW_SAVED_QUERIES,
                 visible: this.showSavedQueriesVisibility
             }, {
-                name: 'shareQuery',
+                name: YasqeButtonName.SHARE_QUERY,
                 visible: this.shareQueryVisibility
             }, {
-                name: 'includeInferredStatements',
+                name: YasqeButtonName.INCLUDE_INFERRED_STATEMENTS,
                 visible: this.includeInferredStatementsVisibility
             }
         ];
     }
 }
+
+export const YasqeButtonName = {
+    CREATE_SAVED_QUERY: 'createSavedQuery',
+    SHOW_SAVED_QUERIES: 'showSavedQueries',
+    SHARE_QUERY: 'shareQuery',
+    EXPANDS_RESULTS: 'expandResults',
+    INFER_STATEMENTS: 'inferStatements',
+    INCLUDE_INFERRED_STATEMENTS: 'includeInferredStatements'
+};
 
 export const DISABLE_YASQE_BUTTONS_CONFIGURATION = new YasqeButtonsBuilder().build();
 export const INFERRED_AND_SAME_AS_BUTTONS_CONFIGURATION = new YasqeButtonsBuilder().addIncludeInferredStatements().build();

--- a/src/js/angular/models/similarity/similarity-index-info.js
+++ b/src/js/angular/models/similarity/similarity-index-info.js
@@ -1,5 +1,6 @@
 import {SimilarityIndex} from "./similarity-index";
 import {SimilarityQueryType} from "./similarity-query-type";
+import {RenderingMode} from "../../ontotext-yasgui/rendering-mode";
 
 const filenamePattern = new RegExp('^[a-zA-Z0-9-_]+$');
 
@@ -19,6 +20,7 @@ export class SimilarityIndexInfo {
          * @type {string} - any of {@SimilarityQueryType} values.
          */
         this.selectedQueryType = SimilarityQueryType.DATA;
+        this.selectedYasguiRenderMode = RenderingMode.YASQE;
     }
 
     /**
@@ -118,6 +120,14 @@ export class SimilarityIndexInfo {
         return this.selectedQueryType;
     }
 
+    setSelectedYasguiRenderMode(renderMode) {
+        this.selectedYasguiRenderMode = renderMode;
+    }
+
+    getSelectedYasguiRenderMode() {
+        return this.selectedYasguiRenderMode;
+    }
+
     isDataQueryTypeSelected() {
         return SimilarityQueryType.DATA === this.selectedQueryType;
     }
@@ -160,6 +170,14 @@ export class SimilarityIndexInfo {
 
     hasAnalogicalQuery() {
         return !!this.similarityIndex.analogicalQuery;
+    }
+
+    isYasqeRenderMode() {
+        return RenderingMode.YASQE === this.getSelectedYasguiRenderMode();
+    }
+
+    isYasrRenderMode() {
+        return RenderingMode.YASR === this.getSelectedYasguiRenderMode();
     }
 
     ////////////////////////////

--- a/src/js/angular/models/similarity/similarity-index-info.js
+++ b/src/js/angular/models/similarity/similarity-index-info.js
@@ -1,6 +1,6 @@
 import {SimilarityIndex} from "./similarity-index";
 import {SimilarityQueryType} from "./similarity-query-type";
-import {RenderingMode} from "../../ontotext-yasgui/rendering-mode";
+import {RenderingMode} from "../ontotext-yasgui/rendering-mode";
 
 const filenamePattern = new RegExp('^[a-zA-Z0-9-_]+$');
 

--- a/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/src/js/angular/similarity/controllers/create-index.controller.js
@@ -401,6 +401,8 @@ function CreateSimilarityIdxCtrl($scope, toastr, $uibModal, $timeout, Similarity
             showResultTabs: false,
             showYasqeActionButtons: false,
             showQueryButton: false,
+            downloadAsOn: false,
+            showResultInfo: false,
             pageSize: 100,
             prefixes: $scope.usedPrefixes,
             render: $scope.similarityIndexInfo.getSelectedYasguiRenderMode(),

--- a/src/pages/create-index.html
+++ b/src/pages/create-index.html
@@ -1,3 +1,5 @@
+<link href="css/create-similarity-index.css?v=[AIV]{version}[/AIV]" rel="stylesheet">
+
 <div class="container-fluid">
 
     <h1>


### PR DESCRIPTION
## What
Changes implementation of switching between "yasqe" and "yasr" 'ontotext-yasgui-web-component' render mode.

## Why
For performance reason.

## How
The old implementation modifies the configuration of the 'ontotext-yasgui-web-component', which leads to the destruction of the component and the creation of a new one with the new configuration. The new one uses method of component, that changes the render mode without destroying of component.