### PR TITLE
GDB-9360: Yasr - wrong extending the result table when sorting by column

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.19",
+                "ontotext-yasgui-web-component": "1.1.21",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10113,9 +10113,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.19",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.19.tgz",
-            "integrity": "sha512-MymeFV9JPgWlh29x79aS8dl3L0KQ4QZhSSWntNQIQsnLdJtJBbjRCUw+ICqGfAr5i0RRPvmd8Gs+2Ul7wWdYaw==",
+            "version": "1.1.21",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.21.tgz",
+            "integrity": "sha512-qqtnDLRIHiOLsr0oPdIG4ArCkOdzUB9cSB0RrVKv0SpSzYdU2dFw9fgGCl0ML6wzIlxuPPv7Fu3UN7Yu8o+9Jw==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24725,9 +24725,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.19",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.19.tgz",
-            "integrity": "sha512-MymeFV9JPgWlh29x79aS8dl3L0KQ4QZhSSWntNQIQsnLdJtJBbjRCUw+ICqGfAr5i0RRPvmd8Gs+2Ul7wWdYaw==",
+            "version": "1.1.21",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.21.tgz",
+            "integrity": "sha512-qqtnDLRIHiOLsr0oPdIG4ArCkOdzUB9cSB0RrVKv0SpSzYdU2dFw9fgGCl0ML6wzIlxuPPv7Fu3UN7Yu8o+9Jw==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.19",
+        "ontotext-yasgui-web-component": "1.1.21",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/src/css/sparql-editor.css
+++ b/src/css/sparql-editor.css
@@ -47,7 +47,3 @@
 .sparql-editor-view #query-editor .yasgui-toolbar .btn-selected {
     color: #fff;
 }
-
-.sparql-editor-view #query-editor .dataTables_wrapper {
-    overflow-x: auto;
-}


### PR DESCRIPTION
GDB-9360: Yasr - wrong extending the result table when sorting by one column

## What
 - When expanding some columns in the result table, the table overflows its parent container;
 - GDB-9431: The width of the first column is not set properly when columns are not resizable and the number column is hidden;
 - GDB-9449: When refreshing the SPARQL view ,the checkboxes for "Hide row numbers" and "Compact view" are reset to their default values, disregarding user changes;
 - GDB-9242: When selecting/deselecting the checkbox "Hide row numbers", the yasr result table is updated too slowly;
 - GDB-9443: change charts plugin label.

## Why
 - The overflow properties were not set;
 - GDB-9431: When the result table becomes unresizable, we set a fixed width for columns by CSS, excluding the first column for row numbers. However, the selector skips the first column even when the numbers column is hidden, causing the issue;
 - GDB-9449: The plugin configurations are persisted with a key using their plugin name. We use "extended_table" instead of "table" (the original YASGUI plugin) as it extends the table plugin. The plugin stores the configuration in "handleSetEllipsisToggle", "handleSetCompactToggle", and "handleTableSizeSelect" functions, but these are implemented in the table plugin. The issue arises as the incorrect name of the plugin "table" is passed as the first argument;
 - GDB-9242: Changing the checkbox value triggers a re-render of the entire table;
 - GDB-9443: For consistency with old YASR labels.

## How
- Increased the version of "ontotext-yasgui-web-component";