### PR TITLE
GDB-8610 download sparql results via POST request

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1706,6 +1706,7 @@
     "target.label": "Target",
     "show.blank.nodes.label": "Show Blank Nodes",
     "download.as.label": "Download as",
+    "download.as.progress.msg": "Downloading SPARQL result",
     "visual.graph.label": "Visual graph",
     "explore.graph.visually.popover": "Click to explore the graph visually",
     "pred.label": "Predicate",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1696,6 +1696,7 @@
     "target.label": "Cible",
     "show.blank.nodes.label": "Afficher les nœuds vides",
     "download.as.label": "Télécharger en tant que",
+    "download.as.progress.msg": "Téléchargement du résultat SPARQL",
     "visual.graph.label": "Graphique visuel",
     "explore.graph.visually.popover": "Cliquez pour explorer le graphe visuellement.",
     "edit.label": "Éditer",

--- a/src/js/angular/core/directives/queryeditor/query-editor.directive.js
+++ b/src/js/angular/core/directives/queryeditor/query-editor.directive.js
@@ -593,10 +593,6 @@ function queryEditorDirective($timeout, $location, toastr, $repositories, Sparql
             window.yasr = yasr;
             yasr.afterCopy = afterCopy;
             yasr.getQueryResultsAsFormat = function (downloadFormat) {
-                // JSON and JSON-LD have to be fetched in memory before sending, so error handling must be introduced
-                // Valid for construct queries only
-                const exportTypesToFetchWithErrorHandling = ['application/rdf+json', 'application/ld+json'];
-                const isConstructQuery = window.editor.getQueryType() === 'CONSTRUCT';
                 const queryParams = {
                     query: scope.currentQuery.query,
                     infer: scope.currentQuery.inference,
@@ -605,38 +601,23 @@ function queryEditorDirective($timeout, $location, toastr, $repositories, Sparql
                 };
                 const accept = downloadFormat;
 
-                const fetchWithErrorHandling = exportTypesToFetchWithErrorHandling.includes(downloadFormat);
                 if (window.editor.getValue() !== queryParams.query) {
                     toastr.warning($translate.instant('query.editor.query.results.mismatch'));
                 }
-                if (isConstructQuery && fetchWithErrorHandling) {
-                    RDF4JRepositoriesRestService.downloadResultsAsFile($repositories.getActiveRepository(), queryParams, accept)
-                        .then(function ({data, filename}) {
-                            saveAs(data, filename);
-                        }).catch(function (res) {
-                        // data is received as blob
-                        res.data.text()
-                            .then((message) => {
-                                if (res.status === 431) {
-                                    toastr.error(res.statusText, $translate.instant('common.error'));
-                                } else {
-                                    toastr.error(message, $translate.instant('common.error'));
-                                }
-                            });
-                    });
-                } else {
-                    // Simple cross-browser download with a form
-                    const $wbDownload = $('#wb-download');
-                    $wbDownload.attr('action', 'repositories/' + $repositories.getActiveRepository());
-                    $('#wb-download-query').val(queryParams.query);
-                    $('#wb-download-infer').val(queryParams.infer);
-                    $('#wb-download-sameAs').val(queryParams.sameAs);
-                    if (queryParams.auth) {
-                        $('#wb-auth-token').val(queryParams.auth);
-                    }
-                    $('#wb-download-accept').val(downloadFormat);
-                    $wbDownload.trigger('submit');
-                }
+                RDF4JRepositoriesRestService.downloadResultsAsFile($repositories.getActiveRepository(), queryParams, accept)
+                    .then(function ({data, filename}) {
+                        saveAs(data, filename);
+                    }).catch(function (res) {
+                    // data is received as blob
+                    res.data.text()
+                        .then((message) => {
+                            if (res.status === 431) {
+                                toastr.error(res.statusText, $translate.instant('common.error'));
+                            } else {
+                                toastr.error(message, $translate.instant('common.error'));
+                            }
+                        });
+                });
             };
             window.editor.options.sparql.handlers.complete = function (dataOrJqXhr, textStatus, jqXhrOrErrorString) {
                 function setNewTabStateForThis() {


### PR DESCRIPTION
## What
Perform spraql results download only via POST request.

## Why
In order to prevent request errors due to the GET request size limit being hit.

## How
Removed the branching in the code which limited the expected behavior only for construct queries.