### PR TITLE
GDB-8914 Fix OpenId authentication process (#1066)

### DIFF
--- a/src/js/angular/core/interceptors/authentication.interceptor.js
+++ b/src/js/angular/core/interceptors/authentication.interceptor.js
@@ -8,6 +8,14 @@ angular.module('graphdb.framework.core.interceptors.authentication', [
             return {
                 'request': function(config) {
                     const headers = config.headers || {};
+
+                    // When using OpenID, during authentication process, the additional headers modification must be skipped
+                    const openIDUrls = [AuthTokenService.OPENID_CONFIG.openIdKeysUri, AuthTokenService.OPENID_CONFIG.openIdTokenUrl];
+                    const isOpenIdUrl = openIDUrls.some((url) => config.url.indexOf(url) > -1);
+                    if (isOpenIdUrl) {
+                        return config;
+                    }
+
                     // Angular doesn't send this header by default, and we need it to detect XHR requests
                     // so that we don't advertise Basic auth with them.
                     headers['X-Requested-With'] = 'XMLHttpRequest';

--- a/src/js/angular/core/services.js
+++ b/src/js/angular/core/services.js
@@ -290,12 +290,14 @@ function ClassInstanceDetailsService($http) {
 
 function AuthTokenService() {
     const authStorageName = 'com.ontotext.graphdb.auth';
+    const OPENID_CONFIG = {};
 
     return {
         AUTH_STORAGE_NAME: authStorageName,
         getAuthToken: getAuthToken,
         setAuthToken: setAuthToken,
-        clearAuthToken: clearAuthToken
+        clearAuthToken: clearAuthToken,
+        OPENID_CONFIG: OPENID_CONFIG
     };
 
     function setAuthToken(token) {

--- a/src/js/angular/core/services/jwt-auth.service.js
+++ b/src/js/angular/core/services/jwt-auth.service.js
@@ -153,7 +153,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                                     // so keep it clean of other logic.
                                     // The variable justLoggedIn will be set to true if this is
                                     // a new login that just happened.
-                                    that.auth = $openIDAuth.authHeaderGraphDB();
+                                    AuthTokenService.setAuthToken($openIDAuth.authHeaderGraphDB());
                                     console.log('oidc: set id/access token as GraphDB auth');
                                     // When logging via OpenID we may get a token that doesn't have
                                     // rights in GraphDB, this should be considered invalid.
@@ -230,6 +230,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
             };
 
             this.loginOpenID = function () {
+                // FIX: This causes the workbench to always return to this.gdbUrl after login, which breaks the logic for multitab login
                 $openIDAuth.login(this.openIDConfig, this.gdbUrl);
             };
 
@@ -273,10 +274,11 @@ angular.module('graphdb.framework.core.services.jwtauth', [
 
             this.authenticate = function (data, authHeaderValue) {
                 return new Promise((resolve) => {
-                    AuthTokenService.clearAuthToken();
                     if (authHeaderValue) {
                         AuthTokenService.setAuthToken(authHeaderValue);
                         this.externalAuthUser = false;
+                    } else {
+                        AuthTokenService.clearAuthToken();
                     }
 
                     this.principal = data;

--- a/src/js/angular/core/services/openid-auth.service.js
+++ b/src/js/angular/core/services/openid-auth.service.js
@@ -13,8 +13,8 @@ const openIDReqHeaders = {headers: {
 
 
 angular.module('graphdb.framework.core.services.openIDService', modules)
-    .service('$openIDAuth', ['$http', '$location', '$window', 'toastr', '$translate',
-        function ($http, $location, $window, toastr, $translate) {
+    .service('$openIDAuth', ['$http', '$location', '$window', 'toastr', '$translate', 'AuthTokenService',
+        function ($http, $location, $window, toastr, $translate, AuthTokenService) {
             const storagePrefix = 'com.ontotext.graphdb.openid.';
             const that = this;
 
@@ -132,9 +132,9 @@ angular.module('graphdb.framework.core.services.openIDService', modules)
              */
             this.withOpenIdKeys = function(openIdKeysUri, callback) {
                 $http.get(openIdKeysUri, openIDReqHeaders).success(function(jwks) {
-                    that.openIdKeys = {};
+                    AuthTokenService.OPENID_CONFIG.openIdKeys = {};
                     jwks['keys'].forEach(function(k) {
-                        that.openIdKeys[k.kid] = k
+                        AuthTokenService.OPENID_CONFIG.openIdKeys[k.kid] = k
                     });
                     callback();
                 });
@@ -162,21 +162,21 @@ angular.module('graphdb.framework.core.services.openIDService', modules)
                 that.accessTokenIssuer = openIDConfig.tokenIssuer;
 
                 // Set the token and keys url properly depending on a proxy
-                that.openIdTokenUrl = openIDConfig.oidcTokenEndpoint;
-                let openIdKeysUri = openIDConfig.oidcJwksUri;
+                AuthTokenService.OPENID_CONFIG.openIdTokenUrl = openIDConfig.oidcTokenEndpoint;
+                AuthTokenService.OPENID_CONFIG.openIdKeysUri = openIDConfig.oidcJwksUri;
                 if (openIDConfig.proxyOidc) {
-                    openIdKeysUri = 'rest/openid/jwks';
-                    that.openIdTokenUrl = 'rest/openid/token';
+                    AuthTokenService.OPENID_CONFIG.openIdKeysUri = 'rest/openid/jwks';
+                    AuthTokenService.OPENID_CONFIG.openIdTokenUrl = 'rest/openid/token';
                 }
-                that.openIdEndSessionUrl = openIDConfig.oidcEndSessionEndpoint;
-                that.supportsOfflineAccess = openIDConfig.oidcScopesSupported.includes('offline_access');
+                AuthTokenService.OPENID_CONFIG.openIdEndSessionUrl = openIDConfig.oidcEndSessionEndpoint;
+                AuthTokenService.OPENID_CONFIG.supportsOfflineAccess = openIDConfig.oidcScopesSupported.includes('offline_access');
 
                 if (openIDConfig.oracleDomain) {
                     // Oracle OAM deviates from the spec and requires this as well
                     openIDReqHeaders['headers']['X-OAuth-Identity-Domain-Name'] = openIDConfig.oracleDomain;
                 }
 
-                that.withOpenIdKeys(openIdKeysUri, function() {
+                that.withOpenIdKeys(AuthTokenService.OPENID_CONFIG.openIdKeysUri, function() {
                     that.isLoggedIn = that.hasValidIdToken();
                     if (that.isLoggedIn) {
                         that.setupTokensRefresh(false, successCallback, errorCallback);
@@ -252,9 +252,9 @@ angular.module('graphdb.framework.core.services.openIDService', modules)
              */
             this.hardLogout = function(redirectUrl) {
                 that.softLogout();
-                if (that.openIdEndSessionUrl) {
+                if (AuthTokenService.OPENID_CONFIG.openIdEndSessionUrl) {
                     $window.location.href =
-                        `${that.openIdEndSessionUrl}?client_id=${encodeURIComponent(that.clientId)}&post_logout_redirect_uri=${encodeURIComponent(redirectUrl)}`;
+                        `${AuthTokenService.OPENID_CONFIG.openIdEndSessionUrl}?client_id=${encodeURIComponent(that.clientId)}&post_logout_redirect_uri=${encodeURIComponent(redirectUrl)}`;
                 }
             }
 
@@ -339,7 +339,7 @@ angular.module('graphdb.framework.core.services.openIDService', modules)
                         return false;
                     }
                 }
-                const jwk = that.openIdKeys[headerObj.kid];
+                const jwk = AuthTokenService.OPENID_CONFIG.openIdKeys[headerObj.kid];
                 if (!jwk) {
                     console.log('oidc: no key to verify JWT token (token considered invalid)');
                     return false;
@@ -479,7 +479,7 @@ angular.module('graphdb.framework.core.services.openIDService', modules)
 
                 $http({
                     method: 'POST',
-                    url: that.openIdTokenUrl,
+                    url: AuthTokenService.OPENID_CONFIG.openIdTokenUrl,
                     headers: headers,
                     transformRequest: transformURLEncodedRequest,
                     data: params
@@ -509,7 +509,7 @@ angular.module('graphdb.framework.core.services.openIDService', modules)
                     const headers = {...openIDReqHeaders['headers'], ...{'Content-type': 'application/x-www-form-urlencoded; charset=utf-8'}};
                     $http({
                         method: 'POST',
-                        url: that.openIdTokenUrl,
+                        url: AuthTokenService.OPENID_CONFIG.openIdTokenUrl,
                         headers: headers,
                         transformRequest: transformURLEncodedRequest,
                         data: params
@@ -634,7 +634,7 @@ angular.module('graphdb.framework.core.services.openIDService', modules)
              * @returns {string} The OpenID scope to request.
              */
             this.getScope = function(extraScopes) {
-                let scope = 'openid' + (that.supportsOfflineAccess ? ' offline_access' : '');
+                let scope = 'openid' + (AuthTokenService.OPENID_CONFIG.supportsOfflineAccess ? ' offline_access' : '');
                 if (extraScopes) {
                     scope += ' ' + extraScopes;
                 }

--- a/test-cypress/integration/explore/similarity.spec.js
+++ b/test-cypress/integration/explore/similarity.spec.js
@@ -269,6 +269,7 @@ describe('Similarity screen validation', () => {
 
     function disableSimilarityPlugin() {
         const disableSimilarityPluginQuery = 'INSERT DATA { <u:a> <http://www.ontotext.com/owlim/system#stopplugin> \'similarity\' . }';
+        cy.waitUntilQueryIsVisible();
         cy.pasteQuery(disableSimilarityPluginQuery);
         cy.executeQuery();
     }
@@ -421,6 +422,7 @@ describe('Similarity screen validation', () => {
             'filter(isLiteral(?documentText)) \n' +
             '}order by asc(str(?documentID))';
 
+        cy.waitUntilQueryIsVisible();
         cy.pasteQuery(MODIFIED_DATA_QUERY);
         cy.get('.test-query-btn').click();
         cy.get('.sparql-loader').should('not.exist');
@@ -430,6 +432,7 @@ describe('Similarity screen validation', () => {
 
     function changeSearchQuery() {
         getSearchQueryTab().scrollIntoView().should('be.visible').click();
+        cy.waitUntilQueryIsVisible();
         cy.pasteQuery(MODIFIED_SEARCH_QUERY);
     }
 
@@ -438,6 +441,7 @@ describe('Similarity screen validation', () => {
             .scrollIntoView()
             .should('be.visible').click()
             .then(() => {
+                cy.waitUntilQueryIsVisible();
                 cy.pasteQuery(MODIFIED_ANALOGICAL_QUERY);
             });
     }
@@ -476,6 +480,7 @@ describe('Similarity screen validation', () => {
 
     function verifyQueryIsChanged() {
         const query = 'OPTIONAL { ?result <http://dbpedia.org/ontology/birthPlace> ?birthDate .';
+        cy.waitUntilQueryIsVisible();
         cy.verifyQueryAreaContains(query);
     }
 });

--- a/test-cypress/integration/setup/my-settings.spec.js
+++ b/test-cypress/integration/setup/my-settings.spec.js
@@ -128,12 +128,12 @@ describe('My Settings', () => {
 
                 //clear default query and paste a new one that will generate more than 1000 results
                 cy.get('#queryEditor .CodeMirror').find('textarea')
-                    .type(Cypress.env('modifierKey') + 'a{backspace}', {force: true})
-                    .then(() => {
-                        cy.get('#queryEditor .CodeMirror').find('textarea')
-                            .invoke('val', testResultCountQuery).trigger('change', {force: true})
-                            .then(() => cy.verifyQueryAreaContains(testResultCountQuery));
-                    });
+                    .type(Cypress.env('modifierKey') + 'a{backspace}', {force: true});
+
+                cy.get('#queryEditor .CodeMirror').find('textarea')
+                    .invoke('val', testResultCountQuery).trigger('change', {force: true})
+                cy.waitUntilQueryIsVisible();
+                cy.verifyQueryAreaContains(testResultCountQuery);
 
                 cy.get('#wb-sparql-runQuery')
                     .should('be.visible')

--- a/test-cypress/integration/sparql/sparql.menu.spec.js
+++ b/test-cypress/integration/sparql/sparql.menu.spec.js
@@ -372,6 +372,8 @@ describe('SPARQL screen validation', () => {
 
         it('should test text mining plugin', () => {
             cy.waitUntilQueryIsVisible();
+            cy.pasteQuery(GATE_CLIENT_CREATE_QUERY);
+            cy.executeQuery();
             cy.pasteQuery(GATE_CLIENT_SEARCH_QUERY);
             cy.executeQuery();
             getResultPages().should('have.length', 1);

--- a/test-cypress/integration/sparql/sparql.menu.spec.js
+++ b/test-cypress/integration/sparql/sparql.menu.spec.js
@@ -225,6 +225,7 @@ describe('SPARQL screen validation', () => {
 
             let describeQuery = 'describe ?t {bind (<<?s ?p ?o>> as ?t) .}';
 
+            cy.waitUntilQueryIsVisible();
             cy.pasteQuery(describeQuery);
 
             SparqlSteps.executeQuery();
@@ -305,6 +306,7 @@ describe('SPARQL screen validation', () => {
         it('Test execute (Describe) query', () => {
             let describeQuery = 'DESCRIBE <http://www.ontotext.com/SYSINFO> FROM <http://www.ontotext.com/SYSINFO>';
 
+            cy.waitUntilQueryIsVisible();
             cy.pasteQuery(describeQuery);
 
             SparqlSteps.executeQuery();
@@ -332,6 +334,7 @@ describe('SPARQL screen validation', () => {
         it('Test execute (ASK) query', () => {
             let askQuery = 'ASK WHERE { ?s ?p ?o .FILTER (regex(?o, "ontotext.com")) }';
 
+            cy.waitUntilQueryIsVisible();
             cy.pasteQuery(askQuery);
             SparqlSteps.executeQuery();
 
@@ -347,6 +350,7 @@ describe('SPARQL screen validation', () => {
         // This test depends on external service http://factforge.net/repositories/ff-news which can occasionally fail.
         it.skip('Test execute (CONSTRUCT) query', () => {
             cy.fixture('queries/construct-query.sparql').then(constructQuery => {
+                cy.waitUntilQueryIsVisible();
                 cy.pasteQuery(constructQuery);
             });
 
@@ -367,8 +371,7 @@ describe('SPARQL screen validation', () => {
         });
 
         it('should test text mining plugin', () => {
-            cy.pasteQuery(GATE_CLIENT_CREATE_QUERY);
-            cy.executeQuery();
+            cy.waitUntilQueryIsVisible();
             cy.pasteQuery(GATE_CLIENT_SEARCH_QUERY);
             cy.executeQuery();
             getResultPages().should('have.length', 1);
@@ -412,6 +415,7 @@ describe('SPARQL screen validation', () => {
                 '\t?s ?p ?o .\n' +
                 '}';
 
+            cy.waitUntilQueryIsVisible();
             cy.pasteQuery(defaultQueryWithoutLimit);
             SparqlSteps.executeQuery();
 
@@ -446,6 +450,7 @@ describe('SPARQL screen validation', () => {
                 '  :a ?p ?o .\n' +
                 '}';
 
+            cy.waitUntilQueryIsVisible();
             cy.pasteQuery(updateToExecute);
             SparqlSteps.executeQuery();
             getUpdateMessage()
@@ -687,6 +692,7 @@ describe('SPARQL screen validation', () => {
         it('Test create, edit and delete saved query', () => {
             let savedQueryName = 'Saved query - ' + Date.now();
 
+            cy.waitUntilQueryIsVisible();
             cy.pasteQuery(QUERY_FOR_SAVING);
 
             saveQuery();
@@ -885,6 +891,7 @@ describe('SPARQL screen validation', () => {
 
         it('Test URL to current query', () => {
             const query = 'SELECT ?sub ?pred ?obj WHERE {?sub ?pred ?obj .} LIMIT 100';
+            cy.waitUntilQueryIsVisible();
             cy.pasteQuery(query);
 
             // Press the link icon to generate a link for a query

--- a/test-cypress/support/sparql-commands.js
+++ b/test-cypress/support/sparql-commands.js
@@ -64,7 +64,7 @@ function verifyQueryAreaContains(query) {
         getQueryArea()
             .then(codeMirrorEl => codeMirrorEl && typeof codeMirrorEl[0].CodeMirror.getValue() === 'string'));
     // Using the CodeMirror instance because getting the value from the DOM is very cumbersome
-    getQueryArea().should('contain', query);
+    getQueryArea().then(codeMirrorEl => codeMirrorEl && codeMirrorEl[0].CodeMirror.getValue()).should('contain', query);
 }
 
 function getRunQueryButton() {

--- a/test-cypress/support/sparql-commands.js
+++ b/test-cypress/support/sparql-commands.js
@@ -20,8 +20,8 @@ Cypress.Commands.add('verifyResultsPageLength', (resultLength) => {
 
 Cypress.Commands.add('verifyResultsMessage', (msg) => {
     cy.waitUntil(() =>
-        getResultsMessage()
-            .then((resultInfo) => resultInfo && resultInfo.text().trim().indexOf(msg) > -1));
+        getResultsMessage().then((resultInfo) => resultInfo && resultInfo.text().trim().length > 0));
+    getResultsMessage().should('contain', msg);
 });
 
 Cypress.Commands.add('getResultsMessage', () => {
@@ -60,10 +60,11 @@ function waitUntilQueryIsVisible() {
 }
 
 function verifyQueryAreaContains(query) {
-    // Using the CodeMirror instance because getting the value from the DOM is very cumbersome
     cy.waitUntil(() =>
         getQueryArea()
-            .then(codeMirrorEl => codeMirrorEl && codeMirrorEl[0].CodeMirror.getValue().trim().indexOf(query) > -1));
+            .then(codeMirrorEl => codeMirrorEl && typeof codeMirrorEl[0].CodeMirror.getValue() === 'string'));
+    // Using the CodeMirror instance because getting the value from the DOM is very cumbersome
+    getQueryArea().should('contain', query);
 }
 
 function getRunQueryButton() {

--- a/test/security/openid-service.spec.js
+++ b/test/security/openid-service.spec.js
@@ -1,5 +1,5 @@
 describe('$openIDAuth tests', function () {
-    let $openIDAuth, $httpBackend, $window;
+    let $openIDAuth, $httpBackend, $window, AuthTokenService;
 
     const graphdbUrl = 'http://localhost:7200/';
     let openIdConfig;
@@ -45,11 +45,12 @@ describe('$openIDAuth tests', function () {
         });
     }));
 
-    beforeEach(angular.mock.inject(function (_$openIDAuth_, _$httpBackend_, _$window_) {
+    beforeEach(angular.mock.inject(function (_$openIDAuth_, _$httpBackend_, _$window_, _AuthTokenService_) {
         // The injector unwraps the underscores (_) from around the parameter names when matching
         $openIDAuth = _$openIDAuth_;
         $httpBackend = _$httpBackend_;
         $window = _$window_;
+        AuthTokenService = _AuthTokenService_;
 
         // The client ID and the issuer need to stay the same as the JWT token contains them
         // and they are used for validation.
@@ -184,10 +185,10 @@ describe('$openIDAuth tests', function () {
         console.log('$openIDAuth initial state');
         initOpenId(false, false);
         expectEmptyTokens();
-        expect($openIDAuth.supportsOfflineAccess)
+        expect(AuthTokenService.OPENID_CONFIG.supportsOfflineAccess)
             .toBe(openIdConfig.oidcScopesSupported.includes('offline_access'));
         expect($openIDAuth.getScope())
-            .toBe($openIDAuth.supportsOfflineAccess ? 'openid offline_access' : 'openid');
+            .toBe(AuthTokenService.OPENID_CONFIG.supportsOfflineAccess ? 'openid offline_access' : 'openid');
         expect($openIDAuth.getLoginUrl('some state/foo', 'some challenge/bar',
             graphdbUrl, openIdConfig)).toBe(expectedUrl);
 


### PR DESCRIPTION
## What
Fix invalid client authentication scheme error when trying to log in with OpenID

## Why
When authenticating with OpenId, the calls that are made during the auth process were amended by the authentication interceptor, which caused failure of getting tokens. Also the OpenId access token, was not set in the AuthTokenService

## How
- moved the OpenId configuration to AuthTokenService
- skipped headers change in authentication interceptor for OpenId requests
- set OpenId access token in AuthTokenService
- there was a problem with logout/login flow with multiple tabs
- the localStorage listener was triggered by an unnecessary clearing of the token