### PR TITLE
GDB-7732: Added change repository listener and dirty check functionality

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1262,6 +1262,7 @@
     "similarity.error.invalid.search.query": "The search query must be a SELECT query",
     "similarity.error.invalid.analogical.query": "The analogical query must be a SELECT query",
     "similarity.error.query.invalid": "Invalid query",
+    "similarity.warning.unsaved.changes": "You have unsaved changes. Are you sure that you want to exit?",
     "sparql.template.get.templates.error": "Could not get SPARQL templates",
     "sparql.template.delete.template.warning": "Are you sure you want to delete the SPARQL template '{{templateID}}'?",
     "sparql.template.delete.template.success": "Deleted successfully SPARQL template",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1251,6 +1251,7 @@
     "similarity.error.invalid.search.query": "La requête de recherche doit être une requête SELECT",
     "similarity.error.invalid.analogical.query": "La requête analogique doit être une requête SELECT",
     "similarity.error.query.invalid": "Requete invalide",
+    "similarity.warning.unsaved.changes": "Vous avez des modifications non sauvegardées. Etes-vous sûr de vouloir quitter?",
     "sparql.template.get.templates.error": "Impossible de récupérer des modèles SPARQL",
     "sparql.template.delete.template.warning": "Êtes-vous sûr de vouloir supprimer le modèle SPARQL '{{templateID}}'?",
     "sparql.template.delete.template.success": "Suppression réussie du modèle SPARQL",

