### PR TITLE
GDB-8992 change yasqe font family

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -20,6 +20,10 @@ yasgui-component .btn-orientation {
     color: var(--primary-color) !important;
 }
 
+yasgui-component .yasqe .CodeMirror {
+    font-family: var(--mono-font) !important;
+}
+
 yasgui-component .yasqe .yasqe_buttons {
     right: 21px;
 }


### PR DESCRIPTION
## What
Change yasqe font family.

## Why
For consistency with the current workbench.

## How
Applied the existing font in the codemirror