### PR TITLE
GDB-9317 increase tab close confirmation dialog font size

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -6,8 +6,10 @@ yasgui-component :not(h3,h4,sup) {
     font-size: 1rem !important;
 }
 
-/* Dialog body should have slightly bigger font-size */
-yasgui-component .dialog-body {
+/* Dialog body should have slightly bigger font-size. */
+yasgui-component .dialog-body,
+/* When it is attached directly to the html body. */
+.confirmation-dialog .dialog-body {
     font-size: 1.25rem !important;
 }
 


### PR DESCRIPTION
## What
Increase tab close confirmation dialog font size.

## Why
It differs from current workbench. The reason is that we use the custom confirmation-dialog web component from the ontotext-yasgui library where it is styled but the style is applied in the context of the yasgui-component and this dialog here is attached to the html body directly instead.

## How
Added additional css selector for when the dialog is attached to the html body directly