### PR TITLE
GDB-8810 introduces iri autocomplete select and integrates it in the acl view (#1055)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,7 @@ import 'angular/core/directives/languageselector/language-selector.directive';
 import 'angular/core/directives/angulartooltips/angular-tooltips.js';
 import 'angular/core/directives/uppercased.directive';
 import 'angular/core/directives/operations-statuses-monitor/operations-statuses-monitor.directive'
+import 'angular/core/directives/autocomplete/autocomplete.directive'
 
 // $translate.instant converts <b> from strings to &lt;b&gt
 // and $sce.trustAsHtml could not recognise that this is valid html
@@ -34,7 +35,8 @@ const modules = [
     'graphdb.framework.core.directives.angular-tooltips',
     'graphdb.framework.core.directives.uppercased',
     'graphdb.framework.guides.services',
-    'graphdb.framework.core.directives.operationsstatusesmonitor'
+    'graphdb.framework.core.directives.operationsstatusesmonitor',
+    'graphdb.framework.core.directives.autocomplete'
 ];
 
 const providers = [

--- a/src/css/aclmanagement.css
+++ b/src/css/aclmanagement.css
@@ -2,6 +2,12 @@
     table-layout: fixed;
 }
 
+.acl-management-view .acl-rules .labels-row th {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;;
+}
+
 .acl-management-view .acl-rules .toolbar {
     height: 35px;
     padding: 0;
@@ -18,11 +24,16 @@
 }
 
 .acl-management-view .acl-rules .index-column {
-    width: 2%;
+    width: 4ch;
 }
 
 .acl-management-view .acl-rules .reorder-column {
     width: 25px;
+}
+
+.acl-management-view .acl-rules .index-cell {
+    padding: 0;
+    text-align: center;
 }
 
 .acl-management-view .acl-rules .reorder-cell {

--- a/src/css/autocomplete-select.css
+++ b/src/css/autocomplete-select.css
@@ -1,0 +1,62 @@
+.autocomplete-select-wrapper {
+    position: relative;
+}
+
+.autocomplete-select-wrapper .autocomplete-results-wrapper {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    max-height: 204px;
+    margin-bottom: 0;
+    overflow: auto;
+    background-color: #fff;
+}
+
+.autocomplete-select-wrapper .autocomplete-results-wrapper div:hover {
+    background-color: var(--autocomplete-background);
+    cursor: pointer;
+}
+
+.autocomplete-select-wrapper .autocomplete-results-wrapper div.active {
+    background-color: var(--autocomplete-background);
+    cursor: pointer;
+}
+
+.autocomplete-select-wrapper .autocomplete-results-wrapper div.selected {
+    background-color: var(--autocomplete-background-selected);
+    cursor: pointer;
+}
+
+.autocomplete-select-wrapper .autocomplete-results-wrapper div p b,
+.autocomplete-select-wrapper .autocomplete-results-wrapper div.active p b {
+    color: var(--autocomplete-match);
+}
+
+.autocomplete-select-wrapper .autocomplete-results-wrapper div p {
+    margin-bottom: 0;
+    padding: 5px 25px;
+    white-space: nowrap;
+}
+
+.autocomplete-select-wrapper .autocomplete-select {
+    color: red;
+}
+
+.templates .tag {
+    cursor: pointer;
+    font-size: 100%;
+}
+
+.autocomplete-loader {
+    position: relative;
+    z-index: 100000;
+}
+
+.autocomplete-loader .ot-loader-new-content {
+    position: absolute;
+    z-index: 100000;
+    width: 100%;
+    height: calc(100vh - 120px);
+    padding-top: calc((100vh - 300px) / 2);
+    background-color: rgba(255,255,255,0.66);
+}

--- a/src/js/angular/core/directives/autocomplete/autocomplete.directive.js
+++ b/src/js/angular/core/directives/autocomplete/autocomplete.directive.js
@@ -1,0 +1,313 @@
+import {decodeHTML} from "../../../../../app";
+import {mapUriAsNtripleAutocompleteResponse} from "../../../rest/mappers/autocomplete-mapper";
+
+angular
+    .module('graphdb.framework.core.directives.autocomplete', [])
+    .directive('autocomplete', autocomplete);
+
+autocomplete.$inject = ['$location', 'toastr', 'ClassInstanceDetailsService', 'AutocompleteRestService', '$q', '$sce', '$repositories', '$translate', '$timeout'];
+
+function autocomplete($location, toastr, ClassInstanceDetailsService, AutocompleteRestService, $q, $sce, $repositories, $translate, $timeout) {
+    return {
+        restrict: 'E',
+        require: 'ngModel',
+        scope: {
+            ngModel: '=',
+            namespaces: '=',
+            autocompleteStatusLoader: '=',
+            placeholder: '@',
+            styleClass: '@'
+        },
+        templateUrl: 'js/angular/core/directives/autocomplete/templates/autocomplete.html',
+        link: linkFunction
+    };
+
+    function linkFunction($scope, element, attrs) {
+
+        //
+        // Private variables
+        //
+
+        /**
+         * The minimum characters that must be typed into the autocomplete field before autocomplete to be triggered.
+         * @type {number}
+         */
+        const MIN_CHAR_LEN = 0;
+
+        /**
+         * An instance of the input field wrapped by this component.
+         */
+        const SEARCH_INPUT_FIELD = element.find('.autocomplete-input');
+
+        /**
+         * Keeps the old uri in order to change it when a new one appears.
+         */
+        let expandedUri;
+
+        /**
+         * An http canceler function which might be invoked in order to stop old requests if new one starts.
+         */
+        let canceler;
+
+        //
+        // Public variables
+        //
+
+        /**
+         * The search term value which will be displayed in the input field either when the user types it in the field
+         * or it's passed as default value from the parent.
+         * @type {string}
+         */
+        $scope.searchInput = $scope.ngModel || '';
+
+        /**
+         * The placeholder which will be displayed inside the input field.
+         */
+        $scope.placeholder = attrs.$attr.placeholder || $translate.instant('search.resources.msg');
+
+        element.autoCompleteStatus = undefined;
+
+        element.autoCompleteWarning = false;
+
+        //
+        // Public methods
+        //
+
+        /**
+         * Handle blur event in a timeout in order to allow if it was triggered by a click on the dropdown menu itself.
+         * Hiding the menu immediately otherwise would cause the selection to fail because the blur event happens before
+         * the click.
+         */
+        $scope.onBlur = () => {
+            setTimeout(() => {
+                $scope.autoCompleteUriResults = [];
+            }, 0);
+        };
+
+        $scope.onChange = () => {
+            $scope.searchInput = expandPrefix($scope.searchInput);
+            if (element.autoCompleteStatus) {
+                return checkUriAutocomplete($scope.searchInput);
+            }
+            return Promise.resolve();
+        };
+
+        $scope.onKeyDown = (event) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                checkIfValidAndSearch();
+            } else if ($scope.searchInput.length > MIN_CHAR_LEN && !element.autoCompleteWarning && !element.autoCompleteStatus) {
+                element.autoCompleteWarning = true;
+                const warningMsg = decodeHTML($translate.instant('explore.autocomplete.warning.msg'));
+                toastr.warning('', `<div class="autocomplete-toast"><a href="autocomplete">${warningMsg}</a></div>`,
+                    {allowHtml: true});
+            }
+
+            if (!element.autoCompleteStatus || angular.isUndefined($scope.autoCompleteUriResults)) {
+                return;
+            }
+            if (event.key === 'ArrowDown' && $scope.activeSearchElm < $scope.autoCompleteUriResults.length - 1) {
+                $scope.activeSearchElm++;
+                $scope.searchInput = $scope.autoCompleteUriResults[$scope.activeSearchElm].value;
+                scrollContentToBottom();
+            }
+            if (event.key === 'ArrowUp' && $scope.activeSearchElm > 0) {
+                event.preventDefault();
+                $scope.activeSearchElm--;
+                $scope.searchInput = $scope.autoCompleteUriResults[$scope.activeSearchElm].value;
+                scrollContentToTop();
+            }
+            if (event.key === 'Escape') {
+                $scope.searchInput = '';
+                $scope.autoCompleteUriResults = [];
+            }
+
+            if (!$scope.searchInput) {
+                clearInput();
+            }
+        };
+
+        /**
+         * Sanitizes the description so that it can be rendered safely in the UI.
+         * @param {{description: string}} resultItem
+         * @return {*}
+         */
+        $scope.getResultItemHtml = (resultItem) => {
+            return $sce.trustAsHtml(resultItem.description);
+        };
+
+        $scope.selectResource = (resource) => {
+            if (resource.type === 'prefix') {
+                $scope.searchInput = expandPrefix(resource.value + ':');
+                SEARCH_INPUT_FIELD.focus();
+                $scope.onChange();
+            } else {
+                $scope.searchInput = '<' + resource.value + '>';
+                $scope.autoCompleteUriResults = [];
+            }
+        };
+
+        $scope.setActiveItemIndex = (index) => {
+            if (!element.autoCompleteStatus) {
+                return;
+            }
+            $scope.activeSearchElm = index;
+        };
+
+        //
+        // Private methods
+        //
+
+        const validateRdfUri = (value) => {
+            const hasAngleBrackets = value.indexOf("<") >= 0 && value.indexOf(">") >= 0;
+            const noAngleBrackets = value.indexOf("<") === -1 && value.lastIndexOf(">") === -1;
+            const validProtocol = /^<?(http|urn).*>?/.test(value) && (hasAngleBrackets || noAngleBrackets);
+            let validPath = false;
+
+            if (validProtocol) {
+                if (value.indexOf("http") >= 0) {
+                    const schemaSlashesIdx = value.indexOf('//');
+                    validPath = schemaSlashesIdx > 4 && value.substring(schemaSlashesIdx + 2).length > 0;
+                } else if (value.indexOf("urn") >= 0) {
+                    validPath = value.substring(4).length > 0;
+                }
+            }
+            return validProtocol && validPath;
+        };
+
+        const expandPrefix = (str) => {
+            const ABS_URI_REGEX = /^<?(http|urn).*>?/;
+            if (!ABS_URI_REGEX.test(str)) {
+                const uriParts = str.split(':');
+                const uriPart = uriParts[0];
+                const localName = uriParts[1];
+                if (!angular.isUndefined(localName)) {
+                    const newExpandedUri = ClassInstanceDetailsService.getNamespaceUriForPrefix($scope.namespaces, uriPart);
+                    expandedUri = (newExpandedUri !== expandedUri) ? newExpandedUri : expandedUri;
+                    if (expandedUri) {
+                        SEARCH_INPUT_FIELD.val(expandedUri);
+                        return '<' + expandedUri + localName + '>';
+                    }
+                }
+            }
+            return str;
+        };
+
+        const clearInput = () => {
+            $scope.searchInput = '';
+            $scope.selectedElementIndex = -1;
+            $scope.autoCompleteUriResults = [];
+        };
+
+        const checkIfValidAndSearch = () => {
+            // autocomplete is enabled and autocomplete results are loaded
+            if (element.autoCompleteStatus && $scope.autoCompleteUriResults && $scope.autoCompleteUriResults.length > 0) {
+                if ($scope.autoCompleteUriResults[$scope.activeSearchElm].type === 'prefix') {
+                    $scope.searchInput = expandPrefix($scope.autoCompleteUriResults[$scope.activeSearchElm].value + ':');
+                    $scope.autoCompleteUriResults = [];
+                } else {
+                    const selectedResource = $scope.autoCompleteUriResults[$scope.activeSearchElm];
+                    $scope.selectResource({
+                        type: selectedResource.type,
+                        value: selectedResource.value,
+                        description: selectedResource.description
+                    });
+                }
+            } else {
+                const fieldValue = $scope.searchInput;
+                if (validateRdfUri(fieldValue)) {
+                    $scope.selectResource(fieldValue);
+                } else {
+                    toastr.error($translate.instant('invalid.uri.msg'));
+                }
+            }
+        };
+
+        const handleAbsUris = (absUri) => {
+            let uri = absUri;
+            if (uri.indexOf(';') === -1 && validateRdfUri(uri)) {
+                uri = uri.replace(/<|>/g, '');
+                const localName = /[^/^#]*$/.exec(uri)[0];
+                const uriPart = uri.split(localName)[0];
+                return uriPart + ";" + localName;
+            }
+            return uri;
+        };
+
+        const checkUriAutocomplete = (searchInput) => {
+            // add semicolon after the expanded uri in order to filter only by local names for this uri
+            let search = searchInput.replace(expandedUri, expandedUri + ';');
+            if (element.autoCompleteStatus) {
+                if (search.charAt(0) === ';') {
+                    search = search.slice(1);
+                }
+                search = handleAbsUris(search);
+                if (canceler) {
+                    canceler.resolve();
+                }
+                canceler = $q.defer();
+                return AutocompleteRestService.getAutocompleteSuggestions(search, canceler.promise)
+                    .then(mapUriAsNtripleAutocompleteResponse)
+                    .then((suggestions) => {
+                        canceler = null;
+                        $scope.autoCompleteUriResults = suggestions;
+                        $scope.activeSearchElm = 0;
+                    });
+            }
+            return Promise.resolve();
+        };
+
+        const scrollContentToBottom = () => {
+            const $autoCompleteWrapper = element.find('.autocomplete-results-wrapper');
+            const $autoCompleteWrapperDiv = $autoCompleteWrapper.children('div');
+            const $autoCompleteWrappreDivActive = $autoCompleteWrapper.children('div.active');
+
+            if ($autoCompleteWrappreDivActive[0] !== undefined &&
+                ($autoCompleteWrappreDivActive[0].offsetTop - $autoCompleteWrapperDiv.height() - 6) - $autoCompleteWrapper.scrollTop() > 90) {
+                $autoCompleteWrapper.scrollTop($autoCompleteWrappreDivActive[0].offsetTop - $autoCompleteWrapperDiv.height() - 6 - 90);
+            }
+        };
+
+        const scrollContentToTop = () => {
+            const $autoCompleteWrapper = element.find('.autocomplete-results-wrapper');
+            const $autoCompleteWrapperDiv = $autoCompleteWrapper.children('div');
+            const $autoCompleteWrappreDivActive = $autoCompleteWrapper.children('div.active');
+
+            if ($autoCompleteWrappreDivActive[0] !== undefined &&
+                $autoCompleteWrappreDivActive[0].offsetTop - $autoCompleteWrapperDiv.height() + 6 <= $autoCompleteWrapper.scrollTop() - 34) {
+                $autoCompleteWrapper.scrollTop($autoCompleteWrapper.scrollTop() - 34);
+            }
+        };
+
+        const autocompletePromiseHandler = () => {
+            if (!$repositories.isActiveRepoFedXType() && angular.isDefined($scope.autocompleteStatusLoader)) {
+                $scope.autocompleteStatusLoader.then((response) => {
+                    element.autoCompleteStatus = !!response.data;
+                    // trigger onChange only if the value was manually populated by the user
+                    if ($scope.searchInput !== '' && !$scope.ngModel) {
+                        $scope.onChange();
+                    }
+                }).catch(() => {
+                    toastr.error($translate.instant('explore.error.autocomplete'));
+                });
+            }
+        };
+
+        const ngModelUpdater = (newValue) => {
+            $scope.ngModel = newValue;
+        };
+
+        const unsubscribeListeners = () => {
+            subscriptions.forEach((subscription) => subscription());
+        };
+
+        //
+        // Watchers
+        //
+
+        const subscriptions = [];
+        subscriptions.push($scope.$watch('autocompleteStatusLoader', autocompletePromiseHandler));
+        subscriptions.push($scope.$watch('searchInput', ngModelUpdater));
+        subscriptions.push($scope.$on('$destroy', unsubscribeListeners));
+    }
+}

--- a/src/js/angular/core/directives/autocomplete/templates/autocomplete.html
+++ b/src/js/angular/core/directives/autocomplete/templates/autocomplete.html
@@ -1,0 +1,18 @@
+<link href="css/autocomplete-select.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+
+<div class="autocomplete-select-wrapper">
+    <div class="autocomplete-select">
+        <input type="text" ng-model="searchInput" ng-change="onChange()" ng-keydown="onKeyDown($event)"
+               ng-blur="onBlur()"
+               class="autocomplete-input" ng-class="styleClass" placeholder="{{placeholder}}">
+    </div>
+    <div class="autocomplete-results-wrapper card">
+        <div ng-repeat="autoCompleteUriResult in autoCompleteUriResults track by $index"
+             ng-click="selectResource(autoCompleteUriResult)"
+             ng-mousemove="setActiveItemIndex($index)"
+             ng-class="{active: activeSearchElm === $index, selected: selectedElementIndex === $index}"
+             class="result-item">
+            <p ng-bind-html="getResultItemHtml(autoCompleteUriResult)"></p>
+        </div>
+    </div>
+</div>

--- a/src/js/angular/rest/mappers/autocomplete-mapper.js
+++ b/src/js/angular/rest/mappers/autocomplete-mapper.js
@@ -1,0 +1,17 @@
+/**
+ * Maps the autocomplete suggestions response to internal model by wrapping uris in triangle brackets.
+ * @param {Object} response
+ * @return {{type: string, value: string, description: string}[]}
+ */
+export const mapUriAsNtripleAutocompleteResponse = (response) => {
+    if (response && response.data && response.data.suggestions) {
+        return response.data.suggestions.map((suggestion) => {
+            return {
+                type: suggestion.type,
+                value: suggestion.value,
+                description: suggestion.description
+            };
+        });
+    }
+    return [];
+};

--- a/src/js/angular/rest/mappers/namespaces-mapper.js
+++ b/src/js/angular/rest/mappers/namespaces-mapper.js
@@ -1,0 +1,16 @@
+/**
+ * Maps the namespaces response to internal model.
+ * @param {Object} response
+ * @return {{prefix: string, uri: string}[]}
+ */
+export const mapNamespacesResponse = (response) => {
+    if (response && response.data) {
+        return response.data.results.bindings.map((binding) => {
+            return {
+                prefix: binding.prefix.value,
+                uri: binding.namespace.value
+            };
+        });
+    }
+    return [];
+};

--- a/src/pages/aclmanagement.html
+++ b/src/pages/aclmanagement.html
@@ -15,52 +15,51 @@
     <div class="acl-management-container">
         <div ng-if="loading" onto-loader-new size="100" style="height: 75vh; display: flex;"></div>
 
-        <div ng-if="rulesModel && !loading" class="table-responsive">
-            <form name="ruleData" novalidate>
-                <table class="acl-rules table table-striped table-hover" aria-describedby="ACL rules table">
-                    <thead>
-                    <tr>
-                        <th scope="col" class="index-column">{{'acl_management.rulestable.column.index' | translate}}
-                        </th>
-                        <th scope="col" class="reorder-column"></th>
-                        <th scope="col" class="subject-column">{{'acl_management.rulestable.column.subject' | translate}}
-                        </th>
-                        <th scope="col" class="predicate-column">
-                            {{'acl_management.rulestable.column.predicate' | translate}}
-                        </th>
-                        <th scope="col" class="object-column">
-                            {{'acl_management.rulestable.column.object' | translate}}
-                        </th>
-                        <th scope="col" class="context-column">{{'acl_management.rulestable.column.context' | translate}}
-                        </th>
-                        <th scope="col" class="role-column">{{'acl_management.rulestable.column.role' | translate}}</th>
-                        <th scope="col" class="policy-column">
-                            {{'acl_management.rulestable.column.policy' | translate}}
-                        </th>
-                        <th scope="col" class="actions-column"></th>
-                    </tr>
-                    <tr>
-                        <th scope="colgroup" colspan="9" class="toolbar">
-                            <div ng-if="editedRuleIndex === undefined" class="pull-right">
-                                <button ng-click="addRule(0)" class="btn btn-link add-rule-btn"
-                                        gdb-tooltip="{{'acl_management.rulestable.actions.add_rule' | translate}}">
-                                    <em class="icon-plus"></em>
-                                </button>
-                            </div>
-                        </th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr ng-if="!rulesModel.size()">
-                        <td colspan="9" class="no-data">
-                            {{'acl_management.rulestable.messages.no_data' | translate}}
-                        </td>
-                    </tr>
-                    <tr ng-repeat-start="rule in rulesModel.aclRules track by $index" ng-if="0"></tr>
-                    <tr ng-if="$index !== editedRuleIndex" class="acl-rule preview-rule-row"
-                        ng-class="{'selected': $index === selectedRule || $index === editedRuleIndex}">
-                        <td>{{$index}}</td>
-                        <td class="reorder-cell">
+        <form name="ruleData" novalidate ng-if="rulesModel && !loading">
+            <table class="acl-rules table table-striped table-hover" aria-describedby="ACL rules table">
+                <thead>
+                <tr class="labels-row">
+                    <th scope="col" class="index-column">{{'acl_management.rulestable.column.index' | translate}}
+                    </th>
+                    <th scope="col" class="reorder-column"></th>
+                    <th scope="col" class="subject-column">{{'acl_management.rulestable.column.subject' | translate}}
+                    </th>
+                    <th scope="col" class="predicate-column">
+                        {{'acl_management.rulestable.column.predicate' | translate}}
+                    </th>
+                    <th scope="col" class="object-column">
+                        {{'acl_management.rulestable.column.object' | translate}}
+                    </th>
+                    <th scope="col" class="context-column">{{'acl_management.rulestable.column.context' | translate}}
+                    </th>
+                    <th scope="col" class="role-column">{{'acl_management.rulestable.column.role' | translate}}</th>
+                    <th scope="col" class="policy-column">
+                        {{'acl_management.rulestable.column.policy' | translate}}
+                    </th>
+                    <th scope="col" class="actions-column"></th>
+                </tr>
+                <tr>
+                    <th scope="colgroup" colspan="9" class="toolbar">
+                        <div ng-if="editedRuleIndex === undefined" class="pull-right">
+                            <button ng-click="addRule(0)" class="btn btn-link add-rule-btn"
+                                    gdb-tooltip="{{'acl_management.rulestable.actions.add_rule' | translate}}">
+                                <em class="icon-plus"></em>
+                            </button>
+                        </div>
+                    </th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr ng-if="!rulesModel.size()">
+                    <td colspan="9" class="no-data">
+                        {{'acl_management.rulestable.messages.no_data' | translate}}
+                    </td>
+                </tr>
+                <tr ng-repeat-start="rule in rulesModel.aclRules track by $index" ng-if="0"></tr>
+                <tr ng-if="$index !== editedRuleIndex" class="acl-rule preview-rule-row"
+                    ng-class="{'selected': $index === selectedRule || $index === editedRuleIndex}">
+                    <td class="index-cell">{{$index}}</td>
+                    <td class="reorder-cell">
                             <span ng-if="editedRuleIndex === undefined" class="reorder-actions-group">
                                 <button ng-click="moveUp($index)" ng-if="$index > 0" class="btn btn-link move-up-btn"
                                         gdb-tooltip="{{'acl_management.rulestable.actions.move_up' | translate}}">
@@ -72,90 +71,97 @@
                                     <em class="fa fa-caret-down"></em>
                                 </button>
                             </span>
-                        </td>
-                        <td class="subject-cell data">{{rule.subject}}</td>
-                        <td class="predicate-cell data">{{rule.predicate}}</td>
-                        <td class="object-cell data">{{rule.object}}</td>
-                        <td class="context-cell data">{{rule.context}}</td>
-                        <td class="role-cell data">{{rule.role}}</td>
-                        <td class="policy-cell data">{{rule.policy}}</td>
-                        <td class="actions-cell">
-                            <div ng-if="editedRuleIndex === undefined" class="crud-actions-group">
-                                <button ng-click="deleteRule($index)" class="btn btn-link delete-rule-btn"
-                                        gdb-tooltip="{{'acl_management.rulestable.actions.delete_rule' | translate}}">
-                                    <em class="icon-trash"></em>
-                                </button>
-                                <button ng-click="editRule($index)" class="btn btn-link edit-rule-btn"
-                                        gdb-tooltip="{{'acl_management.rulestable.actions.edit_rule' | translate}}">
-                                    <em class="icon-edit"></em>
-                                </button>
-                                <button ng-click="addRule($index + 1)" class="btn btn-link add-rule-btn"
-                                        gdb-tooltip="{{'acl_management.rulestable.actions.add_rule' | translate}}">
-                                    <em class="icon-plus"></em>
-                                </button>
-                            </div>
-                        </td>
-                    </tr>
-                    <tr ng-if="$index === editedRuleIndex" class="acl-rule edit-rule-row"
-                        ng-class="{'selected table-info': $index === editedRuleIndex}">
-                        <td>{{$index}}</td>
-                        <td class="reorder-cell"></td>
-                        <td class="data subject-cell">
-                            <input type="text" name="subject" required autocomplete="off" ng-model="rule.subject"
-                                   class="form-control form-control-sm"
-                                   placeholder="{{'acl_management.rulestable.field_placeholders.subject' | translate}}"/>
-                            <em></em>
-                        </td>
-                        <td class="data predicate-cell">
-                            <input type="text" name="predicate" required autocomplete="off" ng-model="rule.predicate"
-                                   class="form-control form-control-sm"
-                                   placeholder="{{'acl_management.rulestable.field_placeholders.predicate' | translate}}"/>
-                            <em></em>
-                        </td>
-                        <td class="data object-cell">
-                            <input type="text" name="object" required autocomplete="off" ng-model="rule.object"
-                                   class="form-control form-control-sm"
-                                   placeholder="{{'acl_management.rulestable.field_placeholders.object' | translate}}"/>
-                            <em></em>
-                        </td>
-                        <td class="data context-cell">
-                            <input type="text" name="context" required autocomplete="off" ng-model="rule.context"
-                                   class="form-control form-control-sm"
-                                   placeholder="{{'acl_management.rulestable.field_placeholders.context' | translate}}"/>
-                            <em></em>
-                        </td>
-                        <td class="data role-cell">
-                            <input type="text" name="role" required ng-model="rule.role" uppercased
-                                   autocomplete="off" class="form-control form-control-sm"
-                                   placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}"/>
-                            <em></em>
-                        </td>
-                        <td class="data policy-cell">
-                            <select ng-model="rule.policy" class="form-control form-control-sm">
-                                <option selected>allow</option>
-                                <option>deny</option>
-                            </select>
-                        </td>
-                        <td class="actions-cell">
-                            <button ng-click="cancelEditing($index)" class="btn btn-link cancel-rule-editing-btn"
-                                    gdb-tooltip="{{'acl_management.rulestable.actions.cancel_rule_editing' | translate}}">
-                                <em class="icon-close"></em>
+                    </td>
+                    <td class="subject-cell data">{{rule.subject}}</td>
+                    <td class="predicate-cell data">{{rule.predicate}}</td>
+                    <td class="object-cell data">{{rule.object}}</td>
+                    <td class="context-cell data">{{rule.context}}</td>
+                    <td class="role-cell data">{{rule.role}}</td>
+                    <td class="policy-cell data">{{rule.policy}}</td>
+                    <td class="actions-cell">
+                        <div ng-if="editedRuleIndex === undefined" class="crud-actions-group">
+                            <button ng-click="deleteRule($index)" class="btn btn-link delete-rule-btn"
+                                    gdb-tooltip="{{'acl_management.rulestable.actions.delete_rule' | translate}}">
+                                <em class="icon-trash"></em>
                             </button>
