### PR TITLE
GDB-8194: Tab is not visible when execute "Close other tabs" command.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.0.6",
+                "ontotext-yasgui-web-component": "1.0.7",
                 "shepherd.js": "^10.0.1"
             },
             "devDependencies": {
@@ -10228,9 +10228,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.6.tgz",
-            "integrity": "sha512-oN7bvXEPykn14FP6Nz7xliB9w67d2m1TVEHhPNIj4S2s3LDgyNLOl7/+ta0/rwqDU1s9dYka3jjLC7WXUhczMw==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.7.tgz",
+            "integrity": "sha512-KgalRXQ/OpQQ9rGIeIlUVhrus2k0P6N7clqChywmMAY9EHykJSEDnBIDTCBqjkzMcXQb26bEeadivGTG1WiRow==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -25111,9 +25111,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.6.tgz",
-            "integrity": "sha512-oN7bvXEPykn14FP6Nz7xliB9w67d2m1TVEHhPNIj4S2s3LDgyNLOl7/+ta0/rwqDU1s9dYka3jjLC7WXUhczMw==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.7.tgz",
+            "integrity": "sha512-KgalRXQ/OpQQ9rGIeIlUVhrus2k0P6N7clqChywmMAY9EHykJSEDnBIDTCBqjkzMcXQb26bEeadivGTG1WiRow==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.0.6",
+        "ontotext-yasgui-web-component": "1.0.7",
         "shepherd.js": "^10.0.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
When the closeOtherTabs function is called, all other tabs are closed, but the YASQE and YASR sections of the active tab are dismissed. Only the tab with the tab name is left.

## Why
There was a bug in ontotext-yasgui-web-component.

## How
The version of ontotext-yasgui-web-component has been incremented.