### PR TITLE
GDB-9086: Usability improvements and cleanup

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -222,6 +222,7 @@ PluginRegistry.add('themes', {
         // A color used for the font/svg icons when placed on a primary color background.
         'icon-on-primary-color': 'rgba(255, 255, 255, 0.8)',
         'gray-color': '#97999C',
+        'gray-color-dark': '#575757',
         // Colors for the toastr notifications, the tag-xxx and the text-xxx classes in any of their four states
         // (i.e. dark colored things)
         'color-danger-dark': 'hsl(353, 78%, 36%)',

--- a/src/js/angular/core/services/theme-service.js
+++ b/src/js/angular/core/services/theme-service.js
@@ -24,6 +24,7 @@ const ThemeDefinitionModel = {
         'tertiary-color-lightness': null,
         'icon-on-primary-color': null,
         'gray-color': null,
+        'gray-color-dark': null,
         'color-danger-dark': null,
         'color-success-dark': null,
         'color-warning-dark': null,
@@ -261,29 +262,6 @@ function ThemeService(workbenchSettingsStorageService, $translate, toastr) {
         `;
     };
 
-    const getPrimaryColorAsString = () => {
-        const themeDefinition = getThemeDefinition();
-        const hue = themeDefinition.variables['primary-color-hue'];
-        const lightness = themeDefinition.variables['primary-color-lightness'];
-        const saturation = themeDefinition.variables['primary-color-saturation'];
-        return `hsl(${hue}, ${saturation}, ${lightness})`;
-    }
-
-    const getSecondaryColorAsString = () => {
-        const themeDefinition = getThemeDefinition();
-        const hue = themeDefinition.variables['secondary-color-hue'];
-        const lightness = themeDefinition.variables['secondary-color-lightness'];
-        const saturation = themeDefinition.variables['secondary-color-saturation'];
-        return `hsl(${hue}, ${saturation}, ${lightness})`;
-    }
-    const getTertiaryColorAsString = () => {
-        const themeDefinition = getThemeDefinition();
-        const hue = themeDefinition.variables['tertiary-color-hue'];
-        const lightness = themeDefinition.variables['tertiary-color-lightness'];
-        const saturation = themeDefinition.variables['tertiary-color-saturation'];
-        return `hsl(${hue}, ${saturation}, ${lightness})`;
-    }
-
     return {
         applyDarkThemeMode,
         toggleThemeMode,
@@ -291,10 +269,7 @@ function ThemeService(workbenchSettingsStorageService, $translate, toastr) {
         getThemeDefinition,
         getTheme,
         getThemes,
-        applyTheme,
-        getPrimaryColorAsString,
-        getSecondaryColorAsString,
-        getTertiaryColorAsString
+        applyTheme
     };
 }
 

--- a/src/js/angular/core/services/theme-service.js
+++ b/src/js/angular/core/services/theme-service.js
@@ -170,7 +170,7 @@ function ThemeService(workbenchSettingsStorageService, $translate, toastr) {
 
     /**
      * Gets a theme definition. If there is a saved theme, then theme definition with that name loaded from
-     * PluginRegistry and returned. Otherwise the default theme definition is returned.
+     * PluginRegistry and returned. Otherwise, the default theme definition is returned.
      * @return {ThemeDefinitionModel}
      */
     const getThemeDefinition = () => {
@@ -187,7 +187,7 @@ function ThemeService(workbenchSettingsStorageService, $translate, toastr) {
      * @param {ThemeDefinitionModel} themeDefinition
      * @return {CSSStyleSheet}
      */
-    const buildStylheet = (themeDefinition) => {
+    const buildStylesheet = (themeDefinition) => {
         const stylesheetContent = themeTag(themeDefinition);
         const stylesheet = new CSSStyleSheet();
         stylesheet.title = themeDefinition.name;
@@ -202,7 +202,7 @@ function ThemeService(workbenchSettingsStorageService, $translate, toastr) {
      */
     const applyTheme = (themeName) => {
       const themeDefinition = getThemeDefinitionByName(themeName);
-      const stylesheet = buildStylheet(themeDefinition);
+      const stylesheet = buildStylesheet(themeDefinition);
       document.adoptedStyleSheets = [stylesheet];
     };
 

--- a/src/js/angular/resources/chart-models/cluster-health/cluster-health-chart.js
+++ b/src/js/angular/resources/chart-models/cluster-health/cluster-health-chart.js
@@ -1,8 +1,8 @@
 import {ChartData} from '../chart-data';
 
 export class ClusterHealthChart extends ChartData {
-    constructor($translate, ThemeService) {
-        super($translate, ThemeService, true, false);
+    constructor($translate) {
+        super($translate, true, false);
         this.nodesCount = 0;
     }
 
@@ -128,6 +128,6 @@ export class ClusterHealthChart extends ChartData {
             value: this.latestData.failedTransactionsCount
         }];
 
-        this.setSubTitle(subTitleKeyValues, false);
+        this.setSubTitle(subTitleKeyValues);
     }
 }

--- a/src/js/angular/resources/chart-models/performance/connections-chart.js
+++ b/src/js/angular/resources/chart-models/performance/connections-chart.js
@@ -1,8 +1,8 @@
 import {ChartData} from "../chart-data";
 
 export class ConnectionsChart extends ChartData {
-    constructor($translate, ThemeService) {
-        super($translate, ThemeService, false, false);
+    constructor($translate) {
+        super($translate, false, false);
     }
 
     createDataHolder() {

--- a/src/js/angular/resources/chart-models/performance/epool-chart.js
+++ b/src/js/angular/resources/chart-models/performance/epool-chart.js
@@ -1,8 +1,8 @@
 import {ChartData} from "../chart-data";
 
 export class EpoolChart extends ChartData {
-    constructor($translate, ThemeService) {
-        super($translate, ThemeService, false, false);
+    constructor($translate) {
+        super($translate, false, false);
     }
 
     chartSetup(chartOptions) {

--- a/src/js/angular/resources/chart-models/performance/queries-chart.js
+++ b/src/js/angular/resources/chart-models/performance/queries-chart.js
@@ -1,8 +1,8 @@
 import {ChartData} from "../chart-data";
 
 export class QueriesChart extends ChartData {
-    constructor($translate, ThemeService) {
-        super($translate, ThemeService, false, false);
+    constructor($translate) {
+        super($translate, false, false);
     }
 
     createDataHolder() {

--- a/src/js/angular/resources/chart-models/resource/cpu-load-chart.js
+++ b/src/js/angular/resources/chart-models/resource/cpu-load-chart.js
@@ -1,8 +1,8 @@
 import {ChartData} from "../chart-data";
 
 export class CpuLoadChart extends ChartData {
-    constructor(translateService, themeService) {
-        super(translateService, themeService, false, false);
+    constructor(translateService) {
+        super(translateService, false, false);
     }
 
     chartSetup(chartOptions) {

--- a/src/js/angular/resources/chart-models/resource/disk-storage-chart.js
+++ b/src/js/angular/resources/chart-models/resource/disk-storage-chart.js
@@ -1,8 +1,8 @@
 import {ChartData} from "../chart-data";
 
 export class DiskStorageChart extends ChartData {
-    constructor($translate, ThemeService) {
-        super($translate, ThemeService, true, true);
+    constructor($translate) {
+        super($translate, true, true);
     }
 
     chartSetup(chartOptions) {
@@ -15,7 +15,7 @@ export class DiskStorageChart extends ChartData {
                     label: null
                 },
                 valueFormatter: function (value) {
-                    return (value * 100).toFixed(2) + '%'
+                    return (value * 100).toFixed(2) + '%';
                 }
             },
             xAxis: {
@@ -25,7 +25,7 @@ export class DiskStorageChart extends ChartData {
                 splitNumber: 2,
                 axisLabel: {
                     formatter: function (value) {
-                        return (value * 100).toFixed(2) + '%'
+                        return (value * 100).toFixed(2) + '%';
                     }
                 }
             },
@@ -33,49 +33,64 @@ export class DiskStorageChart extends ChartData {
                 type: 'category',
                 data: [this.translateService.instant('resource.storage.logs'),
                     this.translateService.instant('resource.storage.work'),
-                    this.translateService.instant('resource.storage.data')],
+                    this.translateService.instant('resource.storage.data')]
             },
-        }
+            legend: {
+                itemStyle: {
+                    // Keeps the colors in the legend solid
+                    opacity: 1
+                }
+            }
+        };
         _.merge(chartOptions, diskStorageChart);
     }
 
     createDataHolder() {
-        return [{
-            name: this.translateService.instant('resource.storage.used'),
+        return [
+            this.createDataHolderForItem('resource.storage.used', ChartData.COLORS[1]),
+            this.createDataHolderForItem('resource.storage.free', ChartData.COLORS[0])
+        ];
+    }
+
+    /**
+     * Creates an item for the data holder.
+     * @param {string} translationKey the translation key of the item
+     * @param {string} color the color of the item
+     * @return {object} the item data object
+     */
+    createDataHolderForItem(translationKey, color) {
+        return {
+            name: this.translateService.instant(translationKey),
             type: 'bar',
             stack: true,
             showSymbol: false,
             smooth: true,
             barCategoryGap: '10%',
-            emphasis: {
-                focus: 'series',
+            color: color,
+            itemStyle: {
+                // Semi-transparent color of the bar
+                opacity: ChartData.AREA_BAR_OPACITY
             },
             label: {
                 show: true,
+                color: 'black',
+                opacity: 1,
                 formatter: function ({value}) {
-                    return (value * 100).toFixed(2) + '%'
-                }
-            },
-            color: ChartData.COLORS[1],
-            data: []
-        }, {
-            name: this.translateService.instant('resource.storage.free'),
-            type: 'bar',
-            stack: true,
-            showSymbol: false,
-            smooth: true,
-            label: {
-                show: true,
-                formatter: function ({value}) {
-                    return (value * 100).toFixed(2) + '%'
+                    return (value * 100).toFixed(2) + '%';
                 }
             },
             emphasis: {
-                focus: 'series'
+                // Solid color of the bar and white text on hover (emphasis)
+                itemStyle: {
+                    color: color,
+                    opacity: 1
+                },
+                label: {
+                    color: 'white'
+                }
             },
-            color: ChartData.COLORS[0],
             data: []
-        }];
+        };
     }
 
     translateLabels() {

--- a/src/js/angular/resources/chart-models/resource/file-descriptors-chart.js
+++ b/src/js/angular/resources/chart-models/resource/file-descriptors-chart.js
@@ -1,8 +1,8 @@
 import {ChartData} from "../chart-data";
 
 export class FileDescriptorsChart extends ChartData {
-    constructor(translateService, themeService, filter) {
-        super(translateService, themeService, false, false, filter);
+    constructor(translateService, filter) {
+        super(translateService, false, false, filter);
     }
 
     chartSetup(chartOptions) {
@@ -28,7 +28,9 @@ export class FileDescriptorsChart extends ChartData {
         return [{
             name: this.translateService.instant('resource.system.file_descriptors.open'),
             type: 'line',
-            areaStyle: {},
+            areaStyle: {
+                opacity: ChartData.AREA_BAR_OPACITY
+            },
             showSymbol: false,
             smooth: true,
             color: ChartData.COLORS[1],

--- a/src/js/angular/resources/chart-models/resource/global-cache-chart.js
+++ b/src/js/angular/resources/chart-models/resource/global-cache-chart.js
@@ -1,8 +1,8 @@
 import {ChartData} from '../chart-data';
 
 export class GlobalCacheChart extends ChartData {
-    constructor(translateService, themeService, filter) {
-        super(translateService, themeService, false, false, filter);
+    constructor(translateService, filter) {
+        super(translateService, false, false, filter);
     }
 
     chartSetup(chartOptions) {

--- a/src/js/angular/resources/chart-models/resource/heap-memory-chart.js
+++ b/src/js/angular/resources/chart-models/resource/heap-memory-chart.js
@@ -1,8 +1,8 @@
 import {ChartData} from "../chart-data";
 
 export class HeapMemoryChart extends ChartData {
-    constructor(translateService, themeService) {
-        super(translateService, themeService, false, false);
+    constructor(translateService) {
+        super(translateService, false, false);
     }
 
     chartSetup(chartOptions) {
@@ -34,7 +34,9 @@ export class HeapMemoryChart extends ChartData {
         }, {
             name: this.translateService.instant('resource.memory.used'),
             type: 'line',
-            areaStyle: {},
+            areaStyle: {
+                opacity: ChartData.AREA_BAR_OPACITY
+            },
             showSymbol: false,
             smooth: true,
             data: []

--- a/src/js/angular/resources/chart-models/resource/non-heap-memory-chart.js
+++ b/src/js/angular/resources/chart-models/resource/non-heap-memory-chart.js
@@ -1,8 +1,8 @@
 import {HeapMemoryChart} from "./heap-memory-chart";
 
 export class NonHeapMemoryChart extends HeapMemoryChart {
-    constructor(translateService, themeService) {
-        super(translateService, themeService, false, false);
+    constructor(translateService) {
+        super(translateService, false, false);
     }
 
     parseData(data) {

--- a/src/js/angular/resources/controllers.js
+++ b/src/js/angular/resources/controllers.js
@@ -107,7 +107,7 @@ resourcesCtrl.controller('ResourcesCtrl', ['$scope', '$timeout', 'MonitoringRest
         const getQueryMonitor = function() {
             const activeRepository = $scope.getActiveRepository();
             if (!activeRepository) {
-                return Promise.resolve();
+                return Promise.resolve({});
             }
             return $q.all([getPerformanceMonitorData(activeRepository), getActiveQueryMonitor(activeRepository)])
                 .then((response) => {
@@ -130,7 +130,7 @@ resourcesCtrl.controller('ResourcesCtrl', ['$scope', '$timeout', 'MonitoringRest
         const getStructuresMonitorData = function() {
             const activeRepository = $scope.getActiveRepository();
             if (!activeRepository) {
-                return Promise.resolve();
+                return Promise.resolve({});
             }
 
             return MonitoringRestService.monitorStructures(activeRepository);

--- a/src/js/angular/resources/controllers.js
+++ b/src/js/angular/resources/controllers.js
@@ -22,8 +22,8 @@ const modules = [
 
 const resourcesCtrl = angular.module('graphdb.framework.jmx.resources.controllers', modules);
 
-resourcesCtrl.controller('ResourcesCtrl', ['$scope', '$timeout', 'MonitoringRestService', '$translate', '$repositories', '$q', 'ClusterRestService', '$filter', 'ThemeService',
-    function($scope, $timeout, MonitoringRestService, $translate, $repositories, $q, ClusterRestService, $filter, ThemeService) {
+resourcesCtrl.controller('ResourcesCtrl', ['$scope', '$timeout', 'MonitoringRestService', '$translate', '$repositories', '$q', 'ClusterRestService', '$filter',
+    function($scope, $timeout, MonitoringRestService, $translate, $repositories, $q, ClusterRestService, $filter) {
         const POLLING_INTERVAL = 2000;
         const MAX_RETRIES = 3;
 
@@ -44,11 +44,11 @@ resourcesCtrl.controller('ResourcesCtrl', ['$scope', '$timeout', 'MonitoringRest
                 retries: 0
             },
             charts: {
-                cpuLoad: new CpuLoadChart($translate, ThemeService),
-                fileDescriptors: new FileDescriptorsChart($translate, ThemeService, $filter),
-                heapMemory: new HeapMemoryChart($translate, ThemeService),
-                offHeapMemory: new NonHeapMemoryChart($translate, ThemeService),
-                diskStorage: new DiskStorageChart($translate, ThemeService)
+                cpuLoad: new CpuLoadChart($translate),
+                fileDescriptors: new FileDescriptorsChart($translate, $filter),
+                heapMemory: new HeapMemoryChart($translate),
+                offHeapMemory: new NonHeapMemoryChart($translate),
+                diskStorage: new DiskStorageChart($translate)
             }
         };
         $scope.performanceMonitorData = {
@@ -58,9 +58,9 @@ resourcesCtrl.controller('ResourcesCtrl', ['$scope', '$timeout', 'MonitoringRest
                 retries: 0
             },
             charts: {
-                connectionsChart: new ConnectionsChart($translate, ThemeService),
-                epoolChart: new EpoolChart($translate, ThemeService),
-                queriesChart: new QueriesChart($translate, ThemeService)
+                connectionsChart: new ConnectionsChart($translate),
+                epoolChart: new EpoolChart($translate),
+                queriesChart: new QueriesChart($translate)
             }
         };
         $scope.structuresMonitorData = {
@@ -70,7 +70,7 @@ resourcesCtrl.controller('ResourcesCtrl', ['$scope', '$timeout', 'MonitoringRest
                 retries: 0
             },
             charts: {
-                globalCacheChart: new GlobalCacheChart($translate, ThemeService, $filter)
+                globalCacheChart: new GlobalCacheChart($translate, $filter)
             }
         };
         $scope.clusterHealthData = {
@@ -80,7 +80,7 @@ resourcesCtrl.controller('ResourcesCtrl', ['$scope', '$timeout', 'MonitoringRest
                 retries: 0
             },
             charts: {
-                clusterHealthChart: new ClusterHealthChart($translate, ThemeService)
+                clusterHealthChart: new ClusterHealthChart($translate)
             }
         };
 

--- a/src/themes/default/plugin.js
+++ b/src/themes/default/plugin.js
@@ -21,6 +21,7 @@ PluginRegistry.add('themes', {
         // A color used for the font/svg icons when placed on a primary color background.
         'icon-on-primary-color': 'rgba(255, 255, 255, 0.8)',
         'gray-color': '#97999C',
+        'gray-color-dark': '#575757',
         // Colors for the toastr notifications, the tag-xxx and the text-xxx classes in any of their four states
         // (i.e. dark colored things)
         'color-danger-dark': 'hsl(353, 78%, 36%)',

--- a/src/themes/onto-original/plugin.js
+++ b/src/themes/onto-original/plugin.js
@@ -13,6 +13,7 @@ PluginRegistry.add('themes', {
         'tertiary-color-lightness': '33.5%',
         'icon-on-primary-color': 'rgba(255, 255, 255, 0.8)',
         'gray-color': '#97999C',
+        'gray-color-dark': '#575757',
         'color-danger-dark': '#bd362f',
         'color-success-dark': '#51a351',
         'color-warning-dark': '#f89406',

--- a/test/resources/controllers.spec.js
+++ b/test/resources/controllers.spec.js
@@ -3,29 +3,11 @@ import 'angular/core/services/repositories.service';
 import "angular/resources/controllers";
 import {bundle} from "../test-main";
 
-const mocks = angular.module('MocksForResourceMonitor', [
-    'graphdb.framework.utils.workbenchsettingsstorageservice',
-    'graphdb.framework.core.services.theme-service']);
+const mocks = angular.module('MocksForResourceMonitor', ['graphdb.framework.utils.workbenchsettingsstorageservice']);
 mocks.service('$repositories', function () {
     this.getActiveRepository = function () {
         return 'activeRepository';
     };
-});
-
-mocks.service('ThemeService', function () {
-    this.getSecondaryColorAsString = () => {
-        const themeDefinition = {
-            variables: {
-                "secondary-color-hue": "207.3",
-                "secondary-color-saturation": "100%",
-                "secondary-color-lightness": "19.4%",
-            }
-        };
-        const hue = themeDefinition.variables['secondary-color-hue'];
-        const lightness = themeDefinition.variables['secondary-color-lightness'];
-        const saturation = themeDefinition.variables['secondary-color-saturation'];
-        return `hsl(${hue}, ${saturation}, ${lightness})`;
-    }
 });
 
 beforeEach(angular.mock.module('graphdb.framework.jmx.resources.controllers', function ($provide) {
@@ -43,12 +25,11 @@ describe('=> ResourcesCtrl tests', function () {
         MonitoringRestService,
         $jwtAuth,
         httpGetResourcesData,
-        ThemeService;
-        let $translate;
+        $translate;
 
     beforeEach(angular.mock.module('MocksForResourceMonitor'));
 
-    beforeEach(angular.mock.inject(function (_$httpBackend_, _$repositories_, _$location_, _$controller_, _$window_, _$timeout_, $rootScope, _$translate_, _MonitoringRestService_, _$jwtAuth_, _ThemeService_) {
+    beforeEach(angular.mock.inject(function (_$httpBackend_, _$repositories_, _$location_, _$controller_, _$window_, _$timeout_, $rootScope, _$translate_, _MonitoringRestService_, _$jwtAuth_) {
 
         $httpBackend = _$httpBackend_;
         $controller = _$controller_;
@@ -57,7 +38,6 @@ describe('=> ResourcesCtrl tests', function () {
         $translate = _$translate_;
         MonitoringRestService = _MonitoringRestService_;
         $jwtAuth = _$jwtAuth_;
-        ThemeService = _ThemeService_;
 
         $translate.instant = function (key, modification) {
             if (modification) {
@@ -158,7 +138,7 @@ describe('=> ResourcesCtrl tests', function () {
         });
 
         $scope = $rootScope.$new();
-        $controller('ResourcesCtrl', {$scope: $scope, $timeout, MonitoringRestService, $translate, $repositories, $jwtAuth, ThemeService});
+        $controller('ResourcesCtrl', {$scope: $scope, $timeout, MonitoringRestService, $translate, $repositories, $jwtAuth});
 
         jasmine.clock().install();
     }));
@@ -220,24 +200,26 @@ describe('=> ResourcesCtrl tests', function () {
             })])
             expect($scope.resourceMonitorData.charts.fileDescriptors.dataHolder).toEqual([joc({
                 name: "Open file descriptors",
-                areaStyle: {},
+                areaStyle: {
+                    opacity: 0.5
+                },
                 data: [{value: [today, 550]}]
             })])
             expect($scope.resourceMonitorData.charts.heapMemory.dataHolder).toEqual([joc({
                 name: "Committed memory",
                 data: [{value: [today, 703594496]}]
-            }), joc({name: 'Used memory', areaStyle: {}, data: [{value: [today, 212264560]}]})])
+            }), joc({name: 'Used memory', areaStyle: {opacity: 0.5}, data: [{value: [today, 212264560]}]})])
             expect($scope.resourceMonitorData.charts.offHeapMemory.dataHolder).toEqual([joc({
                 name: "Committed memory",
                 data: [{value: [today, 124477440]}]
-            }), joc({name: 'Used memory', areaStyle: {}, data: [{value: [today, 122066392]}]})])
+            }), joc({name: 'Used memory', areaStyle: {opacity: 0.5}, data: [{value: [today, 122066392]}]})])
             expect($scope.resourceMonitorData.charts.diskStorage.dataHolder).toEqual([joc({
                 name: "Used",
-                color: '#E84E0F',
+                color: '',
                 data: [0.9574564407462561, 0.9574564407462561, 0.9574564407462561]
             }), joc({
                 name: 'Free',
-                color: '#003663',
+                color: '',
                 data: [0.042543559253743896, 0.042543559253743896, 0.042543559253743896]
             })])
             $timeout.flush(2000);
@@ -248,24 +230,24 @@ describe('=> ResourcesCtrl tests', function () {
             })])
             expect($scope.resourceMonitorData.charts.fileDescriptors.dataHolder).toEqual([joc({
                 name: "Open file descriptors",
-                areaStyle: {},
+                areaStyle: {opacity: 0.5},
                 data: [{value: [today, 550]}, {value: [today, 550]}]
             })])
             expect($scope.resourceMonitorData.charts.heapMemory.dataHolder).toEqual([joc({
                 name: "Committed memory",
                 data: [{value: [today, 703594496]}, {value: [today, 703594496]}]
-            }), joc({name: 'Used memory', areaStyle: {}, data: [{value: [today, 212264560]}, {value: [today, 212264560]}]})])
+            }), joc({name: 'Used memory', areaStyle: {opacity: 0.5}, data: [{value: [today, 212264560]}, {value: [today, 212264560]}]})])
             expect($scope.resourceMonitorData.charts.offHeapMemory.dataHolder).toEqual([joc({
                 name: "Committed memory",
                 data: [{value: [today, 124477440]}, {value: [today, 124477440]}]
-            }), joc({name: 'Used memory', areaStyle: {}, data: [{value: [today, 122066392]}, {value: [today, 122066392]}]})])
+            }), joc({name: 'Used memory', areaStyle: {opacity: 0.5}, data: [{value: [today, 122066392]}, {value: [today, 122066392]}]})])
             expect($scope.resourceMonitorData.charts.diskStorage.dataHolder).toEqual([joc({
                 name: "Used",
-                color: '#E84E0F',
+                color: '',
                 data: [0.9574564407462561, 0.9574564407462561, 0.9574564407462561, 0.9574564407462561, 0.9574564407462561, 0.9574564407462561]
             }), joc({
                 name: 'Free',
-                color: '#003663',
+                color: '',
                 data: [0.042543559253743896, 0.042543559253743896, 0.042543559253743896, 0.042543559253743896, 0.042543559253743896, 0.042543559253743896]
             })])
         });
@@ -363,19 +345,19 @@ describe('=> ResourcesCtrl tests', function () {
 
             $httpBackend.flush();
             expect($scope.clusterHealthData.charts.clusterHealthChart.dataHolder).toEqual([
-                joc({name: 'In sync', color: '#003663', data: [{value: [today, 3]}]}),
-                joc({name: 'Syncing', color: '#02A99A', data: [{value: [today, 0]}]}),
-                joc({name: 'Out of sync', color: '#E84E0F', data: [{value: [today, 0]}]}),
-                joc({name: 'Disconnected', color: '#999999', data: [{value: [today, 0]}]})
+                joc({name: 'In sync', data: [{value: [today, 3]}]}),
+                joc({name: 'Syncing', data: [{value: [today, 0]}]}),
+                joc({name: 'Out of sync', data: [{value: [today, 0]}]}),
+                joc({name: 'Disconnected', data: [{value: [today, 0]}]})
             ]);
             $timeout.flush(2001);
             $httpBackend.flush();
 
             expect($scope.clusterHealthData.charts.clusterHealthChart.dataHolder).toEqual([
-                joc({name: 'In sync', color: '#003663', data: [{value: [today, 3]}, {value: [today, 3]}]}),
-                joc({name: 'Syncing', color: '#02A99A', data: [{value: [today, 0]}, {value: [today, 0]}]}),
-                joc({name: 'Out of sync', color: '#E84E0F', data: [{value: [today, 0]}, {value: [today, 0]}]}),
-                joc({name: 'Disconnected', color: '#999999', data: [{value: [today, 0]}, {value: [today, 0]}]})
+                joc({name: 'In sync', data: [{value: [today, 3]}, {value: [today, 3]}]}),
+                joc({name: 'Syncing', data: [{value: [today, 0]}, {value: [today, 0]}]}),
+                joc({name: 'Out of sync', data: [{value: [today, 0]}, {value: [today, 0]}]}),
+                joc({name: 'Disconnected', data: [{value: [today, 0]}, {value: [today, 0]}]})
             ]);
         });
 


### PR DESCRIPTION
* Use main font from css variable
* Use colors from theme (via css variables)
* Introduced new color in theme (gray-color-dark, essentially the computed value of rgba(0, 0, 0, 0.66) over a white background)
* Use semi-transparent colors for bulky bits (area, bars) + adjusted emphasis (on hover) for the storage graph
* Don't use ThemeService to access things
* All items in subtitle on one line + centered subtitle
* No tooltip on legend hover (shows the same string as the legend label)
* 24-hour clock for times
* HH:mm + bold format for round minutes in time series (this mimics more or less the default echarts behaviour without a formatter but the default one makes it too bold)