-                            <button ng-if="ruleData.$valid" ng-click="saveRule()"
-                                    class="btn btn-link save-rule-btn"
-                                    ng-disabled="!ruleData.$valid"
-                                    gdb-tooltip="{{'acl_management.rulestable.actions.save_rule' | translate}}">
-                                <em class="icon-save"></em>
+                            <button ng-click="editRule($index)" class="btn btn-link edit-rule-btn"
+                                    gdb-tooltip="{{'acl_management.rulestable.actions.edit_rule' | translate}}">
+                                <em class="icon-edit"></em>
                             </button>
-                            <em ng-if="!ruleData.$valid" class="icon-save icon-lg save-rule-disabled-btn"
-                               gdb-tooltip="{{'acl_management.rulestable.messages.invalid_form' | translate}}"></em>
-                        </td>
-                    </tr>
-                    <tr ng-repeat-end ng-if="0"></tr>
-                    </tbody>
-                </table>
-            </form>
-        </div>
+                            <button ng-click="addRule($index + 1)" class="btn btn-link add-rule-btn"
+                                    gdb-tooltip="{{'acl_management.rulestable.actions.add_rule' | translate}}">
+                                <em class="icon-plus"></em>
+                            </button>
+                        </div>
+                    </td>
+                </tr>
+                <tr ng-if="$index === editedRuleIndex" class="acl-rule edit-rule-row"
+                    ng-class="{'selected table-info': $index === editedRuleIndex}">
+                    <td>{{$index}}</td>
+                    <td class="reorder-cell"></td>
+                    <td class="data subject-cell">
+                        <autocomplete ng-model="rule.subject" name="subject" required
+                                      style-class="form-control form-control-sm"
+                                      namespaces="namespaces"
+                                      autocomplete-status-loader="getAutocompletePromise"
+                                      placeholder="{{'acl_management.rulestable.field_placeholders.subject' | translate}}"></autocomplete>
+                        <em></em>
+                    </td>
+                    <td class="data predicate-cell">
+                        <autocomplete ng-model="rule.predicate" name="predicate" required
+                                      style-class="form-control form-control-sm"
+                                      namespaces="namespaces"
+                                      autocomplete-status-loader="getAutocompletePromise"
+                                      placeholder="{{'acl_management.rulestable.field_placeholders.predicate' | translate}}"></autocomplete>
+                        <em></em>
+                    </td>
+                    <td class="data object-cell">
+                        <autocomplete ng-model="rule.object" name="object" required
+                                      style-class="form-control form-control-sm"
+                                      namespaces="namespaces"
+                                      autocomplete-status-loader="getAutocompletePromise"
+                                      placeholder="{{'acl_management.rulestable.field_placeholders.object' | translate}}"></autocomplete>
+                        <em></em>
+                    </td>
+                    <td class="data context-cell">
+                        <autocomplete ng-model="rule.context" name="context" required
+                                      style-class="form-control form-control-sm"
+                                      namespaces="namespaces"
+                                      autocomplete-status-loader="getAutocompletePromise"
+                                      placeholder="{{'acl_management.rulestable.field_placeholders.context' | translate}}"></autocomplete>
+                        <em></em>
+                    </td>
+                    <td class="data role-cell">
+                        <input type="text" name="role" required ng-model="rule.role" uppercased
+                               autocomplete="off" class="form-control form-control-sm"
+                               placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}"/>
+                        <em></em>
+                    </td>
+                    <td class="data policy-cell">
+                        <select ng-model="rule.policy" class="form-control form-control-sm">
+                            <option selected>allow</option>
+                            <option>deny</option>
+                        </select>
+                    </td>
+                    <td class="actions-cell">
+                        <button ng-click="cancelEditing($index)" class="btn btn-link cancel-rule-editing-btn"
+                                gdb-tooltip="{{'acl_management.rulestable.actions.cancel_rule_editing' | translate}}">
+                            <em class="icon-close"></em>
+                        </button>
+                        <button ng-if="ruleData.$valid" ng-click="saveRule()"
+                                class="btn btn-link save-rule-btn"
+                                ng-disabled="!ruleData.$valid"
+                                gdb-tooltip="{{'acl_management.rulestable.actions.save_rule' | translate}}">
+                            <em class="icon-save"></em>
+                        </button>
+                        <em ng-if="!ruleData.$valid" class="icon-save icon-lg save-rule-disabled-btn"
+                            gdb-tooltip="{{'acl_management.rulestable.messages.invalid_form' | translate}}"></em>
+                    </td>
+                </tr>
+                <tr ng-repeat-end ng-if="0"></tr>
+                </tbody>
+            </table>
+        </form>
 
         <div ng-if="editedRuleIndex === undefined && rulesModel && modelIsDirty" class="text-right">
             <button class="btn btn-secondary cancel-acl-save-btn"

