### PR TITLE
GDB-8908: Repositories view does not load after log in through another tab

### DIFF
--- a/src/js/angular/core/services/repositories.service.js
+++ b/src/js/angular/core/services/repositories.service.js
@@ -421,6 +421,7 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
         };
 
         $rootScope.$on('securityInit', function (scope, securityEnabled, userLoggedIn, freeAccess) {
+            locationsRequestPromise = null;
             if (!securityEnabled || userLoggedIn || freeAccess) {
                 // This has to happen in a separate cycle because otherwise some properties in init() are undefined
                 $timeout(function () {


### PR DESCRIPTION
## What
Repositories not loaded in "Repositories" view when two tabs are opened, the "Repositories" view is opened in first tab, the user is logged out from the second tab and logged in from the first tab. After the login in first tab a loader is displayed and never disappear, the repositories not loaded.

## Why
Two reason are reason for this behaviour:
 - The "repositories" service has state. The function "getLocations" calls back end to fetch all locations. When the BE is called a promise of $http client is saved as service variable if another client of the service calls the function, the same instance of the promise will be returned. When request finish without matter successfully or not the variable is cleaned.

 - The "unauthorized" interceptor checks all error from BE if the user is not authorized or has no permission. If error code is 401 or 403 the user is redirected to login page. A changes of interceptor logic has been made because of bug [GDB-4965](https://ontotext.atlassian.net/browse/GDB-4965). The user's redirection is wrapped with a promise and when the user is redirected then the BE request is rejected.

 The second reason somehow breaks the promise returned from the "getLocation" function. The promise never resolves, and the loader displayed on the page never disappears.

## How
Added clearing of the service promise when user authorization changes (removes the broken promise instance). When the function is called next time a new one will be returned.