### PR TITLE
GDB-9108 removed node replacement operation for GDB10.5 version

### DIFF
--- a/src/pages/cluster-management/clusterInfo.html
+++ b/src/pages/cluster-management/clusterInfo.html
@@ -40,11 +40,12 @@
                     gdb-tooltip="{{'cluster_management.buttons.add_nodes_btn_tooltip' | translate}}" tooltip-placement="bottom">
                 <span class="icon-plus"></span> {{'cluster_management.buttons.add_nodes_btn' | translate}}
             </button>
-            <button type="button" class="btn btn-primary replace-nodes-btn mr-2" ng-if="currentLeader"
-                    ng-click="showReplaceNodesDialog()"
-                    gdb-tooltip="{{'cluster_management.buttons.replace_nodes_btn_tooltip' | translate}}" tooltip-placement="bottom">
-                <span class="icon-exchange"></span> {{'cluster_management.buttons.replace_nodes_btn' | translate}}
-            </button>
+<!--            TODO: removed for GDB10.5 version due to instability of the cluster in the backend -->
+<!--            <button type="button" class="btn btn-primary replace-nodes-btn mr-2" ng-if="currentLeader"-->
+<!--                    ng-click="showReplaceNodesDialog()"-->
+<!--                    gdb-tooltip="{{'cluster_management.buttons.replace_nodes_btn_tooltip' | translate}}" tooltip-placement="bottom">-->
+<!--                <span class="icon-exchange"></span> {{'cluster_management.buttons.replace_nodes_btn' | translate}}-->
+<!--            </button>-->
         </div>
     </div>
     <button class="btn btn-link preview-cluster-config-btn"

--- a/test-cypress/integration/cluster/cluster-management.spec.js
+++ b/test-cypress/integration/cluster/cluster-management.spec.js
@@ -9,7 +9,8 @@ import {ReplaceNodesDialogSteps} from "../../steps/cluster/replace-nodes-dialog-
 import {ApplicationSteps} from "../../steps/application-steps";
 import {ClusterViewSteps} from "../../steps/cluster/cluster-view-steps";
 
-describe('Cluster management', () => {
+// TODO: removed for GDB10.5 version due to instability of the cluster in the backend
+describe.skip('Cluster management', () => {
 
     let repositoryId;
 


### PR DESCRIPTION
## What
Removed node replacement operation for GDB10.5 version.

## Why
Removed it due to instability of the cluster in the backend after introducing the feature.

## How
Hide the button that opens the replace node dialog and skipped the tests.