### PR TITLE
Update yasgui component version to 1.1.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.25",
+                "ontotext-yasgui-web-component": "1.1.26",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10075,9 +10075,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.25",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.25.tgz",
-            "integrity": "sha512-LgHPdENpaxiqpgUWLrzaKgMZ+6MgX7f9fQj8vH1szmKoZZjRLuMDFeO+ytzps4UB1g9jbPcK3vPkO1BzdEzKTg==",
+            "version": "1.1.26",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.26.tgz",
+            "integrity": "sha512-bcxK+Sk8cQ4aC13V+2NS6zc0wnGBVFUA9JtHcXZATUqtH/P1+piuEtTB+pQyk5iMlG3iDrxA59/yTUXwRZg4JQ==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24618,9 +24618,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.25",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.25.tgz",
-            "integrity": "sha512-LgHPdENpaxiqpgUWLrzaKgMZ+6MgX7f9fQj8vH1szmKoZZjRLuMDFeO+ytzps4UB1g9jbPcK3vPkO1BzdEzKTg==",
+            "version": "1.1.26",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.26.tgz",
+            "integrity": "sha512-bcxK+Sk8cQ4aC13V+2NS6zc0wnGBVFUA9JtHcXZATUqtH/P1+piuEtTB+pQyk5iMlG3iDrxA59/yTUXwRZg4JQ==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.25",
+        "ontotext-yasgui-web-component": "1.1.26",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Update yasgui component version to 1.1.26

## Why
Includes fixes for:
* GDB-8247 improve styling of yasr results containing long strings

## How
Updated version