### PR TITLE
GDB-8826: Stop refreshing the operations status when security is enabled and the user is logged out.

### DIFF
--- a/src/js/angular/core/directives/operations-statuses-monitor/operations-statuses-monitor.directive.js
+++ b/src/js/angular/core/directives/operations-statuses-monitor/operations-statuses-monitor.directive.js
@@ -8,9 +8,9 @@ const UPDATE_ACTIVE_OPERATION_TIME_INTERVAL = 2000;
 angular.module('graphdb.framework.core.directives.operationsstatusesmonitor', [])
     .directive('operationsStatusesMonitor', operationsStatusesMonitorDirectives);
 
-operationsStatusesMonitorDirectives.$inject = ['$interval', '$repositories', 'MonitoringRestService'];
+operationsStatusesMonitorDirectives.$inject = ['$interval', '$repositories', 'MonitoringRestService', '$jwtAuth'];
 
-function operationsStatusesMonitorDirectives($interval, $repositories, MonitoringRestService) {
+function operationsStatusesMonitorDirectives($interval, $repositories, MonitoringRestService, $jwtAuth) {
 
     return {
         restrict: 'E',
@@ -82,7 +82,7 @@ function operationsStatusesMonitorDirectives($interval, $repositories, Monitorin
         };
 
         const reloadActiveOperations = () => {
-            if (updateActiveRepositoryRun) {
+            if (!$jwtAuth.isAuthenticated() || updateActiveRepositoryRun) {
                 return;
             }
 


### PR DESCRIPTION
## What
There is a redundant backend call to fetch running operations information when security is enabled, and the user is not logged in.

## Why
The check for security status and user login is not implemented.

## How
A Check to verify user authentication has been added before sending the request.