### PR TITLE
GDB-9310 make yasqe height consistent with current workbench

### DIFF
--- a/src/css/jdbc-create.css
+++ b/src/css/jdbc-create.css
@@ -4,5 +4,5 @@
 }
 
 yasgui-component .CodeMirror {
-    height: 498px !important;
+    height: 330px !important;
 }

--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -39,6 +39,7 @@ yasgui-component .yasgui-toolbar .btn-orientation {
 yasgui-component .yasqe .CodeMirror {
     font-family: var(--mono-font) !important;
     font-size: 16px;
+    border-color: #ddd !important;
 }
 
 /* Unset the font-family so that it can inherit from workbench */

--- a/src/css/sparql-templates.css
+++ b/src/css/sparql-templates.css
@@ -1,3 +1,3 @@
 yasgui-component .CodeMirror {
-    height: 567px !important;
+    height: 330px !important;
 }

--- a/src/pages/jdbc-create.html
+++ b/src/pages/jdbc-create.html
@@ -20,7 +20,7 @@
     <div class="card jdbc-configuration">
         <div class="card-block pt-1">
             <p class="lead">{{'table.name' | translate}}</p>
-            <div class="container-fluid">
+            <div>
                 <input required
                        class="form-control jdbc-configuration-name"
                        type="text"

--- a/src/pages/sparql-template-create.html
+++ b/src/pages/sparql-template-create.html
@@ -22,7 +22,7 @@
     <div class="card mb-2 sparql-template">
         <div class="card-block pt-1">
             <p class="lead">{{'template.iri.header' | translate}}</p>
-            <div class="container-fluid">
+            <div>
                 <input required
                        class="form-control sparql-template-id"
                        type="text"


### PR DESCRIPTION
## What
Make yasqe height consistent with current workbench.

## Why
For consistency with current workbench.

## How
* Changed the height of the codemirror inside yasqe.
* Also removed the fluid container class from the yasgui wrapper to prevent the excessive padding comming from it.
* Applied darker border color to codemirror to be consistent with the one in the workbench.