### PR TITLE
GDB-8891 disable the ask gpt button while previous question is in flight (#1070)

### DIFF
--- a/src/js/angular/chatgpt/templates/chat.html
+++ b/src/js/angular/chatgpt/templates/chat.html
@@ -93,7 +93,7 @@
                 <form>
                     <div class="mb-2 d-flex">
                         <input class="form-control" ng-model="question" type="text">
-                        <button class="btn btn-primary" ng-disabled="loading" ng-click="ask()">{{ 'ttyg.ask.button' | translate }}</button>
+                        <button class="btn btn-primary" ng-disabled="loader" ng-click="ask()">{{ 'ttyg.ask.button' | translate }}</button>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
## What
Disable the ask gpt button while previous question is in flight.

## Why
If the button is not disabled and another question is asked while the previous one is not already answered, then the answers in the pane are mismatched.

## How
Disabled the button during the request is in progress using the `loading` flag.

(cherry picked from commit 81ab5cf495a02fcd2215177d00a15c225b2c44ea)