### PR TITLE
GDB-8620 sparql view should not be empty when there is no active repository

### DIFF
--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -358,7 +358,7 @@ function SparqlEditorCtrl($scope,
             .then(([principal, usedPrefixes]) => {
                 $scope.prefixes = usedPrefixes;
                 setInferAndSameAs(principal);
-                // check is there is a savedquery or query url parameter and init the editor
+                // check is there is a saved query or query url parameter and init the editor
                 initViewFromUrlParams();
 
             });

--- a/src/pages/sparql-editor.html
+++ b/src/pages/sparql-editor.html
@@ -10,6 +10,8 @@
               popover-append-to-body="true"><span class="icon-info"></span></span>
     </h1>
 
-    <yasgui-component id="query-editor" yasgui-config="yasguiConfig"
+    <div core-errors></div>
+
+    <yasgui-component id="query-editor" yasgui-config="yasguiConfig" ng-if="yasguiConfig"
                       after-init="initViewFromUrlParams()"></yasgui-component>
 </div>


### PR DESCRIPTION
## What
Sparql view should not be empty when there is no active repository.

## Why
When there is no selected active repository the sparql view is not initialized correctly as it was in the old sparql view. The old implementation used to show a list with the available repositories for the user to select from. Aside from that the yasgui component threw an error because it was unconditionally included in the view while its config was missing in the case of missing repository.

## How
Added check for the yasgui config object before including it in the view. Also added the generic core-errors directive which used to render the repositories list as in the old implementation.