### PR TITLE
GDB-8676 fixing the color of the info message icons

### DIFF
--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -144,8 +144,7 @@
 				<div class="card" id="workbench-settings" ng-if="showWorkbenchSettings">
 					<div class="card-block">
 						<h3>{{'security.workbench.settings.title' | translate}}
-							<em class="icon-info text-primary small" gdb-tooltip="{{'security.workbench.settings.theme.tooltip' | translate}}"></em></h3>
-
+							<em class="icon-info text-tertiary small" gdb-tooltip="{{'security.workbench.settings.theme.tooltip' | translate}}"></em></h3>
 						<div>
                             <div class="form-group">
                                 <label class="col-lg-2">{{'security.workbench.settings.theme.label' | translate}}</label>
@@ -239,7 +238,7 @@
                                 </tr>
                                 <tr>
                                     <th>{{'security.any.data.repo' | translate}}
-                                        <em class="icon-info text-primary" gdb-tooltip="{{'security.data.repos' | translate}}"></em>
+                                        <em class="icon-info text-tertiary" gdb-tooltip="{{'security.data.repos' | translate}}"></em>
                                     </th>
                                     <th class="text-xs-center">
                                         <input class="read" type="checkbox" ng-model="grantedAuthorities.READ_REPO['*']"  ng-checked="hasReadPermission('*')" ng-disabled="readCheckDisabled('*')" ng-click="setGrantedAuthorities()">


### PR DESCRIPTION
## What
Fixing the color of the info message icons to be consistent in all views.

## Why
When the WB theme was changed, the info icons on these views were missed and they were presented with the old text-primary color whereas the new color used for the info icons is the text-tertiary

## How
* Changed the icons color