### PR TITLE
GDB-7789 GDB-7790 integrates the chart and pivot table yasr plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.0.12",
+                "ontotext-yasgui-web-component": "1.1.1",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -9973,9 +9973,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.12.tgz",
-            "integrity": "sha512-KORuytJi21htZ0RiWVMDSibFrMSI+M/PEH7rqXEM+D+fy4ypD1bjxTHUTcPN+slOTHl5Lec8xdbMjX1w/h812w==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.1.tgz",
+            "integrity": "sha512-UEJ/A5iaNgChNfuoXG/zpLRaTGzihGISScH40X2Z9eqN0BXBHow6EMRqtNQQB4J8yMulabfNaOsJX9yVzmRE0Q==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24544,9 +24544,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.0.12.tgz",
-            "integrity": "sha512-KORuytJi21htZ0RiWVMDSibFrMSI+M/PEH7rqXEM+D+fy4ypD1bjxTHUTcPN+slOTHl5Lec8xdbMjX1w/h812w==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.1.tgz",
+            "integrity": "sha512-UEJ/A5iaNgChNfuoXG/zpLRaTGzihGISScH40X2Z9eqN0BXBHow6EMRqtNQQB4J8yMulabfNaOsJX9yVzmRE0Q==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.0.12",
+        "ontotext-yasgui-web-component": "1.1.1",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -69,7 +69,12 @@ yasgui-component .yasr-toolbar .explore-visual-graph-button:hover {
     background-color: var(--primary-color-dark) !important;
 }
 
-yasgui-component .yasr-toolbar .explore-visual-graph-button-name {
+yasgui-component .yasr-toolbar .chart-download-as-button,
+yasgui-component .yasr-toolbar .pivot-table-download-as-button {
+    background-color: var(--primary-color-dark) !important;
+}
+
+yasgui-component .yasr-toolbar .chart-download-as-button {
     padding-left: 5px;
 }
 
@@ -195,6 +200,10 @@ yasgui-component .tabsList .tab a:hover {
 yasgui-component .yasr_response_chip {
     font-size: 16px;
     color: var(--secondary-color) !important;
+}
+
+yasgui-component .yasr_response_chip .response-info-message {
+    padding-left: 10px;
 }
 
 yasgui-component .yasr_plugin_control label {


### PR DESCRIPTION
## What
Integrates the chart and pivot table yasr plugins.

## Why
These two plugins are not part of the opensource yasgui library from version 4 but are present in the workbench which currently uses an older yasgui version where they are still present. That's why both plugins needed to be reimplemented and introduced in the yasr as plugins again.

## How
Implemented both plugins from scratch based on their versions from the old yasgui.