### PR TITLE
GDB-8610 reimplemented the sparql results download as functionality

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1621,6 +1621,7 @@
     "target.label": "Target",
     "show.blank.nodes.label": "Show Blank Nodes",
     "download.as.label": "Download as",
+    "download.as.progress.msg": "Downloading SPARQL result",
     "visual.graph.label": "Visual graph",
     "explore.graph.visually.popover": "Click to explore the graph visually",
     "pred.label": "Predicate",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1611,6 +1611,7 @@
     "target.label": "Cible",
     "show.blank.nodes.label": "Afficher les nœuds vides",
     "download.as.label": "Télécharger en tant que",
+    "download.as.progress.msg": "Téléchargement du résultat SPARQL",
     "visual.graph.label": "Graphique visuel",
     "explore.graph.visually.popover": "Cliquez pour explorer le graphe visuellement.",
     "edit.label": "Éditer",

--- a/src/js/angular/rest/rdf4j.repositories.rest.service.js
+++ b/src/js/angular/rest/rdf4j.repositories.rest.service.js
@@ -117,26 +117,33 @@ function RDF4JRepositoriesRestService($http, $repositories, $translate) {
         return graphsInRepo;
     }
 
-    function downloadResultsAsFile(repositoryId, queryParams, acceptHeader) {
-        return $http.get(`${REPOSITORIES_ENDPOINT}/${repositoryId}`, {
+    /**
+     * Downloads sparql results as a file in given format provided by the accept header parameter.
+     * @param {Repository} repoInfo
+     * @param {*} data
+     * @param {string} acceptHeader
+     * @return {Promise<any>}
+     */
+    function downloadResultsAsFile(repoInfo, data, acceptHeader) {
+        const properties = Object.entries(data)
+            .filter(([property, value]) => value !== undefined)
+            .map(([property, value]) => `${property}=${value}`);
+        const payloadString = properties.join('&');
+        return $http({
+            method: 'POST',
+            url: `${REPOSITORIES_ENDPOINT}/${repoInfo.id}`,
             headers: {
-                accept: acceptHeader
+                'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+                'Accept': acceptHeader
             },
-            params: queryParams,
+            data: payloadString,
             responseType: "blob"
         }).then(function (res) {
             const data = res.data;
-            const headersGetter = res.headers;
-            const headers = headersGetter();
-            const disposition = headers['content-disposition'];
-            let filename = 'query-result.txt';
-            if (disposition && disposition.indexOf('attachment') !== -1) {
-                const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
-                const matches = filenameRegex.exec(disposition);
-                if (matches != null && matches[1]) {
-                    filename = matches[1].replace(/['"]/g, '');
-                }
-            }
+            const headers = res.headers();
+            const contentDisposition = headers['content-disposition'];
+            let filename = contentDisposition.split('filename=')[1];
+            filename = filename.substring(0, filename.length);
             return {data, filename};
         });
     }

--- a/src/models/repository/repository.js
+++ b/src/models/repository/repository.js
@@ -1,0 +1,28 @@
+export class Repository {
+    /**
+     * @param {string} id
+     * @param {string} title
+     * @param {string} type
+     * @param {string} sesameType
+     * @param {string} uri
+     * @param {string} externalUrl
+     * @param {string} location
+     * @param {string} state
+     * @param {boolean} local
+     * @param {boolean} readable
+     * @param {boolean} writable
+     * @param {boolean} unsupported
+     */
+    constructor(id,
+                title,
+                type,
+                sesameType,
+                uri,
+                externalUrl,
+                location,
+                state,
+                local,
+                readable,
+                writable,
+                unsupported) {}
+}

--- a/src/pages/sparql.html
+++ b/src/pages/sparql.html
@@ -46,11 +46,4 @@
             ng-keyup="saveQueryToLocal(currentQuery)"
             nocount="{{skipCountQuery}}" enable-column-resizing-on-window-width>
     </query-editor>
-    <form id="wb-download" method="GET" action="" target="_self">
-        <input id="wb-download-query" name="query" type="hidden"/>
-        <input id="wb-download-infer" name="infer" type="hidden"/>
-        <input id="wb-download-sameAs" name="sameAs" type="hidden"/>
-        <input id="wb-download-accept" name="Accept" type="hidden"/>
-        <input id="wb-auth-token" name="authToken" type="hidden"/>
-    </form>
 </div>


### PR DESCRIPTION
## What
Reimplemented the sparql results download as functionality to go trough a post request instead of get

## Why
The old implementation used to send a get request with form data containing the sparql query string which happened to break the browser limit for get request size.

## How
* Removed the old form used for sending request data needed for the download and replaced with an actual http.post request and saved result according to provided file type.