### PR TITLE
GDB-8336 WB edit of some context triples gives syntax toast errors

### DIFF
--- a/src/js/angular/explore/statements.service.js
+++ b/src/js/angular/explore/statements.service.js
@@ -38,11 +38,17 @@ function StatementsService() {
             for (let j = 0; j < value.length; j++) {
                 const statement = value[j];
                 data += '\n\t<' + statement.subject + '> <' + statement.predicate + '> ';
-                const statementObjectValue = statement.object.value;
+                let statementObjectValue = statement.object.value;
                 if (statement.object.type === 'uri') {
                     data += '<' + statementObjectValue + '> .';
                 } else {
                     if (statementObjectValue.toString().includes('"')) {
+                        if (statementObjectValue[0] === "'") {
+                            statementObjectValue = '"' + statementObjectValue.slice(1, statementObjectValue.length);
+                        }
+                        if (statementObjectValue[statementObjectValue.length - 1]) {
+                            statementObjectValue = statementObjectValue.slice(0, -1) + '"';
+                        }
                         data += "'''" + statementObjectValue + "'''" + (statement.object.datatype ? '^^<' + statement.object.datatype + '>' : (statement.object.lang ? '@' + statement.object.lang : '')) + ' .';
                     } else {
                         data += '"""' + statementObjectValue + '"""' + (statement.object.datatype ? '^^<' + statement.object.datatype + '>' : (statement.object.lang ? '@' + statement.object.lang : '')) + ' .';


### PR DESCRIPTION
What
Corner case of parsing resource in single quotes.

Why
Turtle parser embraces literals in """ or '''.

How
Added check for a corner case when a literal start or/and ends with a single quote.