### PR TITLE
GDB-9117 fix jdbc preview table results

### DIFF
--- a/src/js/angular/core/services/repositories.service.js
+++ b/src/js/angular/core/services/repositories.service.js
@@ -320,6 +320,12 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
             return this.locations.find((location) => location.uri === locationUri);
         };
 
+        this.setRepositoryHeaders = function (repository) {
+            $.ajaxSetup()['headers'] = $.ajaxSetup()['headers'] || {};
+            $.ajaxSetup()['headers']['X-GraphDB-Repository'] = repository ? repository.id : undefined;
+            $.ajaxSetup()['headers']['X-GraphDB-Repository-Location'] = repository ? repository.location : undefined;
+        };
+
         this.setRepository = function (repo) {
             if (repo) {
                 LocalStorageAdapter.set(LSKeys.REPOSITORY_ID, repo.id);
@@ -328,6 +334,7 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
                 LocalStorageAdapter.remove(LSKeys.REPOSITORY_ID);
                 LocalStorageAdapter.remove(LSKeys.REPOSITORY_LOCATION);
             }
+            this.setRepositoryHeaders(repo);
             $rootScope.$broadcast('repositoryIsSet', {newRepo: true});
 
             // if the current repo is unreadable by the currently logged in user (or free access user)

--- a/src/js/angular/jdbc/controllers.js
+++ b/src/js/angular/jdbc/controllers.js
@@ -452,6 +452,12 @@ function JdbcCreateCtrl($scope, $location, toastr, $repositories, $window, $time
         $scope.executedQueryTab = $scope.currentQuery;
 
         if (!$scope.queryIsRunning) {
+            // set proper headers because on page reload these might not be present until active repository is not
+            // changed via the menu
+            $.ajaxSetup()['headers'] = $.ajaxSetup()['headers'] || {};
+            const repositoryConfig = $repositories.getActiveRepositoryObject();
+            $.ajaxSetup()['headers']['X-GraphDB-Repository'] = repositoryConfig ? repositoryConfig.id : undefined;
+            $.ajaxSetup()['headers']['X-GraphDB-Repository-Location'] = repositoryConfig ? repositoryConfig.location : undefined;
             $scope.currentQuery.outputType = 'table';
             $scope.resetCurrentTabConfig();
 
@@ -475,10 +481,10 @@ function JdbcCreateCtrl($scope, $location, toastr, $repositories, $window, $time
                     columns: $scope.currentQuery.columns || []
                 });
                 JdbcRestService.getNewSqlTablePreview(sqlView)
-                    .then(successCallback).catch(failCallback);
+                    .done(successCallback).fail(failCallback);
             } else {
                 JdbcRestService.getExistingSqlTablePreview($scope.currentQuery.name)
-                    .then(successCallback).catch(failCallback);
+                    .done(successCallback).fail(failCallback);
             }
         }
     };

