### PR TITLE
GDB-9504: Create rule button not translated to french

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -143,6 +143,9 @@
         }
     },
     "acl_management": {
+        "buttons": {
+            "create_rule": "Create rule"
+        },
         "rulestable": {
             "tab": {
                 "statement": "Statement",

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -143,9 +143,6 @@
         }
     },
     "acl_management": {
-        "buttons": {
-            "create_rule": "Create rule"
-        },
         "rulestable": {
             "tab": {
                 "statement": "Statement",
@@ -182,7 +179,8 @@
                 "apply_rule": "Confirm rule editing",
                 "cancel_rule_editing": "Cancel rule editing",
                 "save_acl": "Save ACL",
-                "cancel_acl_saving": "Cancel"
+                "cancel_acl_saving": "Cancel",
+                "create_rule": "Create rule"
             },
             "messages": {
                 "no_data": "There are no rules defined in current scope",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -143,6 +143,9 @@
         }
     },
     "acl_management": {
+        "buttons": {
+            "create_rule": "Créer une règle"
+        },
         "rulestable": {
             "tab": {
                 "statement": "Déclaration",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -143,9 +143,6 @@
         }
     },
     "acl_management": {
-        "buttons": {
-            "create_rule": "Créer une règle"
-        },
         "rulestable": {
             "tab": {
                 "statement": "Déclaration",
@@ -182,7 +179,8 @@
                 "apply_rule": "Confirmer la modification de la règle",
                 "cancel_rule_editing": "Annuler la modification des règles",
                 "save_acl": "Enregistrer la ACL",
-                "cancel_acl_saving": "Annuler"
+                "cancel_acl_saving": "Annuler",
+                "create_rule": "Créer une règle"
             },
             "messages": {
                 "no_data": "Aucune règle n'est définie dans le champ d'application actuel",

--- a/src/pages/aclmanagement.html
+++ b/src/pages/aclmanagement.html
@@ -19,7 +19,7 @@
                 <button ng-click="addRule(activeTabScope, 0)" ng-disabled="editedRuleIndex !== undefined"
                         class="btn btn-primary add-first-rule-btn"
                         gdb-tooltip="{{'acl_management.rulestable.actions.add_rule_first' | translate}}">
-                    <em class="icon-plus"></em>{{'acl_management.buttons.create_rule' | translate}}
+                    <em class="icon-plus"></em>{{'acl_management.rulestable.actions.create_rule' | translate}}
                 </button>
             </div>
             <ul class="nav nav-tabs acl-tabs">

--- a/src/pages/aclmanagement.html
+++ b/src/pages/aclmanagement.html
@@ -19,7 +19,7 @@
                 <button ng-click="addRule(activeTabScope, 0)" ng-disabled="editedRuleIndex !== undefined"
                         class="btn btn-primary add-first-rule-btn"
                         gdb-tooltip="{{'acl_management.rulestable.actions.add_rule_first' | translate}}">
-                    <em class="icon-plus"></em> Create rule
+                    <em class="icon-plus"></em>{{'acl_management.buttons.create_rule' | translate}}
                 </button>
             </div>
             <ul class="nav nav-tabs acl-tabs">

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -143,6 +143,9 @@
         }
     },
     "acl_management": {
+        "buttons": {
+            "create_rule": "Create rule"
+        },
         "rulestable": {
             "tab": {
                 "statement": "Statement",

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -143,9 +143,6 @@
         }
     },
     "acl_management": {
-        "buttons": {
-            "create_rule": "Create rule"
-        },
         "rulestable": {
             "tab": {
                 "statement": "Statement",
@@ -182,7 +179,8 @@
                 "apply_rule": "Confirm rule editing",
                 "cancel_rule_editing": "Cancel rule editing",
                 "save_acl": "Save ACL",
-                "cancel_acl_saving": "Cancel"
+                "cancel_acl_saving": "Cancel",
+                "create_rule": "Create rule"
             },
             "messages": {
                 "no_data": "There are no rules defined in current scope",


### PR DESCRIPTION
## What
The "Create rule" button is not translated to French.

## Why
The label was hardcoded, it missed to be translated.

## How
Added translation to the button.