--- a/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/src/js/angular/similarity/controllers/create-index.controller.js
@@ -836,11 +836,11 @@ function CreateSimilarityIdxCtrl(
     }, function (activeRepo) {
         if (activeRepo) {
             Promise.all([SimilarityRestService.getSearchQueries(), SimilarityRestService.getSamples(), $repositories.getPrefixes(activeRepo.id)])
-                .then(([searchQueriesResponses, samples, usedPrefixes]) => {
+                .then(([searchQueriesResponses, samplesResponse, usedPrefixesResponse]) => {
                     $scope.canEditActiveRepo = $scope.canWriteActiveRepo();
                     searchQueries = searchQueriesResponses ? searchQueriesResponses.data : [];
-                    allSamples = samples ? samples.data : [];
-                    usedPrefixes = usedPrefixes;
+                    allSamples = samplesResponse ? samplesResponse.data : [];
+                    usedPrefixes = usedPrefixesResponse;
                     init();
                 }).catch((error) => {
                 console.log(error)

--- a/src/pages/create-index.html
+++ b/src/pages/create-index.html
@@ -196,54 +196,56 @@
 
                 <div class="row">
                     <div class="col-md-9">
-                        <yasgui-component id="query-editor" yasgui-config="yasguiConfig" query-changed="setDirty()"></yasgui-component>
+                        <yasgui-component id="query-editor" yasgui-config="yasguiConfig" query-changed="queryChanged()"></yasgui-component>
 
-                        <div ng-if="similarityIndexInfo.isDataQueryTypeSelected()">
+                        <div ng-if="saveOrUpdateExecuted">
+                            <div ng-if="similarityIndexInfo.isDataQueryTypeSelected()">
 
-                            <div ng-if="similarityIndexInfo.invalidSelectQuery"
-                                 class="idError alert alert-danger mt-1">
-                                {{'similarity.error.query.invalid' | translate}}
-                            </div>
+                                <div ng-if="similarityIndexInfo.invalidSelectQuery"
+                                     class="idError alert alert-danger mt-1">
+                                    {{'similarity.error.query.invalid' | translate}}
+                                </div>
 
-                            <div ng-if="!similarityIndexInfo.hasSelectQuery()"
-                                 class="idError alert alert-danger mt-1">
-                                {{'similarity.empty.select.query.error' | translate}}
-                            </div>
+                                <div ng-if="!similarityIndexInfo.hasSelectQuery()"
+                                     class="idError alert alert-danger mt-1">
+                                    {{'similarity.empty.select.query.error' | translate}}
+                                </div>
 
-                            <div ng-if="similarityIndexInfo.invalidSelectQueryType"
-                                 class="idError alert alert-danger mt-1">
-                                {{'similarity.error.invalid.select.query' | translate}}
-                            </div>
-                        </div>
-
-                        <div ng-if="similarityIndexInfo.isSearchQueryTypeSelected()">
-                            <div ng-if="similarityIndexInfo.invalidSearchQuery"
-                                 class="idError alert alert-danger mt-1">
-                                {{'similarity.error.query.invalid' | translate}}
+                                <div ng-if="similarityIndexInfo.invalidSelectQueryType"
+                                     class="idError alert alert-danger mt-1">
+                                    {{'similarity.error.invalid.select.query' | translate}}
+                                </div>
                             </div>
 
-                            <div ng-if="!similarityIndexInfo.hasSearchQuery()"
-                                 class="idError alert alert-danger mt-1">
-                                {{'similarity.empty.search.query.error' | translate}}
-                            </div>
-                            <div ng-if="similarityIndexInfo.invalidSearchQueryType"
-                                 class="idError alert alert-danger mt-1">
-                                {{'similarity.error.invalid.search.query' | translate}}
-                            </div>
-                        </div>
+                            <div ng-if="similarityIndexInfo.isSearchQueryTypeSelected()">
+                                <div ng-if="similarityIndexInfo.invalidSearchQuery"
+                                     class="idError alert alert-danger mt-1">
+                                    {{'similarity.error.query.invalid' | translate}}
+                                </div>
 
-                        <div ng-if="similarityIndexInfo.isAnalogicalQueryTypeSelected()">
-                            <div ng-if="similarityIndexInfo.invalidAnalogicalQuery"
-                                 class="idError alert alert-danger mt-1">
-                                {{'similarity.error.query.invalid' | translate}}
+                                <div ng-if="!similarityIndexInfo.hasSearchQuery()"
+                                     class="idError alert alert-danger mt-1">
+                                    {{'similarity.empty.search.query.error' | translate}}
+                                </div>
+                                <div ng-if="similarityIndexInfo.invalidSearchQueryType"
+                                     class="idError alert alert-danger mt-1">
+                                    {{'similarity.error.invalid.search.query' | translate}}
+                                </div>
                             </div>
-                            <div ng-if="!similarityIndexInfo.hasAnalogicalQuery()"
-                                 class="idError alert alert-danger mt-1">
-                                {{'similarity.empty.analogical.query.error' | translate}}
-                            </div>
-                            <div ng-if="similarityIndexInfo.invalidAnalogicalQueryType"
-                                 class="idError alert alert-danger mt-1">
-                                {{'similarity.error.invalid.analogical.query' | translate}}
+
+                            <div ng-if="similarityIndexInfo.isAnalogicalQueryTypeSelected()">
+                                <div ng-if="similarityIndexInfo.invalidAnalogicalQuery"
+                                     class="idError alert alert-danger mt-1">
+                                    {{'similarity.error.query.invalid' | translate}}
+                                </div>
+                                <div ng-if="!similarityIndexInfo.hasAnalogicalQuery()"
+                                     class="idError alert alert-danger mt-1">
+                                    {{'similarity.empty.analogical.query.error' | translate}}
+                                </div>
+                                <div ng-if="similarityIndexInfo.invalidAnalogicalQueryType"
+                                     class="idError alert alert-danger mt-1">
+                                    {{'similarity.error.invalid.analogical.query' | translate}}
+                                </div>
                             </div>
                         </div>
 

--- a/src/pages/create-index.html
+++ b/src/pages/create-index.html
@@ -71,10 +71,11 @@
                                type="text"
                                ng-model="similarityIndexInfo.similarityIndex.options"
                                id="indexParameters"
+                               ng-change="setDirty()"
                                placeholder="-vectortype binary">
                         <div class="small text-muted mt-1">
                             {{'see.full.label' | translate}}
-                            <a href="http://graphdb.ontotext.com/documentation/{{info.productShortVersion}}/semantic-similarity-searches.html#create-index-parameters"
+                            <a href="http://graphdb.ontotext.com/documentation/{{productInfo.productShortVersion}}/semantic-similarity-searches.html#create-index-parameters"
                                rel="noopener" target="_blank">
                                 {{'list.of.supported.params' | translate}}
                             </a>
@@ -88,26 +89,37 @@
                         <input class="form-control stop-words"
                                type="text"
                                placeholder="{{'default.lucene.stop.list' | translate}}"
-                               ng-model="similarityIndexInfo.similarityIndex.stopList">
+                               ng-model="similarityIndexInfo.similarityIndex.stopList"
+                               ng-change="setDirty()">
                     </div>
                 </div>
                 <div class="form-group row" ng-if="similarityIndexInfo.isTextType() || similarityIndexInfo.isTextLiteralType()">
                     <label class="col-md-4 col-form-label">{{'analyzer.class' | translate}}</label>
                     <div class="col-md-8">
-                        <input class="form-control analyzer-class" type="text" ng-model="similarityIndexInfo.similarityIndex.analyzer">
+                        <input class="form-control analyzer-class"
+                               type="text"
+                               ng-model="similarityIndexInfo.similarityIndex.analyzer"
+                               ng-change="setDirty()">
                     </div>
                 </div>
                 <div class="checkbox offset-xs-3 offset-md-4" ng-show="similarityIndexInfo.isTextType() || similarityIndexInfo.isTextLiteralType()">
                     <label class="col-xs-6 col-md-6" gdb-tooltip="{{'literal.index.input' | translate}}" tooltip-placement="bottom">
-                        <input type="checkbox" class="literal-index" ng-true-value="'true'" ng-false-value="'false'"
-                               ng-model="similarityIndexInfo.similarityIndex.isLiteralIndex"/>
+                        <input type="checkbox"
+                               class="literal-index"
+                               ng-true-value="'true'"
+                               ng-false-value="'false'"
+                               ng-model="similarityIndexInfo.similarityIndex.isLiteralIndex"
+                               ng-change="setDirty()"/>
                         {{'literal.index.label' | translate}}
                     </label>
                 </div>
                 <div class="form-group row" ng-show="similarityIndexInfo.isPredicationType()">
                     <label class="col-md-4 col-form-label">{{'input.literal.index.label' | translate}}</label>
                     <div class="col-md-8">
-                        <select class="form-control" ng-options="idx for idx in literalIndexes" ng-model="similarityIndexInfo.similarityIndex.inputIndex"></select>
+                        <select class="form-control"
+                                ng-options="idx for idx in literalIndexes"
+                                ng-model="similarityIndexInfo.similarityIndex.inputIndex"
+                                ng-change="setDirty()"></select>
                     </div>
                 </div>
             </div>
@@ -184,7 +196,7 @@
 
                 <div class="row">
                     <div class="col-md-9">
-                        <yasgui-component id="query-editor" yasgui-config="yasguiConfig""></yasgui-component>
+                        <yasgui-component id="query-editor" yasgui-config="yasguiConfig" query-changed="setDirty()"></yasgui-component>
 
                         <div ng-if="similarityIndexInfo.isDataQueryTypeSelected()">
 
@@ -253,7 +265,7 @@
 
             <div class="clearfix">
                 <div class="pull-right">
-                    <a ng-href="similarity" class="btn btn-lg btn-secondary"
+                    <a ng-href="similarity" class="btn btn-lg btn-secondary cancel-similarity-index-btn"
                        uib-popover="{{getCloseBtnMsg()}}"
                        popover-placement="top"
                        popover-trigger="mouseenter">

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -1256,6 +1256,7 @@
     "similarity.get.resource.error": "Could not get resource!",
     "similarity.delete.index.warning": "Are you sure you want to delete the index '{{name}}'?",
     "similarity.rebuild.index.warning": "Are you sure you want to rebuild the whole index '{{name}}'?<br>You will still be able to use the latest successful build!",
+    "similarity.warning.unsaved.changes": "You have unsaved changes. Are you sure that you want to exit?",
     "sparql.template.get.templates.error": "Could not get SPARQL templates",
     "sparql.template.delete.template.warning": "Are you sure you want to delete the SPARQL template '{{templateID}}'?",
     "sparql.template.delete.template.success": "Deleted successfully SPARQL template",

--- a/test-cypress/integration/explore/similarity-index.spec.js
+++ b/test-cypress/integration/explore/similarity-index.spec.js
@@ -1,0 +1,88 @@
+import {SimilarityIndexCreateSteps} from "../../steps/explore/similarity-index-create-steps";
+import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";
+import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
+import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../steps/modal-dialog-steps";
+import {SimilarityIndexesSteps} from "../../steps/explore/similarity-indexes-steps";
+
+const FILE_TO_IMPORT = 'people.zip';
+
+describe('Confirmations when try to change repository', () => {
+
+    let secondRepositoryId;
+    let repositoryId;
+
+    beforeEach(() => {
+        const repositoryId = 'similarity-index-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        cy.importServerFile(repositoryId, FILE_TO_IMPORT);
+        secondRepositoryId = 'create-similarity-index-second-repo' + Date.now();
+        cy.createRepository({id: secondRepositoryId});
+        SimilarityIndexCreateSteps.visit();
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+        cy.deleteRepository(secondRepositoryId);
+    });
+
+    it('should not display confirm message if create similarity form is dirty and try to change repository', () => {
+        // Given I opened the create similarity view,
+        // and create similarity form is dirty.
+        SimilarityIndexCreateSteps.getSimilarityIndexNameInput().type('index name');
+
+        // When I change the  repository.
+        RepositorySelectorSteps.selectRepository(secondRepositoryId);
+        // Then I expect to not be redirected to similarity indexes view.
+        SimilarityIndexCreateSteps.verifyUrl();
+    });
+
+    it('should display confirm message if edit similarity create form is dirty (Search query changed) and try to change repository', () => {
+        const similarityIndexName = 'SimilarityIndex';
+        YasqeSteps.waitUntilQueryIsVisible();
+        SimilarityIndexCreateSteps.getSimilarityIndexNameInput().type(similarityIndexName);
+        SimilarityIndexCreateSteps.create();
+        SimilarityIndexesSteps.getEditButton(similarityIndexName).click();
+
+        // Given I opened the edit similarity view,
+        // During the initialization query is changed and this broke the test.
+        // Most the time the broken flow is:
+        // 1.   cypress start to type 's';
+        // 2.   query is changed
+        // 3.   cypress continuous to type 'ome changes'.
+        // as result query is 'ome changes<data query>. YasqeSteps.writeInEditor function has check if parameter is filled, in our case 'some changes',
+        // and this broke the test. Add a little wait time to give chance yasqe query to be filled.
+        cy.wait(1000);
+        // and change "Search query".
+        YasqeSteps.writeInEditor('some changes');
+
+        // When I try to change repository.
+        // Then I expect to be asked for confirmation to be redirected to similarity indexes view.
+        ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
+    });
+
+    it('should display confirm message if edit similarity create form is dirty (Analogical query changed) and try to change repository', () => {
+        // Given I opened the edit similarity view,
+        const similarityIndexName = 'SimilarityIndex';
+        YasqeSteps.waitUntilQueryIsVisible();
+        SimilarityIndexCreateSteps.getSimilarityIndexNameInput().type(similarityIndexName);
+        SimilarityIndexCreateSteps.switchToCreatePredictionIndexTab();
+        SimilarityIndexCreateSteps.create();
+        SimilarityIndexesSteps.getEditButton(similarityIndexName).click();
+        // and change "Analogical query".
+        SimilarityIndexCreateSteps.switchToAnalogicalQueryTab();
+        YasqeSteps.writeInEditor('some changes');
+
+        // When I try to change repository.
+        // Then I expect to be asked for confirmation to be redirected to similarity indexes view.
+        ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
+    });
+
+    function createVerifyConfirmationDialogOptions() {
+        return new VerifyConfirmationDialogOptions()
+            .setChangePageFunction(() => RepositorySelectorSteps.selectRepository(secondRepositoryId))
+            .setConfirmationMessage('You have unsaved changes. Are you sure that you want to exit?')
+            .setVerifyCurrentUrl(() => cy.url().should('include', `${Cypress.config('baseUrl')}/similarity/index/create`))
+            .setVerifyRedirectedUrl(() => cy.url().should('eq', `${Cypress.config('baseUrl')}/similarity`));
+    }
+});

--- a/test-cypress/integration/explore/similarity.spec.js
+++ b/test-cypress/integration/explore/similarity.spec.js
@@ -43,13 +43,9 @@ const MODIFIED_DATA_QUERY = 'SELECT ?documentID ?documentText { \n' +
 describe('Similarity screen validation', () => {
 
     let repositoryId;
-    let secondRepositoryId;
 
     afterEach(() => {
         cy.deleteRepository(repositoryId);
-        if (secondRepositoryId) {
-            cy.deleteRepository(secondRepositoryId);
-        }
     });
 
     it('Test similarity page default state', () => {
@@ -246,64 +242,6 @@ describe('Similarity screen validation', () => {
         });
     });
 
-    context('Confirmations when try to change repository', () => {
-        beforeEach(() => {
-            secondRepositoryId = 'create-similarity-index-second-repo' + Date.now();
-            cy.createRepository({id: secondRepositoryId});
-            initRepositoryAndVisitSimilarityView();
-            openCreateNewIndexForm();
-        });
-
-        it('should not display confirm message if create similarity form is dirty and try to change repository', () => {
-            // Given I opened the create similarity view,
-            // and create similarity form is dirty.
-            SimilarityIndexCreateSteps.getSimilarityIndexNameInput().type('index name');
-
-            // When I change the  repository.
-            RepositorySelectorSteps.selectRepository(secondRepositoryId);
-            // Then I expect to not be redirected to similarity indexes view.
-            SimilarityIndexCreateSteps.verifyUrl();
-        });
-
-        it('should display confirm message if edit similarity create form is dirty (Search query changed) and try to change repository', () => {
-            setIndexName();
-            createSimilarityIndex();
-            openEditQueryView();
-            // Given I opened the edit similarity view,
-            // During the initialization query is changed and this broke the test.
-            // Most the time the broken flow is:
-            // 1.   cypress start to type 's';
-            // 2.   query is changed
-            // 3.   cypress continuous to type 'ome changes'.
-            // as result query is 'ome changes<data query>. YasqeSteps.writeInEditor function has check if parameter is filled, in our case 'some changes',
-            // and this broke the test. Add a little wait time to give chance yasqe query to be filled.
-            cy.wait(1000);
-            // and change "Search query".
-            YasqeSteps.writeInEditor('some changes');
-
-            // When I try to change repository.
-            // Then I expect to be asked for confirmation to be redirected to similarity indexes view.
-            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => RepositorySelectorSteps.selectRepository(secondRepositoryId)));
-        });
-
-        it('should display confirm message if edit similarity create form is dirty (Analogical query changed) and try to change repository', () => {
-            switchToPredicationIndex();
-            setIndexName();
-            clickMoreOptionsMenu();
-            addBuildParam();
-            clickMoreOptionsMenu();
-            createSimilarityIndex();
-            openEditQueryView(true);
-            // and change "Analogical query".
-            SimilarityIndexCreateSteps.switchToAnalogicalQueryTab();
-            YasqeSteps.writeInEditor('some changes');
-
-            // When I try to change repository.
-            // Then I expect to be asked for confirmation to be redirected to similarity indexes view.
-            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => RepositorySelectorSteps.selectRepository(secondRepositoryId)));
-        });
-    });
-
     context('Confirmations when try to change location', () => {
 
         beforeEach(() => {
@@ -328,7 +266,7 @@ describe('Similarity screen validation', () => {
 
             // When click on cancel button.
             // Then I expect to be redirected to similarity indexes view.
-            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
         });
 
         it('should display confirm message if data query is changed', () => {
@@ -346,7 +284,7 @@ describe('Similarity screen validation', () => {
 
             // When click on cancel button.
             // Then I expect to be redirected to similarity indexes view.
-            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
         });
 
         it('should display confirm message if "Semantic Vectors create index parameters" is changed', () => {
@@ -357,7 +295,7 @@ describe('Similarity screen validation', () => {
 
             // When click on cancel button.
             // Then I expect to be redirected to similarity indexes view.
-            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
         });
 
         it('should display confirm message if "Stop words" is changed', () => {
@@ -368,7 +306,7 @@ describe('Similarity screen validation', () => {
 
             // When click on cancel button.
             // Then I expect to be redirected to similarity indexes view.
-            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
         });
 
         it('should display confirm message if "Analyzer Class" is changed', () => {
@@ -379,7 +317,7 @@ describe('Similarity screen validation', () => {
 
             // When click on cancel button.
             // Then I expect to be redirected to similarity indexes view.
-            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
         });
 
         it('should display confirm message if "Literal index" is changed', () => {
@@ -390,7 +328,7 @@ describe('Similarity screen validation', () => {
 
             // When click on cancel button.
             // Then I expect to be redirected to similarity indexes view.
-            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
         });
 
         it('should display confirm message if "Search query" is changed', () => {
@@ -401,7 +339,7 @@ describe('Similarity screen validation', () => {
 
             // When click on cancel button.
             // Then I expect to be redirected to similarity indexes view.
-            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
         });
 
         it('should display confirm message if "Analogical query" is changed', () => {
@@ -413,7 +351,7 @@ describe('Similarity screen validation', () => {
 
             // When click on cancel button.
             // Then I expect to be redirected to similarity indexes view.
-            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
         });
     });
 
@@ -645,9 +583,9 @@ describe('Similarity screen validation', () => {
         YasqeSteps.verifyQueryContains(query);
     }
 
-    function createVerifyConfirmationDialogOptions(changePageFunction) {
+    function createVerifyConfirmationDialogOptions() {
         return new VerifyConfirmationDialogOptions()
-            .setChangePageFunction(() => changePageFunction())
+            .setChangePageFunction(() => SimilarityIndexCreateSteps.getCancelButton().click())
             .setConfirmationMessage('You have unsaved changes. Are you sure that you want to exit?')
             .setVerifyCurrentUrl(() => cy.url().should('include', `${Cypress.config('baseUrl')}/similarity/index/create`))
             .setVerifyRedirectedUrl(() => cy.url().should('eq', `${Cypress.config('baseUrl')}/similarity`));

--- a/test-cypress/integration/explore/similarity.spec.js
+++ b/test-cypress/integration/explore/similarity.spec.js
@@ -1,6 +1,10 @@
 import {SparqlEditorSteps} from "../../steps/sparql-editor-steps";
 import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
 import {YasrSteps} from "../../steps/yasgui/yasr-steps";
+import {SimilarityIndexCreateSteps} from "../../steps/explore/similarity-index-create-steps";
+import {SimilarityIndexesSteps} from "../../steps/explore/similarity-indexes-steps";
+import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../steps/modal-dialog-steps";
+import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";
 
 const INDEX_NAME = 'index-' + Date.now();
 const FILE_TO_IMPORT = 'people.zip';
@@ -39,9 +43,13 @@ const MODIFIED_DATA_QUERY = 'SELECT ?documentID ?documentText { \n' +
 describe('Similarity screen validation', () => {
 
     let repositoryId;
+    let secondRepositoryId;
 
     afterEach(() => {
         cy.deleteRepository(repositoryId);
+        if (secondRepositoryId) {
+            cy.deleteRepository(secondRepositoryId);
+        }
     });
 
     it('Test similarity page default state', () => {
@@ -238,6 +246,177 @@ describe('Similarity screen validation', () => {
         });
     });
 
+    context('Confirmations when try to change repository', () => {
+        beforeEach(() => {
+            secondRepositoryId = 'create-similarity-index-second-repo' + Date.now();
+            cy.createRepository({id: secondRepositoryId});
+            initRepositoryAndVisitSimilarityView();
+            openCreateNewIndexForm();
+        });
+
+        it('should not display confirm message if create similarity form is dirty and try to change repository', () => {
+            // Given I opened the create similarity view,
+            // and create similarity form is dirty.
+            SimilarityIndexCreateSteps.getSimilarityIndexNameInput().type('index name');
+
+            // When I change the  repository.
+            RepositorySelectorSteps.selectRepository(secondRepositoryId);
+            // Then I expect to not be redirected to similarity indexes view.
+            SimilarityIndexCreateSteps.verifyUrl();
+        });
+
+        it('should display confirm message if edit similarity create form is dirty (Search query changed) and try to change repository', () => {
+            setIndexName();
+            createSimilarityIndex();
+            openEditQueryView();
+            // Given I opened the edit similarity view,
+            // During the initialization query is changed and this broke the test.
+            // Most the time the broken flow is:
+            // 1.   cypress start to type 's';
+            // 2.   query is changed
+            // 3.   cypress continuous to type 'ome changes'.
+            // as result query is 'ome changes<data query>. YasqeSteps.writeInEditor function has check if parameter is filled, in our case 'some changes',
+            // and this broke the test. Add a little wait time to give chance yasqe query to be filled.
+            cy.wait(1000);
+            // and change "Search query".
+            YasqeSteps.writeInEditor('some changes');
+
+            // When I try to change repository.
+            // Then I expect to be asked for confirmation to be redirected to similarity indexes view.
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => RepositorySelectorSteps.selectRepository(secondRepositoryId)));
+        });
+
+        it('should display confirm message if edit similarity create form is dirty (Analogical query changed) and try to change repository', () => {
+            switchToPredicationIndex();
+            setIndexName();
+            clickMoreOptionsMenu();
+            addBuildParam();
+            clickMoreOptionsMenu();
+            createSimilarityIndex();
+            openEditQueryView(true);
+            // and change "Analogical query".
+            SimilarityIndexCreateSteps.switchToAnalogicalQueryTab();
+            YasqeSteps.writeInEditor('some changes');
+
+            // When I try to change repository.
+            // Then I expect to be asked for confirmation to be redirected to similarity indexes view.
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => RepositorySelectorSteps.selectRepository(secondRepositoryId)));
+        });
+    });
+
+    context('Confirmations when try to change location', () => {
+
+        beforeEach(() => {
+            initRepositoryAndVisitSimilarityView();
+            openCreateNewIndexForm();
+        });
+
+        it('should not display confirm message when there are not changes', () => {
+            // Given I opened the create similarity view.
+            // When I click on cancel button.
+            SimilarityIndexCreateSteps.cancel();
+
+            // Then I expect to be redirected to similarity indexes view.
+            SimilarityIndexesSteps.verifyUrl();
+
+        });
+
+        it('should display confirm message if index name is filled', () => {
+            // Given I opened the create similarity view,
+            // and similarity index name is filled.
+            SimilarityIndexCreateSteps.getSimilarityIndexNameInput().type('index');
+
+            // When click on cancel button.
+            // Then I expect to be redirected to similarity indexes view.
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+        });
+
+        it('should display confirm message if data query is changed', () => {
+            // Given I opened the create similarity view,
+            // and data query is changed.
+            // During the initialization query is changed and this broke the test.
+            // Most the time the broken flow is:
+            // 1.   cypress start to type 's';
+            // 2.   query is changed
+            // 3.   cypress continuous to type 'ome changes'.
+            // as result query is 'ome changes<data query>. YasqeSteps.writeInEditor function has check if parameter is filled, in our case 'some changes',
+            // and this broke the test. Add a little wait time to give chance yasqe query to be filled.
+            cy.wait(1000);
+            YasqeSteps.writeInEditor('some changes');
+
+            // When click on cancel button.
+            // Then I expect to be redirected to similarity indexes view.
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+        });
+
+        it('should display confirm message if "Semantic Vectors create index parameters" is changed', () => {
+            // Given I opened the create similarity view,
+            // and "Semantic Vectors create index parameters" is changed.
+            SimilarityIndexCreateSteps.showMoreOptions();
+            SimilarityIndexCreateSteps.getSemanticVectorsInput().type('semantic vector');
+
+            // When click on cancel button.
+            // Then I expect to be redirected to similarity indexes view.
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+        });
+
+        it('should display confirm message if "Stop words" is changed', () => {
+            // Given I opened the create similarity view,
+            // and "Stop words" is changed.
+            SimilarityIndexCreateSteps.showMoreOptions();
+            SimilarityIndexCreateSteps.getStopWordsInput().type('stop words');
+
+            // When click on cancel button.
+            // Then I expect to be redirected to similarity indexes view.
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+        });
+
+        it('should display confirm message if "Analyzer Class" is changed', () => {
+            // Given I opened the create similarity view,
+            // and "Analyzer Class" is changed.
+            SimilarityIndexCreateSteps.showMoreOptions();
+            SimilarityIndexCreateSteps.getAnalyzerClassInput().type('BulgarianAnalyzer');
+
+            // When click on cancel button.
+            // Then I expect to be redirected to similarity indexes view.
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+        });
+
+        it('should display confirm message if "Literal index" is changed', () => {
+            // Given I opened the create similarity view,
+            // and "Literal index" is changed.
+            SimilarityIndexCreateSteps.showMoreOptions();
+            SimilarityIndexCreateSteps.checkLiteralIndex();
+
+            // When click on cancel button.
+            // Then I expect to be redirected to similarity indexes view.
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+        });
+
+        it('should display confirm message if "Search query" is changed', () => {
+            // Given I opened the create similarity view,
+            // and "Search query" is changed.
+            SimilarityIndexCreateSteps.switchToSearchQueryTab();
+            YasqeSteps.writeInEditor('some changes');
+
+            // When click on cancel button.
+            // Then I expect to be redirected to similarity indexes view.
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+        });
+
+        it('should display confirm message if "Analogical query" is changed', () => {
+            // Given I opened the create similarity view,
+            // and "Analogical query" is changed.
+            SimilarityIndexCreateSteps.switchToCreatePredictionIndexTab();
+            SimilarityIndexCreateSteps.switchToAnalogicalQueryTab();
+            YasqeSteps.writeInEditor('some changes');
+
+            // When click on cancel button.
+            // Then I expect to be redirected to similarity indexes view.
+            ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions(() => SimilarityIndexCreateSteps.getCancelButton().click()));
+        });
+    });
+
     function initRepository() {
         repositoryId = 'similarity-repo-' + Date.now();
         cy.createRepository({id: repositoryId});
@@ -399,6 +578,7 @@ describe('Similarity screen validation', () => {
         // Verify that 'similarity-index-name' input field is disabled
         getSimilarity().should('be.disabled');
         getSearchQueryTab().should('be.visible');
+        YasqeSteps.waitUntilQueryIsVisible();
         const shouldAnalogicalTabBeVisible = (isPredication ? '' : 'not.') + 'exist';
         getAnalogicalQueryTab().should(shouldAnalogicalTabBeVisible);
         if (isPredication) {
@@ -415,7 +595,7 @@ describe('Similarity screen validation', () => {
     }
 
     function changeSearchQuery() {
-        getSearchQueryTab().scrollIntoView().should('be.visible').click();
+        SimilarityIndexCreateSteps.switchToSearchQueryTab();
         YasqeSteps.pasteQuery(MODIFIED_SEARCH_QUERY);
     }
 
@@ -463,5 +643,13 @@ describe('Similarity screen validation', () => {
     function verifyQueryIsChanged() {
         const query = 'OPTIONAL { ?result <http://dbpedia.org/ontology/birthPlace> ?birthDate .';
         YasqeSteps.verifyQueryContains(query);
+    }
+
+    function createVerifyConfirmationDialogOptions(changePageFunction) {
+        return new VerifyConfirmationDialogOptions()
+            .setChangePageFunction(() => changePageFunction())
+            .setConfirmationMessage('You have unsaved changes. Are you sure that you want to exit?')
+            .setVerifyCurrentUrl(() => cy.url().should('include', `${Cypress.config('baseUrl')}/similarity/index/create`))
+            .setVerifyRedirectedUrl(() => cy.url().should('eq', `${Cypress.config('baseUrl')}/similarity`));
     }
 });

--- a/test-cypress/integration/setup/jdbc-create.spec.js
+++ b/test-cypress/integration/setup/jdbc-create.spec.js
@@ -3,7 +3,7 @@ import {JdbcCreateSteps} from "../../steps/setup/jdbc-create-steps";
 import {ToasterSteps} from "../../steps/toaster-steps";
 import {YasrSteps} from "../../steps/yasgui/yasr-steps";
 import {LoaderSteps} from "../../steps/loader-steps";
-import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
+import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../steps/modal-dialog-steps";
 import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
 import {MainMenuSteps} from "../../steps/main-menu-steps";
 import ImportSteps from "../../steps/import-steps";
@@ -223,14 +223,14 @@ describe('JDBC configuration', () => {
         // type configuration name,
         JdbcCreateSteps.typeTableName('Configuration name');
         JdbcCreateSteps.getJDBCConfigNameField().should('have.value', 'Configuration name');
-        ModalDialogSteps.verifyUrlChangedConfirmation('You have unsaved changes. Are you sure that you want to exit?');
+        ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
     });
 
     it('should display confirm message when the configuration query data is changed', () => {
         // When I open the create JDBC configuration page,
         // type and change the query,
         YasqeSteps.writeInEditor("Some changes");
-        ModalDialogSteps.verifyUrlChangedConfirmation('You have unsaved changes. Are you sure that you want to exit?');
+        ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
     });
 
     it('should display confirm message when the selected columns are changed', () => {
@@ -239,7 +239,7 @@ describe('JDBC configuration', () => {
         JdbcCreateSteps.openColumnTypesTab();
         JdbcCreateSteps.clickOnDeleteColumnButton(0);
         ModalDialogSteps.clickOnConfirmButton();
-        ModalDialogSteps.verifyUrlChangedConfirmation('You have unsaved changes. Are you sure that you want to exit?');
+        ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
     });
 
     it('should display confirm message when try to change the repository', () => {
@@ -305,5 +305,13 @@ describe('JDBC configuration', () => {
 
         // Opens created configuration for edit.
         JdbcSteps.clickOnEditButton(0);
+    }
+
+    function createVerifyConfirmationDialogOptions() {
+        return new VerifyConfirmationDialogOptions()
+            .setChangePageFunction(() => MainMenuSteps.clickOnMenuImport())
+            .setConfirmationMessage('You have unsaved changes. Are you sure that you want to exit?')
+            .setVerifyCurrentUrl(() => cy.url().should('eq', `${Cypress.config('baseUrl')}/jdbc/configuration/create`))
+            .setVerifyRedirectedUrl(() => cy.url().should('eq', `${Cypress.config('baseUrl')}/import#user`));
     }
 });

--- a/test-cypress/steps/explore/similarity-index-create-steps.js
+++ b/test-cypress/steps/explore/similarity-index-create-steps.js
@@ -1,0 +1,90 @@
+export class SimilarityIndexCreateSteps {
+
+    static visit() {
+        cy.visit('/similarity/index/create');
+    }
+
+    static verifyUrl() {
+        cy.url().should('include', '/similarity/index/create');
+    }
+
+    static getCancelButton() {
+        return cy.get('.cancel-similarity-index-btn');
+    }
+
+    static cancel() {
+        SimilarityIndexCreateSteps.getCancelButton().click();
+    }
+
+    static getCreateButton() {
+        return cy.get('.create-similarity-index-btn');
+    }
+
+    static create() {
+        SimilarityIndexCreateSteps.getCreateButton().click();
+    }
+
+    static getQueryButton() {
+        return cy.get('.save-query-btn');
+    }
+
+    static save() {
+        SimilarityIndexCreateSteps.getQueryButton().click();
+    }
+
+    static getSimilarityIndexNameInput() {
+        return cy.get('.similarity-index-name');
+    }
+
+    static getSemanticVectorsInput() {
+        return cy.get('#indexParameters');
+    }
+
+    static getStopWordsInput() {
+        return cy.get('.stop-words');
+    }
+
+    static getAnalyzerClassInput() {
+        return cy.get('.analyzer-class');
+    }
+
+    static getLiteralIndexCheckbox() {
+        return cy.get('.literal-index');
+    }
+
+    static checkLiteralIndex() {
+        SimilarityIndexCreateSteps.getLiteralIndexCheckbox().check();
+    }
+
+    static getMoreOptions() {
+        return cy.get('.more-options-btn');
+    }
+
+    static showMoreOptions() {
+        SimilarityIndexCreateSteps.getMoreOptions().click();
+    }
+
+    static getSearchQueryTab() {
+        return cy.get('.search-query-tab');
+    }
+
+    static switchToSearchQueryTab() {
+        SimilarityIndexCreateSteps.getSearchQueryTab().click();
+    }
+
+    static getAnalogicalQueryTab() {
+        return cy.get('.analogical-query-tab');
+    }
+
+    static switchToAnalogicalQueryTab() {
+        SimilarityIndexCreateSteps.getAnalogicalQueryTab().click();
+    }
+
+    static getCreatePredictionIndexTab() {
+        return cy.get('#create-predication-index');
+    }
+
+    static switchToCreatePredictionIndexTab() {
+        SimilarityIndexCreateSteps.getCreatePredictionIndexTab().click();
+    }
+}

--- a/test-cypress/steps/explore/similarity-indexes-steps.js
+++ b/test-cypress/steps/explore/similarity-indexes-steps.js
@@ -1,0 +1,10 @@
+export class SimilarityIndexesSteps {
+
+    static visit() {
+        cy.visit('/similarity');
+    }
+
+    static verifyUrl() {
+        cy.url().should('eq', `${Cypress.config('baseUrl')}/similarity`);
+    }
+}

--- a/test-cypress/steps/explore/similarity-indexes-steps.js
+++ b/test-cypress/steps/explore/similarity-indexes-steps.js
@@ -7,4 +7,12 @@ export class SimilarityIndexesSteps {
     static verifyUrl() {
         cy.url().should('eq', `${Cypress.config('baseUrl')}/similarity`);
     }
+
+    static getSimilarityIndexRow(similarityIndexName) {
+        return cy.get('.index-row').contains(similarityIndexName).parent().parent();
+    }
+
+    static getEditButton(similarityIndexName) {
+        return SimilarityIndexesSteps.getSimilarityIndexRow(similarityIndexName).find('.edit-query-btn');
+    }
 }

--- a/test-cypress/steps/modal-dialog-steps.js
+++ b/test-cypress/steps/modal-dialog-steps.js
@@ -1,6 +1,8 @@
 import {MainMenuSteps} from "./main-menu-steps";
 import {JdbcCreateSteps} from "./setup/jdbc-create-steps";
 import ImportSteps from "./import-steps";
+import {SimilarityIndexCreateSteps} from "./explore/similarity-index-create-steps";
+import {SimilarityIndexesSteps} from "./explore/similarity-indexes-steps";
 
 export class ModalDialogSteps {
     static getDialog() {
@@ -47,41 +49,71 @@ export class ModalDialogSteps {
         ModalDialogSteps.getCancelButton().click();
     }
 
-    static verifyUrlChangedConfirmation(confirmMessage) {
+    static verifyUrlChangedConfirmation(verifyConfirmationDialogOptions = new VerifyConfirmationDialogOptions()) {
         // and try to change the page
-        MainMenuSteps.clickOnMenuImport();
+        verifyConfirmationDialogOptions.changePageFunction();
 
         // Then I expect to be asked to confirm the leaving tha page.
-        ModalDialogSteps.verifyDialogBody(confirmMessage);
+        ModalDialogSteps.verifyDialogBody(verifyConfirmationDialogOptions.confirmationMessage);
 
         // When I click on close dialog button.
         ModalDialogSteps.clickOnCloseButton();
 
         // Then I expect to stay on same page.
-        JdbcCreateSteps.verifyUrl();
+        verifyConfirmationDialogOptions.verifyCurrentUrl();
+
 
         // When I try to change the page again.
-        MainMenuSteps.clickOnMenuImport();
+        verifyConfirmationDialogOptions.changePageFunction();
 
         // Then I expect to be asked to confirm the leaving tha page.
-        ModalDialogSteps.verifyDialogBody(confirmMessage);
+        ModalDialogSteps.verifyDialogBody(verifyConfirmationDialogOptions.confirmationMessage);
 
         // When I click on cancel dialog button.
         ModalDialogSteps.clickOnCancelButton();
 
         // Then I expect to stay on same page.
-        JdbcCreateSteps.verifyUrl();
+        verifyConfirmationDialogOptions.verifyCurrentUrl();
 
         // When I try to change the page again.
-        MainMenuSteps.clickOnMenuImport();
+        verifyConfirmationDialogOptions.changePageFunction();
 
         // Then I expect to be asked to confirm the leaving tha page.
-        ModalDialogSteps.verifyDialogBody(confirmMessage);
+        ModalDialogSteps.verifyDialogBody(verifyConfirmationDialogOptions.confirmationMessage);
 
         // When I click on confirm dialog button.
         ModalDialogSteps.clickOnConfirmButton();
 
-        // Then I expect to stay on same page.
-        ImportSteps.verifyUserImportUrl();
+        // Then I expect to be redirected.
+        verifyConfirmationDialogOptions.verifyRedirectedUrl();
+    }
+}
+
+export class VerifyConfirmationDialogOptions {
+    constructor() {
+        this.changePageFunction = () => {};
+        this.confirmationMessage = "";
+        this.verifyCurrentUrl = () => {};
+        this.verifyRedirectedUrl = () => {};
+    }
+
+    setChangePageFunction(changePageFunction) {
+        this.changePageFunction = changePageFunction;
+        return this;
+    }
+
+    setConfirmationMessage(confirmationMessage) {
+        this.confirmationMessage = confirmationMessage;
+        return this;
+    }
+
+    setVerifyCurrentUrl(verifyCurrentUrl) {
+        this.verifyCurrentUrl = verifyCurrentUrl;
+        return this;
+    }
+
+    setVerifyRedirectedUrl(verifyRedirectedUrl) {
+        this.verifyRedirectedUrl = verifyRedirectedUrl;
+        return this;
     }
 }


### PR DESCRIPTION
What
Added functionality to prevent changing the repository or location without user confirmation.

Why
- Similarity indexes are specific to each repository, so when a similarity index is open for editing, the repository should not be changed. If this occurs, the user should be notified.
- If a similarity index is open for editing, or if the create similarity index form is open and the user makes changes in the form but tries to change the location without saving the changes, they should be notified about the unsaved changes.

How
Added a listener for changes in the repository. Added a listener for changes in the location. Implemented confirmation prompts if any of these events occur.