### PR TITLE
GDB-9398 top align yasgui in sparql view

### DIFF
--- a/src/js/angular/core/directives.js
+++ b/src/js/angular/core/directives.js
@@ -123,12 +123,19 @@ coreErrors.$inject = ['$timeout'];
 
 function coreErrors($timeout) {
     return {
-        // FIXME: Why doesn't require find mainCtrl?
-        // require: '^^mainCtrl',
         restrict: 'EA',
         transclude: true,
         templateUrl: 'js/angular/core/templates/core-errors.html',
         link: function (scope, element, attrs) {
+            // watch for changes in the active repository hide host element of this directive
+            scope.$watch('getActiveRepository()', function (newValue) {
+                if (newValue && !scope.isRestricted) {
+                    element.hide();
+                } else {
+                    element.show();
+                }
+            });
+
             scope.setAttrs(attrs);
 
             scope.setRestricted();

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -84,6 +84,10 @@ function SparqlEditorCtrl($scope,
         };
     };
 
+    $scope.getActiveRepositoryNoError = () => {
+        return $repositories.getActiveRepository();
+    };
+
     // =========================
     // Private functions
     // =========================

--- a/src/pages/sparql-editor.html
+++ b/src/pages/sparql-editor.html
@@ -12,7 +12,8 @@
 
     <div core-errors></div>
 
-    <yasgui-component id="query-editor" yasgui-config="yasguiConfig" ng-if="yasguiConfig"
+    <yasgui-component id="query-editor" yasgui-config="yasguiConfig"
+                      ng-if="yasguiConfig && getActiveRepositoryNoError()"
                       after-init="initViewFromUrlParams()"></yasgui-component>
 
     <form id="wb-download" method="POST" action="" target="_self">


### PR DESCRIPTION
## What
Top align yasgui in sparql view.

## Why
It received some top offset when the core-errors directive was added. The way directive is implemented results in weird behavior where its content elements being always rendered in the DOM but invisible. That's why everything laying beneath being pushed down needlessly.

## How
Refactored the directive a bit to check if there is actually a need to be rendered and show or hide its host element respectively.