### PR TITLE
GDB-8988: Disable the edit button for renaming a repository while in cluster

### DIFF
--- a/src/css/repositories.css
+++ b/src/css/repositories.css
@@ -257,6 +257,11 @@ span.required {
     color: #c53e3e
 }
 
+.edit-repository-denied {
+    cursor: not-allowed;
+    opacity: .65;
+}
+
 .ot-edit-input {
     position: absolute;
     right: 5px

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1188,6 +1188,7 @@
     "repo.properties": "Repository properties",
     "repo.id.label": "Repository ID*",
     "edit.repo.id.tooltip": "Edit repository id",
+    "edit.repo.id.cannot_edit_in_cluster.tooltip": "Cannot rename repository while in cluster.",
     "invalid.repo.name.error": "Repository name can contain only letters (a-z, A-Z), numbers (0-9), \"-\" and \"_\"",
     "upload.custom.ruleset.file": "Upload a custom ruleset file.",
     "custom.ruleset": "Custom ruleset...",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1179,6 +1179,7 @@
     "repo.properties": "Propriétés du dépôt",
     "repo.id.label": "ID du dépôt*",
     "edit.repo.id.tooltip": "Modifier l'ID du dépôt",
+    "edit.repo.id.cannot_edit_in_cluster.tooltip": "Impossible de renommer le référentiel en mode cluster.",
     "invalid.repo.name.error": "Le nom du dépôt ne peut contenir que des lettres (a-z, A-Z), des chiffres (0-9), \"-\" et \"_\".",
     "upload.custom.ruleset.file": "Téléchargez un fichier de jeu de règles personnalisé.",
     "custom.ruleset": "Jeu de règles personnalisé...",

--- a/src/js/angular/models/monitoring/operations/active-operation-model.js
+++ b/src/js/angular/models/monitoring/operations/active-operation-model.js
@@ -6,7 +6,7 @@ import {OPERATION_STATUS} from "./operation-status";
 export class ActiveOperationModel {
     constructor() {
         /**
-         * @type {string} - the value must be one of the {@see OPERATION_GROUP} option.
+         * @type {string} - the value must be one of the {@see OPERATION_GROUP_TYPE} option.
          */
         this.operationGroup = undefined;
         this.runningOperationCount = 0;

--- a/src/js/angular/models/monitoring/operations/active-operations-model.js
+++ b/src/js/angular/models/monitoring/operations/active-operations-model.js
@@ -1,4 +1,5 @@
 import {OPERATION_STATUS} from "./operation-status";
+import {OPERATION_GROUP_TYPE} from "./operation-group";
 
 export class ActiveOperationsModel {
     constructor() {
@@ -8,5 +9,12 @@ export class ActiveOperationsModel {
          */
         this.operations = [];
         this.status = OPERATION_STATUS.INFORMATION;
+    }
+
+    hasClusterOperation() {
+        if (this.operations) {
+            return this.operations.some((operation) => OPERATION_GROUP_TYPE.CLUSTER_OPERATION === operation.operationGroup);
+        }
+        return false;
     }
 }

--- a/src/js/angular/repositories/controllers.js
+++ b/src/js/angular/repositories/controllers.js
@@ -806,9 +806,9 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
         if ($scope.hasActiveLocation) {
             // Should get locations before getting repository info
             Promise.all([loadRepositoryData(), MonitoringRestService.monitorActiveOperations($scope.repositoryInfo.id)])
-                .then(([response, monitoringResponse]) => {
+                .then(([repositoryInfo, monitoringResponse]) => {
                     $scope.isRepoInCluster = monitoringResponse.hasClusterOperation();
-                    const data = response.data;
+                    const data = repositoryInfo.data;
                     if (angular.isDefined(data.params.ruleset)) {
                         let ifRulesetExists = false;
                         angular.forEach($scope.rulesets, function (item) {

--- a/src/pages/repository.html
+++ b/src/pages/repository.html
@@ -37,8 +37,11 @@
                         <label for="id" class="col-md-3 col-lg-2 col-form-label">{{'repo.id.label' | translate}}</label>
                         <div class="col-md-7 col-lg-6 col-xl-5" gdb-tooltip="{{'repoTooltips.id' | translate}}">
                             <a class="btn btn-link ot-edit-input" ng-click="editRepositoryId()"
+                               ng-class="{'edit-repository-denied': isRepoInCluster}"
                                ng-if="!canEditRepoId && editRepoPage"
-                               gdb-tooltip="{{'edit.repo.id.tooltip' | translate}}" tooltip-placement="right"><span class="icon-edit"></span></a>
+                               gdb-tooltip="{{(isRepoInCluster ? 'edit.repo.id.cannot_edit_in_cluster.tooltip' : 'edit.repo.id.tooltip') | translate}}" tooltip-placement="right">
+                                <span class="icon-edit"></span>
+                            </a>
                             <input name="id" id="id" class="form-control" ng-disabled="!canEditRepoId && editRepoPage"
                                    placeholder="{{'required.field' | translate}}" type="text" ng-model="repositoryInfo.id"
                                    required ng-attr-autofocus="{{ autofocusId }}" guide-selector="graphDBRepositoryIdInput">

--- a/test-cypress/steps/repository-steps.js
+++ b/test-cypress/steps/repository-steps.js
@@ -12,6 +12,10 @@ export class RepositorySteps {
         RepositorySteps.waitUntilRepositoriesPageIsLoaded();
     }
 
+    static visitEditPage(repositoryId) {
+        cy.visit(`repository/edit/${repositoryId}?location=`);
+    }
+
     static getCreateRepositoryButton() {
         return cy.get('#wb-repositories-addRepositoryLink');
     }
@@ -107,6 +111,14 @@ export class RepositorySteps {
 
     static getRepositoryTitleField() {
         return RepositorySteps.getRepositoryCreateForm().find('#title');
+    }
+
+    static getRepositoryIdEditElement() {
+        return cy.get('.ot-edit-input');
+    }
+
+    static editRepositoryId() {
+        this.getRepositoryIdEditElement().click();
     }
 
     static typeRepositoryTitle(title) {

--- a/test/repositories/controllers.spec.js
+++ b/test/repositories/controllers.spec.js
@@ -400,6 +400,7 @@ describe('==> Repository module controllers tests', function () {
             };
 
             $httpBackend.when('GET', 'rest/locations?filterClusterLocations=true').respond(200, [{}]);
+            $httpBackend.when('GET', 'rest/monitor/repo/operations').respond(200, {});
             routeParamsMock = {repositoryId: 'repo'};
             locationMock = {path: jasmine.createSpy('locationMock.path')};
 


### PR DESCRIPTION
## What
If we are in a cluster, the edit button of the repository name should be disabled.

## Why
We decided to disable this operation while repository is in cluster for GraphDB 10.4.1.

## How
- The edit button of repository name has been disabled when the repo is in cluster;
- A tool tip described that repo is in cluster and its name can't be edited has been added when mouse is hover the edit button.