### PR TITLE
GDB-8750: Added Unique Validation for ACL Rules

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -168,7 +168,8 @@
         },
         "errors": {
             "loading_rules": "Error during ACL rules",
-            "updating_rules": "Error during ACL rules update"
+            "updating_rules": "Error during ACL rules update",
+            "duplicated_rules": "Every ACL rule should be unique."
         }
     },
     "config.name.label": "Config name",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -168,7 +168,8 @@
         },
         "errors": {
             "loading_rules": "Erreur lors du chargement des règles ACL",
-            "updating_rules": "Erreur lors de la mise à jour des règles ACL"
+            "updating_rules": "Erreur lors de la mise à jour des règles ACL",
+            "duplicated_rules": "Chaque règle ACL doit être unique."
         }
     },
     "config.name.label": "Nom de configuration",

--- a/src/js/angular/aclmanagement/controllers.js
+++ b/src/js/angular/aclmanagement/controllers.js
@@ -107,7 +107,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
     $scope.editRule = (index) => {
         $scope.editedRuleIndex = index;
         $scope.isNewRule = false;
-        $scope.editedRuleCopy = $scope.rulesModel.getRule(index);
+        $scope.editedRuleCopy = $scope.rulesModel.getRuleCopy(index);
         setModelDirty();
     };
 
