### PR TITLE
Gdb 8267_GDB-8286

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.0.10",
+                "ontotext-yasgui-web-component": "1.0.11",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10251,9 +10251,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.10.tgz",
-            "integrity": "sha512-O8t9EovSh7nnTlvff92yHilmfojrX9RfdetNDadNpEskszhLmdkUvhuUqCqywoqsQvpcVDyJ5O7rr2fp62pZ+g==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.11.tgz",
+            "integrity": "sha512-jKOl4Us4bs+70a51fl8ZzTMF5niwWo9ffxfjfRCfsE7in6EyovWr+aAm1MXG6PlU2Vcumn1J74NwpjytnPKe3Q==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -25170,9 +25170,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.10.tgz",
-            "integrity": "sha512-O8t9EovSh7nnTlvff92yHilmfojrX9RfdetNDadNpEskszhLmdkUvhuUqCqywoqsQvpcVDyJ5O7rr2fp62pZ+g==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.11.tgz",
+            "integrity": "sha512-jKOl4Us4bs+70a51fl8ZzTMF5niwWo9ffxfjfRCfsE7in6EyovWr+aAm1MXG6PlU2Vcumn1J74NwpjytnPKe3Q==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.0.10",
+        "ontotext-yasgui-web-component": "1.0.11",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -13,6 +13,10 @@ yasgui-component .custom-button {
     color: var(--primary-color) !important;
 }
 
+yasgui-component .custom-button:disabled:hover, yasgui-component .custom-button:disabled:focus {
+    color: #818a91 !important;
+}
+
 yasgui-component .yasqe_queryButton {
     background-color: var(--primary-color) !important;
 }

--- a/src/js/angular/core/directives/yasgui-component/yasgui-component-directive.util.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component-directive.util.js
@@ -122,6 +122,10 @@ export class YasqeButtonsBuilder {
         return this;
     }
 
