### PR TITLE
GDB-8881 Don't reload the ACL when an error happens during ACL update

### DIFF
--- a/src/js/angular/aclmanagement/controllers.js
+++ b/src/js/angular/aclmanagement/controllers.js
@@ -181,6 +181,10 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
         $scope.loading = true;
         updateAcl()
             .then(fetchAcl)
+            .catch((data) => {
+                const msg = getError(data);
+                toastr.error(msg, $translate.instant('acl_management.errors.updating_rules'));
+            })
             .finally(() => {
                 $scope.loading = false;
             });
@@ -220,9 +224,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
         return AclManagementRestService.updateAcl(repositoryId, $scope.rulesModel.toJSON())
             .then(() => {
                 toastr.success($translate.instant('acl_management.rulestable.messages.rules_updated'));
-            }).catch((data) => {
-                const msg = getError(data);
-                toastr.error(msg, $translate.instant('acl_management.errors.updating_rules'));
+                return true;
             });
     };
 


### PR DESCRIPTION
## What
The ACL list should not be reloaded when ACL update fails due to some error.

## Why
Currently when ACL save operation completes the ACL list in reloaded in the UI, but when an error occurs in the backend the list should not be reloaded in order to allow the user to correct his data and just lose it.

## How
Moved the catch handler in the proper method where the update error should be caught thus effectively skipping the ACL reloading.