### PR TITLE
GDB-8677 fix download as menu items color

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -18,8 +18,9 @@ yasgui-component .yasqe_queryButton {
 }
 
 yasgui-component .ontotext-dropdown-button,
-yasgui-component .ontotext-dropdown-menu-item {
+yasgui-component .ontotext-dropdown-menu.open .ontotext-dropdown-menu-item {
     background-color: var(--primary-color) !important;
+    color: #fff !important;
 }
 yasgui-component .ontotext-dropdown-button.icon-caret-down-after:after,
 yasgui-component .ontotext-dropdown-button.icon-caret-up-after:after {


### PR DESCRIPTION
## What
Fix the color of the menu items in the download as dropdown.

## Why
The font color in the menu items in download as dropdown was incorrectly overridden by the style of the links in the yasr because the items in the dropdown are also links.

## How
Change the specificity of the css selector and set the white color as expected.