### PR TITLE
Increase yasgui version to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.2.0",
+                "ontotext-yasgui-web-component": "1.2.1",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10051,9 +10051,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.0.tgz",
-            "integrity": "sha512-hYlqFrHgD0jg9bLI3l2J8/3mVetFOQUnM/3VMa6eqDpJxZTfuieeFSvy/bs71HaZfp0Z9+9m13R0k9Fvmnsj4Q==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.1.tgz",
+            "integrity": "sha512-XToAGNJU9PJO/4AtX/yLOLH9g8oMl9yT9FUCEivV9UP/l2QhY8KIUz6QLZDGoKunFS0jnkFKuQml8DSr3yrKzQ==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24534,9 +24534,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.0.tgz",
-            "integrity": "sha512-hYlqFrHgD0jg9bLI3l2J8/3mVetFOQUnM/3VMa6eqDpJxZTfuieeFSvy/bs71HaZfp0Z9+9m13R0k9Fvmnsj4Q==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.1.tgz",
+            "integrity": "sha512-XToAGNJU9PJO/4AtX/yLOLH9g8oMl9yT9FUCEivV9UP/l2QhY8KIUz6QLZDGoKunFS0jnkFKuQml8DSr3yrKzQ==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.2.0",
+        "ontotext-yasgui-web-component": "1.2.1",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Increase yasgui version to 1.2.1

## Why
Includes fixes for:
* GDB-9500 fix explain plan styling

## What
Increased version