### PR TITLE
Added error icon to similarity query tabs

### DIFF
--- a/src/css/bootstrap-graphdb-theme.css
+++ b/src/css/bootstrap-graphdb-theme.css
@@ -1313,6 +1313,17 @@ footer.footer .container-fluid.main-container p {
     content: "\e920";
 }
 
+.tab-error:after {
+    font-family: 'icomoon', sans-serif !important;
+    font-size: 1em;
+    vertical-align: middle;
+    line-height: 1;
+    position: absolute;
+    left: 0.1em;
+    content: "\e920";
+    color: var(--onto-orange);
+}
+
 .alert-success:before {
     content: "\e914";
 }

--- a/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/src/js/angular/similarity/controllers/create-index.controller.js
@@ -184,6 +184,7 @@ function CreateSimilarityIdxCtrl(
     }
 
     $scope.saveSearchQuery = function () {
+        $scope.saveOrUpdateExecuted = true;
         if (!isDirty) {
             goToSimilarityIndexesView();
         }
@@ -192,6 +193,8 @@ function CreateSimilarityIdxCtrl(
             .then(validateSimilarityIndexName)
             .then(validateQuery)
             .then(validateQueryType)
+            .then(validateSearchQuery)
+            .then(validateAnalogicalQuery)
             .then(saveQuery)
             .then(notifySaveSuccess)
             .catch((error) => {
@@ -275,6 +278,69 @@ function CreateSimilarityIdxCtrl(
     $scope.getCloseBtnMsg = function () {
         let operationType = $scope.editSearchQuery ? $translate.instant('similarity.query.edition.msg') : $translate.instant('similarity.index.creation.msg');
         return $translate.instant('similarity.close.btn.msg', {operation: operationType});
+    }
+
+    $scope.getTabErrorMessage = (similarityQueryTab) => {
+
+        if (!$scope.similarityIndexInfo) {
+            return;
+        }
+
+        if (SimilarityQueryType.DATA === similarityQueryTab) {
+           return getSelectQueryErrorMessage();
+        }
+
+        if (SimilarityQueryType.SEARCH === similarityQueryTab) {
+            return getSearchQueryErrorMessage();
+        }
+
+        if (SimilarityQueryType.ANALOGICAL === similarityQueryTab) {
+            return getAnalogicalQueryErrorMessage();
+        }
+
+        return $translate.instant('similarity.empty.select.query.error');
+    }
+
+    const getSelectQueryErrorMessage = () => {
+        if (!$scope.similarityIndexInfo.hasSelectQuery()) {
+            return $translate.instant('similarity.empty.select.query.error');
+        }
+
+        if ($scope.similarityIndexInfo.invalidSelectQueryType) {
+            return $translate.instant('similarity.error.invalid.select.query');
+        }
+
+        if ($scope.similarityIndexInfo.invalidSelectQuery) {
+            return $translate.instant('similarity.error.query.invalid');
+        }
+    }
+
+    const getSearchQueryErrorMessage = () => {
+        if (!$scope.similarityIndexInfo.hasSearchQuery()) {
+            return $translate.instant('similarity.empty.search.query.error');
+        }
+
+        if ($scope.similarityIndexInfo.invalidSelectQueryType) {
+            return $translate.instant('similarity.error.invalid.search.query');
+        }
+
+        if ($scope.similarityIndexInfo.invalidSelectQuery) {
+            return $translate.instant('similarity.error.query.invalid');
+        }
+    }
+
+    const getAnalogicalQueryErrorMessage = () => {
+        if (!$scope.similarityIndexInfo.hasAnalogicalQuery()) {
+            return $translate.instant('similarity.empty.select.query.error');
+        }
+
+        if ($scope.similarityIndexInfo.invalidAnalogicalQueryType) {
+            return $translate.instant('similarity.error.invalid.analogical.query');
+        }
+
+        if ($scope.similarityIndexInfo.invalidAnalogicalQuery) {
+            return $translate.instant('similarity.error.query.invalid');
+        }
     }
 
     // =========================

--- a/src/pages/create-index.html
+++ b/src/pages/create-index.html
@@ -137,17 +137,36 @@
             <ul class="nav nav-tabs">
                 <li ng-if="!isEditViewMode()" class="nav-item">
                     <a ng-class="similarityIndexInfo.isDataQueryTypeSelected() ? 'active' : ''" ng-click="changeQueryTab(SimilarityQueryType.DATA)" class="nav-link" href>
-                        {{'data.query.label' | translate}}
+                        <div>{{'data.query.label' | translate}}
+                            <sup ng-if="saveOrUpdateExecuted && (!similarityIndexInfo.hasSelectQuery() || similarityIndexInfo.invalidSelectQuery || similarityIndexInfo.invalidSelectQueryType)"
+                                 class="tab-error"
+                                 uib-popover="{{getTabErrorMessage(SimilarityQueryType.DATA)}}"
+                                 popover-placement="top"
+                                 popover-trigger="mouseenter">
+                            </sup>
+                        </div>
                     </a>
                 </li>
                 <li class="nav-item search-query-tab">
                     <a ng-class="similarityIndexInfo.isSearchQueryTypeSelected() ? 'active' : ''" ng-click="changeQueryTab(SimilarityQueryType.SEARCH)" class="nav-link" href>
                         {{'search.query.label' | translate}}
+                        <sup ng-if="saveOrUpdateExecuted && (!similarityIndexInfo.hasSearchQuery() || similarityIndexInfo.invalidSearchQuery || similarityIndexInfo.invalidSearchQueryType)"
+                             class="tab-error"
+                             uib-popover="{{getTabErrorMessage(SimilarityQueryType.SEARCH)}}"
+                             popover-placement="top"
+                             popover-trigger="mouseenter">
+                        </sup>
                     </a>
                 </li>
                 <li class="nav-item analogical-query-tab" ng-if="similarityIndexInfo.isPredicationType()">
                     <a ng-class="similarityIndexInfo.isAnalogicalQueryTypeSelected() ? 'active' : ''" ng-click="changeQueryTab(SimilarityQueryType.ANALOGICAL)" class="nav-link" href>
                         {{'analogical.query.label' | translate}}
+                        <sup ng-if="saveOrUpdateExecuted && (!similarityIndexInfo.hasAnalogicalQuery() || similarityIndexInfo.invalidAnalogicalQuery || similarityIndexInfo.invalidAnalogicalQueryType)"
+                             class="tab-error"
+                             uib-popover="{{getTabErrorMessage(SimilarityQueryType.ANALOGICAL)}}"
+                             popover-placement="top"
+                             popover-trigger="mouseenter">
+                        </sup>
                     </a>
                 </li>
             </ul>


### PR DESCRIPTION
## What
 - Added an icon to the top-right corner of the query type tab when the tab's query is invalid.

## Why
 - The similarity indexes consist of two or three queries that are visualized on different tab. If there is an invalid query in a tab that is not currently visible and  the user clicks the "Create" button, they might not easily understand why the index is not being created. The added icon provides a visual indication of the error.

## How
 - An error icon was added to the top-right corner of the query type tab when the tab's query contains an error.