### PR TITLE
GDB-9510: Interactive guides panels point to browser corner instead o…

### DIFF
--- a/src/js/angular/guides/steps/complex/class-hierarchy/plugin.js
+++ b/src/js/angular/guides/steps/complex/class-hierarchy/plugin.js
@@ -183,6 +183,8 @@ PluginRegistry.add('guide.step', [
                         content: 'guide.step_plugin.class-hierarchy-instances-query.content',
                         url: '/sparql',
                         elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
+                        beforeShowPromise: () => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3)
+                            .then(() => GuideUtils.deferredShow(500)()),
                         class: 'class-hierarchy-instances-query-guide-dialog',
                         scrollToHandler: GuideUtils.scrollToTop
                     }, options)


### PR DESCRIPTION
## What
When open the step 36 or 58 from the "The Movies database guide" the guide dialog is appeared in top left corner of the browser instead under the query in YASQE.

## Why
When the SPARQL view is opened from a user guide, a new tab is opened. It is used by the guide because we don't want to change a user's query if we use the currently opened tab. The problem occurred in both steps because they have to display the dialog under the query in the YASQE editor. To find the editor they use selector that finds a "CodeMirror" element, after the element is visible the dialog is opened, but this process is quicker than this that opens the new tab. When tab is open the selected element is hidden this is why the dialog is moved to the upper lef corner of the view.

The problem occurred after replaced old YASGUI with new one. In the old implementation the sparql view used a global variable "editor" (instance of YASQE) and it is used from the view so if editor query is changed regardless from where, the editor always show a query this is in the editor variable. This behaviour was used and in user guides in those steps needed query is updated in the editor and after refreshing the SPARQL view the query is this that steps expect. In the new implementation this is not the case every one tab has own instance of YASQE so steps have to care where set the need query. When steps call query method of ontotext-yasgui-web-component, it writes the query in currently opened tab.

## How
Unfortunately, the steps do not know when the query will be opened in a new tab or not. This is why we cannot implement some functionality that can write the query in the right tab without coupling all WB functionality with user guide steps. Before the dialogs of the steps are opened, we just wait a few milliseconds to give a chance for a new tab to open (if open) and then modify the query in the currently opened tab. Before waiting, we select the "CodeMirror" element to be sure that YASGUI is loaded, and then wait for only the operation that eventually opens a new tab (which is a very quick process).