### PR TITLE
Cherry-pick GDB-8336: WB edit of some context triples gives syntax toast errors

### DIFF
--- a/src/js/angular/explore/statements.service.js
+++ b/src/js/angular/explore/statements.service.js
@@ -38,10 +38,12 @@ function StatementsService() {
             for (let j = 0; j < value.length; j++) {
                 const statement = value[j];
                 data += '\n\t<' + statement.subject + '> <' + statement.predicate + '> ';
+                let statementObjectValue = statement.object.value;
                 if (statement.object.type === 'uri') {
-                    data += '<' + statement.object.value + '> .';
+                    data += '<' + statementObjectValue + '> .';
                 } else {
-                    data += '"""' + statement.object.value + '"""' + (statement.object.datatype ? '^^<' + statement.object.datatype + '>' : (statement.object.lang ? '@' + statement.object.lang : '')) + ' .';
+                    statementObjectValue = statementObjectValue.replace(/"/g, '\\"');
+                    data += '"""' + statementObjectValue + '"""' + (statement.object.datatype ? '^^<' + statement.object.datatype + '>' : (statement.object.lang ? '@' + statement.object.lang : '')) + ' .';
                 }
             }
 


### PR DESCRIPTION
What
There is an error when try to save some triples in resource edit view.

Why
The error is caused by a string literal that ends with a double quote, leading to an exception in the backend.

How
Added escaping of double quotes of the literal.