### PR TITLE
GDB-8686 Disable the save sparql template button if the query is not changed

### DIFF
--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -337,19 +337,19 @@ function yasguiComponentDirective(
 
                     $scope.ontotextYasguiConfig = config;
 
-                    setInitialQueryState();
-
-                    if (angular.isFunction($scope.afterInit)) {
-                        $scope.afterInit();
-                    }
-
                     addDirtyCheckHandlers();
                     $scope.language = $languageService.getLanguage();
+
+                    setInitialQueryState().then(() => {
+                        if (angular.isFunction($scope.afterInit)) {
+                            $scope.afterInit();
+                        }
+                    });
                 }
             };
 
             const setInitialQueryState = () => {
-                $scope.getOntotextYasguiElement().getQuery()
+                return $scope.getOntotextYasguiElement().getQuery()
                     .then((query) => {
                         initialQueryValue = JSON.stringify(query);
                     });

--- a/src/js/angular/rest/sparql.rest.service.js
+++ b/src/js/angular/rest/sparql.rest.service.js
@@ -112,8 +112,8 @@ function SparqlRestService($http) {
         return $http.delete(`${SAVED_QUERIES_ENDPOINT}?name=${encodeURIComponent(savedQueryName)}`);
     }
 
-    function addKnownPrefixes(prefixes) {
-        return $http.post(`${SPARQL_ENDPOINT}/add-known-prefixes`, prefixes);
+    function addKnownPrefixes(query) {
+        return $http.post(`${SPARQL_ENDPOINT}/add-known-prefixes`, query);
     }
 
     function getQueryResult(repositoryId, sendData, accept) {

--- a/src/js/angular/sparql-template/controllers.js
+++ b/src/js/angular/sparql-template/controllers.js
@@ -463,11 +463,19 @@ function SparqlTemplateCreateCtrl(
         }
     };
 
+    const queryChangeHandler = (evt, queryState) => {
+        if (queryState.dirty) {
+            $scope.markDirty();
+        } else {
+            $scope.markPristine();
+        }
+    };
+
     // =========================
     // Subscriptions
     // =========================
     const subscriptions = [];
-
+    subscriptions.push($scope.$on('queryChanged', queryChangeHandler));
     subscriptions.push($rootScope.$on('$translateChangeSuccess', languageChangedHandler));
     subscriptions.push($scope.$on('$locationChangeStart', locationChangedHandler));
     subscriptions.push(eventEmitterService.subscribe('repositoryWillChangeEvent', repositoryWillChangedHandler));

--- a/src/pages/sparql-template-create.html
+++ b/src/pages/sparql-template-create.html
@@ -41,7 +41,7 @@
                     </div>
                 </div>
 
-                <yasgui-component id="query-editor" class="pt-1" yasgui-config="yasguiConfig" query-changed="markDirty()"></yasgui-component>
+                <yasgui-component id="query-editor" class="pt-1" yasgui-config="yasguiConfig"></yasgui-component>
 
                 <div ng-if="!sparqlTemplateInfo.isValidQuery"
                      class="idError alert alert-danger  invalid-query"
@@ -59,7 +59,7 @@
                 uib-popover="{{'save.sparql.template.tooltip' | translate}}"
                 popover-placement="top"
                 popover-trigger="mouseenter"
-                ng-if="canEditActiveRepo">
+                ng-if="canEditActiveRepo" ng-disabled="!isDirty">
             {{'common.save.btn' | translate}}
         </button>
         <a ng-href="sparql-templates" class="btn btn-lg btn-secondary cancel-query-btn"

--- a/src/pages/sparql-template-create.html
+++ b/src/pages/sparql-template-create.html
@@ -59,7 +59,7 @@
                 uib-popover="{{'save.sparql.template.tooltip' | translate}}"
                 popover-placement="top"
                 popover-trigger="mouseenter"
-                ng-if="canEditActiveRepo" ng-disabled="!isDirty">
+                ng-if="canEditActiveRepo" ng-disabled="!isDirty && !sparqlTemplateInfo.isNewTemplate">
             {{'common.save.btn' | translate}}
         </button>
         <a ng-href="sparql-templates" class="btn btn-lg btn-secondary cancel-query-btn"


### PR DESCRIPTION
## What
Disable the save sparql template button if the query is not changed.

## Why
It should be possible to perform sparql template saving only if there is a change in the existing query in the editor. Otherwise the backend throws error. It's not clear why this error happens but it is what it is for now.

## How
Extended the ontotext-yasgui facade component to do dirty checking for the query value and emit a `queryChanged` event. The event is then handled in the sparql template edit controller where the `isDirty` flag is toggled. Also the save button is conditionally disabled or enabled according to the `isDirty` flag value.