### PR TITLE
GDB-8670 - Decode HTML tag in toastr message

### DIFF
--- a/src/js/angular/jdbc/controllers.js
+++ b/src/js/angular/jdbc/controllers.js
@@ -9,6 +9,7 @@ import {JdbcConfigurationError} from "../models/jdbc/jdbc-configuration-error";
 import {RenderingMode} from "../models/ontotext-yasgui/rendering-mode";
 import {toJDBCColumns, updateColumn} from "../models/jdbc/jdbc-column";
 import {DISABLE_YASQE_BUTTONS_CONFIGURATION, YasguiComponentDirectiveUtil} from "../core/directives/yasgui-component/yasgui-component-directive.util";
+import {decodeHTML} from "../../../app";
 
 const modules = [
     'ui.bootstrap',
@@ -305,10 +306,10 @@ function JdbcCreateCtrl(
 
     const notifyColumnTypeChanged = (currentColumnType, prevColumnType) => {
         if (currentColumnType === prevColumnType) {
-            toastr.info($translate.instant('jdbc.same.suggested.sql.type', {type: currentColumnType}),
+            toastr.info(decodeHTML($translate.instant('jdbc.same.suggested.sql.type', {type: currentColumnType})),
                 $translate.instant('jdbc.suggest.sql.type'), {allowHtml: true});
         } else {
-            toastr.success($translate.instant('jdbc.suggested.sql.type', {type: currentColumnType}),
+            toastr.success(decodeHTML($translate.instant('jdbc.suggested.sql.type', {type: currentColumnType})),
                 $translate.instant('jdbc.suggest.sql.type'), {allowHtml: true});
         }
     };


### PR DESCRIPTION
## What?
The information messages in the SQL table configuration will display bold text correctly.
![Screenshot from 2024-02-08 10-31-59](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/9554683a-abae-4116-bcd6-57699b1f0521)
![Screenshot from 2024-02-08 10-31-45](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/bb714014-e2b6-41c5-b1fd-e8f36c2fed74)


## Why?
The HTML tags were visible in the message.


## How?
I added a function to decode the HTML in the text.