### PR TITLE
fix(GDB-9098): Show ACL table rules when repository is selected

### DIFF
--- a/src/pages/aclmanagement.html
+++ b/src/pages/aclmanagement.html
@@ -12,7 +12,7 @@
 
     <div core-errors></div>
 
-    <div class="acl-management-container">
+    <div class="acl-management-container" ng-if="getActiveRepository()">
         <div class="acl-management-container">
             <ul class="nav nav-tabs acl-tabs">
                 <li class="resource-tab nav-item">


### PR DESCRIPTION
## WHAT
Show ACL table rules when repository is selected

## WHY
There are no rules when not connected to repository

## HOW
Check added