### PR TITLE
GDB-9471 enable inferred data and expand on same as property buttons in visual graph config

### DIFF
--- a/src/js/angular/graphexplore/controllers/graphs-config.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-config.controller.js
@@ -2,7 +2,10 @@ import 'angular/utils/notifications';
 import 'angular/utils/local-storage-adapter';
 import {YasqeMode} from "../../models/ontotext-yasgui/yasqe-mode";
 import {RenderingMode} from "../../models/ontotext-yasgui/rendering-mode";
-import {YasguiComponentDirectiveUtil} from "../../core/directives/yasgui-component/yasgui-component-directive.util";
+import {
+    INFERRED_AND_SAME_AS_BUTTONS_CONFIGURATION,
+    YasguiComponentDirectiveUtil
+} from "../../core/directives/yasgui-component/yasgui-component-directive.util";
 import {GraphsConfig, StartMode} from "../../models/graphs/graphs-config";
 import {mapGraphConfigSamplesToGraphConfigs} from "../../rest/mappers/graphs-config-mapper";
 
@@ -488,7 +491,7 @@ function GraphConfigCtrl(
         showToolbar: false,
         showResultTabs: false,
         showYasqeActionButtons: false,
-        yasqeActionButtons: DISABLE_YASQE_BUTTONS_CONFIGURATION,
+        yasqeActionButtons: INFERRED_AND_SAME_AS_BUTTONS_CONFIGURATION,
         showQueryButton: false,
         initialQuery: ' ',
         componentId: 'graphs-config',


### PR DESCRIPTION
## What
Enable inferred data and expand on same as property buttons in visual graph config view.

## Why
The user should be able to configure these two properties in the visual graph config.

## How
Provided configuration for enabling these two buttons in the yasqe.