### PR TITLE
GDB-8755 edit existing ACL rule

### DIFF
--- a/src/js/angular/aclmanagement/controllers.js
+++ b/src/js/angular/aclmanagement/controllers.js
@@ -56,6 +56,12 @@ function AclManagementCtrl($scope, toastr, AclManagementRestService, $repositori
      */
     $scope.editedRuleIndex = undefined;
 
+    /**
+     * Flag showing if currently edited rule is a new one or not.
+     * @type {boolean}
+     */
+    $scope.isNewRule = false;
+
     //
     // Public functions
     //
@@ -67,6 +73,7 @@ function AclManagementCtrl($scope, toastr, AclManagementRestService, $repositori
     $scope.addRule= (index) => {
         $scope.rulesModel.addRule(index);
         $scope.editedRuleIndex = index;
+        $scope.isNewRule = true;
     };
 
     /**
@@ -74,7 +81,8 @@ function AclManagementCtrl($scope, toastr, AclManagementRestService, $repositori
      * @param {number} index
      */
     $scope.editRule= (index) => {
-        // TODO: implement
+        $scope.editedRuleIndex = index;
+        $scope.isNewRule = false;
     };
 
     /**
@@ -95,6 +103,7 @@ function AclManagementCtrl($scope, toastr, AclManagementRestService, $repositori
      */
     $scope.saveRule= () => {
         $scope.editedRuleIndex = undefined;
+        $scope.isNewRule = false;
     };
 
     /**
@@ -102,7 +111,10 @@ function AclManagementCtrl($scope, toastr, AclManagementRestService, $repositori
      * @param {number} index
      */
     $scope.cancelEditing = (index) => {
-        $scope.rulesModel.removeRule(index);
+        if ($scope.isNewRule) {
+            $scope.rulesModel.removeRule(index);
+            $scope.isNewRule = false;
+        }
         $scope.editedRuleIndex = undefined;
     };
 

--- a/src/js/angular/aclmanagement/model.js
+++ b/src/js/angular/aclmanagement/model.js
@@ -50,7 +50,7 @@ export class ACRuleModel {
      * @param {string} role
      * @param {string} policy
      */
-    constructor(subject = '', predicate = '', object= '', context= '', role= '', policy= ACL_POLICY.ALLOW) {
+    constructor(subject = '*', predicate = '*', object= '*', context= '*', role= '', policy= ACL_POLICY.ALLOW) {
         this._subject = subject;
         this._predicate = predicate;
         this._object = object;

--- a/test-cypress/steps/setup/acl-management-steps.js
+++ b/test-cypress/steps/setup/acl-management-steps.js
@@ -70,7 +70,7 @@ export class AclManagementSteps {
     }
 
     static getEditRuleButton(index) {
-        return this.getRule(index).find('.add-rule-btn');
+        return this.getRule(index).find('.edit-rule-btn');
     }
 
     static editRule(index) {
@@ -110,7 +110,7 @@ export class AclManagementSteps {
     }
 
     static fillSubject(index, value) {
-        this.getSubjectField(index).type(value);
+        this.getSubjectField(index).clear().type(value);
     }
 
     static getPredicateField(index) {
@@ -118,7 +118,7 @@ export class AclManagementSteps {
     }
 
     static fillPredicate(index, value) {
-        this.getPredicateField(index).type(value);
+        this.getPredicateField(index).clear().type(value);
     }
 
     static getObjectField(index) {
@@ -126,7 +126,7 @@ export class AclManagementSteps {
     }
 
     static fillObject(index, value) {
-        this.getObjectField(index).type(value);
+        this.getObjectField(index).clear().type(value);
     }
 
     static getContextField(index) {
@@ -134,7 +134,7 @@ export class AclManagementSteps {
     }
 
     static fillContext(index, value) {
-        this.getContextField(index).type(value);
+        this.getContextField(index).clear().type(value);
     }
 
     static getRoleField(index) {
@@ -142,7 +142,7 @@ export class AclManagementSteps {
     }
 
     static fillRole(index, value) {
-        this.getRoleField(index).type(value);
+        this.getRoleField(index).clear().type(value);
     }
 
     static getPolicySelectorField(index) {


### PR DESCRIPTION
## What
Implemented the edit ACL rule operation

## Why
* By requirement users should be able to edit rules from the ACL list.

## How
* Implemented the action for editing rule.
* Made the default values for subject, predicate, object, context to be '*'.
* Implemented tests.