### PR TITLE
GDB-8626 show error mark on yasgui a tab when query is invalid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.0.4",
+                "ontotext-yasgui-web-component": "1.0.5",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -10228,9 +10228,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.4.tgz",
-            "integrity": "sha512-wJkLhRDsX4/bivHZN8E9My5N+nOdex0HXxwlq9NEP7Y4+RfATsa3a2zKdZXgfFgcn8/hsf4xIx8g1fK1d0jCXw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.5.tgz",
+            "integrity": "sha512-giIBiXyB32PyQbY0+7eWMrnbkwm5iOjN+HU+JbHPbVMbrm2YYjfBlyiuhscIyvXXfH+Al2kJTQGePaARYc+WyA==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -25111,9 +25111,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.4.tgz",
-            "integrity": "sha512-wJkLhRDsX4/bivHZN8E9My5N+nOdex0HXxwlq9NEP7Y4+RfATsa3a2zKdZXgfFgcn8/hsf4xIx8g1fK1d0jCXw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.5.tgz",
+            "integrity": "sha512-giIBiXyB32PyQbY0+7eWMrnbkwm5iOjN+HU+JbHPbVMbrm2YYjfBlyiuhscIyvXXfH+Al2kJTQGePaARYc+WyA==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.0.4",
+        "ontotext-yasgui-web-component": "1.0.5",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {

--- a/src/css/bootstrap-graphdb-theme.css
+++ b/src/css/bootstrap-graphdb-theme.css
@@ -2589,6 +2589,14 @@ yasgui-component .tabsList .tab {
     margin-right: 0.2rem;
 }
 
+yasgui-component .tabsList .tab.query-invalid a {
+    text-decoration: none !important;
+}
+
+yasgui-component .tabsList .tab.query-invalid a :first-child {
+    text-decoration: underline dotted var(--color-danger-dark);
+}
+
 yasgui-component .tabsList :last-child {
     background-color: #eee;
     padding-right: 14px;


### PR DESCRIPTION
## What
Show an error mark on the yasgui tab when the query inside its editor is invalid.

## Why
In the old implementation in the GDB workbench was implemented such behavior and we want it here as well.

## How
Implemented a new event queryStatus fired by yasqe and propagated to TabsList component where it's possible to update the respective tab by adding a marker css class and a title message.