### PR TITLE
GDB-9071 fix saved queries actions triggering

### DIFF
--- a/src/css/new-sparql.css
+++ b/src/css/new-sparql.css
@@ -57,9 +57,39 @@
   cursor: pointer;
 }
 
-#wb-sparql-queryInSampleQueries{
+#wb-sparql-queryInSampleQueries {
+    width: 300px;
     max-height: 170px;
     overflow-y: auto;
+    position: relative;
+}
+
+#wb-sparql-queryInSampleQueries .saved-query {
+    height: 22px;
+    position: relative;
+}
+
+#wb-sparql-queryInSampleQueries .saved-query a {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+#wb-sparql-queryInSampleQueries .saved-query .actions-bar {
+    display: none;
+}
+
+#wb-sparql-queryInSampleQueries .saved-query .actions-bar .not-user-query {
+    display: none;
+}
+
+#wb-sparql-queryInSampleQueries .saved-query:hover .actions-bar {
+    display: inline;
+    position: absolute;
+    right: 0;
+    top: 0;
+    background-color: #fff;
 }
 
 .CodeMirror {

--- a/src/js/angular/core/directives/queryeditor/query-editor.controller.js
+++ b/src/js/angular/core/directives/queryeditor/query-editor.controller.js
@@ -397,31 +397,15 @@ function QueryEditorCtrl($scope, $timeout, toastr, $repositories, $uibModal, Mod
     });
 
     function toggleSampleQueries() {
-        $scope.showSampleQueries = !$scope.showSampleQueries;
-        if ($scope.showSampleQueries) {
-            SparqlRestService.getSavedQueries()
-                .success(function (data) {
-                    $scope.sampleQueries = data;
-                    $('#sampleQueriesCollapse').collapse('show').width('300px');
-                })
-                .error(function (data) {
-                    const msg = getError(data);
-                    toastr.error(msg, $translate.instant('query.editor.get.saved.queries.error'));
-                });
-        } else {
-            $('#sampleQueriesCollapse').collapse('hide');
-        }
+        SparqlRestService.getSavedQueries()
+            .success(function (savedQueries) {
+                $scope.sampleQueries = savedQueries.filter((savedQuery) => !$scope.ignoreSharedQueries || savedQuery.owner !== $scope.principal.username);
+            })
+            .error(function (data) {
+                const msg = getError(data);
+                toastr.error(msg, $translate.instant('query.editor.get.saved.queries.error'));
+            });
     }
