### PR TITLE
GDB-8997 and GDB-8998 reorder yasr toolbar and make yasr more responsive

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -1,5 +1,16 @@
 @import "../common.css";
 
+/* Resets the default font-size for every tag in the yasgui */
+yasgui-component * {
+    font-size: 16px !important;
+}
+
+/* And scale it down on given viewport width */
+@media (max-width: 1439px) {
+    yasgui-component * {
+        font-size: 14px !important;
+    }
+}
 
 yasgui-component .yasgui-btn.btn-selected {
     background-color: var(--primary-color) !important;
@@ -100,6 +111,14 @@ yasgui-component .yasr a {
     color: var(--secondary-color) !important;
 }
 
+yasgui-component .yasr .yasr_header .yasr_response_chip {
+    background-color: unset !important;
+}
+
+yasgui-component .yasr .yasr_header {
+    background-color: var(--color-info-light) !important;
+}
+
 yasgui-component .yasr .yasr_btnGroup .yasr_btn {
     margin-left: 0;
     margin-right: .2rem;
@@ -129,6 +148,10 @@ yasgui-component .yasr .extended-boolean-plugin .response-error {
 
 yasgui-component .yasr .extended-boolean-plugin .response-success {
     background-color: var(--color-success-light) !important;
+}
+
+.yasr .dataTables_wrapper .dataTable thead tr th {
+    font-weight: 500;
 }
 
 yasgui-component .yasr .dataTable a {
@@ -273,8 +296,20 @@ yasgui-component .page-selector {
     display: none;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1200px) {
+    .ontotext-dropdown .ontotext-dropdown-button:after {
+        padding-left: 0 !important;
+    }
+
+    .ontotext-dropdown .button-name {
+        display: none;
+    }
+
     .explore-visual-graph-button-name {
+        display: none;
+    }
+
+    .yasr_btn span {
         display: none;
     }
 }

--- a/test-cypress/integration/sparql-editor/yasr/toolbar/visual-graph-button.spec.js
+++ b/test-cypress/integration/sparql-editor/yasr/toolbar/visual-graph-button.spec.js
@@ -3,8 +3,9 @@ import {YasqeSteps} from "../../../../steps/yasgui/yasqe-steps";
 import {YasrSteps} from "../../../../steps/yasgui/yasr-steps";
 import {QueryStubs} from "../../../../stubs/yasgui/query-stubs";
 
-describe('Visual button when user execute a CONSTRUCT query.', () => {
+describe('Visual graph button when user execute a CONSTRUCT query', () => {
     let repositoryId;
+
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
         QueryStubs.stubQueryCountResponse();
@@ -18,7 +19,7 @@ describe('Visual button when user execute a CONSTRUCT query.', () => {
         cy.deleteRepository(repositoryId);
     });
 
-    it('should display a "Visual" button configured by user .', {
+    it('Should display a "Visual" graph button configured by user', {
         retries: {
             runMode: 1,
             openMode: 0

--- a/test-cypress/steps/yasgui/yasr-steps.js
+++ b/test-cypress/steps/yasgui/yasr-steps.js
@@ -91,7 +91,7 @@ export class YasrSteps {
     }
 
     static getVisualButton() {
-        return YasrSteps.getYasrToolbar().find('.explore-visual-graph-button-name');
+        return YasrSteps.getYasrToolbar().find('.explore-visual-graph-button');
     }
 
     static getNoDataElement() {


### PR DESCRIPTION
## What
Reorder yasr toolbar and make it responsive.

## Why
In order to comply with the existing visualization in the workbench

## How
* Added media queries to improve responsiveness.
* Changed some styles to better match the existing workbench styling.