### PR TITLE
GDB-9361 show copy of sample query in user query section in graphs config

### DIFF
--- a/src/pages/graph-config/saveGraphConfig.html
+++ b/src/pages/graph-config/saveGraphConfig.html
@@ -237,7 +237,7 @@
                 </div>
 
                 <p class="mt-1">{{'user.queries' | translate}} </p>
-                <div ng-repeat="tab in tabsViewModel track by tab.page" ng-if="tab.page == 1"
+                <div ng-repeat="tab in tabsViewModel track by tab.page" ng-if="tab.page === page"
                      class="user-queries list-group">
                     <div ng-repeat="sample in samples | filter:isUserGraph">
                         <a href="#" ng-if="sample[tab.type]" ng-click="setQuery(sample[tab.type])"


### PR DESCRIPTION
## What
Show copy of sample query in user query section in graphs config.

## Why
There was a wrong condition which prevented showing the query copy only on the first page.

## How
Fixed the condition allowing to show the selected sample queries from previous configs to appear in the user queries section.