### PR TITLE
GDB-8280 Add missing extensions to import file selector

### DIFF
--- a/src/js/angular/import/controllers.js
+++ b/src/js/angular/import/controllers.js
@@ -48,7 +48,8 @@ importCtrl.controller('CommonCtrl', ['$scope', '$http', 'toastr', '$interval', '
 
         $scope.getAppData();
 
-        $scope.fileFormats = ['ttl', 'ttls',  'rdf', 'rj', 'n3', 'nt', 'nq', 'trig', 'trigs', 'trix', 'brf', 'owl', 'jsonld'];
+        $scope.fileFormats = ['ttl', 'ttls', 'rdf', 'rj', 'n3', 'nt', 'nq', 'trig', 'trigs', 'trix', 'brf', 'owl', 'jsonld', 'xml', 'rdfs',
+            'ndjsonld', 'ndjson', 'jsonl'];
 
         {
             const gzs = _.map($scope.fileFormats, function (f) {

--- a/test-cypress/steps/import-steps.js
+++ b/test-cypress/steps/import-steps.js
@@ -32,7 +32,7 @@ class ImportSteps {
     static openImportURLDialog(importURL) {
         cy.get('#import-user .import-from-url-btn').click()
             // Forces the popover to disappear as it covers the modal and Cypress refuses to continue
-            .trigger('mouseout', {force: true});
+            .trigger('mouseleave', {force: true});
         ImportSteps.getModal()
             .find('.url-import-form input[name="dataUrl"]')
             .type(importURL)
@@ -44,7 +44,7 @@ class ImportSteps {
     static openImportTextSnippetDialog() {
         cy.get('#import-user .import-rdf-snippet-btn').click()
             // Forces the popover to disappear as it covers the modal and Cypress refuses to continue
-            .trigger('mouseout', {force: true});
+            .trigger('mouseleave', {force: true});
         ImportSteps.getModal().find('#wb-import-textarea').should('be.visible');
 
         return ImportSteps;


### PR DESCRIPTION
## What
Added support for additional file formats

## Why
To enhance the import feature's compatibility and usability, this commit introduces support for several new file formats, including 'xml', 'rdfs', 'ndjsonld', 'ndjson', and 'jsonl'.

## How
Updated the 'controllers.js' file to include the newly supported formats in the 'fileFormats' array, ensuring that the import feature can now handle these formats seamlessly. This expansion of supported formats increases the versatility of the import functionality.