### PR TITLE
GDB-9269 fix dialog font and color issues

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -1,15 +1,23 @@
 @import "../common.css";
 
 /* Resets the default font-size for every tag in the yasgui */
-yasgui-component * {
+/* Omit the heading  tags */
+yasgui-component :not(h3):not(h4) {
     font-size: 16px !important;
 }
 
 /* And scale it down on given viewport width */
 @media (max-width: 1439px) {
-    yasgui-component * {
+    /* Omit the heading  tags */
+    yasgui-component :not(h3):not(h4) {
         font-size: 14px !important;
     }
+}
+
+yasgui-component .dialog .dialog-footer .cancel-button {
+    margin-right: 3px;
+    background-color: #ebebeb;
+    border-color: #ebebeb;
 }
 
 yasgui-component .yasgui-btn.btn-selected {
@@ -102,6 +110,7 @@ yasgui-component .ok-button,
 yasgui-component .primary-button,
 yasgui-component .confirm-button {
     background-color: var(--primary-color) !important;
+    border-color: var(--primary-color) !important;
 }
 
 yasgui-component .yasr a,


### PR DESCRIPTION
## What
Fix dialog font and color issues.
* Improve the selector used to reset the font-size in ontotext-yasgui so that it omits the heading tags to prevent breaking their native styling.
* Decrease margin between buttons in the dialog footer to be more consistent with the current workbench.
* Fix colors of the buttons in the dialog.

## Why
For consistency with other buttons and with the current workbench

## How
Changed the css selectors and style properties of the buttons.