### PR TITLE
GDB-8984: Fixes YASQE tabs issues.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.15",
+                "ontotext-yasgui-web-component": "1.1.16",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10113,9 +10113,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.15.tgz",
-            "integrity": "sha512-b3fuuUtKpw2vfEWwWGXFqGBL9YqH7Sf9SHoi6b4oX67zTOi7zdbksy2DYxQIXYlqQfQRiM8kHBUKlL+9PzeO2g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.16.tgz",
+            "integrity": "sha512-dLGXbqiMNguPvRjwUVEGwIor/DmNJA1aFXIo3oU4rODBFcUxLH0lYPhYOylNrZhIeMcDdiOPHHwOER9pp9z3RA==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24725,9 +24725,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.15.tgz",
-            "integrity": "sha512-b3fuuUtKpw2vfEWwWGXFqGBL9YqH7Sf9SHoi6b4oX67zTOi7zdbksy2DYxQIXYlqQfQRiM8kHBUKlL+9PzeO2g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.16.tgz",
+            "integrity": "sha512-dLGXbqiMNguPvRjwUVEGwIor/DmNJA1aFXIo3oU4rODBFcUxLH0lYPhYOylNrZhIeMcDdiOPHHwOER9pp9z3RA==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.15",
+        "ontotext-yasgui-web-component": "1.1.16",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -74,6 +74,12 @@ yasgui-component .yasqe_queryButton {
     height: 38px !important;
 }
 
+yasgui-component .editable-text-field-wrapper,
+yasgui-component .yasgui .tabsList .tab {
+    color: inherit;
+    font-weight: 400;
+}
+
 yasgui-component .editable-text-field-wrapper, yasgui-component .yasgui .tabsList .tab .closeTab {
     color: var(--secondary-color);
 }

--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -80,19 +80,28 @@ yasgui-component .yasgui .tabsList .tab {
     font-weight: 400;
 }
 
-yasgui-component .editable-text-field-wrapper, yasgui-component .yasgui .tabsList .tab .closeTab {
-    color: var(--secondary-color);
+yasgui-component .yasgui .tabsList .tab .closeTab,
+yasgui-component .yasgui .tabsList .addTab {
+    color: rgba(0, 0, 0, 0.66) !important;
 }
 
-yasgui-component .yasgui .tabsList .tab .closeTab:hover {
+yasgui-component .yasgui .tabsList .tab .closeTab .icon-close,
+yasgui-component .yasgui .tabsList .addTab .icon-plus {
+    font-size: 1.225em !important;
+}
+
+yasgui-component .yasgui .tabsList .tab .closeTab:hover,
+yasgui-component .yasgui .tabsList .addTab:hover {
     color: var(--primary-color-dark) !important;
 }
 
-yasgui-component .editable-text-field-wrapper .save-btn, yasgui-component .editable-text-field-wrapper .save-btn:hover {
+yasgui-component .editable-text-field-wrapper .save-btn,
+yasgui-component .editable-text-field-wrapper .save-btn:hover {
     background-color: var(--primary-color);
 }
 
-yasgui-component .editable-text-field-wrapper .save-btn span, yasgui-component .editable-text-field-wrapper .close-btn span {
+yasgui-component .editable-text-field-wrapper .save-btn span,
+yasgui-component .editable-text-field-wrapper .close-btn span {
     font-weight: 900;
 }
 


### PR DESCRIPTION
## What
 - Changed the color and weight of text in YASQE tabs;
 - Changes color and sizing of tabs icon.

## Why
 - The colors and weights were different from the old implementation;
 - The colors and sizing were different from the old implementation.

## How
 - Changed the color to inherit from its parent and set the weight to 400;
 - Changed the color to 'rgba(0, 0, 0, 0.66)' and set the size to 1.225em.

# Additional work
## What
Increased the version of "ontotext-yasgui-web-component."

## Why
The new version includes:
 - When opening "ontotext-editable-text-field" in edit mode, the buttons are positioned outside its container;
 - When opening "ontotext-editable-text-field" in preview mode, the tab name and close button are not properly aligned;
 - When hovering over the "Close tab" and "Add tab" icons, they do not resemble the appearance of the old version in Workbench;
 - The cancel icon X on edit is different from the old version;
 - When opening the "ontotext-edit-text-field," everything below is pushed down;
 - Added a bottom border to inactive tabs when hovered;
 - Added tooltips to the save/cancel "rename tag" buttons.