### PR TITLE
Changes position of the user guide skip button

### DIFF
--- a/src/js/angular/guides/tour-lib-services/shepherd.service.js
+++ b/src/js/angular/guides/tour-lib-services/shepherd.service.js
@@ -428,6 +428,10 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
     this._toGuideStep = (guide, previousStepDescription, currentStepDescription, nextStepDescription) => {
         const step = this._toBaseGuideStep(guide, $translate, currentStepDescription, () => this._updateLocalStorage());
         const buttons = [];
+        if (currentStepDescription.skipPoint) {
+            buttons.push(this._getSkipButton(guide));
+        }
+
         if (previousStepDescription) {
             buttons.push(this._getPreviousButton(guide));
         }
@@ -435,9 +439,6 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
             buttons.push(this._getNextButton(guide, currentStepDescription, nextStepDescription));
         }
 
-        if (currentStepDescription.skipPoint) {
-            buttons.push(this._getSkipButton(guide));
-        }
         step.buttons = buttons;
         return step;
     };


### PR DESCRIPTION
What
Changes position of the user guide skip button

Why
We need to improve the consistency and adhere to the user experience where it needs to always be obvious where to expect such buttons to appear and what will be their order.

How
The skip button has been moved on the left side.