+    /**
+     *
+     * @return {YasqeActionButtonDefinition[]}
+     */
     build() {
         return [
             {

--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -40,7 +40,9 @@ yasguiComponentDirective.$inject = [
  * and with minimal code duplication and coupling.
  *
  * Directive attributes:
- * @attr yasguiConfig The directive configuration. TODO: add type def
+ *
+ * @attr yasguiConfig The directive configuration.
+ * @type {OntotextYasguiConfig}
  *
  * @attr afterInit Event handler function which will be invoked immediately after the component gets initialized.
  *

--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -320,8 +320,13 @@ function yasguiComponentDirective(
 
             const init = (newVal, oldValue) => {
                 if (!$scope.ontotextYasguiConfig && newVal || newVal && !isEqual(newVal, oldValue)) {
+                    const virtualRepository = $repositories.isActiveRepoOntopType();
                     const config = {
-                        isVirtualRepository: $repositories.isActiveRepoOntopType(),
+                        isVirtualRepository: virtualRepository,
+                        infer: virtualRepository || newVal.infer,
+                        immutableInfer: virtualRepository,
+                        sameAs: virtualRepository || newVal.sameAs,
+                        immutableSameAs: virtualRepository,
                         yasqeAutocomplete: {
                             LocalNamesAutocompleter: (term) => {
                                 const canceler = $q.defer();

--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -333,6 +333,7 @@ function yasguiComponentDirective(
                                 return autocompleteLocalNames(term, canceler);
                             }
                         },
+                        language: $languageService.getLanguage(),
                         i18n: TranslationService.getTranslations(),
                         getRepositoryStatementsCount: getRepositoryStatementsCount,
                         onQueryAborted: onQueryAborted
@@ -343,7 +344,6 @@ function yasguiComponentDirective(
                     $scope.ontotextYasguiConfig = config;
 
                     addDirtyCheckHandlers();
-                    $scope.language = $languageService.getLanguage();
 
                     setInitialQueryState().then(() => {
                         if (angular.isFunction($scope.afterInit)) {

--- a/src/js/angular/models/ontotext-yasgui/ontotext-yasgui-config.js
+++ b/src/js/angular/models/ontotext-yasgui/ontotext-yasgui-config.js
@@ -7,7 +7,7 @@ import {YasrPluginName} from "./yasr-plugin-name";
 /**
  * Holds all configurations related with ontotext-yasgui-web-component.
  */
-export class YasguiConfig {
+export class OntotextYasguiConfig {
     constructor() {
 
         /**
@@ -77,7 +77,7 @@ export class YasguiConfig {
         /**
          * The sparql endpoint which will be used when a query request is made.
          * It is important to note that if the endpoint configuration is passed as string, it will be persisted when first time initializes
-         * the instance with specific {@link YasguiConfig#componentId}. Subsequent query executions will
+         * the instance with specific {@link OntotextYasguiConfig#componentId}. Subsequent query executions will
          * use the endpoint stored in the persistence regardless if the configuration is changed.
          * If the endpoint is defined as a function, it will be called before each query execution.
          *

--- a/src/js/angular/models/ontotext-yasgui/yasgui-config.js
+++ b/src/js/angular/models/ontotext-yasgui/yasgui-config.js
@@ -1,0 +1,357 @@
+import {RenderingMode} from "./rendering-mode";
+import {YasguiOrientation} from "./yasgui-orientation";
+import {YasguiQueryHttpMethod} from "./yasgui-query-http-method";
+import {YasqeMode} from "./yasqe-mode";
+import {YasrPluginName} from "./yasr-plugin-name";
+
+/**
+ * Holds all configurations related with ontotext-yasgui-web-component.
+ */
+export class YasguiConfig {
+    constructor() {
+
+        /**
+         * Configure what part of the yasgui should be rendered.
+         *
+         * @type {string} - the value have to be one of the {@link RenderingMode} options.
+         */
+        this.render = RenderingMode.YASGUI;
+
+
+        /**
+         * Configure the yasgui layout orientation.
+         *
+         * @type {string} - the value have to be one of the {@link YasguiOrientation} options.
+         */
+        this.orientation = YasguiOrientation.VERTICAL;
+
+        /**
+         * If the yasgui tabs should be rendered or not.
+         *
+         * @type {boolean}
+         */
+        this.showEditorTabs = true;
+
+        /**
+         * If the yasr tabs should be rendered or not.
+         *
+         * @type {boolean}
+         */
+        this.showResultTabs = true;
+
+        /**
+         * If the result information header of YASR should be rendered or not.
+         *
+         * @type {boolean}
+         */
+        this.showResultInfo = true;
+
+        /**
+         * If the toolbar with render mode buttons should be rendered or not.
+         *
+         * @type {boolean}
+         */
+        this.showToolbar = true;
+
+        /**
+         * If the control bar should be rendered or not.
+         *
+         * @type {boolean}
+         */
+        this.showControlBar = true;
+
+        /**
+         * If "Run" button should be rendered or not. Default is true.
+         *
+         * @type {boolean}
+         */
+        this.showQueryButton = true;
+
+        /**
+         * Flag that controls displaying the loader during the run query process.
+         *
+         * @type {boolean}
+         */
+        this.showQueryLoader = true;
+
+        /**
+         * The sparql endpoint which will be used when a query request is made.
+         * It is important to note that if the endpoint configuration is passed as string, it will be persisted when first time initializes
+         * the instance with specific {@link YasguiConfig#componentId}. Subsequent query executions will
+         * use the endpoint stored in the persistence regardless if the configuration is changed.
+         * If the endpoint is defined as a function, it will be called before each query execution.
+         *
+         * @type {string | ((yasgui: Yasgui) => string)}
+         */
+        this.endpoint = '';
+
+        /**
+         * Key -> value translations as JSON. If the language is supported, then not needed to pass all label values.
+         * If pass a new language then all label's values have to be present, otherwise they will be translated to the default English language.
+         * Example:
+         * {
+         *   en: {
+         *     "yasgui.toolbar.orientation.btn.tooltip.switch_orientation_horizontal": "Switch to horizontal view",
+         *     "yasgui.toolbar.orientation.btn.tooltip.switch_orientation_vertical": "Switch to vertical view",
+         *     "yasgui.toolbar.mode_yasqe.btn.label": "Editor only",
+         *     "yasgui.toolbar.mode_yasgui.btn.label": "Editor and results",
+         *     "yasgui.toolbar.mode_yasr.btn.label": "Results only",
+         *   }
+         *   fr: {
+         *     "yasgui.toolbar.orientation.btn.tooltip.switch_orientation_vertical": "Basculer vers verticale voir",
+         *     "yasgui.toolbar.mode_yasqe.btn.label": "Éditeur seulement",
+         *   }
+         * }
+         */
+        this.i18n = undefined;
+
+        /**
+         * The request type.
+         *
+         * @type {string} - the value have to be one of the {@link YasguiQueryHttpMethod} options.
+         */
+        this.method = YasguiQueryHttpMethod.GET;
+
+        /**
+         * A function which should return an object with request header types and values.
+         * For instance the function can return an object something like:
+         *  {
+         *      'Content-Type': 'application/x-www-form-urlencoded',
+         *      'X-GraphDB-Local-Consistency': 'updating',
+         *      'X-GraphDB-Track-Alias': trackAlias,
+         *      'X-Requested-With': 'XMLHttpRequest'
+         *      ...
+         *  };
+         */
+        this.headers = undefined;
+
+        /**
+         * The value of "infer" parameter when a query is executed. Default value is true.
+         *
+         * @type {boolean}
+         */
+        this.infer = undefined;
+
+        /**
+         * If set to true, the 'infer' value cannot be changed. Default value is false.
+         *
+         * @type {boolean}
+         */
+        this.immutableInfer = undefined;
+
+        /**
+         * The value of "sameAs" parameter when a query is executed. Default value is true.
+         *
+         * @type {boolean}
+         */
+        this.sameAs = undefined;
+
+        /**
+         * If set to true, the 'sameAs' value cannot be changed. Default value is false.
+         *
+         * @type {boolean}
+         */
+        this.immutableSameAs = undefined;
+
+        /**
+         * If the configured endpoint should be preconfigured to any new opened editor tab.
+         *
+         * @type {boolean}
+         */
+        this.copyEndpointOnNewTab = true;
+
+        /**
+         * Yasgui use browser local storage to persist its state. In its state, yasgui holds information about:
+         * 1. default query when a tab is opened;
+         * 2. YASR plugins configuration;
+         * 3. selected plugin;
+         * 4. request configuration: endpoint, headers, method and so on;
+         * 5. opened tabs;
+         * 5. which tab is active.
+         * The <code>componentId</code> configuration options defines uniqueness of this persistent state. Passed value will be used to generate
+         * the key which will be used into browser local store. For example if value is "123" then the key will be "yasgui__123".
+         * Default value is "ontotext-yasgui-config".
+         *
+         * @type {string}
+         */
+        this.componentId = undefined;
+
+        /**
+         * @type {string} - the value have to be one of the {@link YasqeMode} options.
+         */
+        this.yasqeMode = YasqeMode.WRITE;
+
+        /**
+         * Default query when a tab is opened.
+         *
+         * @type {string}
+         */
+        this.query = undefined;
+
+        /**
+         * Initial query when yasgui is rendered if not set the default query will be set.
+         *
+         * @type {string}
+         */
+        this.initialQuery = undefined;
+
+        /**
+         * The translation label key that should be used to fetch the default tab name when a new tab is created.
+         *
+         * @type {string}
+         */
+        this.defaultTabNameLabelKey = undefined;
+
+        /**
+         * Action button definitions which can be plugged in the yasqe extension point.
+         *
+         * @type {YasqeActionButtonDefinition[]}
+         */
+        this.yasqeActionButtons = undefined;
+
+        /**
+         * Function which is used by yasgui internally to create a shareable links. We
+         * expose it here just to allow the share button to be hidden but in reality it
+         * doesn't work due to a bug in the yasgui configuration merge code.
+         *
+         * @type {(yasqe: Yasqe) => string | null}
+         */
+        this.createShareableLink = null;
+
+        /**
+         * This allows to skip the code in yasgui handling url parameters and internally
+         * initializing the editor using them.
+         *
+         * @type {boolean}
+         */
+        this.populateFromUrl = false;
+
+        /**
+         * Object with uris and their corresponding prefixes.
+         *
+         * @type {{[prefixLabel: string]: string} }
+         * For instance:
+         * <pre>
+         *   {
+         *     "gn": "http://www.geonames.org/ontology#",
+         *     "path": "http://www.ontotext.com/path#",
+         *     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+         *     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+         *     "xsd": "http://www.w3.org/2001/XMLSchema#",
+         *   }
+         * </pre>
+         */
+        this.prefixes = undefined;
+
+        /**
+         * The name of plugin which have to be active when yasr is created.
+         *
+         * @type {string} - the value have to be one of the {@link YasrPluginName} options.
+         */
+        this.defaultPlugin = YasrPluginName.EXTENDED_TABLE;
+
+        /**
+         * Describes the order of how plugins will be displayed.
+         *
+         * @type {string[]} the values of the array have to be {@link YasrPluginName} options.
+         * For example: ["extended_table", "response"]
+         */
+        this.pluginOrder = [YasrPluginName.EXTENDED_TABLE, YasrPluginName.RAW_RESPONSE];
+
+        /**
+         * Map with configuration of given plugin. The key of map is the name of a plugin. The value is any object which fields are supported by
+         * the plugin configuration.
+         *
+         * @type {{[pluginName]: any}}
+         */
+        this.pluginsConfigurations = undefined;
+
+        /**
+         * Defines pageSize of pagination. Default value is 10.
+         *
+         * @type {number}
+         */
+        this.pageSize = 1000;
+
+        /**
+         * Flag that controls usage of pagination. When it is true then pagination will be used.
+         *
+         * @type {boolean}
+         */
+        this.paginationOn = true;
+
+        /**
+         * A flag that controls creation of "Download as" dropdown. When false, the dropdown will not be created. Default value is true.
+         *
+         * @type {boolean}
+         */
+        this.downloadAsOn = true;
+
+        /**
+         * Maximum length of response which will be persisted. If response is bigger it will not be persisted in browser local store.
+         * Default value is 100000.
+         *
+         * @type {number}
+         */
+        this.maxPersistentResponseSize = 500000;
+
+        /**
+         * Registered yasqe autocomplete handlers. Every handler is mapped by its name.
+         */
+        this.yasqeAutocomplete = undefined;
+
+        /**
+         * Flag that controls update operations. If this flag is set to true, then all update operations will be disabled.
+         * For virtual repositories only select queries are allowed.
+         *
+         * @type {boolean}
+         */
+        this.isVirtualRepository = undefined;
+
+        /**
+         * This function will be called before the update query be executed. The client can abort execution of query for some reason and can
+         * provide a message or label key for the reason of aborting.
+         *
+         * @type {(query: string, tabId: string) => Promise <BeforeUpdateQueryResult> | undefined}
+         */
+        this.beforeUpdateQuery = undefined;
+
+        /**
+         * This function will be called before and after execution of an update query. Depends on results a corresponding result message info will be generated.
+         *
+         * @type {() => Promise <number>}
+         */
+        this.getRepositoryStatementsCount = undefined;
+
+        /**
+         * If this function is present, then an "Abort query" button wil be displayed when a query is running. If the  button is clicked then
+         * this function will be invoked after the abort operation was triggered. The button will be visible until "ontotext-yasgui-web-component" client resolve returned promise.
+         *
+         * @type {(req) => Promise <void>}
+         */
+        this.onQueryAborted = undefined;
+
+        /**
+         * All passed plugins will be displayed on the right of the ontotext-yasgui-web-component toolbar.
+         *
+         * @type {YasrToolbarPlugin[]}
+         */
+        this.yasrToolbarPlugins = undefined;
+
+        /**
+         * If this function is present, then it will be called on every one result cell.
+         * @param {Parser.BindingValue} binding - binding value that will be shown into a cell.
+         * @param {Prefixes} prefixes - Object with uris and their corresponding prefixes.
+         *
+         * @return {string} - html that will display in the cell.
+         */
+        this.getCellContent = (binding, prefixes) => '';
+
+        /**
+         * A response of a sparql query as string. If the parameter is provided, the result will be visualized in YASR.
+         *
+         * @type {string | undefined}
+         */
+        this.sparqlResponse = undefined;
+    }
+}

--- a/src/js/angular/models/ontotext-yasgui/yasgui-orientation.js
+++ b/src/js/angular/models/ontotext-yasgui/yasgui-orientation.js
@@ -1,0 +1,4 @@
+export const YasguiOrientation = {
+    VERTICAL: 'orientation-vertical',
+    HORIZONTAL: 'orientation-horizontal'
+};

--- a/src/js/angular/models/ontotext-yasgui/yasgui-query-http-method.js
+++ b/src/js/angular/models/ontotext-yasgui/yasgui-query-http-method.js
@@ -1,0 +1,4 @@
+export const YasguiQueryHttpMethod = {
+    POST: 'POST',
+    GET: 'GET'
+};

--- a/src/js/angular/models/ontotext-yasgui/yasqe-action-button-definition.js
+++ b/src/js/angular/models/ontotext-yasgui/yasqe-action-button-definition.js
@@ -1,0 +1,4 @@
+export class YasqeActionButtonDefinition {
+    constructor(name, disabled) {
+    }
+}

--- a/src/js/angular/models/ontotext-yasgui/yasqe-mode.js
+++ b/src/js/angular/models/ontotext-yasgui/yasqe-mode.js
@@ -13,4 +13,4 @@ export const YasqeMode = {
      * The editor is read-only and the query can't be copied.
      */
     PROTECTED: 'PROTECTED'
-}
+};

--- a/src/js/angular/models/ontotext-yasgui/yasr-before-update-query-result.js
+++ b/src/js/angular/models/ontotext-yasgui/yasr-before-update-query-result.js
@@ -1,0 +1,24 @@
+export class YasrBeforeUpdateQueryResult {
+    constructor() {
+
+        /**
+         * @type {string} - the value have to be one of the {@link QueryResponseStatus} options.
+         */
+        this.status = undefined;
+
+        /**
+         * @type {string}
+         */
+        this.message = undefined;
+
+        /**
+         * @type {string}
+         */
+        this.messageLabelKey = undefined;
+
+        /**
+         * @type {{[parameterName: string]: string}}
+         */
+        this.parameters = undefined;
+    }
+}

--- a/src/js/angular/models/ontotext-yasgui/yasr-query-response-status.js
+++ b/src/js/angular/models/ontotext-yasgui/yasr-query-response-status.js
@@ -1,0 +1,4 @@
+export const YasrQueryResponseStatus = {
+    ERROR: 'error',
+    SUCCESS: 'success'
+};

--- a/src/js/angular/models/ontotext-yasgui/yasr-toolbar-plugin.js
+++ b/src/js/angular/models/ontotext-yasgui/yasr-toolbar-plugin.js
@@ -1,0 +1,41 @@
+/**
+ * An interface for elements that can be plugged into yasr toolbar.
+ * These elements will be sorted depends on {@link YasrToolbarPlugin#getOrder};
+ */
+export class YasrToolbarPlugin {
+
+    constructor() {
+        /**
+         * This method is called when the yasr toolbar is created.
+         *
+         * @param {Yasr} yasr - the parent yasr of toolbar.
+         * @return {HTMLElement}
+         */
+        this.createElement = (yasr) => undefined;
+
+        /**
+         * This method is called when draw method of yasr is called.
+         *
+         * @param {HTMLElement} element - the element created in {@link YasrToolbarPlugin#createElement}.
+         * @param {Yasr} yasr - the parent yasr of toolbar.
+         */
+        this.updateElement = (element, yasr) => {
+        };
+
+        /**
+         * Returned value will be used for toolbar element ordering.
+         *
+         * @return {number} - the order number.
+         */
+        this.getOrder = () => 0;
+
+        /**
+         * This method is called when yasr is destroyed.
+         *
+         * @param {HTMLElement} element - the element created in {@link YasrToolbarPlugin#createElement}.
+         * @param {Yasr} yasr - the parent yasr of toolbar.
+         */
+        this.destroy = (element, yasr) => {
+        };
+    }
+}

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -51,6 +51,9 @@ function SparqlEditorCtrl($scope,
                           ModalService) {
     this.repository = '';
 
+    /**
+     * @type {YasguiConfig}
+     */
     $scope.yasguiConfig = undefined;
     $scope.savedQueryConfig = undefined;
     $scope.prefixes = {};

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -52,7 +52,7 @@ function SparqlEditorCtrl($scope,
     this.repository = '';
 
     /**
-     * @type {YasguiConfig}
+     * @type {OntotextYasguiConfig}
      */
     $scope.yasguiConfig = undefined;
     $scope.savedQueryConfig = undefined;

--- a/test-cypress/integration/sparql-editor/actions/inferred-sameas.spec.js
+++ b/test-cypress/integration/sparql-editor/actions/inferred-sameas.spec.js
@@ -1,0 +1,47 @@
+import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {RepositoriesStub} from "../../../stubs/repositories-stub";
+
+describe('Expand results over owl:sameAs', () => {
+
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'sparql-editor-' + Date.now();
+        cy.setLocalStorage("ls.repository-id", repositoryId);
+        RepositoriesStub.stubOntopRepository(repositoryId);
+        RepositoriesStub.stubNameSpaces(repositoryId);
+    });
+
+    it('should not be able to toggle the sameAs button state if repository is virtual', () => {
+        // When I open the editor configured for virtual repository.
+        SparqlEditorSteps.visitSparqlEditorPage();
+
+        // Then I expect sameAs button to be on.
+        YasqeSteps.getExpandResultsOverSameAsButtonTooltip().should('have.attr', 'data-tooltip', 'Expand results over owl:sameAs: ON');
+        YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-same-as-on');
+
+        // When I click on inferred button
+        YasqeSteps.getExpandResultsOverSameAsButton().click({force: true});
+
+        // Then I expect sameAs button to not be toggled.
+        YasqeSteps.getExpandResultsOverSameAsButtonTooltip().should('have.attr', 'data-tooltip', 'Expand results over owl:sameAs: ON');
+        YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-same-as-on');
+    });
+
+    it('should not be able to toggle the inferred button state if repository is virtual', () => {
+        // When I open the editor configured for virtual repository.
+        SparqlEditorSteps.visitSparqlEditorPage();
+
+        // Then I expect inferred button to be on.
+        YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'data-tooltip', 'Include inferred data in results: ON');
+        YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+
+        // When I click on inferred button
+        YasqeSteps.getActionButton(3).click({force: true});
+
+        // Then I expect inferred button to not be toggled.
+        YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'data-tooltip', 'Include inferred data in results: ON');
+        YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+    });
+});

--- a/test-cypress/stubs/repositories-stub.js
+++ b/test-cypress/stubs/repositories-stub.js
@@ -1,0 +1,58 @@
+export class RepositoriesStub {
+
+    static stubOntopRepository(repositoryId) {
+        const alRepositoryResponse = `{
+        "":[{
+                    "id": "${repositoryId}",
+                    "title": "",
+                    "uri": "http://b:9000/repositories/${repositoryId}",
+                    "externalUrl": "http://b:9000/repositories/${repositoryId}",
+                    "local": true,
+                    "type": "ontop",
+                    "sesameType": "graphdb:OntopRepository",
+                    "location": "",
+                    "readable": true,
+                    "writable": true,
+                    "unsupported": false,
+                    "state": "RUNNING"
+        }]}`;
+
+
+        cy.intercept('GET', '/rest/repositories/all', {
+            statusCode: 200,
+            body: alRepositoryResponse
+        });
+    }
+
+    /**
+     * @param {string} repositoryId
+     * @param {[]}namespaces - An instance of array object have to be:
+     *         {
+     *             "prefix" : {
+     *                 "type" : "literal",
+     *                 "value" : "agg"
+     *             },
+     *             "namespace" : {
+     *                 "type" : "literal",
+     *                 "value" : "http://jena.apache.org/ARQ/function/aggregate#"
+     *             }
+     *         }
+     */
+    static stubNameSpaces(repositoryId, namespaces = []) {
+        const namespacesResponse = `{
+                                      "head" : {
+                                        "vars" : [
+                                          "prefix",
+                                          "namespace"
+                                        ]
+                                      },
+                                      "results" : {
+                                        "bindings" : ${JSON.stringify(namespaces)}
+                                      }
+                                    }`;
+        cy.intercept('GET', `/repositories/${repositoryId}/namespaces`, {
+            statusCode: 200,
+            body: namespacesResponse
+        });
+    }
+}


### PR DESCRIPTION
## What
- GDB-8267: When repository is virtual. the inferred and sameAs buttons have to be active and should not be toggleable.
- GDB-8286: A new configuration property "language" has been introduced.


## Why
- GDB-8267: Missed requirement during development;
-  GDB-8286: There was no way to set the language when the component is created. The default language was English, so if the client wanted to open the component with French, for instance, they had to open it with English and then refresh it as set language on French. This flow caused component to be redrawn twice.

## How
- GDB-8267,  GDB-8286:  The version of "ontotext-yasgui-web-component" has been updated.
- GDB-8267: Added styling when infer and sameAs are disabled.


Additional work:
- Added ontotext-yasgui-web-component configuration model.