### PR TITLE
GDB-8996 fix pivot table and charts tabs icon color

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -227,6 +227,7 @@ yasgui-component .yasr .yasr_btnGroup .yasr_btn {
     font-size: 16px;
     font-weight: 400;
     color: #55595c !important;
+    fill: #55595c !important;
     background-color: #eee;
     border-bottom: 1px solid transparent;
 }


### PR DESCRIPTION
## What
Fix pivot table and charts tabs icon color.

## Why
For consistency with current workbench

## How
Add `fill` color to override the svg styling of the icon coming from yasgui.