### PR TITLE
GDB-8994 and GDB-9006 integrate latest fixes in ontottext yasgui component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.3",
+                "ontotext-yasgui-web-component": "1.1.4",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -9973,9 +9973,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.3.tgz",
-            "integrity": "sha512-MI8xo6+d56HFQmWL9dzuMi98GA9sDTW56irQjorZ5g6FNhkKvz5bsxUnJrBnfqAcFdQ1NAGOf0Z0OdxNhfwxwA==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.4.tgz",
+            "integrity": "sha512-EXoVa2AHUIbW4utcB8veksrOSx4VT0qmsCB3510tZPN++FsXMLrIrhBVqwR/USo7glLPQcPKN3gFerIaFech1A==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24544,9 +24544,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.3.tgz",
-            "integrity": "sha512-MI8xo6+d56HFQmWL9dzuMi98GA9sDTW56irQjorZ5g6FNhkKvz5bsxUnJrBnfqAcFdQ1NAGOf0Z0OdxNhfwxwA==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.4.tgz",
+            "integrity": "sha512-EXoVa2AHUIbW4utcB8veksrOSx4VT0qmsCB3510tZPN++FsXMLrIrhBVqwR/USo7glLPQcPKN3gFerIaFech1A==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.3",
+        "ontotext-yasgui-web-component": "1.1.4",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
* yasr ellipsis checkbox is disabled by default
* styling improvements in yasgui

## Why
* Trying to improve consistency with the old yasgui.
* Ellipsis should be unchecked by default by requirement.

## How
Integrated the latest released ontotext yasgui component version