### PR TITLE
GDB-9236: User Guides stop on Vis Graph segment and block the workbench

### DIFF
--- a/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -1531,7 +1531,7 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
             }, 1000);
         };
 
-        const touchEndEventHandler = function (d) {
+        const touchEndEventHandler = function () {
             $timeout.cancel(touchHoldEventTimer);
             touchHoldEventTimer = null;
         };
@@ -1738,15 +1738,15 @@ function GraphsVisualizationsCtrl($scope, $rootScope, $repositories, $licenseSer
             .on('mouseover', showNodeTipAndIcons)
             .on('mouseout', hideTipForNode)
             .on("click", clickEventHandler)
-            .on("touchstart", touchStartEventHandler)
+            .on("touchstart", (event, d) => touchStartEventHandler(d))
             // no need to track move for mouse
             .on("touchmove", moveEventHandler)
             .on("touchend", touchEndEventHandler)
             .on("contextmenu", rightClickHandler)
             // custom event used when user is following a guide
-            .on("gdb-expand-node", expandEventHandler)
+            .on("gdb-expand-node", (event, d) => expandEventHandler(d, 0, event.srcElement.parentNode))
             // custom event used when user is following a guide
-            .on("gdb-show-node-info", showNodeInfo)
+            .on("gdb-show-node-info", (event, d) => showNodeInfo(d))
             .call(drag);
 
         const nodeLabels = container.selectAll(".node-wrapper").append("foreignObject")

--- a/src/js/angular/graphexplore/directives/rdf-class-hierarchy.directive.js
+++ b/src/js/angular/graphexplore/directives/rdf-class-hierarchy.directive.js
@@ -229,8 +229,8 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
                     }
                 })
                 // custom event used when user is following a guide
-                .on("gdb-focus", doFocus)
-                .on("gdb-zoom", zoom);
+                .on("gdb-focus", (event, d) => doFocus(d))
+                .on("gdb-zoom", (event, d) => zoom(d));
 
 
             if (flattenedClassNames) {


### PR DESCRIPTION
## What
- visual graph steps where user have click/doubleclick in user guides are broken;
- hierarchy steps where a node is zoomed or focused.

## Why
We updated the d3 library.

## How
Changed behaviour to work with the new version of d3.