### PR TITLE
GDB-8516: Updated function "headers" configuration.

### DIFF
--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -52,24 +52,6 @@ function yasguiComponentDirective(
     ShareQueryLinkService
 ) {
 
-    const HEADERS = {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Accept': 'application/sparql-results+json',
-        'X-GraphDB-Local-Consistency': 'updating'
-    };
-
-    const DEFAULT_CONFIG = {
-        showEditorTabs: true,
-        showToolbar: true,
-        componentId: 'yasgui-component',
-        headers: () => {
-            return HEADERS;
-        },
-        pageSize: 1000,
-        maxPersistentResponseSize: 500000,
-        showResultTabs: true
-    };
-
     return {
         restrict: 'E',
         templateUrl: 'js/angular/core/directives/yasgui-component/templates/yasgui-component.html',
@@ -214,7 +196,6 @@ function yasguiComponentDirective(
              * @param {QueryRequestEvent} queryRequest - the event payload containing the query and the request object.
              */
             const queryHandler = (queryRequest) => {
-                updateRequestHeaders(queryRequest.request, queryRequest.queryMode, queryRequest.queryType, queryRequest.pageSize);
                 const pageNumber = queryRequest.getPageNumber();
                 const pageSize = queryRequest.getPageSize();
                 if (pageSize && pageNumber) {
@@ -232,7 +213,6 @@ function yasguiComponentDirective(
              * @param {CountQueryRequestEvent} countQueryRequest - the event payload containing the query and the request object.
              */
             const countQueryRequestHandler = (countQueryRequest) => {
-                updateRequestHeaders(countQueryRequest.request, countQueryRequest.queryMode, countQueryRequest.queryType, countQueryRequest.pageSize);
                 countQueryRequest.setPageSize(undefined);
                 countQueryRequest.setPageNumber(undefined);
                 countQueryRequest.setCount(1);
@@ -346,7 +326,7 @@ function yasguiComponentDirective(
                         onQueryAborted: onQueryAborted
                     };
 
-                    angular.extend(config, DEFAULT_CONFIG, $scope.yasguiConfig);
+                    angular.extend(config, getDefaultConfig(), $scope.yasguiConfig);
 
                     $scope.ontotextYasguiConfig = config;
 
@@ -436,25 +416,48 @@ function yasguiComponentDirective(
                 }
             };
 
-            const updateRequestHeaders = (req, queryMode, queryType, pageSize) => {
+            const getHeaders = (yasgui) => {
+                const yasqe = yasgui.getTab().getYasqe();
+                const pageSize = yasqe.getPageSize();
+
+                // Generates a new tracking alias for queries based on time
+                const trackAlias = `yasgui-component-${performance.now()}-${Date.now()}`;
+
+                const headers = {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'X-GraphDB-Local-Consistency': 'updating',
+                    'X-GraphDB-Catch': `${pageSize}; throw`,
+                    'X-GraphDB-Track-Alias': trackAlias,
+                    'X-GraphDB-Repository-Location': $repositories.getActiveRepositoryObject().location,
+                    'X-Requested-With': 'XMLHttpRequest'
+                };
+
                 const authToken = $jwtAuth.getAuthToken();
                 if (authToken) {
-                    req.header['Authorization'] = authToken;
+                    headers['Authorization'] = authToken;
                 }
-                req.header['X-GraphDB-Catch'] = `${pageSize}; throw`;
-                // Generates a new tracking alias for queries based on time
-                $scope.currentTrackAlias = `query-editor-${performance.now()}-${Date.now()}`;
-                req.header['X-GraphDB-Track-Alias'] = $scope.currentTrackAlias;
-                req.header['X-GraphDB-Repository-Location'] = $repositories.getActiveRepositoryObject().location;
-                req.header['X-Requested-With'] = 'XMLHttpRequest';
 
-                if (QueryMode.UPDATE === queryMode) {
-                    req.header['Accept'] = 'text/plain,/;q=0.9';
+                const queryType = yasqe.getQueryType();
+                if (QueryMode.UPDATE === yasqe.getQueryMode()) {
+                    headers['Accept'] = 'text/plain,/;q=0.9';
                 } else if (QueryType.CONSTRUCT === queryType || QueryType.DESCRIBE === queryType) {
-                    req.header['Accept'] = 'application/x-graphdb-table-results+json, application/rdf+json;q=0.9, */*;q=0.8';
+                    headers['Accept'] = 'application/x-graphdb-table-results+json, application/rdf+json;q=0.9, */*;q=0.8';
                 } else {
-                    req.header['Accept'] = 'application/x-sparqlstar-results+json, application/sparql-results+json;q=0.9, */*;q=0.8';
+                    headers['Accept'] = 'application/x-sparqlstar-results+json, application/sparql-results+json;q=0.9, */*;q=0.8';
                 }
+                return headers;
+            };
+
+            const getDefaultConfig = () => {
+                return {
+                    showEditorTabs: true,
+                    showToolbar: true,
+                    componentId: 'yasgui-component',
+                    headers: getHeaders,
+                    pageSize: 1000,
+                    maxPersistentResponseSize: 500000,
+                    showResultTabs: true
+                };
             };
 
             const querySaveErrorHandler = (err) => {


### PR DESCRIPTION
## What
Changed the "headers" configuration function that serves request headers. The old implementation applied the headers in two steps:
1. The "headers" configuration function returned static headers only, those headers that didn't change.
2. Before a query is executed, a "query" event is fired. We had a listener for that event and updated the headers with calculated dynamic values.

In the new implementation, the logic of the second step has been merged into the first one.

## Why
- The "headers" function is called every time wen a query is executed, so calculated values are alveis up to its dependences.

-The "headers" function is called every time a query is executed, ensuring that calculated values are always up-to-date.
- Simplifies the process of applying headers.
- Reduces code dependencies, which will make updating yasgui easier in the future.

## How
The logic of the "query" event listener has been removed and is now executed within the "headers" configuration function.