### PR TITLE
GDB-8682 fix loading of visual graph using rdf*

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -197,7 +197,7 @@ yasgui-component .page-selector {
     border: none;
     outline: none;
     color: #FFFFFF;
-    background-color: var(--onto-orange);
+    background-color: var(--primary-color);
 }
 .explore-visual-graph-button:hover {
     cursor: pointer;

--- a/src/js/angular/rest/graph-data.rest.service.js
+++ b/src/js/angular/rest/graph-data.rest.service.js
@@ -147,12 +147,13 @@ function GraphDataRestService($http) {
     }
 
     function updateGraph(payload) {
-        return $http.post(`${EXPORE_GRAPH_ENDPOINT}/graph`, {
+        let data = {
             headers: {
                 'Content-Type': 'application/json'
-            },
-            data: payload
-        });
+            }
+        };
+        data = Object.assign(data, payload);
+        return $http.post(`${EXPORE_GRAPH_ENDPOINT}/graph`, data);
     }
 
     function getRdfsLabelAndComment(targetUri, languages, extraParams) {

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -224,7 +224,7 @@ function SparqlEditorCtrl($scope,
         createElement: (yasr) => {
             const buttonName = document.createElement('span');
             buttonName.classList.add("explore-visual-graph-button-name");
-            const exploreVisualButtonWrapperElement = document.createElement('div');
+            const exploreVisualButtonWrapperElement = document.createElement('button');
             exploreVisualButtonWrapperElement.classList.add("explore-visual-graph-button");
             exploreVisualButtonWrapperElement.classList.add("icon-data");
             exploreVisualButtonWrapperElement.onclick = function () {


### PR DESCRIPTION
## What
* When visual graph was opened with rdf* query the API request was made with wrong request payload which resulted in a NPE in the backend.
* Also fixed visualization of the open Visual Graph button in the sparql editor which was invisible due to missing color variable.

## Why
Prevent error when loading visual graph view. Also make the button visible again.

## How
* Fixed request parameters building to return proper payload format.
* Fixed button color by applying the correct color variable.
* Changed the html tag used for the button from `div` to `button` which is semantically correct.