### PR TITLE
GDB-8425 Fix user manipulations with special chars in firefox

### DIFF
--- a/src/js/angular/rest/security.rest.service.js
+++ b/src/js/angular/rest/security.rest.service.js
@@ -114,7 +114,7 @@ function SecurityRestService($http) {
      * @returns {string} The provided string encoded as a URI component.
      */
     function fixedEncodeURIComponent(str) {
-        return encodeURIComponent(str).replace(/[.!'()*]/g, function (c) {
+        return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
             return '%' + c.charCodeAt(0).toString(16);
         });
     }


### PR DESCRIPTION
## What
Removed . from fixedEncodeURIComponent function which replaces chars from path params

## Why
This causes . to be encoded and spring security has problem with that

## How
- removed . from regex