### PR TITLE
GDB-8994 reposition yasqe action buttons

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -10,7 +10,7 @@ yasgui-component .btn-orientation {
 }
 
 yasgui-component .yasqe .yasqe_buttons {
-    right: 12px;
+    right: 21px;
 }
 
 yasgui-component .custom-button {


### PR DESCRIPTION
## What
Reposition yasqe action buttons to prevent overlapping with the vertical scrollbar when it's present in the yasqe.

## Why
Yasqe buttons were placed too close to the right-side border of the editor which led to overlapping between the vertical scrollbar and the run query button.

## How
Increased the space between the buttons and the right-side editor border