### PR TITLE
GDB-8757 Prevent some operations and leaving the page when ACL model is changed

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -162,7 +162,8 @@
                 "delete_rule_confirmation": "Are you sure you want to delete the selected rule #{{index}}?",
                 "revert_acl_list": "This operation will revert all the changes done in the ACL. Are you sure you want to proceed?",
                 "rules_updated": "ACL was updated successfully",
-                "rules_reverted": "ACL was reverted successfully"
+                "rules_reverted": "ACL was reverted successfully",
+                "unsaved_changes_confirmation": "You have unsaved changes. Are you sure that you want to exit?"
             }
         },
         "errors": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -162,7 +162,8 @@
                 "delete_rule_confirmation": "Êtes-vous sûr de vouloir supprimer la règle sélectionnée #{{index}}?",
                 "revert_acl_list": "Cette opération annulera toutes les modifications apportées à l'ACL. Êtes-vous sur de vouloir continuer?",
                 "rules_updated": "L'ACL a été mise à jour avec succès",
-                "rules_reverted": "L'ACL a été rétablie avec succès"
+                "rules_reverted": "L'ACL a été rétablie avec succès",
+                "unsaved_changes_confirmation": "Vous avez des modifications non sauvegardées. Etes-vous sûr de vouloir quitter?"
             }
         },
         "errors": {

--- a/src/js/angular/aclmanagement/controllers.js
+++ b/src/js/angular/aclmanagement/controllers.js
@@ -250,15 +250,6 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
     };
 
     /**
-     * Watching for repository changes and reload the rules, because they are stored per repository.
-     */
-    $scope.$watch(function () {
-        return $repositories.getActiveRepository();
-    }, function () {
-        loadRules();
-    });
-
-    /**
      * Should warn the user if he tries to close the browser tab while there are unsaved changes.
      * @param {{returnValue: boolean}} event
      */
@@ -294,8 +285,6 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
                 const path = newPath.substring(baseLen);
                 $location.path(path);
             }, function () {});
-        } else {
-            unsubscribeListeners();
         }
     };
 
@@ -303,7 +292,13 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
      * Initialized the view controller.
      */
     const init = () => {
+        // Watching for repository changes and reload the rules, because they are stored per repository.
+        subscriptions.push($scope.$watch(getActiveRepositoryId, loadRules));
+        // Watching for url changes
         subscriptions.push($scope.$on('$locationChangeStart', locationChangedHandler));
+        // Watching for component destroy
+        subscriptions.push($scope.$on('$destroy', unsubscribeListeners));
+        // Listening for event fired when browser window is going to be closed
         window.addEventListener('beforeunload', beforeUnloadHandler);
     };
 

