### PR TITLE
GDB-8677 change styles of download as button in yasgui

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -95,10 +95,19 @@ yasgui-component .ontotext-dropdown-menu .ontotext-dropdown-menu-item {
     font-size: 1rem;
 }
 
+yasgui-component .ontotext-dropdown-button {
+    height: 40px;
+}
+
 yasgui-component .ontotext-dropdown-button,
 yasgui-component .ontotext-dropdown-menu.open .ontotext-dropdown-menu-item {
     background-color: var(--primary-color) !important;
     color: #fff !important;
+}
+
+yasgui-component .ontotext-download-as .ontotext-dropdown-button .button-name {
+    font-family: var(--main-font);
+    font-weight: 400;
 }
 
 yasgui-component .ontotext-dropdown-button:hover,
@@ -319,27 +328,24 @@ yasgui-component .page-selector {
         font-size: 14px !important;
     }
 
-    yasgui-component .yasqe_queryButton {
+    yasgui-component .yasqe_queryButton,
+    yasgui-component .ontotext-dropdown-button {
         height: 33px !important;
     }
 }
 
-@media (max-width: 1400px) {
-    .ontotext-dropdown .ontotext-dropdown-button:after {
-        padding-left: 0 !important;
-    }
-
-    .ontotext-dropdown .button-name {
+@media (max-width: 1200px) {
+    .yasr_btn span {
         display: none;
     }
 }
 
-@media (max-width: 1200px) {
-    .explore-visual-graph-button-name {
-        display: none;
+@media (max-width: 768px) {
+    .ontotext-dropdown .button-name {
+        display: inline;
     }
 
-    .yasr_btn span {
-        display: none;
+    .ontotext-dropdown .ontotext-dropdown-button:after {
+        padding-left: 10px !important;
     }
 }


### PR DESCRIPTION
## What
Change styles of download as button in yasgui.

## Why
For consistency with current workbench

## How
* Add styles for height and font to make the button responsive.
* Remove media query which used to hide the button text on smaller resolutions. Also removed it for the visual graph button.