### PR TITLE
Gdb 9168 wrong styling of explain plan

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.5",
+        "ontotext-yasgui-web-component": "1.1.6",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -158,6 +158,10 @@ yasgui-component .yasr .dataTable a {
     font-size: 16px;
 }
 
+yasgui-component .yasr #explainPlanQuery {
+    font-family: var(--mono-font);
+}
+
 yasgui-component .tabsList .tab .closeTab {
     color: var(--secondary-color-light) !important;
     opacity: .8 !important;
@@ -265,7 +269,6 @@ yasgui-component .saved-queries-container .saved-queries-popup .saved-query-acti
 }
 
 yasgui-component .abort-button {
-    background-color: var(--primary-color) !important;
 }
 
 yasgui-component .page-button.selected-page {

--- a/test-cypress/integration/sparql-editor/plugins/error-plugin.spec.js
+++ b/test-cypress/integration/sparql-editor/plugins/error-plugin.spec.js
@@ -34,7 +34,7 @@ describe('Error handling', () => {
         // and time when the query is executed,
         ErrorPluginSteps.getErrorPluginErrorTimeMessage().contains(/Query took \d{1}\.\d{1}s, moments ago\./);
         // and error message sent by server,
-        ErrorPluginSteps.getErrorPluginBody().invoke('text').should('eq', SHORT_ERROR_BODY);
+        ErrorPluginSteps.getErrorPluginBody().should('have.text', SHORT_ERROR_BODY);
         // and toolbar with plugins to not be visible,
         YasrSteps.getResultHeader().should('not.be.visible');
         // and message info to not be visible,
@@ -56,7 +56,7 @@ describe('Error handling', () => {
         // and time when the query is executed,
         ErrorPluginSteps.getErrorPluginErrorTimeMessage().contains(/Query took \d{1}\.\d{1}s, moments ago\./);
         // and error message sent by server,
-        ErrorPluginSteps.getErrorPluginBody().invoke('text').should('eq', LESS_MESSAGE);
+        ErrorPluginSteps.getErrorPluginBody().should('have.text', LESS_MESSAGE);
         // and toolbar with plugins to not be visible,
         YasrSteps.getResultHeader().should('not.be.visible');
         // and message info to not be visible,
@@ -68,7 +68,7 @@ describe('Error handling', () => {
         ErrorPluginSteps.getShowFullErrorMessage().click();
 
         // Then I expect to see full message
-        ErrorPluginSteps.getErrorPluginBody().invoke('text').should('eq', LONG_ERROR_BODY);
+        ErrorPluginSteps.getErrorPluginBody().should('have.text', LONG_ERROR_BODY);
         ErrorPluginSteps.getShowFullErrorMessage().should('not.exist');
         ErrorPluginSteps.getShowLessErrorMessage().should('be.visible');
 
@@ -76,7 +76,7 @@ describe('Error handling', () => {
         ErrorPluginSteps.getShowLessErrorMessage().click();
 
         // Then I expect to see first 160 characters of the error message
-        ErrorPluginSteps.getErrorPluginBody().invoke('text').should('eq', LESS_MESSAGE);
+        ErrorPluginSteps.getErrorPluginBody().should('have.text', LESS_MESSAGE);
         ErrorPluginSteps.getShowFullErrorMessage().should('be.visible');
         ErrorPluginSteps.getShowLessErrorMessage().should('not.exist');
     });


### PR DESCRIPTION
## What
- The font of the explain plan query differs from the old yasr;
- The error plugin tests frequently failed.

## Why
- The "font-family" property was not set;
- We don't know exactly why. But the test fail on verification if full error message displayed.

## How
- The "font-family" has been set to the same value as in the old yasr;
- The error text verification has been changed.

Additional work:
Updates the ontotext-yasgui-web-component version because there is a fix for the explain plan query. The result looks like plain text.