### PR TITLE
fix(GDB-9484): Fix ACL functional issues

### DIFF
--- a/src/css/aclmanagement.css
+++ b/src/css/aclmanagement.css
@@ -140,7 +140,7 @@ input::placeholder {
 
 .subject-cell, .predicate-cell, .object-cell, .context-cell {
     font-family: var(--mono-font);
-    font-size: 90%;
+    font-size: 100%;
 }
 
 .context-cell-special {
@@ -158,10 +158,6 @@ input::placeholder {
 .acl-tag {
     padding: 0.25em 0.5em;
     font-weight: 500;
-}
-
-.acl-tag .fa {
-    font-size: 90%;
 }
 
 .acl-tag-allow {
@@ -225,9 +221,14 @@ input::placeholder {
 
 .select-rule {
     height: 29px !important;
+    font-size: 100%;
 }
 
-tr.acl-rule.edit-rule-row .form-control{
+tr.acl-rule.edit-rule-row .form-control:not(.select-rule){
     font-family: var(--mono-font);
     font-size: 100%;
+}
+
+.autocomplete-results-wrapper {
+    z-index: 1000;
 }

--- a/src/css/autocomplete-select.css
+++ b/src/css/autocomplete-select.css
@@ -5,11 +5,12 @@
 .autocomplete-select-wrapper .autocomplete-results-wrapper {
     position: absolute;
     top: 100%;
-    left: 0;
     max-height: 204px;
     margin-bottom: 0;
     overflow: auto;
     background-color: #fff;
+    right: auto;
+    left: auto;
 }
 
 .autocomplete-select-wrapper .autocomplete-results-wrapper div:hover {

--- a/src/js/angular/aclmanagement/controllers.js
+++ b/src/js/angular/aclmanagement/controllers.js
@@ -176,7 +176,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
     $scope.deleteRule = (scope, index) => {
         ModalService.openConfirmation(
             $translate.instant('common.confirm'),
-            $translate.instant('acl_management.rulestable.messages.delete_rule_confirmation', {index}),
+            $translate.instant('acl_management.rulestable.messages.delete_rule_confirmation', {index: index + 1}),
             () => {
                 $scope.rulesModel.removeRule(scope, index);
                 setModelDirty(scope);
@@ -293,6 +293,42 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
         setModelDirty(scope);
     };
 
+    /**
+     * Handles event when the "Enter" key is pressed.
+     *
+     * When "Enter" is pressed, the function first stops the event from propagating and prevents
+     * the default form submission behavior.
+     * It then triggers a validation process on the entire form.
+     * If the form is valid, a save operation is initiated for the current rule associated with the provided scope.
+     *
+     * @param {Object} event - The keypress event object.
+     * @param {string} scope - The affected scope
+     * @param {FormController} form - The form object.
+     */
+    $scope.performSearchActionOnEnter = function (event, scope, form) {
+        if (event.keyCode === 13) {
+            event.stopPropagation();
+            event.preventDefault();
+            $scope.triggerValidation(form);
+            if (form.$valid) {
+                $scope.saveRule(scope);
+            }
+        }
+    };
+
+    /**
+     * Triggers the validation of a form or input fields.
+     *
+     * @param {FormController} form - The form object.
+     */
+    $scope.triggerValidation = function(form) {
+        angular.forEach(form, function(control) {
+            if (typeof control === 'object' && control.hasOwnProperty('$modelValue')) {
+                control.$setTouched();
+            }
+        });
+    };
+
     //
     // Private functions
     //
@@ -364,6 +400,10 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
     };
 
     const loadNamespaces = () => {
+        if (!$repositories.getActiveRepository()) {
+            return;
+        }
+
         RDF4JRepositoriesRestService.getNamespaces($repositories.getActiveRepository())
             .then(mapNamespacesResponse)
             .then((namespacesModel) => {

--- a/src/js/angular/core/directives/autocomplete/templates/autocomplete.html
+++ b/src/js/angular/core/directives/autocomplete/templates/autocomplete.html
@@ -4,7 +4,7 @@
     <div class="autocomplete-select">
         <div ng-hide="isMultiline">
             <input type="text" ng-model="searchInput" ng-change="onChange()" ng-keydown="onKeyDown($event)"
-                   ng-blur="onBlur()"
+                   ng-blur="onBlur()" ng-required="required"
                    class="autocomplete-input" ng-class="styleClass" placeholder="{{placeholder}}">
         </div>
         <div ng-show="isMultiline">
@@ -13,6 +13,7 @@
                 ng-change="onChange()"
                 ng-keydown="onKeyDown($event)"
                 ng-blur="onBlur()"
+                ng-required="required"
                 class="autocomplete-textarea" ng-class="styleClass"
                 placeholder="{{placeholder}}"
                 rows="{{initialRows}}">

--- a/src/pages/aclmanagement.html
+++ b/src/pages/aclmanagement.html
@@ -148,6 +148,7 @@
                                         <textarea type="text" name="role" required
                                                   ng-model="rule.role"
                                                   ng-change="setDirty(activeTabScope)"
+                                                  ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
                                                   uppercased uppercase-placeholder="false"
                                                   custom-role-prefix auto-grow
                                                   autocomplete="off"
@@ -164,10 +165,12 @@
                                         </select>
                                     </td>
                                     <td class="data subject-cell">
-                                        <autocomplete ng-model="rule.subject" on-model-change="setDirty(activeTabScope)" name="subject" required
+                                        <autocomplete ng-model="rule.subject" on-model-change="setDirty(activeTabScope)" name="subject"
+                                                      keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
                                                       multiline="true"
                                                       autoexpand="true"
                                                       defaultresults="DEFAULT_URI_VALUES"
+                                                      required="true"
                                                       style-class="form-control form-control-sm"
                                                       namespaces="namespaces"
                                                       autocomplete-status-loader="getAutocompletePromise"
@@ -175,10 +178,12 @@
                                         <em></em>
                                     </td>
                                     <td class="data predicate-cell">
-                                        <autocomplete ng-model="rule.predicate" on-model-change="setDirty(activeTabScope)" name="predicate" required
+                                        <autocomplete ng-model="rule.predicate" on-model-change="setDirty(activeTabScope)" name="predicate"
+                                                      keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
                                                       multiline="true"
                                                       autoexpand="true"
                                                       defaultresults="DEFAULT_URI_VALUES"
+                                                      required="true"
                                                       style-class="form-control form-control-sm"
                                                       namespaces="namespaces"
                                                       autocomplete-status-loader="getAutocompletePromise"
@@ -186,10 +191,12 @@
                                         <em></em>
                                     </td>
                                     <td class="data object-cell">
-                                        <autocomplete ng-model="rule.object" on-model-change="setDirty(activeTabScope)" name="object" required
+                                        <autocomplete ng-model="rule.object" on-model-change="setDirty(activeTabScope)" name="object"
+                                                      keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
                                                       multiline="true"
                                                       autoexpand="true"
                                                       defaultresults="DEFAULT_URI_VALUES"
+                                                      required="true"
                                                       style-class="form-control form-control-sm"
                                                       namespaces="namespaces"
                                                       autocomplete-status-loader="getAutocompletePromise"
@@ -197,10 +204,12 @@
                                         <em></em>
                                     </td>
                                     <td class="data context-cell">
-                                        <autocomplete ng-model="rule.context" on-model-change="setDirty(activeTabScope)" name="context" required
+                                        <autocomplete ng-model="rule.context" on-model-change="setDirty(activeTabScope)" name="context"
+                                                      keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
                                                       multiline="true"
                                                       autoexpand="true"
                                                       defaultresults="DEFAULT_CONTEXT_VALUES"
+                                                      required="true"
                                                       style-class="form-control form-control-sm"
                                                       namespaces="namespaces"
                                                       autocomplete-status-loader="getAutocompletePromise"
@@ -319,6 +328,7 @@
                                         <textarea type="text" name="role" required
                                                   ng-model="rule.role"
                                                   ng-change="setDirty(activeTabScope)"
+                                                  ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
                                                   uppercased uppercase-placeholder="false"
                                                   custom-role-prefix auto-grow
                                                   autocomplete="off" class="form-control form-control-sm textarea-edit"
@@ -328,10 +338,12 @@
                                         <em></em>
                                     </td>
                                     <td class="data context-cell">
-                                        <autocomplete ng-model="rule.context" on-model-change="setDirty(activeTabScope)" name="context" required
+                                        <autocomplete ng-model="rule.context" on-model-change="setDirty(activeTabScope)" name="context"
+                                                      keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
                                                       multiline="true"
                                                       autoexpand="true"
                                                       defaultresults="DEFAULT_CONTEXT_VALUES"
+                                                      required="true"
                                                       style-class="form-control form-control-sm"
                                                       namespaces="namespaces"
                                                       autocomplete-status-loader="getAutocompletePromise"
@@ -460,6 +472,7 @@
                                         <textarea type="text" name="role" required
                                                   ng-model="rule.role"
                                                   ng-change="setDirty(activeTabScope)"
+                                                  ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
                                                   uppercased uppercase-placeholder="false"
                                                   custom-role-prefix auto-grow
                                                   autocomplete="off"
@@ -479,6 +492,7 @@
                                         <textarea type="text" name="plugin" required
                                                   ng-model="rule.plugin"
                                                   ng-change="setDirty(activeTabScope)"
+                                                  ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
                                                   auto-grow
                                                   autocomplete="off"
                                                   class="form-control form-control-sm textarea-edit"
@@ -602,6 +616,7 @@
                                         <textarea type="text" name="role" required
                                                   ng-model="rule.role"
                                                   ng-change="setDirty(activeTabScope)"
+                                                  ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
                                                   uppercased uppercase-placeholder="false"
                                                   custom-role-prefix auto-grow
                                                   autocomplete="off"

--- a/test-cypress/integration/setup/aclmanagement/delete-rule.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/delete-rule.spec.js
@@ -30,7 +30,7 @@ describe('ACL Management: delete rule', () => {
         AclManagementSteps.deleteRule(0);
         // Then I expect a confirmation dialog
         ModalDialogSteps.getDialog().should('be.visible');
-        ModalDialogSteps.getDialogBody().should('contain', 'Are you sure you want to delete the selected rule #0?');
+        ModalDialogSteps.getDialogBody().should('contain', 'Are you sure you want to delete the selected rule #1?');
         // When I cancel operation
         ModalDialogSteps.clickOnCancelButton();
         // Then I expect the rule to remain in the list
@@ -38,7 +38,7 @@ describe('ACL Management: delete rule', () => {
         AclManagementSteps.getAclRules().should('have.length', 5);
         // When I try remove it again and confirm the operation
         AclManagementSteps.deleteRule(4);
-        ModalDialogSteps.getDialogBody().should('contain', 'Are you sure you want to delete the selected rule #4?');
+        ModalDialogSteps.getDialogBody().should('contain', 'Are you sure you want to delete the selected rule #5?');
         ModalDialogSteps.clickOnConfirmButton();
         // Then I expect the rule to be removed from the list
         ModalDialogSteps.getDialog().should('not.exist');


### PR DESCRIPTION
## What
Fixing functional issues in the ACL view.

## Why
For better perceiving and user experience.

## HOW
- Adjusting the positioning of the autocomplete dropdown to prevent overflow outside the viewport.
- Fixing an off-by-one error in the delete confirmation dialog.
- Modifying the behavior of the Enter key to prevent unintended actions in the input fields.
- Correcting the outline display for required fields when empty.
- Preventing toast errors related to undefined repositories.
- Updating the 'required' field handling in the autocomplete directive.
- The adjustments in the autocomplete directive ensure that dropdowns are positioned correctly and that the Enter key behaves as expected across different input scenarios.