### PR TITLE
Update ontotext-yasgui component version to 1.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.6",
+                "ontotext-yasgui-web-component": "1.1.7",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -9973,9 +9973,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.6.tgz",
-            "integrity": "sha512-ElfPfb0wq4bOHQVpI/5z/oH6xrF1eCNqcVNbBBw1BRLlDZZizFiTCW3tY6TeaQxigRJhes39QHoEtTH8vAj7vA==",
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.7.tgz",
+            "integrity": "sha512-Rq1P7qTCYB2FtynasCn2bNmXsp4RC/o4KFkBuZdhrM0cj9wJSwjT7tsw3bOR9RXKVYqlKa+o9hPSttIzgqWVAQ==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24544,9 +24544,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.6.tgz",
-            "integrity": "sha512-ElfPfb0wq4bOHQVpI/5z/oH6xrF1eCNqcVNbBBw1BRLlDZZizFiTCW3tY6TeaQxigRJhes39QHoEtTH8vAj7vA==",
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.7.tgz",
+            "integrity": "sha512-Rq1P7qTCYB2FtynasCn2bNmXsp4RC/o4KFkBuZdhrM0cj9wJSwjT7tsw3bOR9RXKVYqlKa+o9hPSttIzgqWVAQ==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.7",
+                "ontotext-yasgui-web-component": "1.1.8",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -9973,9 +9973,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.7.tgz",
-            "integrity": "sha512-Rq1P7qTCYB2FtynasCn2bNmXsp4RC/o4KFkBuZdhrM0cj9wJSwjT7tsw3bOR9RXKVYqlKa+o9hPSttIzgqWVAQ==",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.8.tgz",
+            "integrity": "sha512-ZYoVVw63lhvfcz+AkLaY/sEpBrV9ohtK2ygc9xufnOMwfmjvmZcILAsTn1dOFkDarpMZhIwYOK8lZFnOwXnsgg==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24544,9 +24544,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.7.tgz",
-            "integrity": "sha512-Rq1P7qTCYB2FtynasCn2bNmXsp4RC/o4KFkBuZdhrM0cj9wJSwjT7tsw3bOR9RXKVYqlKa+o9hPSttIzgqWVAQ==",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.8.tgz",
+            "integrity": "sha512-ZYoVVw63lhvfcz+AkLaY/sEpBrV9ohtK2ygc9xufnOMwfmjvmZcILAsTn1dOFkDarpMZhIwYOK8lZFnOwXnsgg==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.7",
+        "ontotext-yasgui-web-component": "1.1.8",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.6",
+        "ontotext-yasgui-web-component": "1.1.7",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/test-cypress/integration/resource/resource.spec.js
+++ b/test-cypress/integration/resource/resource.spec.js
@@ -348,7 +348,7 @@ describe('Resource view', () => {
             YasguiSteps.getTabs().should('have.length', 2);
             // and a describe query to be present
             YasqeSteps.getActiveTabQuery().should('contain', 'describe <<<http://example.com/resource/person/W6J1827> <http://example.com/ontology#hasAddress> <http://example.com/resource/person/W6J1827/address>>>');
-            YasguiSteps.getCurrentTab().should('contain', 'Unnamed 2');
+            YasguiSteps.getCurrentTab().should('contain', 'Unnamed 1');
         });
     });
 });


### PR DESCRIPTION
## What
Update ontotext-yasgui component version to 1.1.8

## Why
The version includes following changes:
* GDB-8990 fix default query formatting in yasqe
* GDB-9002 improve styling of the hotkeys dialog
* GDB-8641 properly resolve tab by name and query before open a new one
* GDB-9231 prevent tab duplication when saved query is selected
* GDB-9230 remove chart config button when changing yasr tabs
* GDB-8642 switch labels on yasqe buttons when language is changed

## How
Increased the version