### PR TITLE
GDB-8631: Malfunctions after integrate the new YASGUI component in yasr only mode in the resource view

### DIFF
--- a/src/pages/explore.html
+++ b/src/pages/explore.html
@@ -4,12 +4,12 @@
 <div class="page fit-content-on-mobile">
     <div class="resource-info" ng-if="resourceInfo && !isTripleResource()">
         <div class="thumb" ng-if="resourceInfo.details.img">
-            <a href="resourceInfo.details.img">
+            <a href="{{resourceInfo.details.img}}">
                 <img ng-src="{{details.img}}" alt="details image"/>
             </a>
         </div>
         <h1>
-            <a href="resourceInfo.details.uri" gdb-tooltip="resourceInfo.details.uri">
+            <a href="{{resourceInfo.details.uri}}" gdb-tooltip="{{resourceInfo.details.uri}}">
                 {{resourceInfo.details.label ? resourceInfo.details.label : getLocalName(resourceInfo.details.uri)}}
             </a>
 

--- a/src/pages/explore.html
+++ b/src/pages/explore.html
@@ -79,7 +79,7 @@
                 uib-popover="{{'sidepanel.expand.results.sameas' | translate}}: {{resourceInfo.sameAs ? 'common.on.btn' : 'common.off.btn' | translate}}"
                 popover-trigger="mouseenter"
                 popover-placement="bottom">
-            <span ng-class="{'icon-sameas-on':resourceInfo.sameAs, 'icon-sameas-off':!resourceInfo.sameAs}"></span>
+            <span class="icon-2x" ng-class="{'icon-sameas-on':resourceInfo.sameAs, 'icon-sameas-off':!resourceInfo.sameAs}"></span>
         </button>
 
         <button type="button"


### PR DESCRIPTION
## What
- When clicking on the resource name in the Resource view, an error is displayed instead of the resource source.
- The button “sameAs” is smaller than the others;

## Why
- A mistake occurred during view refactoring. The value of the link's href attribute was resolved as a string instead of a reference to an object;
- The icon's size was not properly set.

## How
- The issue is resolved by correcting the object reference;
- The size of icon has been increased.