### PR TITLE
GDB-8620 properly position repository selector component in sparql view

### DIFF
--- a/src/css/sparql-editor.css
+++ b/src/css/sparql-editor.css
@@ -4,6 +4,11 @@
     z-index: 1;
 }
 
+.sparql-editor-view div[core-errors] {
+    /* compensate for the negative margin on the title above */
+    margin-top: calc(47px + 0.5em);
+}
+
 .sparql-editor-view #sparql-query-update-title-label .btn-link {
     position: relative;
     z-index: 100;


### PR DESCRIPTION
## What
Properly position repository selector component in sparql view.

## Why
The repository selector component when visible used to overlap with the page title.

## How
Fixed the margin of the component.