### PR TITLE
GDB-9074: When only one Query and Update is running in the UI is not displayed

### DIFF
--- a/src/js/angular/core/directives/operations-statuses-monitor/templates/operations-statuses-monitor.html
+++ b/src/js/angular/core/directives/operations-statuses-monitor/templates/operations-statuses-monitor.html
@@ -2,24 +2,25 @@
 
 <div ng-if="activeOperations && activeOperations.operations && activeOperations.operations.length > 0"
      class="operations-statuses btn-group">
-    <button type="button" class="btn btn-secondary operations-statuses-dropdown-toggle dropdown-toggle" data-toggle="dropdown"
+    <button type="button"
+            class="btn btn-secondary operations-statuses-dropdown-toggle dropdown-toggle" data-toggle="dropdown"
+            ng-if="operationsSummary && operationsSummary.length > 0"
             ng-class="{
             'btn-fade-danger': OPERATION_STATUS.CRITICAL === activeOperations.status,
             'btn-fade-warning': OPERATION_STATUS.WARNING === activeOperations.status
             }">
-        <div class="operation-status-header" ng-repeat="operation in activeOperations.operations"
-             ng-if="OPERATION_TYPE.UPDATES !== operation.type">
+        <div class="operation-status-header" ng-repeat="operationGroup in operationsSummary">
             <div ng-class="{
-            'icon-import': OPERATION_GROUP_TYPE.IMPORT_OPERATION === operation.operationGroup,
-            'icon-exchange': OPERATION_GROUP_TYPE.QUERIES_OPERATION === operation.operationGroup,
-            'fa fa-archive': OPERATION_GROUP_TYPE.BACKUP_AND_RESTORE_OPERATION === operation.operationGroup,
-            'fa fa-sitemap': OPERATION_GROUP_TYPE.CLUSTER_OPERATION === operation.operationGroup,
-            'status-critical': OPERATION_STATUS.CRITICAL === operation.status,
-            'status-information': OPERATION_STATUS.INFORMATION === operation.status,
-            'status-warning': OPERATION_STATUS.WARNING === operation.status}">
+            'icon-import': OPERATION_GROUP_TYPE.IMPORT_OPERATION === operationGroup.type,
+            'icon-exchange': OPERATION_GROUP_TYPE.QUERIES_OPERATION === operationGroup.type,
+            'fa fa-archive': OPERATION_GROUP_TYPE.BACKUP_AND_RESTORE_OPERATION === operationGroup.type,
+            'fa fa-sitemap': OPERATION_GROUP_TYPE.CLUSTER_OPERATION === operationGroup.type,
+            'status-critical': OPERATION_STATUS.CRITICAL === operationGroup.status,
+            'status-information': OPERATION_STATUS.INFORMATION === operationGroup.status,
+            'status-warning': OPERATION_STATUS.WARNING === operationGroup.status}">
             </div>
-            <span ng-if="operation.groupRunningOperationCount" class="running-operation-count">
-                <sup class="tag-info">{{operation.groupRunningOperationCount}}</sup>
+            <span ng-if="operationGroup.runningOperations" class="running-operation-count">
+                <sup class="tag-info">{{operationGroup.runningOperations}}</sup>
             </span>
         </div>
         <span class="caret"></span>