--- a/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
@@ -16,6 +16,7 @@ describe('ACL Management: create rule', () => {
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         cy.initializeRepository(repositoryId);
+        cy.enableAutocomplete(repositoryId);
         AclManagementSteps.importRules(repositoryId);
         AclManagementSteps.visit();
         // ensure rules are rendered

--- a/test-cypress/integration/setup/aclmanagement/delete-rule.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/delete-rule.spec.js
@@ -15,6 +15,7 @@ describe('ACL Management: delete rule', () => {
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         cy.initializeRepository(repositoryId);
+        cy.enableAutocomplete(repositoryId);
         AclManagementSteps.importRules(repositoryId);
         AclManagementSteps.visit();
         // ensure rules are rendered

--- a/test-cypress/integration/setup/aclmanagement/edit-rule.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/edit-rule.spec.js
@@ -14,6 +14,7 @@ describe('ACL Management: edit rule', () => {
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         cy.initializeRepository(repositoryId);
+        cy.enableAutocomplete(repositoryId);
         AclManagementSteps.importRules(repositoryId);
         AclManagementSteps.visit();
         // ensure rules are rendered
@@ -61,7 +62,8 @@ describe('ACL Management: edit rule', () => {
         // When I edit the rule again
         AclManagementSteps.editRule(2);
         AclManagementSteps.fillSubject(2, '<urn:Me>');
-        AclManagementSteps.fillPredicate(2, 'rdf:type');
+        // this will be autocompleted to "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"
+        AclManagementSteps.fillPredicate(2, 'rdf:');
         AclManagementSteps.fillObject(2, '*');
         AclManagementSteps.fillContext(2, '*');
         AclManagementSteps.fillRole(2, 'TEST');
@@ -71,7 +73,7 @@ describe('ACL Management: edit rule', () => {
         // Then I expect the rule to be saved with the new data
         const editedRule = {
             subject: '<urn:Me>',
-            predicate: 'rdf:type',
+            predicate: '<http://www.w3.org/1999/02/22-rdf-syntax-ns#>',
             object: '*',
             context: '*',
             role: 'TEST',

--- a/test-cypress/integration/setup/aclmanagement/revert-rules.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/revert-rules.spec.js
@@ -15,6 +15,7 @@ describe('ACL Management: revert rules', () => {
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         cy.initializeRepository(repositoryId);
+        cy.enableAutocomplete(repositoryId);
         AclManagementSteps.importRules(repositoryId);
         AclManagementSteps.visit();
         // ensure rules are rendered

--- a/test-cypress/integration/setup/aclmanagement/update-rules.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/update-rules.spec.js
@@ -15,6 +15,7 @@ describe('ACL Management: update rules', () => {
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
         cy.initializeRepository(repositoryId);
+        cy.enableAutocomplete(repositoryId);
         AclManagementSteps.importRules(repositoryId);
         AclManagementSteps.visit();
         // ensure rules are rendered

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -182,6 +182,11 @@ module.exports = {
                 transform: replaceVersion
             },
             {
+                from: 'src/js/angular/core/directives/autocomplete/templates',
+                to: 'js/angular/core/directives/autocomplete/templates',
+                transform: replaceVersion
+            },
+            {
                 from: 'src/js/angular/templates',
                 to: 'js/angular/templates'
             }


### PR DESCRIPTION
## What
IRI autocomplete component is implemented and integrated it in the ACL management view.

## Why
This improves the user experience allowing easier completion of triples when editing acl rules.

## How
Implemented the autocomplete component based on the rdf-resource-search component. Integrated the component in the ACL management view.

Integrated the autocomplete in the acl view

Make autocomplete to wrap uris in `<...>` because it's expected by the acl service that triples will be encoded as n-triples

Fix text and index column size which needs to fit properly the rule indexes at least to four digits

Cleanup the code

Removed hardcoded test uris

Fix uri wrapping for prefixes

Reset state of the ACL on repo change

Fix selection from suggested uris by mouse click.

Make the autosuggest menu visible when there are no rules in the ACL. This was broken by the table-responsive css class which used to make the table `overflow-x: auto` and this clip the menu. Removed the responsive class because the table doesn't scoll anyway.

Handle blur event in a timeout in order to allow if it was triggered by a click on the dropdown menu itself. Hiding the menu immediately otherwise would cause the selection to fail because the blur event happens before the click.

* flaky test: wait for query to be visible in the editor

(cherry picked from commit f83cd3434cadf622a049fe1b5b563c4aa006a707)