### PR TITLE
Cherry-pick form master Fixes GDB-9475, GDB-9476

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.24",
+                "ontotext-yasgui-web-component": "1.1.25",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -1928,16 +1928,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "file-uri-to-path": "1.0.0"
             }
         },
         "node_modules/bl": {
@@ -6108,13 +6098,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true,
-            "optional": true
-        },
         "node_modules/fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -9536,13 +9519,6 @@
             "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
             "dev": true
         },
-        "node_modules/nan": {
-            "version": "2.18.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-            "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
-            "dev": true,
-            "optional": true
-        },
         "node_modules/nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -10099,9 +10075,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.24",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.24.tgz",
-            "integrity": "sha512-ZVEBW913wtY8yoBfpwBt+iKzR3lsBps/8PRxsmOrHV6RAH2eGWTKBJ9Ihm5NiOfnYnZGwVJ0I3PzkAdWzyRN0Q==",
+            "version": "1.1.25",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.25.tgz",
+            "integrity": "sha512-LgHPdENpaxiqpgUWLrzaKgMZ+6MgX7f9fQj8vH1szmKoZZjRLuMDFeO+ytzps4UB1g9jbPcK3vPkO1BzdEzKTg==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -18238,15 +18214,6 @@
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
         },
-        "bindings": {
-            "version": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
         "bl": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
@@ -21531,13 +21498,6 @@
             "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
             "dev": true
         },
-        "file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true,
-            "optional": true
-        },
         "fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -24205,12 +24165,6 @@
             "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
             "dev": true
         },
-        "nan": {
-            "version": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-            "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
-            "dev": true,
-            "optional": true
-        },
         "nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -24664,9 +24618,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.24",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.24.tgz",
-            "integrity": "sha512-ZVEBW913wtY8yoBfpwBt+iKzR3lsBps/8PRxsmOrHV6RAH2eGWTKBJ9Ihm5NiOfnYnZGwVJ0I3PzkAdWzyRN0Q==",
+            "version": "1.1.25",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.25.tgz",
+            "integrity": "sha512-LgHPdENpaxiqpgUWLrzaKgMZ+6MgX7f9fQj8vH1szmKoZZjRLuMDFeO+ytzps4UB1g9jbPcK3vPkO1BzdEzKTg==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.24",
+        "ontotext-yasgui-web-component": "1.1.25",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
Cherry-pick from master. Fixes GDB-9475, GDB-9476
## What
 - GDB-9476: this issue arises when there are no triples matching the query, leading to improper display empty row message;
 - GDB-9483: fix query explain plan styling when displayed in multiple yasgui tabs;
 - GDB-9475: There is an issue with the display of extended-table plugin controls. The problem can be reproduced with the following scenario:
  - execute a select query;
  - execute an update query.
 - GDB-9475: The info message that describes the result of executed queries is differently positioned than in the old implementation of YASGUI.

## Why
 - GDB-9476: the empty result message is displayed as row of datatable (jquery datatable behaviour). But the first column (row number) can be hidden and this causes the issues;
 - GDB-9483: there was a wrong selector from the document for the explain plan html element on which the styling should be applied which in this case was always the first yasgui tab where there is one. In result the rest tabs with displayed explain plan remained unstyled;
 - GDB-9475: The plugin controls are cleared only if the plugin is changed. In this case, even though the plugin remains the same, no plugin will be displayed;
 - GDB-9475: The header of the result has two sections. The first section is where the rendered plugin can insert some controls related to its functionality, and the second section is the message describing the processed query. Between these sections, there is an element that takes up all available space. In the result, the first section is on the left, and the second is on the right side. The message from the issue is displayed for an update query. The update queries do not return a result, and there is no registered plugin to be rendered. In this case, the old implementation showed the message on the left. However, in the new implementation, the message is pushed out from the spacer on the right side.

## How
Increased the "ontotext-yasgui-web-component" version.

# Additional work
 - Added translation for no results message.