### PR TITLE
Update version of ontotext-yasgui-web-component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.0.11",
+                "ontotext-yasgui-web-component": "1.0.12",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -9973,9 +9973,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.11.tgz",
-            "integrity": "sha512-jKOl4Us4bs+70a51fl8ZzTMF5niwWo9ffxfjfRCfsE7in6EyovWr+aAm1MXG6PlU2Vcumn1J74NwpjytnPKe3Q==",
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.12.tgz",
+            "integrity": "sha512-KORuytJi21htZ0RiWVMDSibFrMSI+M/PEH7rqXEM+D+fy4ypD1bjxTHUTcPN+slOTHl5Lec8xdbMjX1w/h812w==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24544,9 +24544,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.11.tgz",
-            "integrity": "sha512-jKOl4Us4bs+70a51fl8ZzTMF5niwWo9ffxfjfRCfsE7in6EyovWr+aAm1MXG6PlU2Vcumn1J74NwpjytnPKe3Q==",
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.12.tgz",
+            "integrity": "sha512-KORuytJi21htZ0RiWVMDSibFrMSI+M/PEH7rqXEM+D+fy4ypD1bjxTHUTcPN+slOTHl5Lec8xdbMjX1w/h812w==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.0.11",
+        "ontotext-yasgui-web-component": "1.0.12",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
The version of ontotext-yasgui-web-component has been updated.

## Why
There are fixed issues with the new version.
- [GDB-8184](https://ontotext.atlassian.net/browse/GDB-8184)
- [GDB-8021](https://ontotext.atlassian.net/browse/GDB-8021)

## How
The version of ontotext-yasgui-web-component has been updated.