### PR TITLE
GDB-9085 Upgrade D3.js library to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "angular-xeditable": "^0.10.0",
                 "angularjs-slider": "^7.0.0",
                 "autofill-event": "0.0.1",
-                "d3": "4.13.0",
+                "d3": "^7.8.5",
                 "font-awesome": "^4.7.0",
                 "jquery": "^3.4.1",
                 "jsrsasign": "^10.3.0",
@@ -2875,7 +2875,8 @@
         "node_modules/commander": {
             "version": "2.17.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-            "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+            "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+            "dev": true
         },
         "node_modules/commondir": {
             "version": "1.0.1",
@@ -3738,269 +3739,392 @@
             "dev": true
         },
         "node_modules/d3": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
-            "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.5.tgz",
+            "integrity": "sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==",
             "dependencies": {
-                "d3-array": "1.2.1",
-                "d3-axis": "1.0.8",
-                "d3-brush": "1.0.4",
-                "d3-chord": "1.0.4",
-                "d3-collection": "1.0.4",
-                "d3-color": "1.0.3",
-                "d3-dispatch": "1.0.3",
-                "d3-drag": "1.2.1",
-                "d3-dsv": "1.0.8",
-                "d3-ease": "1.0.3",
-                "d3-force": "1.1.0",
-                "d3-format": "1.2.2",
-                "d3-geo": "1.9.1",
-                "d3-hierarchy": "1.1.5",
-                "d3-interpolate": "1.1.6",
-                "d3-path": "1.0.5",
-                "d3-polygon": "1.0.3",
-                "d3-quadtree": "1.0.3",
-                "d3-queue": "3.0.7",
-                "d3-random": "1.1.0",
-                "d3-request": "1.0.6",
-                "d3-scale": "1.0.7",
-                "d3-selection": "1.3.0",
-                "d3-shape": "1.2.0",
-                "d3-time": "1.0.8",
-                "d3-time-format": "2.1.1",
-                "d3-timer": "1.0.7",
-                "d3-transition": "1.1.1",
-                "d3-voronoi": "1.1.2",
-                "d3-zoom": "1.7.1"
+                "d3-array": "3",
+                "d3-axis": "3",
+                "d3-brush": "3",
+                "d3-chord": "3",
+                "d3-color": "3",
+                "d3-contour": "4",
+                "d3-delaunay": "6",
+                "d3-dispatch": "3",
+                "d3-drag": "3",
+                "d3-dsv": "3",
+                "d3-ease": "3",
+                "d3-fetch": "3",
+                "d3-force": "3",
+                "d3-format": "3",
+                "d3-geo": "3",
+                "d3-hierarchy": "3",
+                "d3-interpolate": "3",
+                "d3-path": "3",
+                "d3-polygon": "3",
+                "d3-quadtree": "3",
+                "d3-random": "3",
+                "d3-scale": "4",
+                "d3-scale-chromatic": "3",
+                "d3-selection": "3",
+                "d3-shape": "3",
+                "d3-time": "3",
+                "d3-time-format": "4",
+                "d3-timer": "3",
+                "d3-transition": "3",
+                "d3-zoom": "3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-array": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
-            "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-axis": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
-            "integrity": "sha512-K0djTb26iQ6AsuD2d6Ka08wBHf4V30awIxV4XFuB/iLzYtTqqJlE/nIN0DBJJCX7lbOqbt2/oeX3r+sU5k2veg=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+            "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-brush": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
-            "integrity": "sha512-nUFueDzOlvwFvuOBynGSyJM7Wt1H9fKgJeoWFSg3ScS4c7FJBch92FKUJKum4xtgPYHdgH2C3bRg3GzSVltCJQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+            "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
             "dependencies": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "3",
+                "d3-transition": "3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-chord": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
-            "integrity": "sha512-o0ExexkK1N0KikUakKrQwttP5Flu8AYD6iBUh3AdPJqnTh6xlvcX5wFRuuo29sLOAr9+T4yZPUH1S3CCQJ1SlQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+            "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
             "dependencies": {
-                "d3-array": "1",
-                "d3-path": "1"
+                "d3-path": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
-        "node_modules/d3-collection": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.4.tgz",
-            "integrity": "sha512-+TPxaBFzbzfpLF3Hjz8JPeuStNmJnyWAufu8VUfpDCDn5RieIgY+OQDjhKMDorf2naLgAjjZXLUQN7XFp/kgog=="
-        },
         "node_modules/d3-color": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
-            "integrity": "sha512-t+rSOrshj6m2AUOe8kHvTwfUQ5TFoInEkBfmsHHAHPof58dmbRXNpicB7XAyPbMQbcC7i09p2BxeCEdgBd8xmw=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-contour": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+            "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+            "dependencies": {
+                "d3-array": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-delaunay": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+            "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+            "dependencies": {
+                "delaunator": "5"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-dispatch": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
-            "integrity": "sha512-Qh2DR3neW3lq/ug4oymXHYoIsA91nYt47ERb+fPKjRg6zLij06aP7KqHHl2NyziK9ASxrR3GLkHCtZvXe/jMVg=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+            "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-drag": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
-            "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
             "dependencies": {
-                "d3-dispatch": "1",
-                "d3-selection": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-selection": "3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-dsv": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
-            "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+            "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
             "dependencies": {
-                "commander": "2",
-                "iconv-lite": "0.4",
+                "commander": "7",
+                "iconv-lite": "0.6",
                 "rw": "1"
             },
             "bin": {
-                "csv2json": "bin/dsv2json",
-                "csv2tsv": "bin/dsv2dsv",
-                "dsv2dsv": "bin/dsv2dsv",
-                "dsv2json": "bin/dsv2json",
-                "json2csv": "bin/json2dsv",
-                "json2dsv": "bin/json2dsv",
-                "json2tsv": "bin/json2dsv",
-                "tsv2csv": "bin/dsv2dsv",
-                "tsv2json": "bin/dsv2json"
+                "csv2json": "bin/dsv2json.js",
+                "csv2tsv": "bin/dsv2dsv.js",
+                "dsv2dsv": "bin/dsv2dsv.js",
+                "dsv2json": "bin/dsv2json.js",
+                "json2csv": "bin/json2dsv.js",
+                "json2dsv": "bin/json2dsv.js",
+                "json2tsv": "bin/json2dsv.js",
+                "tsv2csv": "bin/dsv2dsv.js",
+                "tsv2json": "bin/dsv2json.js"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-dsv/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/d3-dsv/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/d3-ease": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
-            "integrity": "sha512-io3QwOJwVPAxRF2UXpKpCdz2wm/7VLFCQQ1yy+GzX6YCtt3vi2BGnimI8agSF5jyUrHsADyF303d2S+ps7zU8w=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-fetch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+            "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+            "dependencies": {
+                "d3-dsv": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-force": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
-            "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+            "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
             "dependencies": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-quadtree": "1",
-                "d3-timer": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-quadtree": "1 - 3",
+                "d3-timer": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-format": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
-            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-geo": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
-            "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+            "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
             "dependencies": {
-                "d3-array": "1"
+                "d3-array": "2.5.0 - 3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-hierarchy": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
-            "integrity": "sha512-PcsLIhThc60mWnxlojIOH7Sc0tQ2DgLWfEwEAyzCtej5f3H9wSsRmrg5pEhKZLrwiJnI2zyw/pznJxL9a/Eugw=="
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+            "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-interpolate": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
-            "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
             "dependencies": {
-                "d3-color": "1"
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-path": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
-            "integrity": "sha512-eD76prgnTKYkLzHlY2UMyOEZXTpC+WOanCr1BLxo38w4fPPPq/LgCFqRQvqFU3AJngfZmmKR7rgKPZ4EGJ9Atw=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-polygon": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
-            "integrity": "sha512-2zP7GOvf4XOWTeQouK7fCO534yQxyhYYTw6GTqcXifIalHgA6qV/es+4GRQii9m6XxEPFcht4loobD/o2iEo1A=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+            "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-quadtree": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
-            "integrity": "sha512-U2Jc3jF3JOBGXIOnvWY9C4ekRwRX9hEVpMMmeduJyaxAwPmoe7t84iZFTLn1RwYOyrXxJF55H/Hrg186TFQQdw=="
-        },
-        "node_modules/d3-queue": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-3.0.7.tgz",
-            "integrity": "sha512-2rs+6pNFKkrJhqe1rg5znw7dKJ7KZr62j9aLZfhondkrnz6U7VRmJj1UGcbD8MRc46c7H8m4SWhab8EalBQrkw=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+            "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-random": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
-            "integrity": "sha512-XuMbjx3Jq4EWfJP4g6nR7zns/bZfaVbWHWfR8auDkEiWCzVbWifmasfszV1ZRN3xXK3nY4RUFL2nTIhceGZSFQ=="
-        },
-        "node_modules/d3-request": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
-            "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
-            "dependencies": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-dsv": "1",
-                "xmlhttprequest": "1"
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+            "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-scale": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
             "dependencies": {
-                "d3-array": "^1.2.0",
-                "d3-collection": "1",
-                "d3-color": "1",
-                "d3-format": "1",
-                "d3-interpolate": "1",
-                "d3-time": "1",
-                "d3-time-format": "2"
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale-chromatic": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+            "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
+            "dependencies": {
+                "d3-color": "1 - 3",
+                "d3-interpolate": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-selection": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
-            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-shape": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.0.tgz",
-            "integrity": "sha512-LP48zJ9ykPKjCdd0vSu5k2l4s8v1vI6vvdDeJtmgtTa+L6Ery0lzvOaV7pMunFuLv11hwSRZQnSnlhFl801aiw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
             "dependencies": {
-                "d3-path": "1"
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-time": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
-            "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-time-format": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
-            "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
             "dependencies": {
-                "d3-time": "1"
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-timer": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
-            "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
-        },
-        "node_modules/d3-transition": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
-            "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
-            "dependencies": {
-                "d3-color": "1",
-                "d3-dispatch": "1",
-                "d3-ease": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "^1.1.0",
-                "d3-timer": "1"
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "engines": {
+                "node": ">=12"
             }
         },
-        "node_modules/d3-voronoi": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-            "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw=="
+        "node_modules/d3-transition": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+            "dependencies": {
+                "d3-color": "1 - 3",
+                "d3-dispatch": "1 - 3",
+                "d3-ease": "1 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-timer": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "d3-selection": "2 - 3"
+            }
         },
         "node_modules/d3-zoom": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
-            "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
             "dependencies": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "2 - 3",
+                "d3-transition": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/date-format": {
@@ -4327,6 +4451,14 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/delaunator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+            "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
+            "dependencies": {
+                "robust-predicates": "^3.0.0"
             }
         },
         "node_modules/depd": {
@@ -7046,6 +7178,7 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3"
             },
@@ -7366,6 +7499,14 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/interpret": {
@@ -12018,6 +12159,11 @@
                 "inherits": "^2.0.1"
             }
         },
+        "node_modules/robust-predicates": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+            "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
+        },
         "node_modules/run-async": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -16334,14 +16480,6 @@
                 }
             }
         },
