### PR TITLE
GDB-9244 fix abort query button styling

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -278,6 +278,11 @@ yasgui-component .saved-queries-container .saved-queries-popup .saved-query-acti
 }
 
 yasgui-component .abort-button {
+    background-color: var(--primary-color) !important;
+}
+
+yasgui-component .abort-button:hover {
+    background-color: var(--primary-color-dark) !important;
 }
 
 yasgui-component .page-button.selected-page {


### PR DESCRIPTION
## What
Fix abort query button styling.

## Why
Its background color on normal and hovered state was not properly set.

## How
Applied the styles