### PR TITLE
GDB-9488 make save and cancel buttons sticky in ACL view

### DIFF
--- a/src/css/aclmanagement.css
+++ b/src/css/aclmanagement.css
@@ -2,6 +2,18 @@
     table-layout: fixed;
 }
 
+.acl-management-view .acl-actions {
+    position: sticky;
+    bottom: 20px;
+    padding: .5em;
+    /* opaque version of the color-warning-light */
+    background-color: #F8F0EE;
+}
+
+.acl-management-view .acl-actions .message {
+    margin-right: 1em;
+}
+
 .acl-management-view .acl-rules .labels-row th {
     white-space: nowrap;
     overflow: hidden;

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -188,7 +188,8 @@
                 "revert_acl_list": "This operation will revert all the changes done in the ACL. Are you sure you want to proceed?",
                 "rules_updated": "ACL was updated successfully",
                 "rules_reverted": "ACL was reverted successfully",
-                "unsaved_changes_confirmation": "You have unsaved changes. Are you sure that you want to exit?"
+                "unsaved_changes_confirmation": "You have unsaved changes. Are you sure that you want to exit?",
+                "save_acl_to_apply_rules": "Rules are not applied until saved"
             }
         },
         "errors": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -188,7 +188,8 @@
                 "revert_acl_list": "Cette opération annulera toutes les modifications apportées à l'ACL. Êtes-vous sur de vouloir continuer?",
                 "rules_updated": "L'ACL a été mise à jour avec succès",
                 "rules_reverted": "L'ACL a été rétablie avec succès",
-                "unsaved_changes_confirmation": "Vous avez des modifications non sauvegardées. Etes-vous sûr de vouloir quitter?"
+                "unsaved_changes_confirmation": "Vous avez des modifications non sauvegardées. Etes-vous sûr de vouloir quitter?",
+                "save_acl_to_apply_rules": "Les règles ne sont pas appliquées tant qu'elles ne sont pas enregistrées"
             }
         },
         "errors": {

--- a/src/pages/aclmanagement.html
+++ b/src/pages/aclmanagement.html
@@ -656,7 +656,8 @@
                 </div>
             </div>
         </div>
-        <div ng-if="editedRuleIndex === undefined && rulesModel && modelIsDirty && dirtyScope.size > 0" class="text-right">
+        <div ng-if="editedRuleIndex === undefined && rulesModel && modelIsDirty && dirtyScope.size > 0" class="acl-actions text-right">
+            <span class="message">{{'acl_management.rulestable.messages.save_acl_to_apply_rules' | translate}}</span>
             <button class="btn btn-secondary cancel-acl-save-btn"
                     ng-click="cancelAclSave()">
                 {{'acl_management.rulestable.actions.cancel_acl_saving' | translate}}

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -188,7 +188,8 @@
                 "revert_acl_list": "This operation will revert all the changes done in the ACL. Are you sure you want to proceed?",
                 "rules_updated": "ACL was updated successfully",
                 "rules_reverted": "ACL was reverted successfully",
-                "unsaved_changes_confirmation": "You have unsaved changes. Are you sure that you want to exit?"
+                "unsaved_changes_confirmation": "You have unsaved changes. Are you sure that you want to exit?",
+                "save_acl_to_apply_rules": "Rules are not applied until saved"
             }
         },
         "errors": {


### PR DESCRIPTION
## What
Make save and cancel buttons sticky in ACL view.

## Why
In order to allow the user to have fast and easy access to those operations.

## How
Styled the panel with the buttons to be sticky and have a background. Also added a message to warn the user that acl rules are not applied until the acl list is saved.