### PR TITLE
GDB-9243 fix size of the yasgui orientation changing button

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -18,6 +18,7 @@ yasgui-component .yasgui-btn.btn-selected {
 
 yasgui-component .btn-orientation {
     color: var(--primary-color) !important;
+    font-size: 2em !important;
 }
 
 yasgui-component .yasqe .CodeMirror {


### PR DESCRIPTION
## What
Fix size of the yasgui orientation changing button.

## Why
Its size was decreased unexpectedly when the font-size was reset in the entire yasgui component.

## How
Applied the correct font-size to the button