### PR TITLE
GDB-8847 increase size of the acl rule reorder buttons

### DIFF
--- a/src/css/aclmanagement.css
+++ b/src/css/aclmanagement.css
@@ -25,9 +25,18 @@
     width: 25px;
 }
 
+.acl-management-view .acl-rules .reorder-cell {
+    padding: 0;
+}
+
 .acl-management-view .acl-rules .reorder-cell button {
     padding: 0;
     cursor: pointer;
+}
+
+.acl-management-view .acl-rules .reorder-cell button em {
+    font-size: 20px;
+    width: 20px;
 }
 
 .acl-management-view .acl-rules .data input {

--- a/src/pages/aclmanagement.html
+++ b/src/pages/aclmanagement.html
@@ -65,7 +65,7 @@
                         ng-class="{'selected': $index === selectedRule || $index === editedRuleIndex}">
                         <td>{{$index}}</td>
                         <td class="reorder-cell">
-                            <div ng-if="editedRuleIndex === undefined" class="reorder-actions-group">
+                            <span ng-if="editedRuleIndex === undefined" class="reorder-actions-group">
                                 <button ng-click="moveUp($index)" ng-if="$index > 0" class="btn btn-link move-up-btn"
                                         gdb-tooltip="{{'acl_management.rulestable.actions.move_up' | translate}}">
                                     <em class="fa fa-caret-up"></em>
@@ -75,7 +75,7 @@
                                         gdb-tooltip="{{'acl_management.rulestable.actions.move_down' | translate}}">
                                     <em class="fa fa-caret-down"></em>
                                 </button>
-                            </div>
+                            </span>
                         </td>
                         <td class="subject-cell data">{{rule.subject}}</td>
                         <td class="predicate-cell data">{{rule.predicate}}</td>


### PR DESCRIPTION
## What
Increase the size of the rule reorder buttons.

## Why
To improve usability.

## How
Increased the font-size of the button which affects the icon as well as removed the table cell padding in order to prevent buttons misalignment.