### PR TITLE
GDB-9366: Drop-down list in Resource view should not be accessible from Context tab

### DIFF
--- a/src/pages/explore.html
+++ b/src/pages/explore.html
@@ -62,7 +62,7 @@
                     class="form-control form-control-sm"
                     ng-model="currentContextType"
                     ng-change="changeInference(currentContextType)"
-                    ng-disabled="loading || role === 'context' || getActiveRepository() === 'SYSTEM'">
+                    ng-disabled="loading || resourceInfo.role === 'context' || getActiveRepository() === 'SYSTEM'">
                 <option ng-repeat="contextType in contextTypes"
                         value="{{contextType.id}}"
                         ng-selected="resourceInfo.contextType.id === contextType.id">

--- a/test-cypress/integration/resource/resource.spec.js
+++ b/test-cypress/integration/resource/resource.spec.js
@@ -287,6 +287,7 @@ describe('Resource view', () => {
             // When I load resource that is used as context.
             ResourceSteps.visit(`uri=${CONTEXT_EXPLICIT}&role=subject`);
 
+
             // Then I expect to see empty results because this resource has not triples as subject.
             YasrSteps.getNoDataElement().should('be.visible');
 
@@ -305,8 +306,10 @@ describe('Resource view', () => {
             // When I click on "context" tab.
             ResourceSteps.selectContextRole();
 
-            // Then I expect to see all triples of resource without mater of its role.
+            // Then I expect to see all triples of resource without mater of its role,
             YasrSteps.getResults().should('have.length', 86);
+            // and inference dropdown should be disabled.
+            ResourceSteps.getInferenceSelectElement().should('be.disabled');
 
             // When I click on "all" tab.
             ResourceSteps.selectAllRole();


### PR DESCRIPTION
## What
The "Inference" dropdown in the resource view is not disabled when the selected role is context.

## Why
After the refactoring of the controller, the variable 'role' has been removed, but the view has not been updated accordingly.

## How
Update the view of the resource view to align with the refactored model.