### PR TITLE
GDB-9365 - Make Similarity index action buttons the same color

### DIFF
--- a/src/pages/similarity-indexes.html
+++ b/src/pages/similarity-indexes.html
@@ -65,21 +65,22 @@
                                   gdb-tooltip="{{'view.sparql.query.title' | translate}}">
 									<em class="icon-sparql"></em>
 							</span>
-                            <span class="actions-bar hovered-item">
-								<a class="btn btn-link edit-query-btn"
-                                   ng-if="canEditRepo && !similarityIndex.isBuildingStatus() && !similarityIndex.isRebuildingStatus() && !similarityIndex.isCreatingStatus()"
-                                   ng-click="editSimilarityIndex(similarityIndex)"
-                                        gdb-tooltip="{{similarityIndex.isPredicationType() ? 'edit.search.analogical.query.title' : 'edit.search.query.title' | translate}}">
-									<em class="icon-edit"></em>
-								</a>
-							</span>
 
-							<a class="btn btn-link clone-index-btn"
-                               ng-if="similarityIndex.selectQuery && (similarityIndex.isTextType() || similarityIndex.isPredicationType() || similarityIndex.isTextLiteralType())"
-                               ng-click="cloneSimilataryIndex(similarityIndex)"
-							   gdb-tooltip="{{'create.index.from.existing.tooltip' | translate}}">
-									<em class="icon-copy"></em>
-							</a>
+                            <span class="actions-bar hovered-item">
+                                <button class="btn btn-link edit-query-btn"
+                                        ng-if="canEditRepo && !similarityIndex.isBuildingStatus() && !similarityIndex.isRebuildingStatus() && !similarityIndex.isCreatingStatus()"
+                                        ng-click="editSimilarityIndex(similarityIndex)"
+                                        gdb-tooltip="{{similarityIndex.isPredicationType() ? 'edit.search.analogical.query.title' : 'edit.search.query.title' | translate}}">
+                                    <span class="icon-edit"></span>
+                                </button>
+                            </span>
+
+                            <button class="btn btn-link clone-index-btn"
+                                    ng-if="similarityIndex.selectQuery && (similarityIndex.isTextType() || similarityIndex.isPredicationType() || similarityIndex.isTextLiteralType())"
+                                    ng-click="cloneSimilataryIndex(similarityIndex)"
+                                    gdb-tooltip="{{'create.index.from.existing.tooltip' | translate}}">
+                                <span class="icon-copy"></span>
+                            </button>
 
 							<button type="button" ng-if="canEditRepo && !similarityIndex.isBuildingStatus() && !similarityIndex.isRebuildingStatus() && !similarityIndex.isCreatingStatus() && (similarityIndex.isTextType() || similarityIndex.isPredicationType() || similarityIndex.isTextLiteralType())" ng-disabled="!similarityIndex.selectQuery"
 									ng-click="rebuildIndex(similarityIndex)" class="btn btn-link reload-index-btn" gdb-tooltip="{{'rebuild.index.tooltip' | translate}}"><span


### PR DESCRIPTION
## What?
The buttons in the Similarity index page are now all in the same color.
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/a7ed4260-0d23-4804-992a-2768efaa2b6e)


## Why?
Previously, two of the buttons didn't match the rest.


## How?
I changed the element tag to `button`.