### PR TITLE
GDB-8914 Fix OpenId authentication process

### DIFF
--- a/src/js/angular/core/interceptors/authentication.interceptor.js
+++ b/src/js/angular/core/interceptors/authentication.interceptor.js
@@ -8,6 +8,14 @@ angular.module('graphdb.framework.core.interceptors.authentication', [
             return {
                 'request': function(config) {
                     const headers = config.headers || {};
+
+                    // When using OpenID, during authentication process, the additional headers modification must be skipped
+                    const openIDUrls = [AuthTokenService.OPENID_CONFIG.openIdKeysUri, AuthTokenService.OPENID_CONFIG.openIdTokenUrl];
+                    const isOpenIdUrl = openIDUrls.some((url) => config.url.indexOf(url) > -1);
+                    if (isOpenIdUrl) {
+                        return config;
+                    }
+
                     // Angular doesn't send this header by default, and we need it to detect XHR requests
                     // so that we don't advertise Basic auth with them.
                     headers['X-Requested-With'] = 'XMLHttpRequest';

--- a/src/js/angular/core/services.js
+++ b/src/js/angular/core/services.js
@@ -290,12 +290,14 @@ function ClassInstanceDetailsService($http) {
 
 function AuthTokenService() {
     const authStorageName = 'com.ontotext.graphdb.auth';
+    const OPENID_CONFIG = {};
 
     return {
         AUTH_STORAGE_NAME: authStorageName,
         getAuthToken: getAuthToken,
         setAuthToken: setAuthToken,
-        clearAuthToken: clearAuthToken
+        clearAuthToken: clearAuthToken,
+        OPENID_CONFIG: OPENID_CONFIG
     };
 
     function setAuthToken(token) {

--- a/src/js/angular/core/services/jwt-auth.service.js
+++ b/src/js/angular/core/services/jwt-auth.service.js
@@ -230,6 +230,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
             };
 
             this.loginOpenID = function () {
+                // FIX: This causes the workbench to always return to this.gdbUrl after login, which breaks the logic for multitab login
                 $openIDAuth.login(this.openIDConfig, this.gdbUrl);
             };
 
@@ -273,10 +274,11 @@ angular.module('graphdb.framework.core.services.jwtauth', [
 
             this.authenticate = function (data, authHeaderValue) {
                 return new Promise((resolve) => {
-                    AuthTokenService.clearAuthToken();
                     if (authHeaderValue) {
                         AuthTokenService.setAuthToken(authHeaderValue);
                         this.externalAuthUser = false;
+                    } else {
+                        AuthTokenService.clearAuthToken();
                     }
 
                     this.principal = data;

--- a/src/js/angular/core/services/jwt-auth.service.js
+++ b/src/js/angular/core/services/jwt-auth.service.js
@@ -153,7 +153,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                                     // so keep it clean of other logic.
                                     // The variable justLoggedIn will be set to true if this is
                                     // a new login that just happened.
-                                    that.auth = $openIDAuth.authHeaderGraphDB();
+                                    AuthTokenService.setAuthToken($openIDAuth.authHeaderGraphDB());
                                     console.log('oidc: set id/access token as GraphDB auth');
                                     // When logging via OpenID we may get a token that doesn't have
                                     // rights in GraphDB, this should be considered invalid.

--- a/src/js/angular/core/services/openid-auth.service.js
+++ b/src/js/angular/core/services/openid-auth.service.js
@@ -634,7 +634,7 @@ angular.module('graphdb.framework.core.services.openIDService', modules)
              * @returns {string} The OpenID scope to request.
              */
             this.getScope = function(extraScopes) {
-                let scope = 'openid' + (that.supportsOfflineAccess ? ' offline_access' : '');
+                let scope = 'openid' + (AuthTokenService.OPENID_CONFIG.supportsOfflineAccess ? ' offline_access' : '');
                 if (extraScopes) {
                     scope += ' ' + extraScopes;
                 }

--- a/test/security/openid-service.spec.js
+++ b/test/security/openid-service.spec.js
@@ -1,5 +1,5 @@
 describe('$openIDAuth tests', function () {
-    let $openIDAuth, $httpBackend, $window;
+    let $openIDAuth, $httpBackend, $window, AuthTokenService;
 
     const graphdbUrl = 'http://localhost:7200/';
     let openIdConfig;
@@ -45,11 +45,12 @@ describe('$openIDAuth tests', function () {
         });
     }));
 
-    beforeEach(angular.mock.inject(function (_$openIDAuth_, _$httpBackend_, _$window_) {
+    beforeEach(angular.mock.inject(function (_$openIDAuth_, _$httpBackend_, _$window_, _AuthTokenService_) {
         // The injector unwraps the underscores (_) from around the parameter names when matching
         $openIDAuth = _$openIDAuth_;
         $httpBackend = _$httpBackend_;
         $window = _$window_;
+        AuthTokenService = _AuthTokenService_;
 
         // The client ID and the issuer need to stay the same as the JWT token contains them
         // and they are used for validation.
@@ -184,10 +185,10 @@ describe('$openIDAuth tests', function () {
         console.log('$openIDAuth initial state');
         initOpenId(false, false);
         expectEmptyTokens();
-        expect($openIDAuth.supportsOfflineAccess)
+        expect(AuthTokenService.OPENID_CONFIG.supportsOfflineAccess)
             .toBe(openIdConfig.oidcScopesSupported.includes('offline_access'));
         expect($openIDAuth.getScope())
-            .toBe($openIDAuth.supportsOfflineAccess ? 'openid offline_access' : 'openid');
+            .toBe(AuthTokenService.OPENID_CONFIG.supportsOfflineAccess ? 'openid offline_access' : 'openid');
         expect($openIDAuth.getLoginUrl('some state/foo', 'some challenge/bar',
             graphdbUrl, openIdConfig)).toBe(expectedUrl);
 


### PR DESCRIPTION
## What
Fix invalid client authentication scheme error when trying to log in with OpenID

## Why
When authenticating with OpenId, the calls that are made during the auth process were amended by the authentication interceptor, which caused failure of getting tokens. Also the OpenId access token, was not set in the AuthTokenService

## How
- moved the OpenId configuration to AuthTokenService
- skipped headers change in authentication interceptor for OpenId requests
- set OpenId access token in AuthTokenService