-        "node_modules/xmlhttprequest": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-            "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -18858,7 +18996,8 @@
         "commander": {
             "version": "2.17.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-            "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+            "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+            "dev": true
         },
         "commondir": {
             "version": "1.0.1",
@@ -19545,258 +19684,281 @@
             "dev": true
         },
         "d3": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
-            "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.5.tgz",
+            "integrity": "sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==",
             "requires": {
-                "d3-array": "1.2.1",
-                "d3-axis": "1.0.8",
-                "d3-brush": "1.0.4",
-                "d3-chord": "1.0.4",
-                "d3-collection": "1.0.4",
-                "d3-color": "1.0.3",
-                "d3-dispatch": "1.0.3",
-                "d3-drag": "1.2.1",
-                "d3-dsv": "1.0.8",
-                "d3-ease": "1.0.3",
-                "d3-force": "1.1.0",
-                "d3-format": "1.2.2",
-                "d3-geo": "1.9.1",
-                "d3-hierarchy": "1.1.5",
-                "d3-interpolate": "1.1.6",
-                "d3-path": "1.0.5",
-                "d3-polygon": "1.0.3",
-                "d3-quadtree": "1.0.3",
-                "d3-queue": "3.0.7",
-                "d3-random": "1.1.0",
-                "d3-request": "1.0.6",
-                "d3-scale": "1.0.7",
-                "d3-selection": "1.3.0",
-                "d3-shape": "1.2.0",
-                "d3-time": "1.0.8",
-                "d3-time-format": "2.1.1",
-                "d3-timer": "1.0.7",
-                "d3-transition": "1.1.1",
-                "d3-voronoi": "1.1.2",
-                "d3-zoom": "1.7.1"
+                "d3-array": "3",
+                "d3-axis": "3",
+                "d3-brush": "3",
+                "d3-chord": "3",
+                "d3-color": "3",
+                "d3-contour": "4",
+                "d3-delaunay": "6",
+                "d3-dispatch": "3",
+                "d3-drag": "3",
+                "d3-dsv": "3",
+                "d3-ease": "3",
+                "d3-fetch": "3",
+                "d3-force": "3",
+                "d3-format": "3",
+                "d3-geo": "3",
+                "d3-hierarchy": "3",
+                "d3-interpolate": "3",
+                "d3-path": "3",
+                "d3-polygon": "3",
+                "d3-quadtree": "3",
+                "d3-random": "3",
+                "d3-scale": "4",
+                "d3-scale-chromatic": "3",
+                "d3-selection": "3",
+                "d3-shape": "3",
+                "d3-time": "3",
+                "d3-time-format": "4",
+                "d3-timer": "3",
+                "d3-transition": "3",
+                "d3-zoom": "3"
             }
         },
         "d3-array": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
