### PR TITLE
Updates the version of 'ontotext-yasgui-web-component'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.9",
+                "ontotext-yasgui-web-component": "1.1.10",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10113,9 +10113,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.9.tgz",
-            "integrity": "sha512-1zrWlcLklTOW9QtHrkiZ6CYNVHqmRLCac/FaBp1nizlK1McbrYft547ibeOo0M6wed2JK/KGfJlKQ8ZctXfXCw==",
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.10.tgz",
+            "integrity": "sha512-bafC+gV7nU7k69YgdJrF2mVaTfoua/AvsX3/TBHiUfIBzhp+5OmvL1fVg/gpJVsakL76ojlDPggTg4XMfACw8Q==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24725,9 +24725,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.9.tgz",
-            "integrity": "sha512-1zrWlcLklTOW9QtHrkiZ6CYNVHqmRLCac/FaBp1nizlK1McbrYft547ibeOo0M6wed2JK/KGfJlKQ8ZctXfXCw==",
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.10.tgz",
+            "integrity": "sha512-bafC+gV7nU7k69YgdJrF2mVaTfoua/AvsX3/TBHiUfIBzhp+5OmvL1fVg/gpJVsakL76ojlDPggTg4XMfACw8Q==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.9",
+        "ontotext-yasgui-web-component": "1.1.10",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -10,6 +10,7 @@ import {isEqual} from "lodash/lang";
 import {QueryType} from "../../../models/ontotext-yasgui/query-type";
 import {YasguiComponent} from "../../../models/yasgui-component";
 import {YasguiComponentDirectiveUtil} from "./yasgui-component-directive.util";
+import {KeyboardShortcutName} from "../../../models/ontotext-yasgui/keyboard-shortcut-name";
 
 const modules = [
     'graphdb.framework.core.services.translation-service',
@@ -348,6 +349,24 @@ function yasguiComponentDirective(
                     };
 
                     angular.extend(config, getDefaultConfig(), $scope.yasguiConfig);
+
+                    if (config.showQueryButton !== undefined && !config.showQueryButton) {
+                        const keyboardShortcutConfiguration = config.keyboardShortcutConfiguration || {};
+                        keyboardShortcutConfiguration[KeyboardShortcutName.EXECUTE_QUERY_OR_UPDATE] = false;
+                        keyboardShortcutConfiguration[KeyboardShortcutName.EXECUTE_EXPLAIN_PLAN_FOR_QUERY] = false;
+                        keyboardShortcutConfiguration[KeyboardShortcutName.EXECUTE_CHAT_GPT_EXPLAIN_PLAN_FOR_QUERY] = false;
+                        keyboardShortcutConfiguration[KeyboardShortcutName.CREATE_TAB] = false;
+                        keyboardShortcutConfiguration[KeyboardShortcutName.CREATE_SAVE_QUERY] = false;
+                        keyboardShortcutConfiguration[KeyboardShortcutName.SWITCH_NEXT_TAB] = false;
+                        keyboardShortcutConfiguration[KeyboardShortcutName.SWITCH_PREVIOUS_TAB] = false;
+                        keyboardShortcutConfiguration[KeyboardShortcutName.CLOSES_ALL_TABS] = false;
+                        config.keyboardShortcutConfiguration = keyboardShortcutConfiguration;
+                    } else {
+                        const keyboardShortcutConfiguration = config.keyboardShortcutConfiguration || {};
+                        keyboardShortcutConfiguration[KeyboardShortcutName.EXECUTE_EXPLAIN_PLAN_FOR_QUERY] = true;
+                        keyboardShortcutConfiguration[KeyboardShortcutName.EXECUTE_CHAT_GPT_EXPLAIN_PLAN_FOR_QUERY] = true;
+                        config.keyboardShortcutConfiguration = keyboardShortcutConfiguration;
+                    }
 
                     $scope.ontotextYasguiConfig = config;
 

--- a/src/js/angular/models/ontotext-yasgui/keyboard-shortcut-name.js
+++ b/src/js/angular/models/ontotext-yasgui/keyboard-shortcut-name.js
@@ -1,0 +1,20 @@
+export const KeyboardShortcutName = {
+    'TRIGGER_AUTOCOMPLETION': 'trigger_autocompletion',
+    'DELETE_CURRENT_LINE': 'delete_current_line',
+    'COMMENT_SELECTED_LINE': 'comment_selected_line',
+    'COPY_LINE_DOWN': 'copy_line_down',
+    'COPY_LINE_UP': 'copy_line_up',
+    'AUTO_FORMAT_SELECTED_LINE': 'auto_format_selected_line',
+    'INDENT_CURRENT_LINE_MORE': 'indent_current_line_more',
+    'INDENT_CURRENT_LINE_LESS': 'indent_current_line_less',
+    'EXECUTE_QUERY_OR_UPDATE': 'execute_query_or_update',
+    'EXECUTE_EXPLAIN_PLAN_FOR_QUERY': 'execute_explain_plan_for_query',
+    'EXECUTE_CHAT_GPT_EXPLAIN_PLAN_FOR_QUERY': 'execute_chat_gpt_explain_plan_for_query',
+    'CREATE_TAB': 'create_tab',
+    'CREATE_SAVE_QUERY': 'create_save_query',
+    'SWITCH_NEXT_TAB': 'switch_next_tab',
+    'SWITCH_PREVIOUS_TAB': 'switch_previous_tab',
+    'CLOSES_ALL_TABS': 'closes_all_tabs',
+    'FULL_SCREEN': 'full_screen',
+    'ESC': 'esc'
+};


### PR DESCRIPTION
## What
The 'ontotext-yasgui-web-component' has been updated.

## Why
This update includes fixes for:
- GDB-8993 preserve cursor position when query is set in the editor;
- GDB-9145: Visual graph cannot open via Sparql view when used pivot table and google chart;
- GDB-8645: Keyboard shortcuts differences between old implementation;
- GDB-8189: When pressing the buttons [Ctrl|Cmd]-D Delete current/selected line(s) - several times in a row, I delete all rows until only the top row remains;
- GDB-9003: Keyboard shortcuts missing/unclear

## How
- The 'ontotext-yasgui-web-component' has been updated to v1.1.10;
- In the new version, a configuration has been introduced to control which keyboard shortcuts are active. According to these changes, the configuration is updated in the yasgui-component directive to configure them. All shortcuts are disabled when the run button is not active. When button is disabled, it means that we are using the component in read-only mode, and all keyboard shortcuts should be disabled.