### PR TITLE
GDB-7116 Add white background to status bar

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -19,7 +19,7 @@
 
 <body>
 
-<div class="status-bar" ng-hide="isSecurityEnabled() && !isUserLoggedIn() && !isFreeAccessEnabled()" ng-cloak>
+<div class="status-bar bg-white" ng-hide="isSecurityEnabled() && !isUserLoggedIn() && !isFreeAccessEnabled()" ng-cloak>
     <div class="btn-group btn-group-lg" role="group" aria-label="Button group with nested dropdown">
         <div class="btn alert alert-warning no-icon" ng-if="!getLicense().valid && showLicense()"
              gdb-tooltip="{{getLicense().message}}" tooltip-placement="bottom">


### PR DESCRIPTION
## What
Add background to status bar

## Why
When you scroll through the page the top status bar is floating with the scroll but as it doesn't have a background in many parts of the page it is not visible

## How
- added bg-white css class to the status bar element which will set the background color to white