-            "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "requires": {
+                "internmap": "1 - 2"
+            }
         },
         "d3-axis": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
-            "integrity": "sha512-K0djTb26iQ6AsuD2d6Ka08wBHf4V30awIxV4XFuB/iLzYtTqqJlE/nIN0DBJJCX7lbOqbt2/oeX3r+sU5k2veg=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+            "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
         },
         "d3-brush": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
-            "integrity": "sha512-nUFueDzOlvwFvuOBynGSyJM7Wt1H9fKgJeoWFSg3ScS4c7FJBch92FKUJKum4xtgPYHdgH2C3bRg3GzSVltCJQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+            "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
             "requires": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "3",
+                "d3-transition": "3"
             }
         },
         "d3-chord": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
-            "integrity": "sha512-o0ExexkK1N0KikUakKrQwttP5Flu8AYD6iBUh3AdPJqnTh6xlvcX5wFRuuo29sLOAr9+T4yZPUH1S3CCQJ1SlQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+            "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
             "requires": {
-                "d3-array": "1",
-                "d3-path": "1"
+                "d3-path": "1 - 3"
             }
         },
-        "d3-collection": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.4.tgz",
-            "integrity": "sha512-+TPxaBFzbzfpLF3Hjz8JPeuStNmJnyWAufu8VUfpDCDn5RieIgY+OQDjhKMDorf2naLgAjjZXLUQN7XFp/kgog=="
-        },
         "d3-color": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
-            "integrity": "sha512-t+rSOrshj6m2AUOe8kHvTwfUQ5TFoInEkBfmsHHAHPof58dmbRXNpicB7XAyPbMQbcC7i09p2BxeCEdgBd8xmw=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+        },
+        "d3-contour": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+            "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+            "requires": {
+                "d3-array": "^3.2.0"
+            }
+        },
+        "d3-delaunay": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+            "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+            "requires": {
+                "delaunator": "5"
+            }
         },
         "d3-dispatch": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
-            "integrity": "sha512-Qh2DR3neW3lq/ug4oymXHYoIsA91nYt47ERb+fPKjRg6zLij06aP7KqHHl2NyziK9ASxrR3GLkHCtZvXe/jMVg=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+            "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
         },
         "d3-drag": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
-            "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
             "requires": {
-                "d3-dispatch": "1",
-                "d3-selection": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-selection": "3"
             }
         },
         "d3-dsv": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
-            "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+            "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
             "requires": {
-                "commander": "2",
-                "iconv-lite": "0.4",
+                "commander": "7",
+                "iconv-lite": "0.6",
                 "rw": "1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+                    "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+                },
+                "iconv-lite": {
+                    "version": "0.6.3",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+                    "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3.0.0"
+                    }
+                }
             }
         },
         "d3-ease": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
-            "integrity": "sha512-io3QwOJwVPAxRF2UXpKpCdz2wm/7VLFCQQ1yy+GzX6YCtt3vi2BGnimI8agSF5jyUrHsADyF303d2S+ps7zU8w=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+        },
+        "d3-fetch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+            "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+            "requires": {
+                "d3-dsv": "1 - 3"
+            }
         },
         "d3-force": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
-            "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+            "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
             "requires": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-quadtree": "1",
-                "d3-timer": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-quadtree": "1 - 3",
+                "d3-timer": "1 - 3"
             }
         },
         "d3-format": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
-            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
         },
         "d3-geo": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
-            "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+            "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
             "requires": {
-                "d3-array": "1"
+                "d3-array": "2.5.0 - 3"
             }
         },
         "d3-hierarchy": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
-            "integrity": "sha512-PcsLIhThc60mWnxlojIOH7Sc0tQ2DgLWfEwEAyzCtej5f3H9wSsRmrg5pEhKZLrwiJnI2zyw/pznJxL9a/Eugw=="
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+            "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
         },
         "d3-interpolate": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
-            "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
             "requires": {
-                "d3-color": "1"
+                "d3-color": "1 - 3"
             }
         },
         "d3-path": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
