### PR TITLE
Updates version of ontotext-yasgui-web-component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.0.9",
+                "ontotext-yasgui-web-component": "1.0.10",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10251,9 +10251,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.9.tgz",
-            "integrity": "sha512-ETYIs/s6+1vXEhHKVTVHYgJd6fbDYPrFWRZ5iINkWWrWKIqJjCnAJoNA7HOcoU6CPkdVfS0bpyDMASOuCOijMA==",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.10.tgz",
+            "integrity": "sha512-O8t9EovSh7nnTlvff92yHilmfojrX9RfdetNDadNpEskszhLmdkUvhuUqCqywoqsQvpcVDyJ5O7rr2fp62pZ+g==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -25170,9 +25170,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.9.tgz",
-            "integrity": "sha512-ETYIs/s6+1vXEhHKVTVHYgJd6fbDYPrFWRZ5iINkWWrWKIqJjCnAJoNA7HOcoU6CPkdVfS0bpyDMASOuCOijMA==",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.10.tgz",
+            "integrity": "sha512-O8t9EovSh7nnTlvff92yHilmfojrX9RfdetNDadNpEskszhLmdkUvhuUqCqywoqsQvpcVDyJ5O7rr2fp62pZ+g==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.0.9",
+        "ontotext-yasgui-web-component": "1.0.10",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/test-cypress/integration/sparql-editor/plugins/error-plugin.spec.js
+++ b/test-cypress/integration/sparql-editor/plugins/error-plugin.spec.js
@@ -1,0 +1,83 @@
+import SparqlSteps from "../../../steps/sparql-steps";
+import {QueryStubs} from "../../../stubs/query-stubs";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {ErrorPluginSteps} from "../../../steps/yasgui/plugin/error-plugin-steps";
+import {YasrSteps} from "../../../steps/yasgui/yasr-steps";
+
+const SHORT_ERROR_BODY = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore';
+const LONG_ERROR_BODY = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+const LESS_MESSAGE = LONG_ERROR_BODY.substring(0, 160);
+
+describe('Error handling', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'sparql-error-handling' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        SparqlSteps.visit();
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('should show error without show full message button when error message is les than 160 characters.', () => {
+        // When I visit a page with "ontotext-yasgui-web-component" in it,
+        // and execute wrong query that returns short error message (less thant 160).
+        QueryStubs.stubQueryErrorResponse(repositoryId, 500, SHORT_ERROR_BODY);
+        YasqeSteps.executeErrorQuery();
+
+        // Then I expect to see a message that
+        // describes error status and error text,
+        ErrorPluginSteps.getErrorPluginErrorStatus().contains('500: Internal Server Error');
+        // and time when the query is executed,
+        ErrorPluginSteps.getErrorPluginErrorTimeMessage().contains(/Query took \d{1}\.\d{1}s, moments ago\./);
+        // and error message sent by server,
+        ErrorPluginSteps.getErrorPluginBody().invoke('text').should('eq', SHORT_ERROR_BODY);
+        // and toolbar with plugins to not be visible,
+        YasrSteps.getResultHeader().should('not.be.visible');
+        // and message info to not be visible,
+        YasrSteps.getResponseInfo().should('not.be.visible');
+        // and show full/less error message not be visible
+        ErrorPluginSteps.getShowFullErrorMessage().should('not.exist');
+        ErrorPluginSteps.getShowLessErrorMessage().should('not.exist');
+    });
+
+    it('should show error with show full message button when error message is more than than 160 characters.', () => {
+        // When I visit a page with "ontotext-yasgui-web-component" in it,
+        // and execute wrong query.
+        QueryStubs.stubQueryErrorResponse(repositoryId, 500, LONG_ERROR_BODY);
+        YasqeSteps.executeErrorQuery();
+
+        // Then I expect to see a message that
+        // describes error status and error text,
+        ErrorPluginSteps.getErrorPluginErrorStatus().contains('500: Internal Server Error');
+        // and time when the query is executed,
+        ErrorPluginSteps.getErrorPluginErrorTimeMessage().contains(/Query took \d{1}\.\d{1}s, moments ago\./);
+        // and error message sent by server,
+        ErrorPluginSteps.getErrorPluginBody().invoke('text').should('eq', LESS_MESSAGE);
+        // and toolbar with plugins to not be visible,
+        YasrSteps.getResultHeader().should('not.be.visible');
+        // and message info to not be visible,
+        YasrSteps.getResponseInfo().should('not.be.visible');
+        ErrorPluginSteps.getShowFullErrorMessage().should('be.visible');
+        ErrorPluginSteps.getShowLessErrorMessage().should('not.exist');
+
+        // When click on show full message
+        ErrorPluginSteps.getShowFullErrorMessage().click();
+
+        // Then I expect to see full message
+        ErrorPluginSteps.getErrorPluginBody().invoke('text').should('eq', LONG_ERROR_BODY);
+        ErrorPluginSteps.getShowFullErrorMessage().should('not.exist');
+        ErrorPluginSteps.getShowLessErrorMessage().should('be.visible');
+
+        // When click on show less message
+        ErrorPluginSteps.getShowLessErrorMessage().click();
+
+        // Then I expect to see first 160 characters of the error message
+        ErrorPluginSteps.getErrorPluginBody().invoke('text').should('eq', LESS_MESSAGE);
+        ErrorPluginSteps.getShowFullErrorMessage().should('be.visible');
+        ErrorPluginSteps.getShowLessErrorMessage().should('not.exist');
+    });
+});

--- a/test-cypress/steps/yasgui/plugin/error-plugin-steps.js
+++ b/test-cypress/steps/yasgui/plugin/error-plugin-steps.js
@@ -4,7 +4,27 @@ export class ErrorPluginSteps {
         return cy.get('.error-response-plugin');
     }
 
+    static getErrorPluginHeader() {
+        return ErrorPluginSteps.getErrorPlugin().find('.error-response-plugin-header');
+    }
+
+    static getErrorPluginErrorStatus() {
+        return ErrorPluginSteps.getErrorPluginHeader().find('.error-response-plugin-error-status');
+    }
+
+    static getErrorPluginErrorTimeMessage() {
+        return ErrorPluginSteps.getErrorPluginHeader().find('.error-response-plugin-error-time-message');
+    }
+
     static getErrorPluginBody() {
         return ErrorPluginSteps.getErrorPlugin().find('.error-response-plugin-body');
+    }
+
+    static getShowFullErrorMessage() {
+        return cy.get('.show-full-message-link');
+    }
+
+    static getShowLessErrorMessage() {
+        return cy.get('.show-less-message-link');
     }
 }


### PR DESCRIPTION
## What
- GDB-8438: "YASR: Update error plugin". When exception is thrown after executing of sparql query, the workbench shows the error. But if the error is too big the error area is too long. Most of the users do not need to see the entire message;
- GDB-8188: "Buttons labels of dialogs are not translated". Some labels are not translated in French;
- GDB-8185: "Тhe button for "Copy URL to clipboard" is not visible on Browser Firefox". When hovering over a URI in Yasr, the "Copy URL to clipboard" button is not visible in the Firefox browser.

## Why
- WB displays all error messages no matter of its length;
- Missed label translation;
- The CSS selector that displays the URI includes a ":has" selector, which is not supported by the Firefox browser.

## How
Updates version of ontotext-yasgui-web-component.