### PR TITLE
GDB-8679 better display keyboard shortcuts button in yasgui

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -174,12 +174,12 @@ yasgui-component .page-selector {
 
 .keyboard-shortcuts-dialog-wrapper {
     height: 20px;
-    line-height: 20px;
+    line-height: 18px;
     font-size: 90%;
 }
 
 .keyboard-shortcuts-dialog-wrapper.resizeable-on {
-    margin-top: -30px;
+    margin-top: -31px;
 }
 
 .keyboard-shortcuts-dialog-button {


### PR DESCRIPTION
## What
The button was not precisely positioned in the editor. Also the text was a bit misplaced more on the bottom part.

## Why
Better UI perception.

## How
Properly position the button and the text via css.