### PR TITLE
GDB-8730 Add notification when adding namespace

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -979,6 +979,7 @@
     "export.clear.graph.msg": "Failed to clear the {{longName}}",
     "export.warning.clear.graph.msg": "Are you sure you want to clear the selected graphs?",
     "export.cleared.graph.msg": "Cleared the selected graphs",
+    "namespace.saved": "Namespace saved",
     "namespace.confirm.replace": "Confirm replace",
     "namespace.already.exists.msg": "This namespace prefix already exists. Do you want to replace it?",
     "namespace.warning.delete.msg": "Are you sure you want to delete the namespace '{{prefix}}'?",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -975,6 +975,7 @@
     "export.clear.graph.msg": "Impossible d'effacer le {{longName}}",
     "export.warning.clear.graph.msg": "Êtes-vous sûr de vouloir effacer les graphes sélectionnés?",
     "export.cleared.graph.msg": "Effacé les graphes sélectionnés",
+    "namespace.saved": "Espace de noms sauvegardé",
     "namespace.confirm.replace": "Confirmer le remplacement",
     "namespace.already.exists.msg": "Ce préfixe d'espace de noms existe déjà. Voulez-vous le remplacer?",
     "namespace.warning.delete.msg": "Êtes-vous sûr de vouloir supprimer l'espace de noms '{{prefix}}'?",

--- a/src/js/angular/namespaces/controllers.js
+++ b/src/js/angular/namespaces/controllers.js
@@ -133,6 +133,7 @@ namespaces.controller('NamespacesCtrl', ['$scope', '$http', '$repositories', 'to
             return RDF4JRepositoriesRestService.updateNamespacePrefix($repositories.getActiveRepository(), namespace, prefix)
                 .success(function () {
                     $scope.getNamespaces();
+                    toastr.success($translate.instant('namespace.saved'));
                     $scope.loader = false;
                 }).error(function (data) {
                     const msg = getError(data);
@@ -217,11 +218,21 @@ namespaces.controller('NamespacesCtrl', ['$scope', '$http', '$repositories', 'to
             if (prefixExist) {
                 $scope.confirmReplace(function () {
                     $scope.saveNamespace($scope.namespace.prefix, $scope.namespace.namespace);
-                    $scope.namespace = {};
+                    $scope.namespace.namespace = '';
+                    $scope.namespace.prefix = '';
+                    setTimeout(() => {
+                        $scope.form.$setUntouched();
+                        $scope.form.$setPristine();
+                    });
                 });
             } else {
                 $scope.saveNamespace($scope.namespace.prefix, $scope.namespace.namespace);
-                $scope.namespace = {};
+                $scope.namespace.namespace = '';
+                $scope.namespace.prefix = '';
+                setTimeout(() => {
+                    $scope.form.$setUntouched();
+                    $scope.form.$setPristine();
+                });
             }
         };
 

--- a/src/pages/namespaces.html
+++ b/src/pages/namespaces.html
@@ -25,7 +25,7 @@
                            class="form-control" gdb-tooltip="{{'prefix.label' | translate}}" style="width: 130px;"/>
                 </div>
                 <div class="form-group" style="width: 260px;">
-                    <input required id="wb-namespaces-namespace"
+                    <input required id="wb-namespaces-namespace" name="namespace"
                            type="url" ng-model="namespace.namespace"
                            placeholder="http://example.com/data#" class="form-control"
                            gdb-tooltip="{{'namespace.label' | translate}}" style="width: 260px;"/>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -979,6 +979,7 @@
     "export.clear.graph.msg": "Failed to clear the {{longName}}",
     "export.warning.clear.graph.msg": "Are you sure you want to clear the selected graphs?",
     "export.cleared.graph.msg": "Cleared the selected graphs",
+    "namespace.saved": "Namespace saved",
     "namespace.confirm.replace": "Confirm replace",
     "namespace.already.exists.msg": "This namespace prefix already exists. Do you want to replace it?",
     "namespace.warning.delete.msg": "Are you sure you want to delete the namespace '{{prefix}}'?",


### PR DESCRIPTION
## What
Add a toastr notification when adding a namespace

## Why
After successfully adding a namespace, the user can not initially notice if the namespace they tried to add, was indeed, applied

## How
- added a toastr notification when the request succeeds
- set input as Pristine after adding the namespace to clear the validator