### PR TITLE
GDB-9349 authorize jdbc preview requests

### DIFF
--- a/src/js/angular/jdbc/controllers.js
+++ b/src/js/angular/jdbc/controllers.js
@@ -454,9 +454,7 @@ function JdbcCreateCtrl($scope, $location, toastr, $repositories, $window, $time
         if (!$scope.queryIsRunning) {
             // set proper headers because on page reload these might not be present until active repository is not
             // changed via the menu
-            let ajaxSetupElement = $.ajaxSetup()['headers'];
-            console.log(`ajax headers`, ajaxSetupElement);
-            $.ajaxSetup()['headers'] = ajaxSetupElement || {};
+            $.ajaxSetup()['headers'] = $.ajaxSetup()['headers'] || {};
             const repositoryConfig = $repositories.getActiveRepositoryObject();
             const authToken = AuthTokenService.getAuthToken();
             if (authToken) {

--- a/src/js/angular/jdbc/controllers.js
+++ b/src/js/angular/jdbc/controllers.js
@@ -60,9 +60,9 @@ function JdbcListCtrl($scope, $repositories, JdbcRestService, toastr, ModalServi
     };
 }
 
-JdbcCreateCtrl.$inject = ['$scope', '$location', 'toastr', '$repositories', '$window', '$timeout', 'JdbcRestService', 'RDF4JRepositoriesRestService', 'SparqlRestService', 'ModalService', '$translate'];
+JdbcCreateCtrl.$inject = ['$scope', '$location', 'toastr', '$repositories', '$window', '$timeout', 'JdbcRestService', 'RDF4JRepositoriesRestService', 'SparqlRestService', 'ModalService', 'AuthTokenService', '$translate'];
 
-function JdbcCreateCtrl($scope, $location, toastr, $repositories, $window, $timeout, JdbcRestService, RDF4JRepositoriesRestService, SparqlRestService, ModalService, $translate) {
+function JdbcCreateCtrl($scope, $location, toastr, $repositories, $window, $timeout, JdbcRestService, RDF4JRepositoriesRestService, SparqlRestService, ModalService, AuthTokenService, $translate) {
 
     $scope.name = $location.search().name || '';
     $scope.getNamespaces = getNamespaces;
@@ -454,8 +454,14 @@ function JdbcCreateCtrl($scope, $location, toastr, $repositories, $window, $time
         if (!$scope.queryIsRunning) {
             // set proper headers because on page reload these might not be present until active repository is not
             // changed via the menu
-            $.ajaxSetup()['headers'] = $.ajaxSetup()['headers'] || {};
+            let ajaxSetupElement = $.ajaxSetup()['headers'];
+            console.log(`ajax headers`, ajaxSetupElement);
+            $.ajaxSetup()['headers'] = ajaxSetupElement || {};
             const repositoryConfig = $repositories.getActiveRepositoryObject();
+            const authToken = AuthTokenService.getAuthToken();
+            if (authToken) {
+                $.ajaxSetup()['headers']['Authorization'] = authToken;
+            }
             $.ajaxSetup()['headers']['X-GraphDB-Repository'] = repositoryConfig ? repositoryConfig.id : undefined;
             $.ajaxSetup()['headers']['X-GraphDB-Repository-Location'] = repositoryConfig ? repositoryConfig.location : undefined;
             $scope.currentQuery.outputType = 'table';


### PR DESCRIPTION
## What
Authorize JDBC preview requests which previously failed with status 401 when GDB security was on.

## Why
The changes related with the following tasks https://ontotext.atlassian.net/browse/GDB-8813, https://ontotext.atlassian.net/browse/GDB-8644 were causing loss of functionality where some of the required by the GDB http headers were not sent with the request for the JDBC preview. The following fix was applied later on https://github.com/Ontotext-AD/graphdb-workbench/pull/1131 but it seemingly missed the criteria for authenticating the preview requests.

## How
Added the Authorization token if present as a header in the request config.