### PR TITLE
GDB-8998 yasr table borders should be collapsed

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -262,6 +262,10 @@ yasgui-component .yasr .extended-boolean-plugin .response-success {
     background-color: var(--color-success-light) !important;
 }
 
+yasgui-component .yasr .dataTables_wrapper .dataTable {
+    border-collapse: collapse;
+}
+
 yasgui-component .yasr .dataTables_wrapper .dataTable thead tr th {
     font-weight: 500;
 }


### PR DESCRIPTION
## What
Yasr table borders should be collapsed.

## Why
The datatable plugin used in yasr comes with the style for `table-collapse: separate` which makes the borders thicker which is not consistent with current workbench

## How
Add style `border-collapse: collapse` to data table in yasr.