### PR TITLE
GDB-9317 add more space between buttons in delete tab dialog

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -21,7 +21,8 @@ yasgui-component .dialog-body,
     }
 }
 
-yasgui-component .dialog .dialog-footer .cancel-button {
+yasgui-component .dialog .dialog-footer .cancel-button,
+.confirmation-dialog .dialog-footer .cancel-button {
     margin-right: 3px;
     background-color: #ebebeb;
     border-color: #ebebeb;


### PR DESCRIPTION
## What
Add more space between buttons in delete tab dialog.

## Why
The delete tab dialog in yasgui is rendered directly in the body and that's why the styles for the dialogs in the yasgui context doesn't affect it. For consistency with the current workbench.

## How
Added additional selector to match the delete tab dialog.