--- a/src/js/angular/rest/jdbc.rest.service.js
+++ b/src/js/angular/rest/jdbc.rest.service.js
@@ -82,7 +82,7 @@ function JdbcRestService($http, $translate) {
     }
     function getExistingSqlTablePreview(name, limit) {
         // Limit in preview is optional. On backend default value is set to 100
-        return $http({
+        return $.ajax({
             method: 'GET',
             url: `rest/sql-views/preview/${name}`,
             params: {
@@ -93,7 +93,7 @@ function JdbcRestService($http, $translate) {
 
     function getNewSqlTablePreview(sqlView, limit) {
         // Limit in preview is optional. On backend default value is set to 100
-        return $http({
+        return $.ajax({
             method: 'POST',
             url: "rest/sql-views/preview",
             contentType: "application/json; charset=utf-8",

--- a/test-cypress/integration/setup/jdbc.spec.js
+++ b/test-cypress/integration/setup/jdbc.spec.js
@@ -33,7 +33,12 @@ describe('JDBC configuration', () => {
     let repositoryId;
 
     beforeEach(() => {
-        initRepositoryAndVisitJdbcView();
+        repositoryId = 'jdbc-repo-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        cy.importServerFile(repositoryId, FILE_TO_IMPORT);
+        cy.visit('/jdbc');
+        cy.window();
     });
 
     afterEach(() => {
@@ -41,33 +46,34 @@ describe('JDBC configuration', () => {
     });
 
     it('Configuration table preview', () => {
-        //cy.visit('/jdbc');
         // SQL configuration table should be visible
         getConfigurationList().should('be.visible');
     });
 
-    //TODO Fix falling test
-    it.skip('Should create a new JDBC configuration, edit, preview, then delete', () => {
+    it('Should create a new JDBC configuration, edit, preview, then delete', () => {
         getCreateNewJDBCConfigurationButon().click();
         cy.pasteQuery(QUERY);
         getJDBCConfigNameField().type(JDBC_CONFIG_NAME);
-        getColumnTypesTab().click(); //switch to SQL columns config tab
 
-        //verify columns length and content
+        // switch to SQL columns config tab
+        getColumnTypesTab().click();
+        // verify columns length and content
         getSQLTableRows().should('have.length', 4);
         getSQLTableConfig()
             .should('be.visible')
             .and('contain', 'sentiment_score');
 
         getSaveButton().click();
-        getConfigurationList().should('contain', JDBC_CONFIG_NAME); //verify config is created
+        // verify config is created
+        getConfigurationList().should('contain', JDBC_CONFIG_NAME);
         getEditButton().click();
+        // used to verify that the input field is active
+        typeQuery("{downarrow}");
 
-        typeQuery("{downarrow}"); //used to verify that the input field is active
-        getPreviewButton().click({force:true}); //click preview button
+        getPreviewButton().click();
         getLoader().should('not.exist');
 
-        //verify results content
+        // verify results content
         getPreviewTable()
             .should('be.visible')
             .and('contain', 'SENTIMENT_SCORE')
@@ -75,135 +81,126 @@ describe('JDBC configuration', () => {
             .and('contain', 'ID')
             .and('contain', 'FRAUD_SCORE');
 
-        //clear current query and paste the edited one, to test the suggest functionality
+        // clear current query and paste the edited one, to test the suggest functionality
         clearQuery();
         cy.pasteQuery(EDIT_QUERY);
         getColumnTypesTab().click();
-        getSuggestButton().click({force:true}); //click suggest button to update the changes from the second query
+        // click suggest button to update the changes from the second query
+        getSuggestButton().click();
         getConfirmSuggestButton().click();
-
-        //verify columns length and content
+        // verify columns length and content
         getSQLTableRows().should('have.length', 3);
         getSQLTableConfig()
             .should('be.visible')
             .and('not.contain', 'sentiment_score');
         getSaveButton().click();
-        getEditButton().click();
 
-        //Verify that changes have been applied upon saving
-        typeQuery("{downarrow}"); //used to verify that the input field is active
-        getPreviewButton().click({force:true}); //click preview button
+        getEditButton().click();
+        // Verify that changes have been applied upon saving
+        // used to verify that the input field is active
+        typeQuery("{downarrow}");
+        getPreviewButton().click();
         getLoader().should('not.exist');
 
-        //verify results content
+        // verify results content
         getPreviewTable()
             .should('be.visible')
-            .and('not.contain', 'SENTIMENT_SCORE')
-            .and('contain', 'CUSTOMER_LOYALTY')
             .and('contain', 'ID')
-            .and('contain', 'FRAUD_SCORE');
-        getCancelButton().click();
+            .and('contain', 'FRAUD_SCORE')
+            .and('contain', 'CUSTOMER_LOYALTY');
 
-        //Delete jdbc configuration
+        getCancelButton().click();
+        // Delete jdbc configuration
         cy.get('.jdbc-list-configurations').should('be.visible');
         getDeleteButton().click();
         getConfirmDialogButton().click();
-        getConfigurationList().should('contain', 'No Indexes');
+        getConfigurationList().should('contain', 'No tables are defined');
     });
-
-    function initRepositoryAndVisitJdbcView() {
-        repositoryId = 'jdbc-repo-' + Date.now();
-        cy.createRepository({id: repositoryId});
-        cy.presetRepository(repositoryId);
-        cy.importServerFile(repositoryId, FILE_TO_IMPORT);
-        cy.visit('/jdbc');
-        cy.window();
-    }
-
-    function getCreateNewJDBCConfigurationButon() {
-        return cy.get('.create-sql-table-configuration');
-    }
-
-    function getJDBCConfigNameField() {
-        return cy.get('.sql-table-name');
-    }
-
-    function getQueryArea() {
-        return cy.get('.CodeMirror');
-    }
-
-    function getQueryTextArea() {
-        return getQueryArea().find('textarea');
-    }
-
-    function typeQuery(query) {
-        // getQueryTextArea().invoke('val', query).trigger('change', {force: true});
-        getQueryTextArea().type(query, {force: true});
-        cy.waitUntilQueryIsVisible();
-    }
-
-    function clearQuery() {
-        // Using force because the textarea is not visible
-        getQueryTextArea().type(Cypress.env('modifierKey') + 'a{backspace}', {force: true});
-    }
-
-    function getColumnTypesTab() {
-        return cy.get('.nav-tabs').contains("Column types");
-    }
-
-    function getDataQueryTab() {
-        return cy.get('.nav-tabs').contains("Data query");
-    }
-
-    function getSaveButton() {
-        return cy.get('.save-query-btn');
-    }
-
-    function getDeleteButton() {
-        return cy.get('.icon-trash');
-    }
-
-    function getCancelButton() {
-        return cy.get('.cancel-query-btn');
-    }
-
-    function getConfirmDialogButton() {
-        return cy.get('.btn-primary');
-    }
-
-    function getConfigurationList() {
-        return cy.get('.jdbc-list-configurations');
-    }
-
-    function getEditButton() {
-        return cy.get('.icon-edit');
-    }
-
-    function getSQLTableRows() {
-        return cy.get('div.form-group.row.pt-1.ng-scope');
-    }
-
-    function getPreviewButton() {
-        return cy.get('.preview-btn');
-    }
-
-    function getSuggestButton(){
-        return cy.get('.sql-table-config .preview-btn');
-    }
-
-    function getConfirmSuggestButton() {
-        return cy.get('.confirm-btn');
-    }
-
-    function getLoader() {
-        return cy.get('.ot-loader-new-content');
-    }
-
-    function getPreviewTable() {
-        return cy.get('.resultsTable');
-    }
-
-    function getSQLTableConfig() {
-        return cy.get('.sql-table-config');
-    }
 });
+
+function getCreateNewJDBCConfigurationButon() {
+    return cy.get('.create-sql-table-configuration');
+}
+
+function getJDBCConfigNameField() {
+    return cy.get('.sql-table-name');
+}
+
+function getQueryArea() {
+    return cy.get('.CodeMirror');
+}
+
+function getQueryTextArea() {
+    return getQueryArea().find('textarea');
+}
+
+function typeQuery(query) {
+    // getQueryTextArea().invoke('val', query).trigger('change', {force: true});
+    getQueryTextArea().type(query, {force: true});
+    cy.waitUntilQueryIsVisible();
+}
+
+function clearQuery() {
+    // Using force because the textarea is not visible
+    getQueryTextArea().type(Cypress.env('modifierKey') + 'a{backspace}', {force: true});
+}
+
+function getColumnTypesTab() {
+    return cy.get('.nav-tabs').contains("Column types");
+}
+
+function getDataQueryTab() {
+    return cy.get('.nav-tabs').contains("Data query");
+}
+
+function getSaveButton() {
+    return cy.get('.save-query-btn');
+}
+
+function getDeleteButton() {
+    return cy.get('.icon-trash');
+}
+
+function getCancelButton() {
+    return cy.get('.cancel-query-btn');
+}
+
+function getConfirmDialogButton() {
+    return cy.get('.btn-primary');
+}
+
+function getConfigurationList() {
+    return cy.get('.jdbc-list-configurations');
+}
+
+function getEditButton() {
+    return cy.get('.icon-edit');
+}
+
+function getSQLTableRows() {
+    return cy.get('div.form-group.row.pt-1.ng-scope');
+}
+
+function getPreviewButton() {
+    return cy.get('.preview-btn');
+}
+
+function getSuggestButton() {
+    return cy.get('.sql-table-config .preview-btn');
+}
+
+function getConfirmSuggestButton() {
+    return cy.get('.confirm-btn');
+}
+
+function getLoader() {
+    return cy.get('.ot-loader-new-content');
+}
+
+function getPreviewTable() {
+    return cy.get('.resultsTable');
+}
+
+function getSQLTableConfig() {
+    return cy.get('.sql-table-config');
+}


### PR DESCRIPTION
## What
Fix jdbc preview table results.

## Why
It was broken during some refactoring a while ago with the https://ontotext.atlassian.net/browse/GDB-8813 and https://ontotext.atlassian.net/browse/GDB-8644. The refactoring removed the http headers for repository and location for the jquery ajax api and then also moved the headers application into the authentication interceptor which were correct and good changes, but it wasn't accounted that for the case in jdbc view the preview request was made with jquery ajax because the response was passed directly to the yasr which expected it to in the format as jquery returned it. So migrating the code to use angular's http service for the request and then headers configuration broke it completely.

## How
* Reverted setting the jquery.ajax header configuration with the repository and location headers.
* Reverted the usage of jquery.ajax for issuing requests for jdbc tables preview.
* Fixed tests