### PR TITLE
GDB-9210 Download As JSON and JSONLD User interface fails to read graphdb.external-url

### DIFF
--- a/src/js/angular/rest/rdf4j.repositories.rest.service.js
+++ b/src/js/angular/rest/rdf4j.repositories.rest.service.js
@@ -134,7 +134,7 @@ function RDF4JRepositoriesRestService($http, $repositories, $translate) {
         const payloadString = properties.join('&');
         return $http({
             method: 'POST',
-            url: `/repositories/${repositoryId}`,
+            url: `repositories/${repositoryId}`,
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
                 'Accept': acceptHeader

--- a/src/js/angular/rest/rdf4j.repositories.rest.service.js
+++ b/src/js/angular/rest/rdf4j.repositories.rest.service.js
@@ -134,7 +134,7 @@ function RDF4JRepositoriesRestService($http, $repositories, $translate) {
         const payloadString = properties.join('&');
         return $http({
             method: 'POST',
-            url: `repositories/${repositoryId}`,
+            url: `${REPOSITORIES_ENDPOINT}/${repositoryId}`,
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
                 'Accept': acceptHeader


### PR DESCRIPTION
## What
Unable to proceed requests to repositories/${repositoryId} when external url given.

## Why
Hard-coded path to rdf4j repositories/${repositoryId}.

## How
Changed building request to rdf4j.repositories.rest.service.js to consider different path if provided.