### PR TITLE
increase version of ontotext-yasgui-web-component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.2.1",
+                "ontotext-yasgui-web-component": "1.2.2",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10051,9 +10051,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.1.tgz",
-            "integrity": "sha512-XToAGNJU9PJO/4AtX/yLOLH9g8oMl9yT9FUCEivV9UP/l2QhY8KIUz6QLZDGoKunFS0jnkFKuQml8DSr3yrKzQ==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.2.tgz",
+            "integrity": "sha512-prv1S3OOxtH/yNA55zZqCAkOt+Y4fXQOmCuTpm4/YNB4odnItkU0KKZUKnMuzNu0Tgb2nP/0qCIZv7xZbx1eBA==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24534,9 +24534,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.1.tgz",
-            "integrity": "sha512-XToAGNJU9PJO/4AtX/yLOLH9g8oMl9yT9FUCEivV9UP/l2QhY8KIUz6QLZDGoKunFS0jnkFKuQml8DSr3yrKzQ==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.2.tgz",
+            "integrity": "sha512-prv1S3OOxtH/yNA55zZqCAkOt+Y4fXQOmCuTpm4/YNB4odnItkU0KKZUKnMuzNu0Tgb2nP/0qCIZv7xZbx1eBA==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.2.1",
+        "ontotext-yasgui-web-component": "1.2.2",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Increase version of ontotext-yasgui-web-component.

## Why
 - GDB-9500 Explain plan should always be displayed in one column;
 - GDB-9480 Rename a tab name should be selected to write on it rather than having to be manually deleted by the user;
 - GDB-9479 Different French label on button Abort query;
 - GDB-9514 SPARQL Editor last tab can be closed which removes the entire view;
 - GDB-9528 Copy link buttons of an RDF star link not properly displayed;
 - GDB-8247 Update results cells to not cut the long IRIs.

## How
The version of ontotext-yasgui-web-component has been increased.