### PR TITLE
GDB-9013: Link underlining issues in Workbench and the documentation

### DIFF
--- a/src/css/bootstrap-graphdb-theme.css
+++ b/src/css/bootstrap-graphdb-theme.css
@@ -15,6 +15,7 @@
     --menu-width: var(--menu-width-expanded);
     /* max usable content width not considering the menu and margins */
     --max-width-minus-menu: calc(100% - var(--menu-width));
+    /* Link decoration, see GDB-9013 before you touch these */
     --link-decoration-thickness: clamp(1px, 6%, 10px);
     --link-underline-offset: clamp(1px, 6%, 10px);
 }

--- a/src/css/bootstrap-graphdb-theme.css
+++ b/src/css/bootstrap-graphdb-theme.css
@@ -15,6 +15,8 @@
     --menu-width: var(--menu-width-expanded);
     /* max usable content width not considering the menu and margins */
     --max-width-minus-menu: calc(100% - var(--menu-width));
+    --link-decoration-thickness: clamp(1px, 6%, 10px);
+    --link-underline-offset: clamp(1px, 6%, 10px);
 }
 
 :root.menu-collapsed {
@@ -380,6 +382,14 @@
     content: "\e92f";
 }
 
+.icon-hbars:before {
+    content: "\e953";
+}
+
+.icon-phone:before {
+    content: "\e954";
+}
+
 .icon-tick:before {
     content: "\e956";
 }
@@ -504,9 +514,12 @@ a {
     color: var(--secondary-color);
 }
 
-/* Actual links that lead to an external site */
-a[href^="http"] {
-    text-decoration: underline;
+/* General links on hover and actual links that lead to an external site */
+a:hover, a:active, a[href^="http"], a[href^="http"]:hover, a[href^="http"]:active {
+    text-decoration-line: underline;
+    text-decoration-style: solid;
+    text-decoration-thickness: var(--link-decoration-thickness);
+    text-underline-offset: var(--link-underline-offset);
 }
 
 a:focus, a:hover {
@@ -1005,8 +1018,13 @@ main menu height*/
 .btn-link, .btn-link a {
     color: var(--primary-color);
     padding: .5em .8em;
-    text-decoration: underline;
-    text-decoration-style: dotted !important;
+}
+
+.btn-link, .btn-link:hover, .btn-link:focus {
+    text-decoration-line: underline;
+    text-decoration-style: dotted;
+    text-decoration-thickness: var(--link-decoration-thickness);
+    text-underline-offset: var(--link-underline-offset);
 }
 
 .btn-link.secondary {
@@ -1028,6 +1046,10 @@ main menu height*/
 .btn-link.active, .btn-link:hover.active, .btn-link:focus.active, .btn-link:active.active {
     background-color: var(--primary-color-dark);
     color: #fff;
+}
+
+.btn-link-text {
+    padding-left: 0.2em;
 }
 
 /* button groups */

--- a/src/js/angular/core/templates/core-errors.html
+++ b/src/js/angular/core/templates/core-errors.html
@@ -51,7 +51,7 @@
 
                 <div class="pull-right" ng-if="isLicenseValid() && canManageRepositories()">
                     <button class="btn btn-link px-0 create-repository-btn" ng-click="goToAddRepo()">
-                        <span class="icon-plus"></span> {{ 'repository.create.btn' | translate }}
+                        <span class="icon-plus"></span><span class="btn-link-text">{{ 'repository.create.btn' | translate }}</span>
                     </button>
                 </div>
             </div>

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -13,7 +13,7 @@
     <div ng-controller="TabCtrl" ng-show="!isRestricted && canWriteActiveRepo()">
 
         <button type="button" ng-click="isCollapsed = !isCollapsed" class="btn btn-link pull-right"><span
-                class="icon-help"></span> {{'menu.help.label' | translate}}
+                class="icon-help"></span><span class="btn-link-text">{{'menu.help.label' | translate}}</span>
         </button>
 
         <ul class="nav nav-tabs mb-2">


### PR DESCRIPTION
In 10.4 we introduced underlining of links:
Dotted for button links in Workbench and internal links in the documentation
Solid for external links in both (was already there)

It looks like the default auto thickness and offset of the underline are a bit of a fringe value. Safari does wonderfully, Firefox has too thin lines on smaller font sizes, Chrome is a bit of an oddball here, especially with the dotted links – too thick and too close to the text. See attached screenshots.
We aim to reproduce a behaviour that is as close as possible to the default auto algorithm in Safari/Firefox on all browsers.
Specifying this seems to do the trick for the most part in a font-size neutral way:
```css
text-decoration-thickness: clamp(1px, 0.06em, 10px);
text-underline-offset: clamp(1px, 0.06em, 10px);
```
While this works well for Workbench and the documentation, Chrome is again the oddball by producing a different (smaller) offset in Workbench when compared to the documentation with exactly the same styling.
Thus, for Workbench it’s this incantation:
```css
text-decoration-thickness: clamp(1px, 6%, 10px);
text-underline-offset: clamp(1px, 6%, 10px);
```
It produces identical output in both Workbench and the documentation in all 3 browsers.
That 0.06em vs 6% is a really weird issue as 1) they should do exactly the same, 2) at font sizes 14 and 16 the clamp should return 1px anyway. Putting 6% on the documentation in Chrome makes the offset larger than the other browsers.

A secondary issue just with Workbench: when a button has an icon and a link, the underlining spills out between the icon and the link. As far as I can tell there are only 2 such buttons, the Create repository shown when no repo is selected and the Help button in the Import view.

Also added two missing icon classes that are used in the documentation (to keep the theme file synced).