### PR TITLE
GDB-9413: Error handling when creating connectors

### DIFF
--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -81,7 +81,7 @@ function yasguiComponentDirective(
         link: ($scope, element, attrs) => {
             $scope.classToApply = attrs.class || '';
             const downloadAsPluginNameToEventHandler = new Map();
-            const outputHandlers = new Map();
+            const outputHandlers = $scope.yasguiConfig && $scope.yasguiConfig.outputHandlers ? new Map($scope.yasguiConfig.outputHandlers) : new Map();
             // The initial query value which is set in the yasqe editor. This is used for dirty checking while the user
             // changes the query.
             let initialQueryValue = undefined;


### PR DESCRIPTION
## What
The dialog displaying progress for creating/updating a connector does not close properly.

## Why
The dialog should be closed after a create/update connector operation succeeds or fails. To close the dialog, an event handler for the "queryExecuted" event is registered. This handler is specific to the SPARQL view, and it is passed as configuration to the "yasgui-component.directive." During the refactoring of the initial code and implementation of the directive, the handler was passed but not read in the directive, resulting in the handler not being registered for the event.

## How
Added the missing registration of the handler.