-
-    // Hide the sample queries when the user clicks somewhere else in the UI.
-    $(document).mouseup(function (event) {
-        const container = $('#sampleQueriesCollapse');
-        if (!container.is(event.target) // if the target of the click isn't the container..
-            && container.has(event.target).length === 0 //... nor a descendant of the container
-            && $scope.showSampleQueries) {
-            toggleSampleQueries();
-        }
-    });
 
     // Add known prefixes
     function addKnownPrefixes() {
@@ -821,8 +805,6 @@ function QueryEditorCtrl($scope, $timeout, toastr, $repositories, $uibModal, Mod
     // end of query tab operations
 
     $scope.currentQuery = {};
-    // $scope.state = {};
-    $scope.showSampleQueries = false;
     $scope.savedQuery = {};
     $scope.sampleQueries = {};
     $scope.editQueryModal = showModal('#editQueryContainer');

--- a/src/js/angular/core/directives/queryeditor/templates/query-editor.html
+++ b/src/js/angular/core/directives/queryeditor/templates/query-editor.html
@@ -20,21 +20,19 @@
 
             <script type="text/ng-template" id="sampleQueriesPopoverTemplate.html">
                 <ul id="wb-sparql-queryInSampleQueries" class="list-unstyled">
-                    <li ng-repeat="query in sampleQueries" ng-hide="ignoreSharedQueries && query.owner != principal.username" class="hovered-parent saved-query">
-                        <a href ng-click="querySelected(query)">{{query.name}}</a>
+                    <li ng-repeat="query in sampleQueries" class="saved-query">
+                        <a href ng-click="querySelected(query)" title="{{query.name}}">{{query.name}}</a>
                         &nbsp;
                         <em class="icon-warning" ng-show="query.owner != principal.username && isUser()"
                            uib-popover="{{'core.popover.shared.query.warning' | translate}}"
                            popover-trigger="mouseenter"></em>
                         <span class="actions-bar hovered-item">
-							<button class="btn btn-link btn-sm"
-                                    ng-show="query.owner == principal.username && isUser()"
+							<button class="btn btn-link btn-sm" ng-class="{'not-user-query': !isUser()}"
                                     uib-popover="{{'core.edit.query' | translate}}" popover-trigger="mouseenter"
                                     ng-click="editQuery(query)">
 								<span class="icon-edit"></span>
 							</button>
-							<button class="btn btn-link btn-sm"
-                                    ng-show="query.owner == principal.username && isUser()"
+							<button class="btn btn-link btn-sm" ng-class="{'not-user-query': !isUser()}"
                                     uib-popover="{{'core.delete.query' | translate}}" popover-trigger="mouseenter"
                                     ng-click="deleteQuery(query.name)">
 								<span class="icon-trash"></span>
@@ -48,23 +46,6 @@
                     </li>
                 </ul>
             </script>
-
-            <!--
-                        <div class="collapse width pull-right well" id="sampleQueriesCollapse">
-                            <div class="list-group-item-heading">Select saved query from the list</div>
-                            <ul id="wb-sparql-queryInSampleQueries" class="queries list-unstyled">
-                                <li ng-repeat="query in sampleQueries">
-
-                                    <a href="#" ng-click="querySelected(query.body)"><i class="fa fa-1x fa-caret-right"></i>{{query.name}}</a>
-                                    <span>
-                                        <i ng-show="canWriteActiveRepo()" gdb-tooltip="Edit query" href="#" class="fa fa-pencil-square-o fa-1x editSampleQuery" ng-click="editQuery(query)"></i>
-                                        <i ng-show="canWriteActiveRepo()" gdb-tooltip="Delete query" href="#" class="fa fa-trash-o fa-1x deleteSampleQuery" ng-click="deleteQuery(query.name)"></i>
-                                        <i gdb-tooltip="Get URL to query" href="#" class="fa fa-link fa-1x" ng-click="copyToClipboardQuery(query.name)"></i>
-                                    </span>
-                                </li>
-                            </ul>
-                        </div>
-            -->
 
             <div id="queryEditor" guide-selector="queryEditor">
                 <textarea ng-model="query" id="query" rows="16" cols="100" guide-selector="inputQuery"></textarea>

--- a/test/core/directives/queryeditor/query-editor.controller.spec.js
+++ b/test/core/directives/queryeditor/query-editor.controller.spec.js
@@ -188,7 +188,6 @@ describe('QueryEditor', function () {
 
         describe('querySelected', () => {
             it('should select tab', () => {
-                $scope.showSampleQueries = true;
                 $scope.tabsData = [
                     {id: 'tab-0', name: 'first tab', query: 'query-0', inference: false, sameAs: false},
                     {id: 'tab-1', name: 'second tab', query: 'query-1', inference: false, sameAs: false}
@@ -200,6 +199,7 @@ describe('QueryEditor', function () {
                 spyOn(window, '$').and.returnValue(elementMock);
                 $httpBackend.when('GET', 'rest/security/all').respond(200);
                 $httpBackend.when('GET', 'rest/locations', {}).respond(200);
+                $httpBackend.when('GET', 'rest/sparql/saved-queries', {}).respond(200, []);
 
                 $scope.querySelected({
                     name: 'second tab',
@@ -207,12 +207,10 @@ describe('QueryEditor', function () {
                 });
                 $timeout.flush();
 
-                expect(elementMock.collapse).toHaveBeenCalled();
                 expect(elementMock.tab).toHaveBeenCalledWith('show');
             });
 
             it('should add new tab', async () => {
-                $scope.showSampleQueries = true;
                 let elementMock = {
                     collapse: jasmine.createSpy(),
                     tab: jasmine.createSpy(),


### PR DESCRIPTION
## What
Fix saved queries actions triggering which occasionally didn't happen.

## Why
The saved queries popup and actions inside it was badly implemented to mix the popover's behavior with the angular's show/hide which led to having the dom elements in inconsistent state at times so that the buttons in the popover had their click handlers not attached properly.

## How
Removed redundant logic which used to rely on jquery.collapse and restyled the saved queries list items and buttons inside the popover to show/hide them by using just regular css instead of using javascript.