### PR TITLE
GDB-8643 Handle repository change and reset results rendered in yasgui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.14",
+                "ontotext-yasgui-web-component": "1.1.15",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10113,9 +10113,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.14.tgz",
-            "integrity": "sha512-zdpMMMoMZlMtBS90Yy3iRRnW6yBtPY+qufcNjOLmNaSGgwZ0mbWlOiARJvuWUygqu8tEDGp+cVi9zdL2iCEdSA==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.15.tgz",
+            "integrity": "sha512-b3fuuUtKpw2vfEWwWGXFqGBL9YqH7Sf9SHoi6b4oX67zTOi7zdbksy2DYxQIXYlqQfQRiM8kHBUKlL+9PzeO2g==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24725,9 +24725,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.14.tgz",
-            "integrity": "sha512-zdpMMMoMZlMtBS90Yy3iRRnW6yBtPY+qufcNjOLmNaSGgwZ0mbWlOiARJvuWUygqu8tEDGp+cVi9zdL2iCEdSA==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.15.tgz",
+            "integrity": "sha512-b3fuuUtKpw2vfEWwWGXFqGBL9YqH7Sf9SHoi6b4oX67zTOi7zdbksy2DYxQIXYlqQfQRiM8kHBUKlL+9PzeO2g==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.13",
+                "ontotext-yasgui-web-component": "1.1.14",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10113,9 +10113,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.13.tgz",
-            "integrity": "sha512-oAkHBB6/BzPH+tYpOPbCzensn1GiaL3hwwP7zBdTa7qzPL2tjnMjSsFktsAeMgqESqC+he/hx25isCFn1YyiEg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.14.tgz",
+            "integrity": "sha512-zdpMMMoMZlMtBS90Yy3iRRnW6yBtPY+qufcNjOLmNaSGgwZ0mbWlOiARJvuWUygqu8tEDGp+cVi9zdL2iCEdSA==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24725,9 +24725,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.13.tgz",
-            "integrity": "sha512-oAkHBB6/BzPH+tYpOPbCzensn1GiaL3hwwP7zBdTa7qzPL2tjnMjSsFktsAeMgqESqC+he/hx25isCFn1YyiEg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.14.tgz",
+            "integrity": "sha512-zdpMMMoMZlMtBS90Yy3iRRnW6yBtPY+qufcNjOLmNaSGgwZ0mbWlOiARJvuWUygqu8tEDGp+cVi9zdL2iCEdSA==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.14",
+        "ontotext-yasgui-web-component": "1.1.15",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/src/js/angular/graphexplore/controllers/graphs-config.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-config.controller.js
@@ -338,18 +338,17 @@ function GraphConfigCtrl(
             // setLoader(true, $translate.instant('evaluating.query.msg'));
 
             executeYasqeQuery();
-            switchToYasr();
         }
     };
 
     const executeYasqeQuery = async () => {
         const yasguiInstance = await getYasguiInstance();
-        yasguiInstance.query();
+        yasguiInstance.query(RenderingMode.YASR);
     }
 
     const switchToYasqe = async () => {
         const yasguiInstance = await getYasguiInstance()
-        yasguiInstance.changeRenderMode(RenderingMode.YASQE);
+        return yasguiInstance.changeRenderMode(RenderingMode.YASQE);
     }
 
     const switchToYasr = async () => {
@@ -364,7 +363,7 @@ function GraphConfigCtrl(
 
     const abortQuery = async () => {
         const yasguiInstance = await getYasguiInstance()
-        yasguiInstance.abortQuery();
+        return yasguiInstance.abortQuery();
     }
 
     const getNamespaces = () => {
@@ -591,6 +590,16 @@ function GraphConfigCtrl(
         }
     };
 
+    const repositoryChangedHandler = () => {
+        // Switch yasgui to editor mode only if the start mode is query or not on the first  tab. Only in these cases
+        // the yasgui is visible.
+        if ($scope.newConfig.isStartMode(StartMode.QUERY) || $scope.page > 1) {
+            // this should be set to `yasr` in order to switch the buttons for preview and editor
+            $scope.viewMode = 'yasr';
+            abortQuery().then(switchToYasqe);
+        }
+    };
+
     // =========================
     // Event handlers
     // =========================
@@ -599,6 +608,7 @@ function GraphConfigCtrl(
     subscriptions.push($scope.$on('autocompleteStatus', checkAutocompleteStatus));
     subscriptions.push($scope.$on('$locationChangeStart', locationChangedHandler));
     subscriptions.push($scope.$on('$destroy', unsubscribeListeners));
+    subscriptions.push($scope.$watch($scope.getActiveRepositoryObject, repositoryChangedHandler));
     window.addEventListener('beforeunload', beforeunloadHandler);
 
     // Trigger for showing the editor and moving it to the right position

--- a/src/js/angular/jdbc/controllers.js
+++ b/src/js/angular/jdbc/controllers.js
@@ -118,7 +118,7 @@ function JdbcCreateCtrl(
     $scope.isQueryRunning = false;
     $scope.canEditActiveRepo = false;
 
-    // This flag is used to prevent loading of the controller resources on consecutive repository change events after
+    // This flag is used to prevent loading of the yasgui on consecutive repository change events after
     // the first.
     let initialRepoInitialization = true;
 

--- a/src/js/angular/jdbc/controllers.js
+++ b/src/js/angular/jdbc/controllers.js
@@ -617,7 +617,7 @@ function JdbcCreateCtrl(
                 loadOntotextYasgui();
                 initialRepoInitialization = false;
             } else {
-                goToJdbcView();
+                getOntotextYasgui().abortQuery().then(goToJdbcView);
             }
         }
     };

--- a/src/js/angular/jdbc/controllers.js
+++ b/src/js/angular/jdbc/controllers.js
@@ -118,6 +118,10 @@ function JdbcCreateCtrl(
     $scope.isQueryRunning = false;
     $scope.canEditActiveRepo = false;
 
+    // This flag is used to prevent loading of the controller resources on consecutive repository change events after
+    // the first.
+    let initialRepoInitialization = true;
+
     // =========================
     // Public functions
     // =========================
@@ -609,7 +613,12 @@ function JdbcCreateCtrl(
     const repositoryChangedHandler = (activeRepo) => {
         if (activeRepo) {
             $scope.canEditActiveRepo = $scope.canWriteActiveRepo();
-            loadOntotextYasgui();
+            if (initialRepoInitialization) {
+                loadOntotextYasgui();
+                initialRepoInitialization = false;
+            } else {
+                goToJdbcView();
+            }
         }
     };
 

--- a/src/js/angular/models/yasgui-component.js
+++ b/src/js/angular/models/yasgui-component.js
@@ -146,4 +146,13 @@ export class YasguiComponent {
     abortQuery() {
         return this.yasguiComponent.abortQuery();
     }
+
+    /**
+     * Resets the YASR results.
+     *
+     * @return {Promise<void>}
+     */
+    resetYasrResults() {
+        return this.yasguiComponent.resetResults();
+    }
 }

--- a/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/src/js/angular/similarity/controllers/create-index.controller.js
@@ -257,10 +257,12 @@ function CreateSimilarityIdxCtrl(
 
     $scope.showEditor = () => {
         const ontotextYasgui = getOntotextYasgui();
-        ontotextYasgui.abortQuery();
-        ontotextYasgui.setQuery($scope.similarityIndexInfo.getQuery());
-        $scope.similarityIndexInfo.setSelectedYasguiRenderMode(RenderingMode.YASQE);
-        ontotextYasgui.changeRenderMode($scope.similarityIndexInfo.getSelectedYasguiRenderMode());
+        ontotextYasgui.abortQuery().then(() => {
+            return ontotextYasgui.setQuery($scope.similarityIndexInfo.getQuery());
+        }).then(() => {
+            $scope.similarityIndexInfo.setSelectedYasguiRenderMode(RenderingMode.YASQE);
+            return ontotextYasgui.changeRenderMode($scope.similarityIndexInfo.getSelectedYasguiRenderMode());
+        });
     };
 
     $scope.toggleHelp = (value) => {

--- a/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/src/js/angular/similarity/controllers/create-index.controller.js
@@ -875,6 +875,10 @@ function CreateSimilarityIdxCtrl(
     };
 
     const repositoryChangedHandler = () => {
+        // when repository is changed we have to switch yasgui back to editor mode
+        if ($scope.isYasrShown() && $scope.similarityIndexInfo.isDataQueryTypeSelected()) {
+            $scope.showEditor();
+        }
         $scope.canEditActiveRepo = $scope.canWriteActiveRepo();
         const config = {...$scope.yasguiConfig, yasqeMode: $scope.canWriteActiveRepo()};
         updateYasguiComponent(config);
@@ -936,13 +940,13 @@ function CreateSimilarityIdxCtrl(
                     usedPrefixes = usedPrefixesResponse;
                     init();
                 }).catch((error) => {
-                console.log(error)
-                $scope.repositoryError = getError(error);
-            }).finally(() => {
-                subscriptions.push($scope.$on('repositoryIsSet', repositoryChangedHandler));
-                repoIsInitialized();
-                $scope.loadingControllerResources = false;
-            });
+                    console.log(error)
+                    $scope.repositoryError = getError(error);
+                }).finally(() => {
+                    subscriptions.push($scope.$on('repositoryIsSet', repositoryChangedHandler));
+                    repoIsInitialized();
+                    $scope.loadingControllerResources = false;
+                });
         }
     });
 }

