### PR TITLE
GDB-8788 Fix GDB logo shown with white background in cluster view

### DIFF
--- a/src/css/clustermanagement.css
+++ b/src/css/clustermanagement.css
@@ -1,4 +1,8 @@
-svg {
+.cluster-view {
+  position: relative;
+}
+
+.cluster-view svg {
   background-color: #FFF;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -7,7 +11,7 @@ svg {
   user-select: none;
 }
 
-path.link {
+.cluster-view path.link {
   stroke-width: 3px;
 }
 
@@ -155,10 +159,6 @@ div.nodetooltip {
   background: rgba(235, 235, 235, 0.9);
   width: 40%;
   max-width: 400px;
-}
-
-.nodes {
-  position: relative;
 }
 
 .main-menu.collapsed ~ div .legend-container {

--- a/src/pages/cluster-management/clusterInfo.html
+++ b/src/pages/cluster-management/clusterInfo.html
@@ -73,7 +73,7 @@
     </div>
 </div>
 
-<div ng-if="!loader" class="nodes">
+<div ng-if="!loader" class="cluster-view">
     <div cluster-graphical-view></div>
     <div id="toggle-legend-button" class="toggle-legend-btn">
         <button class="btn btn-link"


### PR DESCRIPTION
## What
Fix visualization of the logo in the sidebar in the cluster view

## Why
The logo is shown with a white background, because the stylesheet has a generic selector for svg which sets the fill to white

## How
- made the selector more specific for all the svgs that are in the cluster view