### PR TITLE
GDB-9114 fix download as menu styling for consistency with old yasgui

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -27,6 +27,11 @@ yasgui-component .yasqe_queryButton {
     background-color: var(--primary-color) !important;
 }
 
+yasgui-component .ontotext-dropdown-menu .ontotext-dropdown-menu-item {
+    padding: .5em 1.2em;
+    font-size: 1rem;
+}
+
 yasgui-component .ontotext-dropdown-button,
 yasgui-component .ontotext-dropdown-menu.open .ontotext-dropdown-menu-item {
     background-color: var(--primary-color) !important;


### PR DESCRIPTION
## What
Fix download as menu styling for consistency with old yasgui.

## Why
The dropdown menu items padding and font size were left default as in the ontotext yasgui component which resulted in different menu and menu items size.

## How
Overriding the menu items padding and font-size properties.