### PR TITLE
Update ontotext-yasgui component version to 1.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.8",
+                "ontotext-yasgui-web-component": "1.1.9",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10113,9 +10113,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.8.tgz",
-            "integrity": "sha512-ZYoVVw63lhvfcz+AkLaY/sEpBrV9ohtK2ygc9xufnOMwfmjvmZcILAsTn1dOFkDarpMZhIwYOK8lZFnOwXnsgg==",
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.9.tgz",
+            "integrity": "sha512-1zrWlcLklTOW9QtHrkiZ6CYNVHqmRLCac/FaBp1nizlK1McbrYft547ibeOo0M6wed2JK/KGfJlKQ8ZctXfXCw==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24725,9 +24725,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.8.tgz",
-            "integrity": "sha512-ZYoVVw63lhvfcz+AkLaY/sEpBrV9ohtK2ygc9xufnOMwfmjvmZcILAsTn1dOFkDarpMZhIwYOK8lZFnOwXnsgg==",
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.9.tgz",
+            "integrity": "sha512-1zrWlcLklTOW9QtHrkiZ6CYNVHqmRLCac/FaBp1nizlK1McbrYft547ibeOo0M6wed2JK/KGfJlKQ8ZctXfXCw==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.8",
+        "ontotext-yasgui-web-component": "1.1.9",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -307,7 +307,10 @@ yasgui-component .page-selector {
     display: none;
 }
 
-@media (max-width: 1200px) {
+/* =================================================================================
+    Media queries ensuring proper responsive layout on different screen resolutions
+   ================================================================================= */
+@media (max-width: 1400px) {
     .ontotext-dropdown .ontotext-dropdown-button:after {
         padding-left: 0 !important;
     }
@@ -315,7 +318,9 @@ yasgui-component .page-selector {
     .ontotext-dropdown .button-name {
         display: none;
     }
+}
 
+@media (max-width: 1200px) {
     .explore-visual-graph-button-name {
         display: none;
     }


### PR DESCRIPTION
## What
* Update ontotext-yasgui component version to 1.1.9 and also ensure needed changes in workbench styling are applied too.

## Why
The yasgui version includes following changes:
* GDB-9245 refactor yasgui layout to work properly when horizontal ordering is selected
* GDB-8995 refactor yasgui component layout to work properly when rendering mode or orientation are changed
* GDB-8995 rendering mode should be switched to yasgui when query is run

The workbench changes in styling is related with the proper yasr toobar button rendering in order to prevent it from overflowing out of the layout in certain resolutions.

## How
Increased the version