### PR TITLE
Increase yasgui component version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.16",
+                "ontotext-yasgui-web-component": "1.1.17",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10113,9 +10113,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.16.tgz",
-            "integrity": "sha512-dLGXbqiMNguPvRjwUVEGwIor/DmNJA1aFXIo3oU4rODBFcUxLH0lYPhYOylNrZhIeMcDdiOPHHwOER9pp9z3RA==",
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.17.tgz",
+            "integrity": "sha512-xXN4X5AOCfLCGNfXrEeUhfjroWx1b78e+sCCI9tieM9ZrIdc8hmT72w1L0Nb0Y+vzWLuJYXRBRaJFeK25ZD7mw==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24725,9 +24725,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.16.tgz",
-            "integrity": "sha512-dLGXbqiMNguPvRjwUVEGwIor/DmNJA1aFXIo3oU4rODBFcUxLH0lYPhYOylNrZhIeMcDdiOPHHwOER9pp9z3RA==",
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.17.tgz",
+            "integrity": "sha512-xXN4X5AOCfLCGNfXrEeUhfjroWx1b78e+sCCI9tieM9ZrIdc8hmT72w1L0Nb0Y+vzWLuJYXRBRaJFeK25ZD7mw==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.16",
+        "ontotext-yasgui-web-component": "1.1.17",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
* GDB-9414 preserve the query loader indicator while query is running https://github.com/Ontotext-AD/ontotext-yasgui/pull/210
* GDB-9338: When opening a saved query, there should be a very brief highlighting of the tab name in red https://github.com/Ontotext-AD/ontotext-yasgui/pull/209
* GDB-9268 make yasgui layout modes consistent with current workbench https://github.com/Ontotext-AD/ontotext-yasgui/pull/208
* GDB-9004 reposition autocomplete hint to prevent overlapping with the current line in editor https://github.com/Ontotext-AD/ontotext-yasgui/pull/207

## Why
Get latest fixes and features from the component.

## How
Increased the version