-            "integrity": "sha512-eD76prgnTKYkLzHlY2UMyOEZXTpC+WOanCr1BLxo38w4fPPPq/LgCFqRQvqFU3AJngfZmmKR7rgKPZ4EGJ9Atw=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
         },
         "d3-polygon": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
-            "integrity": "sha512-2zP7GOvf4XOWTeQouK7fCO534yQxyhYYTw6GTqcXifIalHgA6qV/es+4GRQii9m6XxEPFcht4loobD/o2iEo1A=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+            "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
         },
         "d3-quadtree": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
-            "integrity": "sha512-U2Jc3jF3JOBGXIOnvWY9C4ekRwRX9hEVpMMmeduJyaxAwPmoe7t84iZFTLn1RwYOyrXxJF55H/Hrg186TFQQdw=="
-        },
-        "d3-queue": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-3.0.7.tgz",
-            "integrity": "sha512-2rs+6pNFKkrJhqe1rg5znw7dKJ7KZr62j9aLZfhondkrnz6U7VRmJj1UGcbD8MRc46c7H8m4SWhab8EalBQrkw=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+            "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
         },
         "d3-random": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
-            "integrity": "sha512-XuMbjx3Jq4EWfJP4g6nR7zns/bZfaVbWHWfR8auDkEiWCzVbWifmasfszV1ZRN3xXK3nY4RUFL2nTIhceGZSFQ=="
-        },
-        "d3-request": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
-            "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
-            "requires": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-dsv": "1",
-                "xmlhttprequest": "1"
-            }
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+            "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
         },
         "d3-scale": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
             "requires": {
-                "d3-array": "^1.2.0",
-                "d3-collection": "1",
-                "d3-color": "1",
-                "d3-format": "1",
-                "d3-interpolate": "1",
-                "d3-time": "1",
-                "d3-time-format": "2"
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            }
+        },
+        "d3-scale-chromatic": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+            "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
+            "requires": {
+                "d3-color": "1 - 3",
+                "d3-interpolate": "1 - 3"
             }
         },
         "d3-selection": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
-            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
         },
         "d3-shape": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.0.tgz",
-            "integrity": "sha512-LP48zJ9ykPKjCdd0vSu5k2l4s8v1vI6vvdDeJtmgtTa+L6Ery0lzvOaV7pMunFuLv11hwSRZQnSnlhFl801aiw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
             "requires": {
-                "d3-path": "1"
+                "d3-path": "^3.1.0"
             }
         },
         "d3-time": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
-            "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "requires": {
+                "d3-array": "2 - 3"
+            }
         },
         "d3-time-format": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
-            "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
             "requires": {
-                "d3-time": "1"
+                "d3-time": "1 - 3"
             }
         },
         "d3-timer": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
-            "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
         },
         "d3-transition": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
-            "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
             "requires": {
-                "d3-color": "1",
-                "d3-dispatch": "1",
-                "d3-ease": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "^1.1.0",
-                "d3-timer": "1"
+                "d3-color": "1 - 3",
+                "d3-dispatch": "1 - 3",
+                "d3-ease": "1 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-timer": "1 - 3"
             }
         },
-        "d3-voronoi": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-            "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw=="
-        },
         "d3-zoom": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
-            "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
             "requires": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "2 - 3",
+                "d3-transition": "2 - 3"
             }
         },
         "date-format": {
@@ -20053,6 +20215,14 @@
                         }
                     }
                 }
+            }
+        },
+        "delaunator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+            "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
+            "requires": {
+                "robust-predicates": "^3.0.0"
             }
         },
         "depd": {
@@ -22186,6 +22356,7 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
@@ -22425,6 +22596,11 @@
                 "has": "^1.0.3",
                 "side-channel": "^1.0.4"
             }
+        },
+        "internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
         },
         "interpret": {
             "version": "1.4.0",
@@ -26131,6 +26307,11 @@
                 "inherits": "^2.0.1"
             }
         },
+        "robust-predicates": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+            "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
+        },
         "run-async": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -29574,11 +29755,6 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
             "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
             "dev": true
-        },
-        "xmlhttprequest": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-            "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA=="
         },
         "xtend": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "angular-xeditable": "^0.10.0",
         "angularjs-slider": "^7.0.0",
         "autofill-event": "0.0.1",
-        "d3": "4.13.0",
+        "d3": "^7.8.5",
         "font-awesome": "^4.7.0",
         "jquery": "^3.4.1",
         "jsrsasign": "^10.3.0",

--- a/src/js/angular/clustermanagement/directives.js
+++ b/src/js/angular/clustermanagement/directives.js
@@ -240,8 +240,8 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
                     CDS.updateNodes(legendNodesElements);
 
                     legendNodesElements.select('.node.member')
