### PR TITLE
GDB-9008 fix the color of the rdf star triples in yasr results

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -119,6 +119,10 @@ yasgui-component .yasr .yasr_header {
     background-color: var(--color-info-light) !important;
 }
 
+yasgui-component .yasr .dataTable .triple-cell .triple-link {
+    color: #708 !important;
+}
+
 yasgui-component .yasr .yasr_btnGroup .yasr_btn {
     margin-left: 0;
     margin-right: .2rem;


### PR DESCRIPTION
## What
Fix the color of the rdf star triples in yasr results.

## Why
For consistency with the current workbench styles.

## How
Overridden the style applied to triple link tag