### PR TITLE
increase version of ontotext-yasgui-web-component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.2.0",
+                "ontotext-yasgui-web-component": "1.3.0",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10075,9 +10075,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.0.tgz",
-            "integrity": "sha512-hYlqFrHgD0jg9bLI3l2J8/3mVetFOQUnM/3VMa6eqDpJxZTfuieeFSvy/bs71HaZfp0Z9+9m13R0k9Fvmnsj4Q==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.0.tgz",
+            "integrity": "sha512-tTu5yyYsHyalrSS4WzUq+XU8hlYRCofXwdxq8XKyW8qFE3NdmoeqYPAKWmUvM8xpwdK3LW1y8kxiLSVMxvqDrw==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24618,9 +24618,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.0.tgz",
-            "integrity": "sha512-hYlqFrHgD0jg9bLI3l2J8/3mVetFOQUnM/3VMa6eqDpJxZTfuieeFSvy/bs71HaZfp0Z9+9m13R0k9Fvmnsj4Q==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.0.tgz",
+            "integrity": "sha512-tTu5yyYsHyalrSS4WzUq+XU8hlYRCofXwdxq8XKyW8qFE3NdmoeqYPAKWmUvM8xpwdK3LW1y8kxiLSVMxvqDrw==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.2.0",
+        "ontotext-yasgui-web-component": "1.3.0",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Increase version of ontotext-yasgui-web-component.

## Why
 - GDB-9500 Explain plan should always be displayed in one column;
 - GDB-9480 Rename a tab name should be selected to write on it rather than having to be manually deleted by the user;
 - GDB-9462 Unable to close the tab when there are numerous saved results in local storage;
 - GDB-9242 Refactoring compact view;
 - GDB-9479 Different French label on button Abort query;
 - GDB-9514 SPARQL Editor last tab can be closed which removes the entire view;
 - GDB-9528 Copy link buttons of an RDF star link not properly displayed.

## How
The version of ontotext-yasgui-web-component has been increased.