### PR TITLE
Cherry-pick from 2.6: Increase the version of "ontotext-yasgui-web-component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.1.26",
+                "ontotext-yasgui-web-component": "1.2.0",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10075,9 +10075,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.1.26",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.26.tgz",
-            "integrity": "sha512-bcxK+Sk8cQ4aC13V+2NS6zc0wnGBVFUA9JtHcXZATUqtH/P1+piuEtTB+pQyk5iMlG3iDrxA59/yTUXwRZg4JQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.0.tgz",
+            "integrity": "sha512-hYlqFrHgD0jg9bLI3l2J8/3mVetFOQUnM/3VMa6eqDpJxZTfuieeFSvy/bs71HaZfp0Z9+9m13R0k9Fvmnsj4Q==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24618,9 +24618,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.1.26",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.1.26.tgz",
-            "integrity": "sha512-bcxK+Sk8cQ4aC13V+2NS6zc0wnGBVFUA9JtHcXZATUqtH/P1+piuEtTB+pQyk5iMlG3iDrxA59/yTUXwRZg4JQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.0.tgz",
+            "integrity": "sha512-hYlqFrHgD0jg9bLI3l2J8/3mVetFOQUnM/3VMa6eqDpJxZTfuieeFSvy/bs71HaZfp0Z9+9m13R0k9Fvmnsj4Q==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.1.26",
+        "ontotext-yasgui-web-component": "1.2.0",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Increase the version of "ontotext-yasgui-web-component"

## Why
WB has a new release 2.6, we increase the version of "ontotext-yasgui-web-component" for management purpose.

## How
The "ontotext-yasgui-web-component" has been increased.