--- a/src/js/angular/aclmanagement/model.js
+++ b/src/js/angular/aclmanagement/model.js
@@ -3,7 +3,7 @@ export class ACListModel {
      * Constructs the ACListModel.
      * @param {ACRuleModel[]} aclRules
      */
-    constructor(aclRules) {
+    constructor(aclRules = []) {
         this._aclRules = aclRules;
     }
 
@@ -11,6 +11,23 @@ export class ACListModel {
         return this.aclRules.length;
     }
 
+    /**
+     * Creates a new ACRuleModel using provided values and appends it at the end of the list.
+     * @param {string} subject
+     * @param {string} predicate
+     * @param {string} object
+     * @param {string} context
+     * @param {string} role
+     * @param {string} policy
+     */
+    appendNewRule(subject, predicate, object, context, role, policy) {
+        this.aclRules.push(new ACRuleModel(subject, predicate, object, context, role, policy));
+    }
+
+    /**
+     * Creates a new ACRuleModel with default values and inserts it into specified index.
+     * @param {number} index
+     */
     addRule(index) {
         this.aclRules.splice(index, 0, new ACRuleModel());
     }

--- a/src/js/angular/rest/mappers/aclmanagement-mapper.js
+++ b/src/js/angular/rest/mappers/aclmanagement-mapper.js
@@ -3,17 +3,18 @@
  * @param {Object} response
  * @return {ACListModel}
  */
-import {ACListModel, ACRuleModel} from "../../aclmanagement/model";
+import {ACListModel} from "../../aclmanagement/model";
 
 /**
  * Maps the ACL rules response to ACListModel.
  * @param {Object} response
- * @return {*[]|ACListModel}
+ * @return {ACListModel}
  */
 export const mapAclRulesResponse = (response) => {
+    const aclModel = new ACListModel();
     if (response && response.data) {
-        const rules = response.data.map((rule) => {
-            return new ACRuleModel(
+        response.data.forEach((rule) => {
+            aclModel.appendNewRule(
                 rule.subject,
                 rule.predicate,
                 rule.object,
@@ -22,7 +23,6 @@ export const mapAclRulesResponse = (response) => {
                 rule.policy
             );
         });
-        return new ACListModel(rules);
     }
-  return [];
+    return aclModel;
 };

--- a/src/pages/aclmanagement.html
+++ b/src/pages/aclmanagement.html
@@ -161,7 +161,7 @@
             </form>
         </div>
 
-        <div ng-if="editedRuleIndex === undefined && rulesModel" class="text-right">
+        <div ng-if="editedRuleIndex === undefined && rulesModel && modelIsDirty" class="text-right">
             <button class="btn btn-secondary cancel-acl-save-btn"
                     ng-click="cancelAclSave()">
                 {{'acl_management.rulestable.actions.cancel_acl_saving' | translate}}

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -162,7 +162,8 @@
                 "delete_rule_confirmation": "Are you sure you want to delete the selected rule #{{index}}?",
                 "revert_acl_list": "This operation will revert all the changes done in the ACL. Are you sure you want to proceed?",
                 "rules_updated": "ACL was updated successfully",
-                "rules_reverted": "ACL was reverted successfully"
+                "rules_reverted": "ACL was reverted successfully",
+                "unsaved_changes_confirmation": "You have unsaved changes. Are you sure that you want to exit?"
             }
         },
         "errors": {

--- a/test-cypress/integration/setup/aclmanagement/revert-rules.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/revert-rules.spec.js
@@ -52,5 +52,9 @@ describe('ACL Management: revert rules', () => {
         ApplicationSteps.getSuccessNotifications().should('be.visible');
         AclManagementSteps.getAclRules().should('have.length', 5);
         AclManagementSteps.checkRules(ACL);
+        // And the model should become pristine again after the revert
+        // I should be able to navigate away from the page without any confirmation
+        ApplicationSteps.openImportPage();
+        cy.url().should('contain', '/import');
     });
 });

--- a/test-cypress/integration/setup/aclmanagement/update-rules.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/update-rules.spec.js
@@ -72,4 +72,61 @@ describe('ACL Management: update rules', () => {
         };
         AclManagementSteps.checkRules([ACL[0], newRule, editedRule, ACL[2], ACL[3]]);
     });
+
+    it('Should prevent leaving the page when there is new rule added', () => {
+        // Given I have opened ACL management page
+        // When I don't change anything and try to leave the page
+        ApplicationSteps.openImportPage();
+        // Then I expect to be redirected to the new page without confirmation
+        cy.url().should('contain', '/import');
+        // When I add a new rule
+        AclManagementSteps.visit();
+        AclManagementSteps.addRule(1);
+        ApplicationSteps.openImportPage();
+        // Then I expect a confirmation dialog
+        ModalDialogSteps.getDialog().should('be.visible');
+        // When I cancel confirmation
+        ModalDialogSteps.clickOnCancelButton();
+        // Then I expect dialog to be closed and to stay on the current page
+        ModalDialogSteps.getDialog().should('not.exist');
+        cy.url().should('contain', '/aclmanagement');
+        // When I try to leave the page and I confirm the operation
+        ApplicationSteps.openImportPage();
+        ModalDialogSteps.clickOnConfirmButton();
+        // Then I expect to be redirected to the new page
+        cy.url().should('contain', '/import');
+    });
+
+    it('Should prevent leaving the page when there is an edited rule', () => {
+        // Given I have opened ACL management page
+        // When I edit a rule
+        AclManagementSteps.editRule(1);
+        AclManagementSteps.fillSubject(1, '<urn:Me>');
+        AclManagementSteps.saveRule(1);
+        // And I try to leave the page
+        ApplicationSteps.openImportPage();
+        // Then I expect a confirmation dialog
+        ModalDialogSteps.getDialog().should('be.visible');
+    });
+
+    it('Should prevent leaving the page when there is a deleted rule', () => {
+        // Given I have opened ACL management page
+        // When I delete a rule
+        AclManagementSteps.deleteRule(1);
+        ModalDialogSteps.clickOnConfirmButton();
+        // And I try to leave the page
+        ApplicationSteps.openImportPage();
+        // Then I expect a confirmation dialog
+        ModalDialogSteps.getDialog().should('be.visible');
+    });
+
+    it('Should prevent leaving the page when there is a moved rule', () => {
+        // Given I have opened ACL management page
+        // When I move a rule
+        AclManagementSteps.moveRuleDown(1);
+        // And I try to leave the page
+        ApplicationSteps.openImportPage();
+        // Then I expect a confirmation dialog
+        ModalDialogSteps.getDialog().should('be.visible');
+    });
 });

--- a/test-cypress/steps/application-steps.js
+++ b/test-cypress/steps/application-steps.js
@@ -19,4 +19,9 @@ export class ApplicationSteps {
     static getWarningNotification() {
         return this.getNotifications().find('.toast-warning');
     }
+
+    // navigation via main menu
+    static openImportPage() {
+        cy.get('.main-menu .menu-element-root[href=import]').click();
+    }
 }


### PR DESCRIPTION
## What
* Prevent save/revert ACL when there are no changes in the ACL model.
* Prevent leaving the page when there are changes in the ACL model. Doing this will raise confirmation dialog for the user to choose to stay on the page or to leave and loose his data.

## Why
This is an UX improvement that makes the work in the ACL management page more friendly and error prone.

## How
Added a modelIsDirty flag that is set on each operation. The flag is used to control the actions visibility and to show confirmation dialog when the user tries to leave the page before saving the changes in the model.