### PR TITLE
Update ontotext-yasgui component version to 1.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.10",
+                "ontotext-yasgui-web-component": "1.1.11",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10113,9 +10113,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.10",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.10.tgz",
-            "integrity": "sha512-bafC+gV7nU7k69YgdJrF2mVaTfoua/AvsX3/TBHiUfIBzhp+5OmvL1fVg/gpJVsakL76ojlDPggTg4XMfACw8Q==",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.11.tgz",
+            "integrity": "sha512-jwNrLfD3lp1tacqXmIZ603rpu5a+SumUtEGGnmMzObHgJDxJ1mH8PwaNzhtV70pdn/tDdiEJ9SNTQdblNLd0lg==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24725,9 +24725,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.10",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.10.tgz",
-            "integrity": "sha512-bafC+gV7nU7k69YgdJrF2mVaTfoua/AvsX3/TBHiUfIBzhp+5OmvL1fVg/gpJVsakL76ojlDPggTg4XMfACw8Q==",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.11.tgz",
+            "integrity": "sha512-jwNrLfD3lp1tacqXmIZ603rpu5a+SumUtEGGnmMzObHgJDxJ1mH8PwaNzhtV70pdn/tDdiEJ9SNTQdblNLd0lg==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.10",
+        "ontotext-yasgui-web-component": "1.1.11",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -113,6 +113,14 @@ yasgui-component .confirm-button {
     border-color: var(--primary-color) !important;
 }
 
+yasgui-component .yasr .alert-box {
+    padding-right: 35px;
+}
+
+yasgui-component .yasr .alert-box .close-button {
+    font-size: 21px !important;
+}
+
 yasgui-component .yasr a,
 yasgui-component .yasr .overlay_content .yasr_btn,
 yasgui-component .yasr .yasr_btn.selected {


### PR DESCRIPTION
## What
* Update ontotext-yasgui component version to 1.1.11 and also ensure needed changes in workbench styling are applied too.

## Why
The yasgui version includes following changes:
* GDB-9234: When scrolling through pages in the SPARQL editor and results, the page order is shortly lost
* GDB-8984: Add close other tabs keyboard shortcut description
* GDB-8984: Add close other tabs functionality when click on close tab button with 'Shift' key pressed
* GDB-9147 introduce an alert box component
* GDB-9147 handle google charts error
* GDB-9267 position the query button at the bottom of the editor
* GDB-9142 make datatable horizontally scrollable

## How
Increased the version