### PR TITLE
GDB-8687: The "isLiteral field" of the similarity index is not properly set

### DIFF
--- a/src/js/angular/models/similarity/similarity-index-info.js
+++ b/src/js/angular/models/similarity/similarity-index-info.js
@@ -180,9 +180,9 @@ export class SimilarityIndexInfo {
         return RenderingMode.YASR === this.getSelectedYasguiRenderMode();
     }
 
-    ////////////////////////////
-    // Similarity index getters
-    ////////////////////////////
+    ///////////////////////////////////////
+    // Similarity index getters and setters
+    ///////////////////////////////////////
 
     getName() {
         return this.similarityIndex.name;
@@ -230,6 +230,10 @@ export class SimilarityIndexInfo {
 
     getType() {
         return this.similarityIndex.type;
+    }
+
+    setOptions(options) {
+        this.similarityIndex.options = options;
     }
 
     getOptions() {

--- a/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/src/js/angular/similarity/controllers/create-index.controller.js
@@ -437,9 +437,9 @@ function CreateSimilarityIdxCtrl(
         similarityIndexInfo.setSelectedQueryType($scope.isEditViewMode() ? SimilarityQueryType.SEARCH : SimilarityQueryType.DATA);
         const options = $location.search().options;
         if (options) {
-            similarityIndexInfo.options = options;
+            similarityIndexInfo.setOptions(options);
         } else {
-            similarityIndexInfo.options = similarityIndexInfo.isTextType() ? textDefaultOptions : predDefaultOptions
+            similarityIndexInfo.setOptions(similarityIndexInfo.isTextType() ? textDefaultOptions : predDefaultOptions);
         }
 
         setDefaultQueries(similarityIndexInfo);


### PR DESCRIPTION
## What
When I create similarity indexes from existing one, the index type of result is not same as source index.

## Why
There was an initialization mistake in setting the "options" field of the SimilarityIndex object when tha view is loading. The field was being set on the SimilarityIndexInfo object instead of the SimilarityIndex.

## How
Wrong setting of "options" field has been corrected.