### PR TITLE
GDB-9516 autocomplete dropdown menu is cut off in acl table

### DIFF
--- a/src/css/aclmanagement.css
+++ b/src/css/aclmanagement.css
@@ -26,6 +26,11 @@ html, body {
     margin-right: 1em;
 }
 
+.acl-management-view .table-responsive {
+    /* override this from bootstrap to allow autocomplete menu appear on top of the table and not to be cut off */
+    overflow-x: visible !important;
+}
+
 .acl-management-view .edit-mode .table-responsive {
     max-height: 88%;
 }


### PR DESCRIPTION
## What
Autocomplete dropdown menu is cut off in acl table.

## Why
A combination of two reasons caused the dropdown menu to be cut off. First is that the autocomplete component is rendered inside the table cells and the second is the `responsive-table` style applied to the table wrapper which style used to apply `overflow-x:auto` property.

## How
Overridden the overflow-x to prevent the overflowing behavior of the table wrapper. In this table we actually don't need this as the ACL table has predefined number of columns and doesn't need to overflow in the X axis.