### PR TITLE
GDB-8635 fix sparql editor view layout to prevent misalignment of various components

### DIFF
--- a/src/css/bootstrap-graphdb-theme.css
+++ b/src/css/bootstrap-graphdb-theme.css
@@ -2609,6 +2609,10 @@ yasgui-component .tabsList :last-child:hover {
     color: var(--primary-color) !important;
 }
 
+yasgui-component .tabsList :last-child .addTab {
+    height: 30px;
+}
+
 yasgui-component .tabsList .tab a {
     color: var(--secondary-color) !important;
     font-size: 16px;

--- a/src/css/sparql-editor.css
+++ b/src/css/sparql-editor.css
@@ -1,19 +1,12 @@
-.sparql-editor-view {
-    position: relative;
-}
-
 .sparql-editor-view #sparql-query-update-title-label {
     position: relative;
+    margin-bottom: -35px;
+    z-index: 1;
 }
 
 .sparql-editor-view #sparql-query-update-title-label .btn-link {
     position: relative;
     z-index: 100;
-}
-
-.sparql-editor-view #query-editor {
-    position: relative;
-    top: -55px;
 }
 
 .sparql-editor-view #query-editor .yasgui-host-element {
@@ -28,11 +21,10 @@
 .sparql-editor-view #query-editor .yasgui-toolbar {
     display: inline;
     float: right;
-}
-
-.sparql-editor-view #query-editor .yasgui-toolbar {
     font-size: 14px;
     font-weight: 400;
+    position: relative;
+    z-index: 100;
 }
 
 .sparql-editor-view #query-editor .yasgui-toolbar .yasgui-btn {


### PR DESCRIPTION
## What
Properly align yasgui components.

## Why
Yasgui container was made position: relative in order to be able to move it slightly up to the page heading so that to look like the other workbench views. This broke the layout in other ways.

## How
Applied positioning outside-in to prevent inner components misalignment.