### PR TITLE
GDB-9265 change background color of the get snippet button in chart and pivot table yasr plugins

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -95,11 +95,7 @@ yasgui-component .yasr-toolbar .explore-visual-graph-button:hover {
 
 yasgui-component .yasr-toolbar .chart-download-as-button,
 yasgui-component .yasr-toolbar .pivot-table-download-as-button {
-    background-color: var(--primary-color-dark) !important;
-}
-
-yasgui-component .yasr-toolbar .chart-download-as-button {
-    padding-left: 5px;
+    background-color: var(--primary-color) !important;
 }
 
 yasgui-component .ok-button,


### PR DESCRIPTION
## What
Change background color of the get snippet button in chart and pivot table yasr plugins.

## Why
For consistency with other buttons and with the current workbench

## How
Changed the background color and also removed some redundant padding from the button which used to decrease the usual offset between the icon and its left border.