### PR TITLE
GDB-9092 Toast messages not handling <> and symbols when stating the iri is invalid.

### DIFF
--- a/src/js/angular/autocomplete/controllers.js
+++ b/src/js/angular/autocomplete/controllers.js
@@ -1,5 +1,6 @@
 import 'angular/rest/autocomplete.rest.service';
 import {mapNamespacesResponse} from "../rest/mappers/namespaces-mapper";
+import {decodeHTML} from "../../../app";
 
 const modules = [
     'toastr',
@@ -82,7 +83,8 @@ function AutocompleteCtrl($scope, $interval, toastr, $repositories, $licenseServ
                 $scope.setLoader(false);
             });
         } else {
-            toastr.error($translate.instant('not.valid.iri', {value: labelIriText}));
+            const errorMessage = decodeHTML($translate.instant('not.valid.iri', {value: labelIriText}));
+            toastr.error(errorMessage);
             $scope.setLoader(false);
         }
     };

--- a/src/js/angular/rdfrank/app.js
+++ b/src/js/angular/rdfrank/app.js
@@ -4,6 +4,7 @@ import 'angular/utils/uri-utils';
 import 'angular/rest/rdfrank.rest.service';
 import 'ng-tags-input/build/ng-tags-input.min';
 import {mapNamespacesResponse} from "../rest/mappers/namespaces-mapper";
+import {decodeHTML} from "../../../app";
 
 const rdfRankApp = angular.module('graphdb.framework.rdfrank', [
     'ngRoute',
@@ -249,7 +250,8 @@ rdfRankApp.controller('RDFRankCtrl', ['$scope', '$interval', 'toastr', '$reposit
                 _addToList(list, iriText);
             } else {
                 refreshFilteringConfig();
-                toastr.error($translate.instant('not.valid.iri', {value: iri.text}));
+                const errorMessage = decodeHTML($translate.instant('not.valid.iri', {value: iriText}));
+                toastr.error(errorMessage);
             }
         };
 


### PR DESCRIPTION
What
Toast messages not handling <>& symbols when stating the iri is invalid.

Why
These are special symbols in HTML that are not properly decoded by HTML

How
Using function decodeHTML() to decode HTML entities (e.g., &lt;, &gt;, &amp;) in a given HTML string back into their corresponding characters. It utilizes the HTML textarea element to perform this decoding.