### PR TITLE
GDB-9269 change yasqe height in all views but sparql

### DIFF
--- a/src/css/create-similarity-index.css
+++ b/src/css/create-similarity-index.css
@@ -6,3 +6,7 @@
     max-height: 345px;
     overflow-y: auto;
 }
+
+yasgui-component .CodeMirror {
+    height: 330px !important;
+}

--- a/src/css/graphs-config.css
+++ b/src/css/graphs-config.css
@@ -8,6 +8,10 @@
     overflow-y: auto;
 }
 
+yasgui-component .CodeMirror {
+    height: 330px !important;
+}
+
 /* Centers loader vertically within the space occupied by the editor */
 #sparql-content .ot-loader-new-content {
     margin-top: 121px;

--- a/src/css/jdbc-create.css
+++ b/src/css/jdbc-create.css
@@ -2,3 +2,7 @@
     /* unset it to prevent yasgui inner controls misalignment */
     position: unset;
 }
+
+yasgui-component .CodeMirror {
+    height: 498px !important;
+}

--- a/src/css/sparql-templates.css
+++ b/src/css/sparql-templates.css
@@ -1,0 +1,3 @@
+yasgui-component .CodeMirror {
+    height: 567px !important;
+}

--- a/src/pages/sparql-template-create.html
+++ b/src/pages/sparql-template-create.html
@@ -1,3 +1,5 @@
+<link href="css/sparql-templates.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+
 <div class="container-fluid fit-content-on-mobile"  ng-if="!queryIsRunning">
     <h1>
         {{title}}


### PR DESCRIPTION
## What
In all views where yasgui is used the yasqe should have fixed height, so that it accomodates also some other elements below it, like buttons, etc.

## Why
There is a function in the yasgui component which dinamically calculates the yasqe height so that the editor to fit tightly in the available screen space. The function works ok for the sparql view, but in the rest of the views it screws the layout a bit, because there are some other elements below the editor and this forces a vertical scrollbar to appear in most places or just its height is not the same as in the current workbench.

## How
Add fixed height to codemirror on each view so that to override the calculated base height.