### PR TITLE
GDB-9042 Fixing rdf search field buttons font size

### DIFF
--- a/src/css/bootstrap-graphdb-theme.css
+++ b/src/css/bootstrap-graphdb-theme.css
@@ -1139,10 +1139,6 @@ h3 [class^=icon-] {
     display: none;
 }
 
-.status-bar .btn {
-    font-size: inherit;
-}
-
 .status-bar .btn-group .dropdown-toggle {
     margin-right: 0;
 }


### PR DESCRIPTION
## What
Fixing rdf search field buttons font size.

## Why
The buttons font size css property was reset to something which doesn't have one which resulted in font size set to 0px.

## How
Fixed the override and now font size is 16px as expected and scales down to 14px on lower resolutions.