--- a/src/js/angular/models/monitoring/operations/active-operation-model.js
+++ b/src/js/angular/models/monitoring/operations/active-operation-model.js
@@ -10,8 +10,10 @@ export class ActiveOperationModel {
          */
         this.operationGroup = undefined;
         this.runningOperationCount = 0;
-        this.groupRunningOperationCount = 0;
         this.status = OPERATION_STATUS.INFORMATION;
+        /**
+         * @type {string} - the value must be one of the {@see OPERATION_TYPE} option.
+         */
         this.type = undefined;
         this.titleLabelKey = '';
         this.monitoringViewUrl = '';

--- a/src/js/angular/models/monitoring/operations/operation-status.js
+++ b/src/js/angular/models/monitoring/operations/operation-status.js
@@ -3,3 +3,25 @@ export const OPERATION_STATUS = {
     'WARNING': 'WARNING',
     'INFORMATION': 'INFORMATION'
 };
+
+export const OPERATION_STATUS_SORT_ORDER = {
+    'INFORMATION': 0,
+    'WARNING': 1,
+    'CRITICAL': 2,
+    /**
+     *
+     * @param {string} operationStatus - the value must be one of the {@see OPERATION_STATUS} option.
+     *
+     * @return {number} the order of operation status.
+     */
+    'getOrder': (operationStatus) => {
+        switch (operationStatus) {
+            case OPERATION_STATUS.WARNING:
+                return OPERATION_STATUS_SORT_ORDER.WARNING;
+            case OPERATION_STATUS.CRITICAL:
+                return OPERATION_STATUS_SORT_ORDER.CRITICAL;
+            default:
+                return OPERATION_STATUS_SORT_ORDER.INFORMATION;
+        }
+    }
+};

--- a/test-cypress/integration/monitor/global-operation-statuses-component.spec.js
+++ b/test-cypress/integration/monitor/global-operation-statuses-component.spec.js
@@ -27,6 +27,41 @@ describe('Operations Status Component', () => {
         OperationsStatusesComponentSteps.getOperationsStatusesComponent().should('not.exist');
     });
 
+    it('should display icons with ongoing operations', () => {
+        // When I visit some page and there are running operations.
+        GlobalOperationsStatusesStub.stubGlobalOperationsStatusesResponse(repositoryId);
+        HomeSteps.visitAndWaitLoader();
+        // Then I expect "Global Operations Component" to be displayed.
+        OperationsStatusesComponentSteps.getOperationsStatusesComponent().should('exist');
+
+        OperationsStatusesComponentSteps.getImportOperationStatusHeaderElement()
+            .should('have.length', 1)
+            .parent()
+            .find('.running-operation-count')
+            .should('exist')
+            .contains('1');
+
+        OperationsStatusesComponentSteps.getQueriesOperationStatusHeaderElement()
+            .should('have.length', 1)
+            .parent()
+            .find('.running-operation-count')
+            .should('exist')
+            .contains('26');
+
+        OperationsStatusesComponentSteps.getBackupAndRestoreOperationStatusHeaderElement()
+            .should('have.length', 1)
+            .parent()
+            .find('.running-operation-count')
+            .should('not.exist');
+
+        OperationsStatusesComponentSteps.getClusterOperationStatusHeaderElement()
+            .should('have.length', 1)
+            .parent()
+            .find('.running-operation-count')
+            .should('not.exist');
+
+    });
+
     it('should redirect to query and update view wen click on queries operation element', () => {
         // When I visit some page and there are running operations.
         GlobalOperationsStatusesStub.stubGlobalOperationsStatusesResponse(repositoryId);

--- a/test-cypress/steps/operations-statuses-component-steps.js
+++ b/test-cypress/steps/operations-statuses-component-steps.js
@@ -4,6 +4,26 @@ export class OperationsStatusesComponentSteps {
         return cy.get('.operations-statuses');
     }
 
+    static getOperationStatusHeader(iconName) {
+        return OperationsStatusesComponentSteps.getOperationsStatusesComponent().find(`.operation-status-header ${iconName}`);
+    }
+
+    static getImportOperationStatusHeaderElement() {
+        return OperationsStatusesComponentSteps.getOperationStatusHeader('.icon-import');
+    }
+
+    static getQueriesOperationStatusHeaderElement() {
+        return OperationsStatusesComponentSteps.getOperationStatusHeader('.icon-exchange');
+    }
+
+    static getBackupAndRestoreOperationStatusHeaderElement() {
+        return OperationsStatusesComponentSteps.getOperationStatusHeader('.fa.fa-archive');
+    }
+
+    static getClusterOperationStatusHeaderElement() {
+        return OperationsStatusesComponentSteps.getOperationStatusHeader('.fa.fa-sitemap');
+    }
+
     static getOperationStatuses() {
         return cy.get('.operation-status-content');
     }


### PR DESCRIPTION
## What
When there are ongoing rebuild similarity index. The global operation component is displayed without icon and count of the ongoing operation.

## Why
The issue arose after a code refactoring that removed the summary object for all operations, done for optimization. To display ongoing operations, the UI relies on an array returned from the backend, which contains information about icons and the count of ongoing operations per operation group. The problem occurred because "queries" and "imports" are part of the same operation group, and they share the same icon and count (the sum of both operations). This resulted in double-displaying the "query" group icon and count, causing the update query to be skipped for visualization. Rebuilding the similarity index triggers only one update operation, which is why the global operation component is displayed without an icon (it's skipped).

## How
Revert the removal of the 'OperationGroupSummary' object and related functionality.

Additional work:
 - added a test to cover this scenario.