### PR TITLE
GDB-9371 - Apply dark theme to dropdown menus

### DIFF
--- a/src/css/bootstrap-graphdb-theme-dark-auto.css
+++ b/src/css/bootstrap-graphdb-theme-dark-auto.css
@@ -34,3 +34,7 @@ input[type="checkbox"] {
     filter: var(--checkbox-filter);
 }
 
+option {
+    background-color: var(--html-background);
+    color: var(--gray-color);
+}


### PR DESCRIPTION
## What?
The dropdown menus will have styling to match the dark theme, whenever it's applied. 

## Why?
The menus used to remain the same as in the light theme. This created a bad experience for users using the dark theme.

## How?
I added new styling for the `option` tags.

## Screenshots?
![Screenshot 2024-02-14 11:56:28](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/e3d4b1d0-73d4-4171-adc7-868323083f06)

