### PR TITLE
GDB-8641: Empty tab when execute RDF* query via resource view

### DIFF
--- a/src/js/angular/models/sparql/tab-query-model.js
+++ b/src/js/angular/models/sparql/tab-query-model.js
@@ -1,5 +1,5 @@
 export class TabQueryModel {
-    constructor(queryName = '', query = '', owner = '', isPublic = true) {
+    constructor(queryName = undefined, query = undefined, owner = undefined, isPublic = true) {
         this.queryName = queryName;
         this.query = query;
         this.owner = owner;

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -10,7 +10,6 @@ import {ConnectorCommand} from "../models/connectors/connector-command";
 import {BeforeUpdateQueryResult, BeforeUpdateQueryResultStatus} from "../models/ontotext-yasgui/before-update-query-result";
 import {EventDataType} from "../models/ontotext-yasgui/event-data-type";
 import {decodeHTML} from "../../../app";
-import {TabQueryModel} from "../models/sparql/tab-query-model";
 import {toBoolean} from "../utils/string-utils";
 import {QueryMode} from "../models/ontotext-yasgui/query-mode";
 
@@ -113,8 +112,7 @@ function SparqlEditorCtrl($scope,
             // init new tab from shared query link
             initTabFromSharedQuery(queryParams);
         } else if (GuidesService.isActive()) {
-            const sparqlQuery = new TabQueryModel();
-            openNewTab(sparqlQuery);
+            openNewTab();
         }
     };
 

--- a/test-cypress/integration/resource/resource.spec.js
+++ b/test-cypress/integration/resource/resource.spec.js
@@ -349,6 +349,7 @@ describe('Resource view', () => {
             YasguiSteps.getTabs().should('have.length', 2);
             // and a describe query to be present
             YasqeSteps.getActiveTabQuery().should('contain', 'describe <<<http://example.com/resource/person/W6J1827> <http://example.com/ontology#hasAddress> <http://example.com/resource/person/W6J1827/address>>>');
+            YasguiSteps.getCurrentTab().should('contain', 'Unnamed 2');
         });
     });
 });


### PR DESCRIPTION
## What
When clicking on the title of a triple resource in the resource view, a new tab opens in the SPARQL view with an empty tab name. The tab name must be "Unnamed <next number>"

## Why
The addTab function in YASGUI takes a second argument, which is the configuration for the new tab. This configuration includes the tab name. When the configuration is missing, YASGUI generates a tab name. In our case, from WB, we pass an empty string as the tab name configuration, which YASGUI treats as a valid name and uses it.

## How
The default value of the tab name configuration has been changed to be undefined instead of an empty string.