### PR TITLE
GDB-9179: Error when I create similarity index from existing one with the same name

### DIFF
--- a/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/src/js/angular/similarity/controllers/create-index.controller.js
@@ -707,15 +707,14 @@ function CreateSimilarityIdxCtrl(
     const validateSimilarityIndexNameExistence = (similarityIndexInfo) => {
         return SimilarityRestService.getIndexes()
             .then((response) => {
-                response.data.forEach((index) => {
-                    if (index.name === similarityIndexInfo.getName()) {
-                        similarityIndexInfo.isNameExist = true;
-                        return Promise.reject(new SimilarityIndexError('Similarity index name exist.'))
-                    }
-                });
-                return similarityIndexInfo
+                if (response.data.some((index) => index.name === similarityIndexInfo.getName())) {
+                    similarityIndexInfo.isNameExist = true;
+                    return Promise.reject(new SimilarityIndexError('Similarity index name exists.'));
+                }
+
+                return similarityIndexInfo;
             });
-    }
+    };
 
     /**
      * Check if similarity index name is filed and if is filled if it's value is correct.

--- a/test-cypress/integration/explore/similarity.spec.js
+++ b/test-cypress/integration/explore/similarity.spec.js
@@ -5,6 +5,7 @@ import {SimilarityIndexCreateSteps} from "../../steps/explore/similarity-index-c
 import {SimilarityIndexesSteps} from "../../steps/explore/similarity-indexes-steps";
 import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../steps/modal-dialog-steps";
 import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";
+import {ErrorSteps} from "../../steps/error-steps";
 
 const INDEX_NAME = 'index-' + Date.now();
 const FILE_TO_IMPORT = 'people.zip';
@@ -100,6 +101,20 @@ describe('Similarity screen validation', () => {
             clickMoreOptionsMenu();
             checkLiteralIndex();
             createSimilarityIndex();
+        });
+
+        it('Should not allow create similarity index with name that already exist', () => {
+            // If we have a similarity index.
+            openCreateNewIndexForm();
+            setIndexName();
+            createSimilarityIndex();
+
+            // When I try to create a similarity index with same name.
+            openCreateNewIndexForm();
+            setIndexName();
+            getCreateIndexButton().click();
+            // Then I expect an error message to be displayed that describes me, that name is mandatory.
+            ErrorSteps.verifyError('Index with this name already exists.');
         });
     });
 


### PR DESCRIPTION
## What
There is not "Index with this name already exists." error message when try to create similarity index with same name.

## Why
There is validation to check if index with same name exist, but the return statement inside the forEach loop doesn't actually terminate the outer function (validateSimilarityIndexNameExistence), so the Promise is not being returned correctly.

## How
The validation function has been fixed.