### PR TITLE
GDB-8711 Allowing users to copy paste roles with space between them, instead of replacing with a dash

### DIFF
--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -214,6 +214,9 @@
                                         use-strings="true"
                                         add-on-space="true"
                                         add-on-comma="true"
+                                        add-on-paste="true"
+                                        replace-spaces-with-dashes="false"
+                                        paste-split-pattern="[\s+]"
                                         on-tag-added="addCustomRole($tag)"
                                         placeholder="{{'security.user.add.custom_role.msg' | translate}}"></tags-input>
                         </div>


### PR DESCRIPTION
Add parameters to the tags-input to enable users to paste multiple roles with space between them