### PR TITLE
GDB-9451 fix repository edit view initialization

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1846,6 +1846,7 @@
     "clear.tooltip": "Clear",
     "repo.page.location.label": "Location",
     "repo.page.location.input.field.tooltip": "The location where to create repository. The default is the local one.",
+    "repo.page.repository.info.loading.error": "Currently selected repository cannot be edited due to an error during repository metadata loading.",
     "guide.button.guide-paused": "Guide paused",
     "guide.button.guide-resume": "Continue the guide",
     "guide.validate.no-next": "Cannot continue to next",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1838,6 +1838,7 @@
     "clear.tooltip": "Clair",
     "repo.page.location.label": "Localisation",
     "repo.page.location.input.field.tooltip": "L'emplacement où créer le dépôt. Par défaut, il s'agit de l'emplacement local.",
+    "repo.page.repository.info.loading.error": "Le référentiel actuellement sélectionné ne peut pas être modifié en raison d'une erreur lors du chargement des métadonnées du référentiel.",
     "guide.button.guide-paused": "Guide en pause",
     "guide.button.guide-resume": "Continuer le guide",
     "guide.validate.no-next": "Impossible de passer au suivant",

--- a/src/pages/repository.html
+++ b/src/pages/repository.html
@@ -8,7 +8,10 @@
     <div class="top-offset row" ng-if="repositoryInfo.type === 'fedx'">
         <p class="alert alert-warning">{{'fedex.experimental.feature.warning' | translate}}</p>
     </div>
-    <div ng-show="hasActiveLocation()">
+    <div ng-if="!repositoryInfo" class="alert alert-warning">
+        {{'repo.page.repository.info.loading.error' | translate}}
+    </div>
+    <div ng-show="hasActiveLocation() && repositoryInfo">
         <div class="ot-loader ot-main-loader" onto-loader size="50" ng-show="loader"></div>
         <div ng-hide="loader">
             <form id="newRepoForm" class="form-horizontal" novalidate="novalidate">

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -153,7 +153,7 @@
             "column": {
                 "index": "#",
                 "policy": "Policy",
-                "role": "Role",
+                "role": "Custom role",
                 "operation": "Operation",
                 "subject": "Subject",
                 "predicate": "Predicate",
@@ -1846,6 +1846,7 @@
     "clear.tooltip": "Clear",
     "repo.page.location.label": "Location",
     "repo.page.location.input.field.tooltip": "The location where to create repository. The default is the local one.",
+    "repo.page.repository.info.loading.error": "Currently selected repository cannot be edited due to an error during repository metadata loading.",
     "guide.button.guide-paused": "Guide paused",
     "guide.button.guide-resume": "Continue the guide",
     "guide.validate.no-next": "Cannot continue to next",


### PR DESCRIPTION
## What
Fix repository edit view initialization to not break when the monitoring service throws some error.

## Why
There was a coupling in loading the monitoring service status and the repository info during the initialization of the view. Both requests were issued in parallel and had a single catch clause to handle the error which used to brake the template.

## How
Decoupled the loading of repository info and monitoring status from each other and applied separate error handlers in order to prevent template braking.