### PR TITLE
GDB-8876 Report download button does not work

### DIFF
--- a/src/js/angular/stats/app.js
+++ b/src/js/angular/stats/app.js
@@ -2,8 +2,8 @@ import 'angular/core/services';
 
 const adminInfoApp = angular.module('graphdb.framework.stats', ['toastr']);
 
-adminInfoApp.controller('AdminInfoCtrl', ['$scope', '$http', 'toastr', '$timeout', '$translate', 'AuthTokenService',
-    function ($scope, $http, toastr, $timeout, $translate, AuthTokenService) {
+adminInfoApp.controller('AdminInfoCtrl', ['$scope', '$http', 'toastr', '$timeout', '$jwtAuth', '$translate', 'AuthTokenService',
+    function ($scope, $http, toastr, $timeout, $jwtAuth, $translate, AuthTokenService) {
 
         $http.get('rest/info/data')
             .success(function (data) {


### PR DESCRIPTION
## What
There’s an error in the browser console saying ""$jwtAuth is not defined" when click on "Download" system information button.

## Why
Injection of $jwtAuth service has been removed by mistake when "GDB-8813 Refactor so token is fetched per request" was implemented.

## How
Injection of $jwtAuth service has been added.