### PR TITLE
GDB-9118 hide all yasr plugin tabs if configured via showResultTabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.1",
+                "ontotext-yasgui-web-component": "1.1.2",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -9973,9 +9973,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.1.tgz",
-            "integrity": "sha512-UEJ/A5iaNgChNfuoXG/zpLRaTGzihGISScH40X2Z9eqN0BXBHow6EMRqtNQQB4J8yMulabfNaOsJX9yVzmRE0Q==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.2.tgz",
+            "integrity": "sha512-SZtGkrilSnN3hJpmKpHU5T+AidGgxgBYprVntinGjZ3F4ILx7wDWd+g+O1o0/AfBHpdJ4aHZ9KZ9aZnrZnEAOw==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24544,9 +24544,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.1.tgz",
-            "integrity": "sha512-UEJ/A5iaNgChNfuoXG/zpLRaTGzihGISScH40X2Z9eqN0BXBHow6EMRqtNQQB4J8yMulabfNaOsJX9yVzmRE0Q==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.2.tgz",
+            "integrity": "sha512-SZtGkrilSnN3hJpmKpHU5T+AidGgxgBYprVntinGjZ3F4ILx7wDWd+g+O1o0/AfBHpdJ4aHZ9KZ9aZnrZnEAOw==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.1",
+        "ontotext-yasgui-web-component": "1.1.2",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/test-cypress/integration/resource/resource.spec.js
+++ b/test-cypress/integration/resource/resource.spec.js
@@ -14,8 +14,9 @@ const PREDICATE_SOURCE = 'http:%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23subCl
 const CONTEXT_EXPLICIT = 'http://www.ontotext.com/explicit';
 const OBJECT_RESOURCE = 'http:%2F%2Fexample.com%2Fontology%23Metric';
 const IMPLICIT_EXPLICIT_RESOURCE = 'http:%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23type';
+const TRIPLE_RESOURCE = '%3C%3C%3Chttp:%2F%2Fexample.com%2Fresource%2Fperson%2FW6J1827%3E%20%3Chttp:%2F%2Fexample.com%2Fontology%23hasAddress%3E%20%3Chttp:%2F%2Fexample.com%2Fresource%2Fperson%2FW6J1827%2Faddress%3E%3E%3E';
 
-describe.skip('Resource view', () => {
+describe('Resource view', () => {
     let repositoryId;
     beforeEach(() => {
         repositoryId = 'repository-' + Date.now();


### PR DESCRIPTION
## What
When `showResultTabs` flag for the yasgui component is set to `false` then all yasr plugins should be hidden.

## Why
There are some integration points like the explore (resource) view where only the yasr results table renderer should be displayed and no tabs should be visible. In the latest version of the yasgu component were introduced two new yasr plugins: charts and pivot table. These two plugins were not registered in the service which used to hide them when the flag is falsy.

## How
* The component was updated and the new version is integrated in the workbench
* Also enabled tests.