### PR TITLE
GDB-9132 "Talk to Your Graph" user interface fails to read graphdb.external-url

### DIFF
--- a/src/js/angular/chatgpt/controllers.js
+++ b/src/js/angular/chatgpt/controllers.js
@@ -10,6 +10,8 @@ angular
 
 ChatGptCtrl.$inject = ['$scope', '$http', '$timeout', '$translate', '$uibModal', '$repositories', 'toastr', 'ModalService', 'LocalStorageAdapter'];
 
+const CHATGPTRETRIEVAL_ENDPOINT = 'rest/chat/retrieval';
+
 function ChatGptCtrl($scope, $http, $timeout, $translate, $uibModal, $repositories, toastr, ModalService, LocalStorageAdapter) {
     function scrollToEnd() {
         $timeout(() => {
@@ -82,7 +84,7 @@ function ChatGptCtrl($scope, $http, $timeout, $translate, $uibModal, $repositori
 
         const questionMsg = {"role": "question", "content": $scope.question};
 
-        $http.post(`/rest/chat/retrieval?repositoryID=${$repositories.getActiveRepository()}`, chatRequest).then((response) => {
+        $http.post(`${CHATGPTRETRIEVAL_ENDPOINT}?repositoryID=${$repositories.getActiveRepository()}`, chatRequest).then((response) => {
             $scope.history.pop();
             response.data.forEach((e) => $scope.history.push(e));
         }).catch((error) => {


### PR DESCRIPTION
What
404 failing request to rest/chat/retrieval when GraphDB started with external url.

Why
Hardcoded request does not take in consideration external url if provided.

How
Changed building request to rest/chat/retrieval to consider different path if provided.