### PR TITLE
GDB-8691: When I edit similarity indexes workbench displays error line

### DIFF
--- a/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/src/js/angular/similarity/controllers/create-index.controller.js
@@ -282,9 +282,21 @@ function CreateSimilarityIdxCtrl(
     }
 
     $scope.hasQueryError = () => {
-        return $scope.hasSelectQueryError() ||
-            $scope.hasSearchQueryError() ||
-            $scope.hasAnalogicalQueryError()
+        const similarityQueryType = $scope.similarityIndexInfo.getSelectedQueryType();
+
+        if (SimilarityQueryType.DATA === similarityQueryType) {
+            return $scope.hasSelectQueryError();
+        }
+
+        if (SimilarityQueryType.SEARCH === similarityQueryType) {
+            return $scope.hasSearchQueryError();
+        }
+
+        if (SimilarityQueryType.ANALOGICAL === similarityQueryType) {
+            return $scope.hasAnalogicalQueryError();
+        }
+
+        return false;
     }
 
     $scope.hasSelectQueryError = () => {

--- a/test-cypress/integration/explore/similariti-index-create.spec.js
+++ b/test-cypress/integration/explore/similariti-index-create.spec.js
@@ -311,5 +311,23 @@ describe('Create similarity index', () => {
             SimilarityIndexCreateSteps.switchToAnalogicalQueryTab();
             YasqeSteps.verifyQueryContains(DEFAULT_ANALOGICAL_QUERY);
         });
+
+        it('should not display query error if current displayed query is valid', () => {
+            // When I open the "Create similarity index" page.
+            // and type wrong select query.
+            SimilarityIndexCreateSteps.typeSimilarityIndexName('indexName');
+            YasqeSteps.pasteQuery('Wrong query');
+            SimilarityIndexCreateSteps.create();
+
+            // Then I expect see error message describes me, that select query is mandatory.
+            ErrorSteps.verifyError("Invalid 'Data' query");
+
+            // When I switch to search query tab.
+            SimilarityIndexCreateSteps.switchToSearchQueryTab();
+
+            // Then I expect to not see the error message.
+            ErrorSteps.getErrorElement().should('not.exist');
+
+        });
     });
 });


### PR DESCRIPTION
## What
An error without a message is displayed when:
- Open a similarity index for editing and click on the "Save" button;
- Open a similarity index view. Write an incorrect select query, click on the "Create" button and then click on the "Search query" tab.

## Why
The check that determines when an error message is displayed incorrectly verified the presence of errors. It checked all queries, regardless of the currently opened query tab.

## How
The check has been fixed to verify only the query of the current opened tab.