### PR TITLE
GDB-9406 migrate old yasgui persistence to new yasgui model

### DIFF
--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -11,6 +11,7 @@ import {QueryType} from "../../../models/ontotext-yasgui/query-type";
 import {YasguiComponent} from "../../../models/yasgui-component";
 import {YasguiComponentDirectiveUtil} from "./yasgui-component-directive.util";
 import {KeyboardShortcutName} from "../../../models/ontotext-yasgui/keyboard-shortcut-name";
+import {YasguiPersistenceMigrationService} from "./yasgui-persistence-migration.service";
 
 const modules = [
     'graphdb.framework.core.services.translation-service',
@@ -33,7 +34,8 @@ yasguiComponentDirective.$inject = [
     'RDF4JRepositoriesRestService',
     'MonitoringRestService',
     'SparqlRestService',
-    'ShareQueryLinkService'
+    'ShareQueryLinkService',
+    'ModalService'
 ];
 
 /**
@@ -67,7 +69,8 @@ function yasguiComponentDirective(
     RDF4JRepositoriesRestService,
     MonitoringRestService,
     SparqlRestService,
-    ShareQueryLinkService
+    ShareQueryLinkService,
+    ModalService
 ) {
 
     return {
@@ -372,10 +375,12 @@ function yasguiComponentDirective(
                         config.keyboardShortcutConfiguration = keyboardShortcutConfiguration;
                     }
 
+                    if (YasguiPersistenceMigrationService.isMigrationNeeded()) {
+                        YasguiPersistenceMigrationService.migrateYasguiPersistence($translate.instant('sparql.tab.directive.unnamed.tab.title'));
+                    }
+
                     $scope.ontotextYasguiConfig = config;
-
                     addDirtyCheckHandlers();
-
                     setInitialQueryState().then(() => {
                         if (angular.isFunction($scope.afterInit)) {
                             $scope.afterInit();

--- a/src/js/angular/core/directives/yasgui-component/yasgui-persistence-migration.service.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-persistence-migration.service.js
@@ -1,0 +1,177 @@
+import {VIEW_SPARQL_EDITOR} from "../../../models/sparql/constants";
+
+// This key is also present in the LSKeys enum in src/js/angular/models/local-storage/local-storage.service.js.
+// We don't import it here because this service is not registered in the AngularJS app.
+const OLD_YASGUI_PERSISTENCE_KEY = 'ls.tabs-state';
+const NEW_YASGUI_PERSISTENCE_KEY = `yagui__${VIEW_SPARQL_EDITOR}`;
+const MIGRATION_STATUS = {
+    COMPLETED: 'completed',
+    FAILED: 'failed',
+    REJECTED: 'rejected'
+};
+
+/**
+ * Service for migrating the old yasgui persistence to the new one.
+ */
+export const YasguiPersistenceMigrationService = (function () {
+
+    /**
+     * Checks if migration is needed by checking if the old yasgui persistence is present in local storage.
+     * @return {boolean} true if migration is needed, false otherwise
+     */
+    const isMigrationNeeded = () => {
+        const yasguiData = getPersistedData(NEW_YASGUI_PERSISTENCE_KEY);
+        let isMigrated = false;
+        if (yasguiData) {
+            isMigrated = yasguiData.val.migration &&
+                (yasguiData.val.migration.status === MIGRATION_STATUS.COMPLETED || yasguiData.val.migration.status === MIGRATION_STATUS.REJECTED);
+        }
+        return !!(localStorage.getItem(OLD_YASGUI_PERSISTENCE_KEY) && !isMigrated);
+    };
+
+    /**
+     * Migrates the old yasgui persistence to the new one.
+     * Migration follows the following steps:
+     * 1. Get the persisted data for the old yasgui in sparql view from local storage
+     * 2. Get the persisted data for the new yasgui in sparql view from local storage
+     * 3. Migrate the data for each tab from the old yasgui to the new one by copying the tab name, id, query, sameAs and inference
+     * 4. Persist the migrated data for the new yasgui in sparql view to local storage
+     * 5. Rename the old yasgui persistence key to prevent further migrations
+     *
+     * The old yasgui persistence key is changed to prevent further automatic migrations.
+     *
+     * @param {string} newTabTitle the title of a new tab
+     */
+    const migrateYasguiPersistence = (newTabTitle) => {
+        // make sure the old sparql view data object properties cannot be changed
+        let oldSparqlViewData = getPersistedData(OLD_YASGUI_PERSISTENCE_KEY);
+        oldSparqlViewData = Object.freeze(oldSparqlViewData);
+        // get persisted data for the new yasgui in sparql view from local storage
+        let sparqlViewData = getPersistedData(NEW_YASGUI_PERSISTENCE_KEY);
+        if (!sparqlViewData) {
+           sparqlViewData = buildDefaultSparqlViewData();
+        }
+        // migrate the data for each tab from the old yasgui to the new one
+        oldSparqlViewData.map((oldTab) => {
+            return {
+                id: oldTab.id,
+                name: oldTab.name,
+                yasqe: {
+                    value: oldTab.query,
+                    sameAs: oldTab.sameAs,
+                    infer: oldTab.inference,
+                    pageSize: 1000,
+                    pageNumber: 1
+                },
+                yasr: {
+                    response: null,
+                    settings: {
+                        selectedPlugin: "extended_table",
+                        pluginsConfig: {}
+                    }
+                },
+                requestConfig: {
+                    method: "POST"
+                }
+            };
+        }).forEach((newTab, index) => {
+            // replace the old tab id with a new one to conform with the new yasgui tab id format
+            newTab.id = '_' + generateTabId();
+            // process tab name
+            newTab.name = newTab.name || generateMigratedTabName(index, newTabTitle);
+            addTabId(sparqlViewData, newTab.id);
+            addTab(sparqlViewData, newTab);
+        });
+        // set the active tab id to be the first one
+        sparqlViewData.val.active = sparqlViewData.val.tabs[0];
+        // set a flag to indicate that the migration has been completed
+        setMigrationStatus(sparqlViewData, MIGRATION_STATUS.COMPLETED);
+        // persist the migrated data for the new yasgui in sparql view to local storage
+        persistJSONValue(NEW_YASGUI_PERSISTENCE_KEY, sparqlViewData);
+    };
+
+    const buildDefaultSparqlViewData = () => {
+        return {
+            val: {
+                active: null,
+                tabs: [],
+                tabConfig: {}
+            }
+        };
+    };
+
+    const setMigrationStatus = (sparqlViewData, migrationStatus, error = null) => {
+        sparqlViewData.val.migration = {
+            date: new Date().toISOString(),
+            status: migrationStatus,
+            error: error
+        };
+    };
+
+    /**
+     * Rejects the migration by setting a marker in the new model.
+     */
+    const rejectMigration = () => {
+        const yasguiData = getPersistedData(NEW_YASGUI_PERSISTENCE_KEY);
+        setMigrationStatus(yasguiData, MIGRATION_STATUS.REJECTED);
+        persistJSONValue(NEW_YASGUI_PERSISTENCE_KEY, yasguiData);
+    };
+
+    const addTabId = (sparqlViewData, tabId) => {
+        sparqlViewData.val.tabs.push(tabId);
+    };
+
+    const addTab = (sparqlViewData, tab) => {
+        sparqlViewData.val.tabConfig[tab.id] = tab;
+    };
+
+    const getPersistedData = (persistenceKey) => {
+        let persistenceData = localStorage.getItem(persistenceKey);
+        if (!persistenceData) {
+            return;
+        }
+        persistenceData = JSON.parse(persistenceData);
+        return persistenceData;
+    };
+
+    /**
+     * Reverts the migration by removing the migrated tabs and tab ids from the new yasgui persistence.
+     */
+    const revertMigration = () => {
+        const sparqlViewData = getPersistedData(NEW_YASGUI_PERSISTENCE_KEY);
+        removePersistedTabIds(sparqlViewData);
+        removePersistedTabs(sparqlViewData);
+        persistJSONValue(NEW_YASGUI_PERSISTENCE_KEY, sparqlViewData);
+    };
+
+    const removePersistedTabIds = (sparqlViewData) => {
+        sparqlViewData.val.tabs = sparqlViewData.val.tabs.filter((tabId) => !tabId.startsWith('_'));
+    };
+
+    const removePersistedTabs = (sparqlViewData) => {
+        for (const tabId in sparqlViewData.val.tabConfig) {
+            if (tabId.startsWith('_')) {
+                delete sparqlViewData.val.tabConfig[tabId];
+            }
+        }
+    };
+
+    const persistJSONValue = (key, JSONvalue) => {
+        localStorage.setItem(key, JSON.stringify(JSONvalue));
+    };
+
+    const generateMigratedTabName = (index, newTabTitle) => {
+        return `${newTabTitle} ${index}`;
+    };
+
+    const generateTabId = () => {
+        return Math.random().toString(36).substring(7);
+    };
+
+    return {
+        isMigrationNeeded,
+        revertMigration,
+        migrateYasguiPersistence,
+        rejectMigration
+    };
+})();

--- a/src/js/angular/models/sparql/constants.js
+++ b/src/js/angular/models/sparql/constants.js
@@ -1,0 +1,1 @@
+export const VIEW_SPARQL_EDITOR = 'graphdb-workbench-sparql-editor';

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -11,6 +11,7 @@ import {BeforeUpdateQueryResult, BeforeUpdateQueryResultStatus} from "../models/
 import {EventDataType} from "../models/ontotext-yasgui/event-data-type";
 import {decodeHTML} from "../../../app";
 import {toBoolean} from "../utils/string-utils";
+import {VIEW_SPARQL_EDITOR} from "../models/sparql/constants";
 
 const modules = [
     'ui.bootstrap',
@@ -51,7 +52,6 @@ function SparqlEditorCtrl($scope,
     this.repository = '';
 
     const QUERY_EDITOR_ID = '#query-editor';
-    const VIEW_NAME = 'graphdb-workbench-sparql-editor';
     // When the view is loaded the repository change watcher will be triggered. We need to have this flag to prevent
     // resetting the yasgui on the first load. This flag will be set to false after the first repository change.
     let initialRepoInitialization = true;
@@ -73,7 +73,7 @@ function SparqlEditorCtrl($scope,
     $scope.updateConfig = () => {
         $scope.yasguiConfig = {
             endpoint: getEndpoint,
-            componentId: VIEW_NAME,
+            componentId: VIEW_SPARQL_EDITOR,
             prefixes: $scope.prefixes,
             infer: $scope.inferUserSetting,
             sameAs: $scope.sameAsUserSetting,

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -5,6 +5,8 @@
             "delete_cluster_tooltip": "Delete existing cluster",
             "add_nodes_btn": "Add nodes",
             "add_nodes_btn_tooltip": "Add nodes to existing cluster",
+            "replace_nodes_btn": "Replace nodes",
+            "replace_nodes_btn_tooltip": "Replace nodes in cluster",
             "remove_nodes_btn": "Remove nodes",
             "remove_nodes_btn_tooltip": "Remove nodes from existing cluster",
             "edit_cluster": "Edit configuration",
@@ -72,6 +74,7 @@
             "edit_page_title": "Edit cluster configuration",
             "creating_cluster_loader": "Creating cluster...",
             "add_nodes_loader": "Adding nodes to cluster...",
+            "replace_nodes_loader": "Replacing nodes in cluster...",
             "remove_nodes_loader": "Removing nodes from cluster...",
             "updating_cluster_loader": "Updating cluster...",
             "cluster_nodes_list": "Cluster nodes list",
@@ -86,6 +89,7 @@
                 "only_positive_integers": "Enter only positive integers",
                 "small_transaction_log_max_size": "Transaction log maximum size must be at least 1 GB or a negative number",
                 "at_least_two_nodes": "Must have at least two nodes",
+                "cant_replace_majority_of_nodes": "Can't replace majority of cluster nodes",
                 "no_rpc_address": "Error retrieving RPC address: {{error}}",
                 "nodes_status_label": "Nodes status",
                 "preconditions_failed": {
@@ -106,6 +110,8 @@
                 "form_invalid": "The form data is invalid",
                 "add_nodes_success": "Nodes added successfully",
                 "add_nodes_fail": "Adding nodes failed",
+                "replace_nodes_success": "Nodes replaced successfully",
+                "replace_nodes_fail": "Replacing nodes failed",
                 "remove_nodes_success": "Nodes removed successfully",
                 "remove_nodes_fail": "Removing nodes failed"
             }
@@ -121,6 +127,11 @@
                 "success_delete_partial": "Not all nodes were deleted",
                 "fail_delete": "Can not delete cluster"
             }
+        },
+        "replace_nodes_dialog": {
+            "title": "Replace nodes in cluster",
+            "nodes_to_replace_label": "Nodes to add to cluster",
+            "cluster_nodes_list": "Select nodes to be removed from existing cluster"
         },
         "add_nodes_dialog": {
             "title": "Add nodes to cluster",
@@ -319,6 +330,7 @@
     "new.sentence.start": "New",
     "no.connectors.available": "No connectors available",
     "current.repo.no.connector.support": "The current repository does not support any connectors. Please check the type of the repository or select another one.",
+    "edit.select.query": "Edit select query",
     "edit.search.query": "Edit search query",
     "edit.analogical.query": "Edit analogical query",
     "current.repo.error": "The currently selected repository cannot be used for queries due to an error:",
@@ -1327,7 +1339,7 @@
     "similarity.could.not.get.indexes.error": "Could not get indexes",
     "similarity.empty.index.name.error": "Index name cannot be empty",
     "similarity.index.name.constraint": "Index name can contain only letters (a-z, A-Z), numbers (0-9), \"-\" and \"_\"",
-    "similarity.query.type.DATA.name": "Select",
+    "similarity.query.type.DATA.name": "Data",
     "similarity.query.type.SEARCH.name": "Search",
     "similarity.query.type.ANALOGICAL.name": "Analogical",
     "similarity.error.query.empty": "The '{{queryType}}' query cannot be empty.",
@@ -1351,6 +1363,7 @@
     "similarity.get.resource.error": "Could not get resource!",
     "similarity.delete.index.warning": "Are you sure you want to delete the index '{{name}}'?",
     "similarity.rebuild.index.warning": "Are you sure you want to rebuild the whole index '{{name}}'?<br>You will still be able to use the latest successful build!",
+    "similarity.copy_of.prefix": "Copy_of",
     "similarity.warning.unsaved.changes": "You have unsaved changes. Are you sure that you want to exit?",
     "sparql.template.get.templates.error": "Could not get SPARQL templates",
     "sparql.template.delete.template.warning": "Are you sure you want to delete the SPARQL template '{{templateID}}'?",
@@ -1362,11 +1375,11 @@
     "update.sparql.template.success.msg": "Updated SPARQL template",
     "save.sparql.template.failure.msg": "Could not save {{templateID}} template",
     "sparql.template.query.constraint": "The template query must be an UPDATE query",
+    "sparql.template.query.invalid": "Invalid query",
     "save.sparql.template.success.msg": "Saved SPARQL template",
     "attach.remote.gdb.instance": "Attach a remote GraphDB instance",
     "remote.location.url": "Location URL*",
     "remote.location.enter.url.msg": "Enter a URL to a remote GraphDB instance",
-    "similarity.copy_of.prefix": "Copy_of",
     "valid.remote.location.warning": "Note that the location should be a URL that points to a remote GraphDB installation, e.g.",
     "auth.type.header": "Authentication type",
     "remote.location.no.auth.used.tooltip": "No authentication used with remote location",
@@ -1464,7 +1477,6 @@
     "index.building.interrupted.tooltip": "Index build interrupted.",
     "index.obsolete.tooltip": "Index cannot be recovered. Please, rebuild.",
     "edit.search.analogical.query.title": "Edit Search, Analogical queries",
-    "edit.select.query": "Edit select query",
     "edit.search.query.title": "Edit Search query",
     "create.index.from.existing.tooltip": "Create index from existing one.",
     "rebuild.index.tooltip": "Rebuild index",
@@ -1662,6 +1674,7 @@
     "visual.config.search.box.starting.point": "Starting point - Search box",
     "visual.config.query.results.starting.point": "Starting point - Query results",
     "visual.config.fixed.resource.starting.point": "Starting point - Fixed resource",
+    "visual.config.warning.unsaved.changes": "You have unsaved changes. Are you sure that you want to exit?",
     "visual.edit.config": "Edit configuration",
     "visual.delete.config": "Delete configuration",
     "visual.saved.graphs": "Saved graphs",
@@ -1950,5 +1963,7 @@
     "global.operations_statuses.IN_SYNC.title": "In sync",
     "global.operations_statuses.RECOVERING.title": "Recovering",
     "global.operations_statuses.OUT_OF_SYNC.title": "Out of sync",
-    "global.operations_statuses.UNAVAILABLE_NODES.title": "Unavailable nodes"
+    "global.operations_statuses.UNAVAILABLE_NODES.title": "Unavailable nodes",
+    "view.sparql-editor.title": "Ontotext Yasgui SPARQL Query & Update",
+    "view.sparql-editor.helpInfo": "The SPARQL Query & Update view is a unified editor for queries and updates. Enter any SPARQL query or update and click Run to execute it. The view also allows you to save queries for future retrieval and execution in the SPARQL editor."
 }


### PR DESCRIPTION
## What
Migrate old yasgui persistence to new yasgui model.

## Why
Users which migrate from GDB workbench version with the old yasgui to a version with the new yasgui may want to have their current opened tabs to be preserved in the new version as well.

## How
* Check if migration is needed and run the migration.
* Migration is done in the new yasgui persistence migration service. It copies the tabs data from the old persistence to the new one and preserves the old data after migration.