### PR TITLE
GDB-8827 Fix plugins menu not showing

### DIFF
--- a/src/js/angular/aclmanagement/plugin.js
+++ b/src/js/angular/aclmanagement/plugin.js
@@ -21,7 +21,7 @@ PluginRegistry.add('main.menu', {
             guideSelector: 'menu-setup'
         },
         {
-            label: 'Plugins',
+            label: 'ACL Management',
             labelKey: 'menu.aclmanagement.label',
             href: 'aclmanagement',
             order: 6,

--- a/test-cypress/integration/sparql/main.menu.spec.js
+++ b/test-cypress/integration/sparql/main.menu.spec.js
@@ -109,12 +109,11 @@ describe('Main menu tests', function () {
                         visible: false,
                         redirect: '/cluster'
                     },
-                    // I wonder, why this sometimes works and others don't.
-                    // {
-                    //     name: 'Plugins',
-                    //     visible: false,
-                    //     redirect: '/plugins'
-                    // },
+                    {
+                        name: 'Plugins',
+                        visible: false,
+                        redirect: '/plugins'
+                    },
                     {
                         name: 'Namespaces',
                         visible: false,


### PR DESCRIPTION
## What
The Plugins menu item is not showing in the main menu Setup

## Why
During the implementation of ACL management, the plugin configuration doubled the label "Plugin" which caused only one menu item to be shown

## How
- renamed the label to ACL Management
- uncommented the test which did not pass correctly