### PR TITLE
GDB-8753 Only authenticated admin users can have access to ACL management page when security is ON

### DIFF
--- a/src/js/angular/aclmanagement/plugin.js
+++ b/src/js/angular/aclmanagement/plugin.js
@@ -26,7 +26,7 @@ PluginRegistry.add('main.menu', {
             href: 'aclmanagement',
             order: 6,
             parent: 'Setup',
-            role: "IS_AUTHENTICATED_FULLY",
+            role: "ROLE_ADMIN",
             guideSelector: 'sub-menu-aclmanagement'
         }
     ]


### PR DESCRIPTION
## What
Allow only authenticated admin users to have access to ACL management page when security is ON.

## Why
ACL management is a task for data administrators (a.k.a. admin users in the GDB).

## How
Changed the role of of the user which can see the ACL management menu to role ROLE_ADMIN.