-                        .on("mouseover", function (d) {
-                            d3.event.stopPropagation();
+                        .on("mouseover", function (event, d) {
+                            event.stopPropagation();
                             showLegendTooltip(d, this);
                         })
                         .on('mouseout', hideLegendTooltip);
@@ -307,8 +307,8 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
                             .html(link.linkTypeText);
 
                         linkG
-                            .on('mouseover', function () {
-                                d3.event.stopPropagation();
+                            .on('mouseover', function (event) {
+                                event.stopPropagation();
                                 showLegendTooltip(link, this);
                             })
                             .on('mouseout', hideLegendTooltip);
@@ -346,22 +346,22 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
                     const nodesElements = CDS.createNodes(nodeData, nodeRadius);
 
                     nodesElements
-                        .on('click', (d) => {
+                        .on('click', (event, d) => {
                             scope.childContext.selectNode(d);
 
                             // position the tooltip according to the node!
                             const tooltip = d3.select('.nodetooltip');
                             const windowWidth = $(window).width();
-                            if (d3.event.pageX < windowWidth / 2) {
+                            if (event.pageX < windowWidth / 2) {
                                 // left
-                                tooltip.style("left", d3.event.pageX + "px");
+                                tooltip.style("left", event.pageX + "px");
                                 tooltip.style("right", "");
                             } else {
                                 // right
                                 tooltip.style("left", "");
-                                tooltip.style("right", (windowWidth - d3.event.pageX) + "px");
+                                tooltip.style("right", (windowWidth - event.pageX) + "px");
                             }
-                            tooltip.style("top", (d3.event.pageY - 28) + "px");
+                            tooltip.style("top", (event.pageY - 28) + "px");
                         });
                     CDS.updateNodes(nodesElements);
                     CDS.positionNodesOnClusterZone(nodesElements, clusterZoneX, clusterZoneY, clusterZoneRadius);

--- a/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -72,12 +72,12 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
     var container;
     var INITIAL_CONTAINER_TRANSFORM = d3.zoomIdentity.translate(0, -70).scale(1);
 
-    function zoomed() {
+    function zoomed(event) {
         if (GuidesService.isActive()) {
             // disable zooming if a guide is active.
             return;
         }
-        transformValues = d3.event.transform;
+        transformValues = event.transform;
         container.attr("transform", transformValues);
     }
 
@@ -1232,8 +1232,8 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
         .style("fill", "none")
         .style("pointer-events", "all")
         .call(zoomLayout)
-        .on("click", function () {
-            d3.event.stopPropagation();
+        .on("click", function (event) {
+            event.stopPropagation();
             removeMenuIfVisible();
             // Clicking outside the graph stops the layout
             force.stop();
@@ -1378,9 +1378,9 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
         svg.call(tip);
 
         // Shows like tooltip list of predicates but with a slight delay
-        const showPredicateToolTip = function (d) {
+        const showPredicateToolTip = function (event, d) {
             $timeout.cancel(tipPredicateTimer);
-            const thisPredicateTipElement = tipPredicateElement = d3.event.target;
+            const thisPredicateTipElement = tipPredicateElement = event.target;
             $timeout(function () {
                 if (tipPredicateElement === thisPredicateTipElement && d.predicates.length > 1) {
                     tipPredicates.show(d, tipPredicateElement);
@@ -1468,14 +1468,14 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
             .attr("dy", "-0.5em")
             .style("text-anchor", "middle")
             .style("display", getSettings()['showLinksText'] ? "" : "none")
-            .on("mouseover", function (d) {
-                d3.event.stopPropagation();
-                showPredicateToolTip(d);
+            .on("mouseover", function (event, d) {
+                event.stopPropagation();
+                showPredicateToolTip(event, d);
             })
             .on('mouseout', hidePredicateToolTip)
-            .on("click", function (d) {
-                d3.event.stopPropagation();
-                linkActions(d);
+            .on("click", function (event, d) {
+                event.stopPropagation();
+                linkActions(event, d);
             });
 
         // node events and variables
@@ -1486,12 +1486,11 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
         let clickTarget = null;
 
         // track single and double click events
-        const clickEventHandler = function (d) {
-            if (d3.event.button && d3.event.button !== 0) {
+        const clickEventHandler = function (event, d) {
+            if (event.button && event.button !== 0) {
                 return;
             }
 
-            const event = d3.event;
             const element = this;
 
             if (singleClickTimer && clickTarget === element) {
@@ -1542,9 +1541,8 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
             moveEventCount++;
         };
 
-        const showNodeTipAndIcons = function (d) {
+        const showNodeTipAndIcons = function (event, d) {
             if (!d.isBeingDragged) {
-                const event = d3.event;
                 $timeout.cancel(removeIconsTimer);
                 showNodeTipAndIconsTimer = $timeout(() => {
                     if (expandNodeIcons(d, this)) {
@@ -1638,13 +1636,13 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
         }
 
         // Unfixes nodes that were dragged previously
-        const rightClickHandler = function (d) {
-            if (d3.event.shiftKey) {
+        const rightClickHandler = function (event, d) {
+            if (event.shiftKey) {
                 // Do nothing with shift key, use to access context menu
                 return;
             }
 
-            d3.event.preventDefault();
+            event.preventDefault();
 
             removeMenuIfVisible();
             $scope.closeInfoPanel();
@@ -1676,12 +1674,12 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
             .on("end", dragended);
 
 
-        function dragstarted(d) {
+        function dragstarted(event, d) {
             if (GuidesService.isActive()) {
                 // disable dragging if a guide is active.
                 return;
             }
-            if (d3.event.sourceEvent.button === 0) {
+            if (event.sourceEvent.button === 0) {
                 d.fixedBeforeDrag = d.fixed;
                 d.isBeingDragged = true;
                 d.beginDragging = true;
@@ -1691,10 +1689,10 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
             }
         }
 
-        function dragged(d) {
+        function dragged(event, d) {
             if (d.isBeingDragged) {
-                d.fx = d3.event.x;
-                d.fy = d3.event.y;
+                d.fx = event.x;
+                d.fy = event.y;
                 if (!d.fixed) {
                     $scope.numberOfPinnedNodes++;
                     d.fixed = true;
@@ -1707,7 +1705,7 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
             }
         }
 
-        function dragended(d) {
+        function dragended(event, d) {
             if (d.isBeingDragged) {
                 if (d.pinWasFixed) {
                     d.pinWasFixed = null;
@@ -2161,8 +2159,8 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
             // init action tips on hover of the icons
             const actionsTip = d3tip()
                 .attr('class', 'd3-tip d3-actions-tip')
-                .customPosition(function () {
-                    const bbox = d3.event.target.getBoundingClientRect();
+                .customPosition(function (d, event) {
+                    const bbox = event.target.getBoundingClientRect();
                     return {
                         top: (bbox.top - 20) + 'px',
                         left: (bbox.right + 10) + 'px'
@@ -2191,8 +2189,8 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
 
                 this.collapseIcon.on("click", function () {
                     collapseNode(node);
-                }).on('mouseover', function () {
-                    actionsTip.show(this.getAttribute("name"));
+                }).on('mouseover', function (event) {
+                    actionsTip.show(this.getAttribute("name"), event);
                     $timeout.cancel(showNodeTipAndIconsTimer);
                     $timeout.cancel(removeIconsTimer);
                 }).on('mouseout', function () {
@@ -2219,8 +2217,8 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
 
                 this.expandIcon.on("click", function () {
                     expandNode(node, false, parentNode);
-                }).on('mouseover', function () {
-                    actionsTip.show(this.getAttribute("name"));
+                }).on('mouseover', function (event) {
+                    actionsTip.show(this.getAttribute("name"), event);
                     $timeout.cancel(removeIconsTimer);
                     $timeout.cancel(showNodeTipAndIconsTimer);
                 }).on('mouseout', function () {
@@ -2249,8 +2247,8 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
 
             this.focusIcon.on("click", function () {
                 $rootScope.$broadcast("onRootNodeChange", node.iri);
-            }).on('mouseover', function () {
-                actionsTip.show(this.getAttribute("name"));
+            }).on('mouseover', function (event) {
+                actionsTip.show(this.getAttribute("name"), event);
                 $timeout.cancel(removeIconsTimer);
                 $timeout.cancel(showNodeTipAndIconsTimer);
             }).on('mouseout', function () {
@@ -2279,8 +2277,8 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
                 copyToClipboard(node.iri);
                 removeMenuIfVisible();
                 actionsTip.hide();
-            }).on('mouseover', function () {
-                actionsTip.show("<div style='text-align: center;'><b>Copy to ClipBoard</b><br>" + node.iri + "</div>");
+            }).on('mouseover', function (event) {
+                actionsTip.show("<div style='text-align: center;'><b>Copy to ClipBoard</b><br>" + node.iri + "</div>", event);
                 $timeout.cancel(removeIconsTimer);
                 $timeout.cancel(showNodeTipAndIconsTimer);
             }).on('mouseout', function () {
@@ -2307,8 +2305,8 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
 
             this.closeIcon.on("click", function () {
                 hideNode(node);
-            }).on('mouseover', function () {
-                actionsTip.show(this.getAttribute("name"));
+            }).on('mouseover', function (event) {
+                actionsTip.show(this.getAttribute("name"), event);
                 $timeout.cancel(removeIconsTimer);
                 $timeout.cancel(showNodeTipAndIconsTimer);
             }).on('mouseout', function () {
@@ -2650,14 +2648,14 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
         }
     }
 
-    function linkActions(d) {
+    function linkActions(event, d) {
         revertElementsStyleToDefault();
         let linkId = convertLinkDataToLinkId(d);
         if (d.predicates.length === 1 && graph.tripleNodes.has(linkId)) {
             openedLink = null;
             let tripleNode = graph.tripleNodes.get(linkId)[0];
             // If there is a triple in this link, show its properties
-            if (clickedNode(tripleNode, this, d3.event.button)) {
+            if (clickedNode(tripleNode, this, event.button)) {
                 let nodeCopy = {};
                 nodeCopy.iri = tripleNode.iri;
                 nodeCopy.pred = getShortPredicate(tripleNode.iri.split(' ')[1]);

--- a/src/js/angular/graphexplore/directives/dependencies-chord.directive.js
+++ b/src/js/angular/graphexplore/directives/dependencies-chord.directive.js
@@ -30,7 +30,7 @@ function dependenciesChordDirective($repositories, GraphDataRestService) {
                 return;
             }
 
-            const fill = d3.scaleOrdinal(d3.schemeCategory20);
+            const fill = d3.scaleOrdinal(d3.schemeCategory10);
 
             const tooltip = d3.select("body").append("div")
                 .attr("class", "tooltip")
@@ -132,11 +132,11 @@ function dependenciesChordDirective($repositories, GraphDataRestService) {
                 d3.select(this).style("fill-opacity", ".67");
             });
 
-            chord.on("click", function (d) {
+            chord.on("click", function (event, d) {
                 const sourceClass = nodes[d.source.index];
                 const destinationClass = nodes[d.target.index];
-                const px = d3.event.pageX;
-                const py = d3.event.pageY;
+                const px = event.pageX;
+                const py = event.pageY;
 
                 GraphDataRestService.getPredicates(sourceClass, destinationClass, scope.selectedGraph && scope.selectedGraph.contextID.uri)
                     .success(function (predicatesData) {
@@ -162,7 +162,9 @@ function dependenciesChordDirective($repositories, GraphDataRestService) {
                     .style("opacity", 1);
             });
 
-            function mouseover(d, i) {
+            function mouseover() {
+                const nodes = group.nodes();
+                const i = nodes.indexOf(this);
                 chord.classed("fade", function (p) {
                     return p.source.index !== i
                         && p.target.index !== i;

--- a/src/js/angular/graphexplore/directives/domain-range-graph.directive.js
+++ b/src/js/angular/graphexplore/directives/domain-range-graph.directive.js
@@ -453,7 +453,7 @@ function domainRangeGraphDirective($rootScope, $window, $repositories, GraphData
                     $("#domain-range").bind("click", disableCollapsedPredicateLabelHightlighting);
                 });
 
-                function onCollapsedPropertyNameClick(d) {
+                function onCollapsedPropertyNameClick(event, d) {
                     disableCollapsedPredicateLabelHightlighting();
                     previousPropertyNameSelection.text = d3.select(this);
 
@@ -465,7 +465,7 @@ function domainRangeGraphDirective($rootScope, $window, $repositories, GraphData
                         scope.showPredicatesInfoPanel = true;
                         scope.selectedPredicate = d;
                     });
-                    d3.event.stopPropagation();
+                    event.stopPropagation();
                 }
 
 
@@ -501,7 +501,7 @@ function domainRangeGraphDirective($rootScope, $window, $repositories, GraphData
                         } else {
                             // for regular predicate labels just attach a link to the "Resources" view
                             // for more helpful information regarding them
-                            sel.on("click", function (d) {
+                            sel.on("click", function (event, d) {
                                 $window.open("resource?uri=" + encodeURIComponent(d.uri), "_blank");
                             });
                         }
@@ -530,8 +530,8 @@ function domainRangeGraphDirective($rootScope, $window, $repositories, GraphData
                         }
                         return "translate(-" + translateX + ",-" + (textPadding + d.calculatedHeight / 2) + ")";
                     })
-                    .on("click", function (d) {
-                        d3.event.stopPropagation();
+                    .on("click", function (event) {
+                        event.stopPropagation();
                     });
 
 
@@ -568,7 +568,7 @@ function domainRangeGraphDirective($rootScope, $window, $repositories, GraphData
                     .call(drag);
 
 
-                function reloadDomainRangeGraphView(d, collapsed) {
+                function reloadDomainRangeGraphView(event, d, collapsed) {
                     scope.$apply(function () {
                         $rootScope.$broadcast('reloadDomainRangeGraphView', d, collapsed);
                     });
@@ -590,7 +590,7 @@ function domainRangeGraphDirective($rootScope, $window, $repositories, GraphData
                     .text(function (d) {
                         return d.objectPropClassName;
                     })
-                    .on("click", function (d) {
+                    .on("click", function (event, d) {
                         $window.open("resource?uri=" + encodeURIComponent(d.objectPropClassUri), "_blank");
                     });
 
@@ -605,7 +605,7 @@ function domainRangeGraphDirective($rootScope, $window, $repositories, GraphData
                                 return D3.Text.calcFontSize(classNodeLabel, mainClassSize)
                             })
                             .text(classNodeLabel)
-                            .on("click", function (d) {
+                            .on("click", function () {
                                 $window.open("resource?uri=" + encodeURIComponent(selectedRdfUri), "_blank");
                             });
                     });
@@ -919,33 +919,28 @@ function domainRangeGraphDirective($rootScope, $window, $repositories, GraphData
 
         let isDragged = false;
 
-        function dragStart() {
-            const event = d3.event;
-
+        function dragStart(event, d) {
             force.stop();
-            event.subject.fx = event.x;
-            event.subject.fy = event.y;
+            d.fx = event.x;
+            d.fy = event.y;
             d3.select(this).classed("selected", true);
 
         }
 
         // Update the subject (dragged node) position during drag.
-        function dragged() {
+        function dragged(event, d) {
             isDragged = true;
 
             force.alphaTarget(0).restart();
-            const event = d3.event;
-            event.subject.fx = event.x;
-            event.subject.fy = event.y;
+            d.fx = event.x;
+            d.fy = event.y;
         }
 
         // Restore the target alpha so the simulation cools after dragging ends.
         // Unfix the subject position now that it’s no longer being dragged.
-        function dragEnd() {
-            const event = d3.event;
-
-            event.subject.fx = null;
-            event.subject.fy = null;
+        function dragEnd(event, d) {
+            d.fx = null;
+            d.fy = null;
             d3.select(this).classed("selected", false);
             if (isDragged) {
                 force.alpha(0.2).restart();

--- a/src/js/angular/graphexplore/directives/rdf-class-hierarchy.directive.js
+++ b/src/js/angular/graphexplore/directives/rdf-class-hierarchy.directive.js
@@ -171,11 +171,11 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
             if (!tip) {
                 tip = d3tip()
                     .attr('class', 'd3-tip')
-                    .customPosition(function (d) {
+                    .customPosition(function (d, event) {
                         return {
                             top: 'inherit',
-                            bottom: ($window.innerHeight - d3.event.clientY) + 'px',
-                            right: ($window.innerWidth - d3.event.clientX) + 'px'
+                            bottom: ($window.innerHeight - event.clientY) + 'px',
+                            right: ($window.innerWidth - event.clientX) + 'px'
                         };
                     })
                     .html(function (d) {
@@ -216,13 +216,13 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
                         flattenedClassData[[key]] = d;
 
                         d.circle.classed("rdf-class", true);
-                        d.circle.on('mouseover', function () {
+                        d.circle.on('mouseover', function (event) {
                             if (config.noPrefixes) {
-                                tip.show(d);
+                                tip.show(d, event);
                             } else if (!d.textHidden) {
                                 tip.hide(d);
                             } else {
-                                tip.show(d);
+                                tip.show(d, event);
                             }
                         });
                         d.circle.on('mouseout', tip.hide);
@@ -283,7 +283,7 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
                 //do not stop event propagation here
             };
 
-            clickCancel.on("click", function (obj) {
+            clickCancel.on("click", function (event, obj) {
                 // add clicked class to browser history
                 if (obj.data.id) {
                     $window.history.pushState({id: obj.data.id}, "classHierarchyPage" + obj.data.id, "hierarchy#" + obj.data.id);
@@ -295,7 +295,7 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
                 doFocus(obj);
             });
 
-            clickCancel.on("dblclick", function (obj) {
+            clickCancel.on("dblclick", function (event, obj) {
                 if (obj === root) {
                     return;
                 }
@@ -304,17 +304,16 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
                 getCurrentClassDataAndMarkSelected(obj);
                 goToDomainRangeGraphView();
 
-                d3.event.stopPropagation();
+                event.stopPropagation();
             });
 
             var lastTimeWheel = 0;
-            svg.on('wheel', function () {
+            svg.on('wheel', function (event) {
                 // hide current d3-tip tooltip
                 tip.hide();
 
-                var e = d3.event;
-                e.preventDefault();
-                e.stopPropagation();
+                event.preventDefault();
+                event.stopPropagation();
 
                 // at least 100ms must have passed since last time we updated
                 var now = new Date().getTime();
@@ -325,13 +324,13 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
                 }
 
                 var direction = '';
-                if (e.deltaY <= -1) {
+                if (event.deltaY <= -1) {
                     direction = 'in';
-                } else if (e.deltaY >= 1) {
+                } else if (event.deltaY >= 1) {
                     direction = 'out';
                 }
 
-                var obj = e.target.__data__;
+                var obj = event.target.__data__;
 
                 if (!obj) {
                     // scroll outside the big circle

--- a/src/js/lib/common/d3-utils.js
+++ b/src/js/lib/common/d3-utils.js
@@ -88,7 +88,7 @@ D3.Transition = function () {
 
 D3.Click = function () {
     function delayDblClick() {
-        var event = d3.dispatch('click', 'dblclick');
+        var dispatchedEvent = d3.dispatch('click', 'dblclick');
 
         function cc(selection) {
             var down,
@@ -102,30 +102,30 @@ D3.Click = function () {
             }
 
             selection.on('mousedown', function () {
-                down = d3.mouse(document.body);
+                down = d3.pointer(document.body);
                 last = +new Date();
             });
-            selection.on('mouseup', function (d) {
-                if (dist(down, d3.mouse(document.body)) > tolerance) {
+            selection.on('mouseup', function (event, d) {
+                if (dist(down, d3.pointer(document.body)) > tolerance) {
                     return;
                 } else {
                     if (wait) {
                         window.clearTimeout(wait);
                         wait = null;
-                        event.call('dblclick', d3.event, d);
+                        dispatchedEvent.call('dblclick', event, event, d);
                     } else {
                         wait = window.setTimeout((function (e) {
                             return function () {
-                                event.call('click', e, d)
+                                dispatchedEvent.call('click', e, e, d)
                                 wait = null;
                             };
-                        })(d3.event), 250);
+                        })(event), 250);
                     }
                 }
             });
         }
 
-        return rebind(cc, event, 'on');
+        return rebind(cc, dispatchedEvent, 'on');
     }
 
     // Copies a variable number of methods from source to target.

--- a/src/js/lib/d3-tip/d3-tip-patch.js
+++ b/src/js/lib/d3-tip/d3-tip-patch.js
@@ -44,7 +44,8 @@ var d3tip = function () {
             .style('pointer-events', 'all')
 
         while (i--) nodel.classed(directions[i], false)
-        coords = direction_callbacks.get(dir).apply(this)
+        const event = args.filter((arg) => arg instanceof Event);
+        coords = direction_callbacks.get(dir).apply(this, event)
 
         if (customPos) {
             Object.keys(customPos).forEach(function (key) {
@@ -172,7 +173,7 @@ var d3tip = function () {
         return ' '
     }
 
-    var direction_callbacks = d3.map({
+    var direction_callbacks = new Map(Object.entries({
             n: direction_n,
             s: direction_s,
             e: direction_e,
@@ -181,68 +182,67 @@ var d3tip = function () {
             ne: direction_ne,
             sw: direction_sw,
             se: direction_se
-        }),
-
+        })),
         directions = direction_callbacks.keys()
 
-    function direction_n() {
-        var bbox = getScreenBBox()
+    function direction_n(event) {
+        var bbox = getScreenBBox(event)
         return {
             top: bbox.n.y - node.offsetHeight,
             left: bbox.n.x - node.offsetWidth / 2
         }
     }
 
-    function direction_s() {
-        var bbox = getScreenBBox()
+    function direction_s(event) {
+        var bbox = getScreenBBox(event)
         return {
             top: bbox.s.y,
             left: bbox.s.x - node.offsetWidth / 2
         }
     }
 
-    function direction_e() {
-        var bbox = getScreenBBox()
+    function direction_e(event) {
+        var bbox = getScreenBBox(event)
         return {
             top: bbox.e.y - node.offsetHeight / 2,
             left: bbox.e.x
         }
     }
 
-    function direction_w() {
-        var bbox = getScreenBBox()
+    function direction_w(event) {
+        var bbox = getScreenBBox(event)
         return {
             top: bbox.w.y - node.offsetHeight / 2,
             left: bbox.w.x - node.offsetWidth
         }
     }
 
-    function direction_nw() {
-        var bbox = getScreenBBox()
+    function direction_nw(event) {
+        var bbox = getScreenBBox(event)
         return {
             top: bbox.nw.y - node.offsetHeight,
             left: bbox.nw.x - node.offsetWidth
         }
     }
 
-    function direction_ne() {
-        var bbox = getScreenBBox()
+    function direction_ne(event) {
+        var bbox = getScreenBBox(event)
         return {
             top: bbox.ne.y - node.offsetHeight,
             left: bbox.ne.x
         }
     }
 
-    function direction_sw() {
-        var bbox = getScreenBBox()
+    function direction_sw(event) {
+        var bbox = getScreenBBox(event)
         return {
             top: bbox.sw.y,
             left: bbox.sw.x - node.offsetWidth
         }
     }
 
-    function direction_se() {
-        var bbox = getScreenBBox()
+    function direction_se(event) {
+        var bbox = getScreenBBox(event)
         return {
             top: bbox.se.y,
             left: bbox.e.x
@@ -291,8 +291,8 @@ var d3tip = function () {
     //    +-+-+
     //
     // Returns an Object {n, s, e, w, nw, sw, ne, se}
-    function getScreenBBox() {
-        var targetel = target || d3.event.target;
+    function getScreenBBox(event) {
+        var targetel = target || event.target;
 
         while ('undefined' === typeof targetel.getScreenCTM && 'undefined' === targetel.parentNode) {
             targetel = targetel.parentNode;

--- a/src/js/lib/d3.patch.js
+++ b/src/js/lib/d3.patch.js
@@ -1,4 +1,4 @@
-define(['d3/build/d3'],
+define(['d3'],
     function() {
         /* nvd3 version 1.8.6 (https://github.com/novus/nvd3) 2017-08-23 */
         (function() {


### PR DESCRIPTION
## What
Update the D3 library to latest version v7

## Why
There is a vulnerability in d3-color package in the used D3 v3 library. The vulnerability is fixed and released with D3 v7.8.5. Since there are major breaking changes in v4, a migration first to v4 and then to v7.

## How
- refactored directives and controllers to update to D3 v7.8.5 (latest)