### PR TITLE
Increase the version of "ontotext-yasgui-web-component"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.21",
+                "ontotext-yasgui-web-component": "1.1.22",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10113,9 +10113,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.21",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.21.tgz",
-            "integrity": "sha512-qqtnDLRIHiOLsr0oPdIG4ArCkOdzUB9cSB0RrVKv0SpSzYdU2dFw9fgGCl0ML6wzIlxuPPv7Fu3UN7Yu8o+9Jw==",
+            "version": "1.1.22",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.22.tgz",
+            "integrity": "sha512-mhCY+4b2OjApv55WS7dgbcUuwlP0Fm6w1xQT0Bf0DxEmIm/iYpemIiWTMauRA4QquanK7MX9XsStI7wJhdRRXg==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24725,9 +24725,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.21",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.21.tgz",
-            "integrity": "sha512-qqtnDLRIHiOLsr0oPdIG4ArCkOdzUB9cSB0RrVKv0SpSzYdU2dFw9fgGCl0ML6wzIlxuPPv7Fu3UN7Yu8o+9Jw==",
+            "version": "1.1.22",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.22.tgz",
+            "integrity": "sha512-mhCY+4b2OjApv55WS7dgbcUuwlP0Fm6w1xQT0Bf0DxEmIm/iYpemIiWTMauRA4QquanK7MX9XsStI7wJhdRRXg==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.21",
+        "ontotext-yasgui-web-component": "1.1.22",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
 - GDB-9433: When attempting to delete a saved query with a long name, the name goes off the confirmation screen;
 - GDB-9315: Warning Message in the Console After Clicking on Google Tab.

## Why
 - GDB-9433: The issue occurs when the saved query name is too long and cannot be broken into a new line;
 - Changes have been made to how the [Google Chart library](https://developers.google.com/chart/interactive/docs/basic_load_libs#update-library-loader-code) is loaded. Both plugins use different methods for loading, leading to the appearance of the warning message.

## How
Increased the version of "ontotext-yasgui-web-component";