### PR TITLE
GDB-9361 sample queries in visual graph should not be repeated

### DIFF
--- a/src/css/graphs-config.css
+++ b/src/css/graphs-config.css
@@ -35,6 +35,7 @@ yasgui-component .CodeMirror {
 }
 
 .image-label {
+    flex: 1;
     border: 1px solid rgba(0, 0, 0, .125);
     padding: 1rem;
     margin: 0 1rem 0 0;

--- a/src/pages/graph-config/saveGraphConfig.html
+++ b/src/pages/graph-config/saveGraphConfig.html
@@ -237,7 +237,7 @@
                 </div>
 
                 <p class="mt-1">{{'user.queries' | translate}} </p>
-                <div ng-repeat="tab in tabsViewModel track by tab.page" ng-if="page == 1"
+                <div ng-repeat="tab in tabsViewModel track by tab.page" ng-if="tab.page == 1"
                      class="user-queries list-group">
                     <div ng-repeat="sample in samples | filter:isUserGraph">
                         <a href="#" ng-if="sample[tab.type]" ng-click="setQuery(sample[tab.type])"


### PR DESCRIPTION
## What
Sample queries in visual graph should not be repeated in the user sample queries section.

## Why
There was a wrong check in the template which caused the repeat of the user samples section to be rendered for each of the configuration tabs.

## How
* Fixed the expression the template to check the page for current active tab.
* Also added small css fix for the start node config type selector to make it equal width in all three instances.