### PR TITLE
GDB-9092 Toast messages not handling <>& symbols when stating the iri is invalid

### DIFF
--- a/src/js/angular/autocomplete/controllers.js
+++ b/src/js/angular/autocomplete/controllers.js
@@ -70,9 +70,10 @@ function AutocompleteCtrl($scope, $interval, toastr, $repositories, $licenseServ
 
     const addLabelConfig = function (label) {
         $scope.setLoader(true, $translate.instant('autocomplete.update'));
-        const labelIriText = label.labelIri;
-        label.labelIri = UriUtils.expandPrefix(label.labelIri, $scope.namespaces);
-        if (UriUtils.isValidIri(label, label.labelIri) && label.labelIri !== "") {
+        let labelIriText = label.labelIri.toString();
+        labelIriText = UriUtils.expandPrefix(labelIriText, $scope.namespaces);
+        if (UriUtils.isValidIri(label, labelIriText) && labelIriText !== "") {
+            label.labelIri = labelIriText;
             AutocompleteRestService.addLabelConfig(label)
                 .success(function () {
                     refreshLabelConfig();
@@ -83,7 +84,7 @@ function AutocompleteCtrl($scope, $interval, toastr, $repositories, $licenseServ
                 $scope.setLoader(false);
             });
         } else {
-            const errorMessage = decodeHTML($translate.instant('not.valid.iri', {value: labelIriText}));
+            const errorMessage = decodeHTML($translate.instant('not.valid.iri', {value: label.labelIri.toString()}));
             toastr.error(errorMessage);
             $scope.setLoader(false);
         }

--- a/src/js/angular/rdfrank/app.js
+++ b/src/js/angular/rdfrank/app.js
@@ -250,7 +250,7 @@ rdfRankApp.controller('RDFRankCtrl', ['$scope', '$interval', 'toastr', '$reposit
                 _addToList(list, iriText);
             } else {
                 refreshFilteringConfig();
-                const errorMessage = decodeHTML($translate.instant('not.valid.iri', {value: iriText}));
+                const errorMessage = decodeHTML($translate.instant('not.valid.iri', {value: iri.text.toString()}));
                 toastr.error(errorMessage);
             }
         };


### PR DESCRIPTION
What
Toast messages not handling <>& symbols when stating the iri is invalid

Why
The iri included in the message is not taken from the initial input but after reformatting it.

How
The error message takes the iri text to make the message from the user input.