--- a/src/js/angular/sparql-template/controllers.js
+++ b/src/js/angular/sparql-template/controllers.js
@@ -124,6 +124,10 @@ function SparqlTemplateCreateCtrl(
     $scope.language = $languageService.getLanguage();
     $scope.canEditActiveRepo = false;
 
+    // This flag is used to prevent loading of the yasgui on consecutive repository change events after
+    // the first.
+    let initialRepoInitialization = true;
+
 
     // =========================
     // Public functions
@@ -459,7 +463,12 @@ function SparqlTemplateCreateCtrl(
     const repositoryChangedHandler = (activeRepo) => {
         if (activeRepo) {
             $scope.canEditActiveRepo = $scope.canWriteActiveRepo();
-            loadOntotextYasgui();
+            if (initialRepoInitialization) {
+                loadOntotextYasgui();
+                initialRepoInitialization = false;
+            } else {
+                goToSparqlTemplatesView();
+            }
         }
     };
 

--- a/test-cypress/integration/setup/sparql-template-create.js
+++ b/test-cypress/integration/setup/sparql-template-create.js
@@ -103,18 +103,25 @@ describe('SPARQL create template', () => {
         ImportSteps.verifyUserImportUrl();
     });
 
-    it('should not change the view if I am creating a new sparql template and change the repository', {
-        retries: {runMode: 1, openMode: 0}
-    }, () => {
+    it('should not change the view if I am creating a new sparql template and change the repository', () => {
         // When I visit 'Sparql create template' view,
         // make some changes.
         SparqlCreateUpdateSteps.typeTemplateId('http://test');
-
         // When I change the repository.
         RepositorySelectorSteps.selectRepository(secondRepositoryId);
-
         // Then I expect the view not changed
         SparqlCreateUpdateSteps.verifyUrl();
+        // And I expect to see a confirmation dialog.
+        ModalDialogSteps.getDialog().should('be.visible');
+    });
+
+    it('Should redirect to templates catalog view when repository is changed', () => {
+        // When I visit 'Sparql create template' view
+        // When I change the repository.
+        RepositorySelectorSteps.selectRepository(secondRepositoryId);
+        // Then I expect to be redirected to templates catalog view.
+        SparqlTemplatesSteps.verifyUrl();
+        SparqlTemplatesSteps.getSparqlTemplatesListContainer().should('be.visible');
     });
 
     it('should ask for confirmation when try to save sparql template with already existing template id', () => {

--- a/test-cypress/integration/sparql-editor/sparql-editor.spec.js
+++ b/test-cypress/integration/sparql-editor/sparql-editor.spec.js
@@ -49,5 +49,7 @@ describe('Sparql editor', () => {
         YasrSteps.getYasrResultsContainer().should('be.empty');
         // And I should see a warning message that there are no results
         YasrSteps.getNoResultsMessage().should('be.visible');
+        // And yasr tabs should not be visible
+        YasrSteps.getResultHeader().should('not.be.visible');
     });
 });

--- a/test-cypress/integration/sparql-editor/sparql-editor.spec.js
+++ b/test-cypress/integration/sparql-editor/sparql-editor.spec.js
@@ -2,7 +2,7 @@ import {SparqlEditorSteps} from "../../steps/sparql-editor-steps";
 import {YasguiSteps} from "../../steps/yasgui/yasgui-steps";
 import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
 import {YasrSteps} from "../../steps/yasgui/yasr-steps";
-import HomeSteps from "../../steps/home-steps";
+import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";
 
 describe('Sparql editor', () => {
     let repositoryId;
@@ -42,7 +42,7 @@ describe('Sparql editor', () => {
         YasqeSteps.executeQuery();
         YasrSteps.getResults().should('be.visible');
         // When I change the repository
-        HomeSteps.selectRepoFromEverywhere(secondRepositoryId);
+        RepositorySelectorSteps.selectRepository(secondRepositoryId);
         // Then I expect yasgui to be visible
         YasguiSteps.getYasgui().should('be.visible');
         // And yasr results and plugins should not be visible

--- a/test-cypress/integration/sparql-editor/sparql-editor.spec.js
+++ b/test-cypress/integration/sparql-editor/sparql-editor.spec.js
@@ -1,20 +1,53 @@
 import {SparqlEditorSteps} from "../../steps/sparql-editor-steps";
 import {YasguiSteps} from "../../steps/yasgui/yasgui-steps";
-import {QueryStubs} from "../../stubs/yasgui/query-stubs";
+import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
+import {YasrSteps} from "../../steps/yasgui/yasr-steps";
+import HomeSteps from "../../steps/home-steps";
 
-describe('Default view', () => {
+describe('Sparql editor', () => {
+    let repositoryId;
+    let secondRepositoryId;
 
     beforeEach(() => {
-        const repositoryId = 'sparql-editor-' + Date.now();
-        QueryStubs.stubQueryCountResponse();
+        repositoryId = 'sparql-editor-' + Date.now();
+        // QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
-        cy.intercept('/repositories/test-repo', {fixture: '/graphql-editor/default-query-response.json'}).as('getGuides');
     });
 
-    it('Should load component with default configuration', () => {
-        SparqlEditorSteps.visitSparqlEditorPage();
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+        cy.deleteRepository(secondRepositoryId);
+    });
 
+    it('Should load yasgui with default configuration', () => {
+        // Given I have opened the workbench
+        // When I visit the sparql editor page
+        SparqlEditorSteps.visitSparqlEditorPage();
+        // Then I should see the yasgui component
         YasguiSteps.getYasgui().should('be.visible');
+        // When I execute the default query
+        YasqeSteps.executeQuery();
+        // Then I should see the results
+        YasrSteps.getResults().should('be.visible').and('have.length.gt', 0);
+    });
+
+    it('Should reset yasgui state when repository is changed', () => {
+        // create second repository
+        secondRepositoryId = repositoryId + '-second';
+        cy.createRepository({id: secondRepositoryId});
+        // Given I have opened the sparql editor and executed a query
+        SparqlEditorSteps.visitSparqlEditorPage();
+        YasguiSteps.getYasgui().should('be.visible');
+        YasqeSteps.executeQuery();
+        YasrSteps.getResults().should('be.visible');
+        // When I change the repository
+        HomeSteps.selectRepoFromEverywhere(secondRepositoryId);
+        // Then I expect yasgui to be visible
+        YasguiSteps.getYasgui().should('be.visible');
+        // And yasr results and plugins should not be visible
+        YasrSteps.getYasrResultsContainer().should('be.empty');
+        // And I should see a warning message that there are no results
+        YasrSteps.getNoResultsMessage().should('be.visible');
     });
 });

--- a/test-cypress/steps/home-steps.js
+++ b/test-cypress/steps/home-steps.js
@@ -54,6 +54,12 @@ class HomeSteps {
             .click();
     }
 
+    static selectRepoFromEverywhere(repositoryId) {
+        cy.get('#btnReposGroup').click();
+        cy.get('.dropdown-menu').should('be.visible');
+        cy.get('.dropdown-menu').contains(repositoryId).click();
+    }
+
     static createRepo() {
         let repositoryId = 'home-repository-' + Date.now();
         cy.createRepository({id: repositoryId});

--- a/test-cypress/steps/home-steps.js
+++ b/test-cypress/steps/home-steps.js
@@ -54,12 +54,6 @@ class HomeSteps {
             .click();
     }
 
-    static selectRepoFromEverywhere(repositoryId) {
-        cy.get('#btnReposGroup').click();
-        cy.get('.dropdown-menu').should('be.visible');
-        cy.get('.dropdown-menu').contains(repositoryId).click();
-    }
-
     static createRepo() {
         let repositoryId = 'home-repository-' + Date.now();
         cy.createRepository({id: repositoryId});

--- a/test-cypress/steps/setup/sparql-templates-steps.js
+++ b/test-cypress/steps/setup/sparql-templates-steps.js
@@ -8,6 +8,10 @@ export class SparqlTemplatesSteps {
         cy.url().should('include', '/sparql-templates');
     }
 
+    static getSparqlTemplatesListContainer() {
+        return cy.get('.sparql-templates-list');
+    }
+
     static getCreateSparqlTemplateButton() {
         return cy.get('.create-sparql-template');
     }

--- a/test-cypress/steps/yasgui/yasr-steps.js
+++ b/test-cypress/steps/yasgui/yasr-steps.js
@@ -19,6 +19,10 @@ export class YasrSteps {
         return YasrSteps.getResultHeader().get('.error-response-plugin-body');
     }
 
+    static getYasrResultsContainer() {
+        return YasrSteps.getYasr().find('.yasr_results');
+    }
+
     static getResults() {
         return YasrSteps.getYasr().find('.yasr_results tbody').find('tr');
     }
@@ -96,5 +100,9 @@ export class YasrSteps {
 
     static getNoDataElement() {
         return cy.get('.dataTables_empty');
+    }
+
+    static getNoResultsMessage() {
+        return YasrSteps.getYasr().find('.alert-success');
     }
 }


### PR DESCRIPTION
## What
Handle repository change and reset results rendered in yasgui. This involves all views where the yasgui is used: sparql editor, jdbc, sparql templates, similarity index create, visual graph, resource view

## Why
For consistency with the current workbench.

## How
Trigger the reset results method in yasgui component when repository gets changed. Also added a flag that prevents the reset on the initialization of the view when the repository change event is also fired.