### PR TITLE
GDB-8866 custom roles should not be editable by regular users

### DIFF
--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -762,6 +762,10 @@ securityCtrl.controller('ChangeUserPasswordSettingsCtrl', ['$scope', 'toastr', '
             return true;
         };
 
+        $scope.isUser = function () {
+            return $scope.userType === UserType.USER;
+        };
+
         $scope.goBack = function () {
             const timer = $timeout(function () {
                 $window.history.back();

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -210,7 +210,7 @@
                         <h3>{{'security.user.custom_role' | translate}}</h3>
                         <div class="input-group">
                             <tags-input class="wb-tags-input" ng-model="customRoles" min-length="2"
-                                        ng-disabled="!isUser()"
+                                        ng-disabled="!isUser() || mode === 'settings'"
                                         use-strings="true"
                                         add-on-space="true"
                                         add-on-comma="true"


### PR DESCRIPTION
## What
In the user settings page the roles field should not be editable for regular users.

## Why
Only admins can change/assign roles to users different than admin or repo manager. For these two, custom roles cannot be assigned.

## How
Added proper validation in the view and a method for checking the user type in the settings controller.