@@ -129,6 +129,10 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
      * Saves a rule at a given index in the rulesModel.
      */
     $scope.saveRule = () => {
+        if (hasDuplication()) {
+            notifyDuplication();
+            return;
+        }
         $scope.editedRuleIndex = undefined;
         $scope.isNewRule = false;
         setModelDirty();
@@ -174,6 +178,11 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
      * Saves the entire ACL list into the DB.
      */
     $scope.saveAcl = () => {
+        if (hasDuplication()) {
+            notifyDuplication();
+            return;
+        }
+
         $scope.loading = true;
         updateAcl()
             .then(fetchAcl)
@@ -247,6 +256,16 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
      */
     const getActiveRepositoryId = () => {
         return $repositories.getActiveRepository();
+    };
+
+    const hasDuplication = () => {
+        const rule = $scope.rulesModel.getRule($scope.editedRuleIndex);
+        const countOccurrences = $scope.rulesModel.countOccurrences(rule);
+        return countOccurrences > 1;
+    };
+
+    const notifyDuplication = () => {
+        toastr.error($translate.instant('acl_management.errors.duplicated_rules'));
     };
 
     /**

--- a/src/js/angular/aclmanagement/controllers.js
+++ b/src/js/angular/aclmanagement/controllers.js
@@ -129,7 +129,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
      * Saves a rule at a given index in the rulesModel.
      */
     $scope.saveRule = () => {
-        if (hasDuplication()) {
+        if ($scope.rulesModel.isRuleDuplicated($scope.editedRuleIndex)) {
             notifyDuplication();
             return;
         }
@@ -178,11 +178,6 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
      * Saves the entire ACL list into the DB.
      */
     $scope.saveAcl = () => {
-        if (hasDuplication()) {
-            notifyDuplication();
-            return;
-        }
-
         $scope.loading = true;
         updateAcl()
             .then(fetchAcl)
@@ -256,12 +251,6 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
      */
     const getActiveRepositoryId = () => {
         return $repositories.getActiveRepository();
-    };
-
-    const hasDuplication = () => {
-        const rule = $scope.rulesModel.getRule($scope.editedRuleIndex);
-        const countOccurrences = $scope.rulesModel.countOccurrences(rule);
-        return countOccurrences > 1;
     };
 
     const notifyDuplication = () => {

--- a/src/js/angular/aclmanagement/model.js
+++ b/src/js/angular/aclmanagement/model.js
@@ -40,7 +40,20 @@ export class ACListModel {
         this.aclRules.splice(index, 1, rule);
     }
 
+    countOccurrences(ruleToCheck) {
+        return this.aclRules.reduce((countOccurrences, rule) => {
+            if (angular.equals(ruleToCheck, rule)) {
+                countOccurrences += 1;
+            }
+            return countOccurrences;
+        }, 0);
+    }
+
     getRule(index) {
+        return this.aclRules[index];
+    }
+
+    getRuleCopy(index) {
         const rule = this.aclRules[index];
         return {
             subject: rule.subject,

--- a/src/js/angular/aclmanagement/model.js
+++ b/src/js/angular/aclmanagement/model.js
@@ -40,17 +40,23 @@ export class ACListModel {
         this.aclRules.splice(index, 1, rule);
     }
 
-    countOccurrences(ruleToCheck) {
-        return this.aclRules.reduce((countOccurrences, rule) => {
-            if (angular.equals(ruleToCheck, rule)) {
-                countOccurrences += 1;
-            }
-            return countOccurrences;
-        }, 0);
-    }
-
     getRule(index) {
         return this.aclRules[index];
+    }
+
+    /**
+     * Checks if the rule at <code>index</code> is duplicated.
+     * @param {number} indexRuleToBeChecked - the index of the rule to be checked.
+     * @return {boolean} true if the model has a duplication of the rule at <code>index</code>.
+     */
+    isRuleDuplicated(indexRuleToBeChecked) {
+        const checkedRule = this.aclRules[indexRuleToBeChecked];
+        return this.aclRules.some((rule, index) => {
+            if (indexRuleToBeChecked !== index) {
+                return angular.equals(checkedRule, rule);
+            }
+            return false;
+        });
     }
 
     getRuleCopy(index) {
@@ -107,7 +113,7 @@ export class ACRuleModel {
      * @param {string} role
      * @param {string} policy
      */
-    constructor(subject = '*', predicate = '*', object= '*', context= '*', role= 'CUSTOM_', policy= ACL_POLICY.ALLOW) {
+    constructor(subject = '*', predicate = '*', object = '*', context = '*', role = 'CUSTOM_', policy = ACL_POLICY.ALLOW) {
         this._subject = subject;
         this._predicate = predicate;
         this._object = object;

--- a/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
@@ -1,6 +1,7 @@
 import {AclManagementSteps} from "../../../steps/setup/acl-management-steps";
 import {ACL} from "../../../steps/setup/acl-management-steps";
 import {ToasterSteps} from "../../../steps/toaster-steps";
+import {ApplicationSteps} from "../../../steps/application-steps";
 
 describe('ACL Management: create rule', () => {
 
@@ -118,7 +119,7 @@ describe('ACL Management: create rule', () => {
         AclManagementSteps.saveRule(0);
 
         // Then I expect an error notification to be displayed that describe me that ACL have to be unique.
-        ToasterSteps.verifyError('Every ACL rule should be unique.');
+        ApplicationSteps.getErrorNotifications().contains('Every ACL rule should be unique.');
     });
 });
 

--- a/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
@@ -1,5 +1,6 @@
 import {AclManagementSteps} from "../../../steps/setup/acl-management-steps";
 import {ACL} from "../../../steps/setup/acl-management-steps";
+import {ToasterSteps} from "../../../steps/toaster-steps";
 
 describe('ACL Management: create rule', () => {
 
@@ -102,6 +103,22 @@ describe('ACL Management: create rule', () => {
         AclManagementSteps.deleteRuleButtons().should('have.length', 0);
         AclManagementSteps.editRuleButtons().should('have.length', 0);
         AclManagementSteps.createRuleButtons().should('have.length', 0);
+    });
+
+    it('should not allow creating of a new rule if it is not unique', () => {
+        // When I am on "ACL Management" page and create a rule that exist,
+        AclManagementSteps.addRuleInBeginning();
+        AclManagementSteps.fillSubject(0, '<urn:Mary>');
+        AclManagementSteps.fillPredicate(0, '*');
+        AclManagementSteps.fillObject(0, '*');
+        AclManagementSteps.fillContext(0, '*');
+        AclManagementSteps.fillRole(0, '!CUSTOM_ROLE2');
+        AclManagementSteps.selectPolicy(0, 'allow');
+        // and try to save it.
+        AclManagementSteps.saveRule(0);
+
+        // Then I expect an error notification to be displayed that describe me that ACL have to be unique.
+        ToasterSteps.verifyError('Every ACL rule should be unique.');
     });
 });
 


### PR DESCRIPTION
## What
A unique validation for ACL rules has been implemented.

## Why
- Only the first rule will ever be matched;
- Managing duplicate rules in multiple positions can be challenging.
- If you want to delete the rule, you will need to identify all rules which are the same.

## How
A unique validation has been implemented. Rules cannot be saved if that validation fails.