### PR TITLE
GDB-9077 fix download sparql results operation in the sparql view

### DIFF
--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -9,6 +9,7 @@ import {YasrPluginName} from "../../../models/ontotext-yasgui/yasr-plugin-name";
 import {isEqual} from "lodash/lang";
 import {QueryType} from "../../../models/ontotext-yasgui/query-type";
 import {YasguiComponent} from "../../../models/yasgui-component";
+import {YasguiComponentDirectiveUtil} from "./yasgui-component-directive.util";
 
 const modules = [
     'graphdb.framework.core.services.translation-service',
@@ -302,16 +303,21 @@ function yasguiComponentDirective(
                 const accept = downloadAsEvent.contentType;
                 const authToken = AuthTokenService.getAuthToken() || '';
 
-                // TODO change it
-                // Simple cross-browser download with a form
-                const $wbDownload = $('#wb-download');
-                $wbDownload.attr('action', $scope.ontotextYasguiConfig.endpoint);
-                $('#wb-download-query').val(query);
-                $('#wb-download-infer').val(infer);
-                $('#wb-download-sameAs').val(sameAs);
-                $('#wb-auth-token').val(authToken);
-                $('#wb-download-accept').val(accept);
-                $wbDownload.submit();
+                YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync('#query-editor')
+                    .then((yasguiComponent) => {
+                        return yasguiComponent.getQueryMode();
+                    }).then((queryMode) => {
+                        const endpoint = $repositories.resolveSparqlEndpoint(queryMode);
+                        // Simple cross-browser download with a form
+                        const $wbDownload = $('#wb-download');
+                        $wbDownload.attr('action', endpoint);
+                        $('#wb-download-query').val(query);
+                        $('#wb-download-infer').val(infer);
+                        $('#wb-download-sameAs').val(sameAs);
+                        $('#wb-auth-token').val(authToken);
+                        $('#wb-download-accept').val(accept);
+                        $wbDownload.submit();
+                    });
             };
             downloadAsPluginNameToEventHandler.set(YasrPluginName.EXTENDED_TABLE, downloadThroughServer);
 

--- a/src/js/angular/core/services/repositories.service.js
+++ b/src/js/angular/core/services/repositories.service.js
@@ -5,6 +5,7 @@ import 'angular/rest/license.rest.service';
 import 'ng-file-upload/dist/ng-file-upload.min';
 import 'ng-file-upload/dist/ng-file-upload-shim.min';
 import 'angular/core/services/event-emitter-service';
+import {QueryMode} from "../../models/ontotext-yasgui/query-mode";
 
 const modules = [
     'ngCookies',
@@ -438,6 +439,21 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
                 });
         };
 
+        /**
+         * Resolve the endpoint which should be used for issuing sparql queries based on the query mode.
+         * @param {'query'|'update'} queryMode
+         * @return {string} The resolved REST endpoint for sparql queries.
+         */
+        this.resolveSparqlEndpoint = (queryMode) => {
+            // if query mode is 'query' -> '/repositories/repo-name'
+            // if query mode is 'update' -> '/repositories/repo-name/statements'
+            if (queryMode === QueryMode.UPDATE) {
+                return `/repositories/${this.getActiveRepository()}/statements`;
+            } else if (queryMode === QueryMode.QUERY) {
+                return `/repositories/${this.getActiveRepository()}`;
+            }
+        };
+
         $rootScope.$on('securityInit', function (scope, securityEnabled, userLoggedIn, freeAccess) {
             locationsRequestPromise = null;
             if (!securityEnabled || userLoggedIn || freeAccess) {
@@ -447,6 +463,7 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
                 });
             }
         });
+
         $rootScope.$on('reloadLocations', function () {
             // the event is emitted when cluster is created/deleted
             that.locationsShouldReload = true;

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -95,14 +95,7 @@ function SparqlEditorCtrl($scope,
             // this can happen if open saprql view for first time (browser local store is clear);
             return;
         }
-        const queryMode = yasqe.getQueryMode();
-        // if query mode is 'query' -> '/repositories/repo-name'
-        // if query mode is 'update' -> '/repositories/repo-name/statements'
-        if (queryMode === QueryMode.UPDATE) {
-            return `/repositories/${$repositories.getActiveRepository()}/statements`;
-        } else if (queryMode === QueryMode.QUERY) {
-            return `/repositories/${$repositories.getActiveRepository()}`;
-        }
+        return $repositories.resolveSparqlEndpoint(yasqe.getQueryMode());
     };
 
     const initViewFromUrlParams = () => {

--- a/src/pages/sparql-editor.html
+++ b/src/pages/sparql-editor.html
@@ -14,4 +14,12 @@
 
     <yasgui-component id="query-editor" yasgui-config="yasguiConfig" ng-if="yasguiConfig"
                       after-init="initViewFromUrlParams()"></yasgui-component>
+
+    <form id="wb-download" method="POST" action="" target="_self">
+        <input id="wb-download-query" name="query" type="hidden"/>
+        <input id="wb-download-infer" name="infer" type="hidden"/>
+        <input id="wb-download-sameAs" name="sameAs" type="hidden"/>
+        <input id="wb-download-accept" name="Accept" type="hidden"/>
+        <input id="wb-auth-token" name="authToken" type="hidden"/>
+    </form>
 </div>


### PR DESCRIPTION
## What
Fix download sparql results operation in the sparql view.

## Why
The `download as` operation seems to be broken for a while because we removed the form used for submitting the parameters needed for the export as well as there was another issue where the sparql endpoint was impossible to be resolved the way it was implemented because the `endpoint` configuration can be a string or a get function which is expected to be evaluated in the context of the YASGUI component and not in the workbench.

## How
* Re-introduced the download as parameters form again.
* Refactored the obtaining of the sparql endpoint based on the query mode so that it can be used correctly in the context of the workbench.