### PR TITLE
GDB-9366: Drop-down list in Resource view should not be accessible from Context tab

### DIFF
--- a/src/js/angular/explore/controllers.js
+++ b/src/js/angular/explore/controllers.js
@@ -59,7 +59,7 @@ function ExploreCtrl(
 
     $scope.ContextTypes = ContextTypes;
     $scope.contextTypes = ContextType.getAllType();
-    $scope.currentContextType = ContextTypes.EXPLICIT;
+    $scope.currentContextTypeId = ContextTypes.EXPLICIT.id;
     $scope.roles = [RoleType.SUBJECT, RoleType.PREDICATE, RoleType.OBJECT, RoleType.CONTEXT, RoleType.ALL];
 
     $scope.resourceInfo = undefined;

--- a/src/pages/explore.html
+++ b/src/pages/explore.html
@@ -60,8 +60,8 @@
         <label for="inference-select" class="mb-0">
             <select id="inference-select"
                     class="form-control form-control-sm"
-                    ng-model="currentContextType"
-                    ng-change="changeInference(currentContextType)"
+                    ng-model="currentContextTypeId"
+                    ng-change="changeInference(currentContextTypeId)"
                     ng-disabled="loading || resourceInfo.role === 'context' || getActiveRepository() === 'SYSTEM'">
                 <option ng-repeat="contextType in contextTypes"
                         value="{{contextType.id}}"


### PR DESCRIPTION
## What
When opening the "Resource" view and clicking on the "inference-select" dropdown, there is an empty option. If a new option is selected, the empty option disappear.

## Why
This can happen if the select does not match any option with the value of "nb-model". [More explanation](https://stackoverflow .com/questions/12654631/why-does-angularjs-include-an-empty-option-in-select/12654812#12654812). The problem in our code is that the value of the select is an id of a context type, but during initialization, an instance of the context type is used instead of the id. This causes the select not to match the initial value with a passed option.

## How
Fixed the initial value to be the ID of the context type instead of the instance. Renamed the variable "currentContextType" to "currentContextTypeId" for more clarity regarding the expected value.