### PR TITLE
GDB-8610 do export results via form submit to allow progress monitoring in the browser

### DIFF
--- a/src/pages/sparql.html
+++ b/src/pages/sparql.html
@@ -46,7 +46,7 @@
             ng-keyup="saveQueryToLocal(currentQuery)"
             nocount="{{skipCountQuery}}" enable-column-resizing-on-window-width>
     </query-editor>
-    <form id="wb-download" method="GET" action="" target="_self">
+    <form id="wb-download" method="POST" action="" target="_self">
         <input id="wb-download-query" name="query" type="hidden"/>
         <input id="wb-download-infer" name="infer" type="hidden"/>
         <input id="wb-download-sameAs" name="sameAs" type="hidden"/>


### PR DESCRIPTION
## What
Export results via form submit to allow progress monitoring in the browser.

## Why
Using the file saver plugin does the job of file downloading, but it's no more user friendly because it doesn't allow the user to see the download progress nor to terminate it.

## How
Changed the form action to be POST instead of GET in order to prevent exceeding the browser's limit for GET requests. This is also the easier way to do simple crossbrowser download with progress and cancelation support.