### PR TITLE
GDB-8247 improve styling of yasr table results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.2",
+                "ontotext-yasgui-web-component": "1.1.3",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -9973,9 +9973,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.2.tgz",
-            "integrity": "sha512-SZtGkrilSnN3hJpmKpHU5T+AidGgxgBYprVntinGjZ3F4ILx7wDWd+g+O1o0/AfBHpdJ4aHZ9KZ9aZnrZnEAOw==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.3.tgz",
+            "integrity": "sha512-MI8xo6+d56HFQmWL9dzuMi98GA9sDTW56irQjorZ5g6FNhkKvz5bsxUnJrBnfqAcFdQ1NAGOf0Z0OdxNhfwxwA==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24544,9 +24544,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.2.tgz",
-            "integrity": "sha512-SZtGkrilSnN3hJpmKpHU5T+AidGgxgBYprVntinGjZ3F4ILx7wDWd+g+O1o0/AfBHpdJ4aHZ9KZ9aZnrZnEAOw==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.3.tgz",
+            "integrity": "sha512-MI8xo6+d56HFQmWL9dzuMi98GA9sDTW56irQjorZ5g6FNhkKvz5bsxUnJrBnfqAcFdQ1NAGOf0Z0OdxNhfwxwA==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.2",
+        "ontotext-yasgui-web-component": "1.1.3",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Improve styling of yasr table results.

## Why
Cells holding literal values were not styled correctly to apply the ellipsis which resulted in value being cut off.

## How
Integrated the latest version of the ontotext yasgui component which improves the styling of the paragraphs inside literal cells in order for the ellipsis to work and also applied a title attribute to them so that when the value gets truncated, the user to still be able to see the whole value.