### PR TITLE
GDB-9237 - Reposition import button text (#1252)

### DIFF
--- a/src/css/import.css
+++ b/src/css/import.css
@@ -12,6 +12,16 @@
     text-overflow: ellipsis;
 }
 
+.grid-container {
+    display: flex;
+}
+
+.text {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: column;
+}
+
 .ng-hide.ng-hide-animate {
     display: none !important;
 }

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -13,21 +13,22 @@
     <div ng-controller="TabCtrl" ng-show="!isRestricted && canWriteActiveRepo()">
 
         <button type="button" ng-click="isCollapsed = !isCollapsed" class="btn btn-link pull-right"><span
-                class="icon-help"></span><span class="btn-link-text">{{'menu.help.label' | translate}}</span>
+            class="icon-help"></span><span class="btn-link-text">{{'menu.help.label' | translate}}</span>
         </button>
 
         <ul class="nav nav-tabs mb-2">
             <li class="nav-item" id="wb-import-tabUpload" ng-click="changeHelpTemplate('uploadInfo.html')"><a
-                    class="nav-link" ng-class="viewType == 'user' ? 'active' : ''" href ng-click="viewType = 'user'"
-                    data-toggle="tab">{{'user.data' | translate}}</a></li>
+                class="nav-link" ng-class="viewType == 'user' ? 'active' : ''" href ng-click="viewType = 'user'"
+                data-toggle="tab">{{'user.data' | translate}}</a></li>
             <li class="nav-item" id="wb-import-tabServer" ng-hide="isS4()"
                 ng-click="changeHelpTemplate('importInfo.html')">
                 <a class="nav-link"
-                    ng-class="viewType == 'server' ? 'active' : ''" href
-                    ng-click="viewType = 'server'" data-toggle="tab">{{'server.files' | translate}}</a></li>
+                   ng-class="viewType == 'server' ? 'active' : ''" href
+                   ng-click="viewType = 'server'" data-toggle="tab">{{'server.files' | translate}}</a></li>
         </ul>
         <div uib-collapse="!isCollapsed" id="ot-help-text" class="alert alert-info">
-            <button type="button" ng-click="isCollapsed = false" gdb-tooltip="{{'common.close' | translate}}" class="close"
+            <button type="button" ng-click="isCollapsed = false" gdb-tooltip="{{'common.close' | translate}}"
+                    class="close"
                     aria-label="Close"></button>
             <div ng-include="templateUrl"></div>
         </div>
@@ -48,40 +49,46 @@
                                accept="{{fileFormatsExtended}}"
                                ngf-change="fileSelected($files, $file, $newFiles, $duplicateFiles, $invalidFiles, $event)"
                                ngf-max-size="maxUploadFileSizeMB + 'MB'">
-                                <em class="icon-upload icon-lg pull-left"></em>
-                                <div>
-                                    <span>{{'upload.rdf.files.label' | translate}}</span>
-                                    <br>
-                                    <small class="text-muted">{{'all.rdf.formats.label' | translate}}{{'up.to' | translate}} {{maxUploadFileSizeMB | number}} MB</small>
+                                <div class="grid-container">
+                                    <em class="icon-upload icon-lg"></em>
+                                    <div class="text">
+                                        <div>{{'upload.rdf.files.label' | translate}}</div>
+                                        <small
+                                            class="text-muted">{{'all.rdf.formats.label' | translate}}{{'up.to' | translate}}
+                                            {{maxUploadFileSizeMB | number}} MB
+                                        </small>
+                                    </div>
                                 </div>
                             </a>
                         </div>
                     </div>
                     <div class="col-xs-12 col-md-6 col-lg-4 mb-1">
-                        <div class="btn btn-outline-primary btn-lg text-xs-left d-block import-from-url-btn" role="button" ng-click="rdfDataFromURL()"
+                        <div class="btn btn-outline-primary btn-lg text-xs-left d-block import-from-url-btn"
+                             role="button" ng-click="rdfDataFromURL()"
                              uib-popover="{{'supported.import.formats.label' | translate}} {{fileFormatsHuman}}"
                              popover-trigger="mouseenter"
                              popover-placement="bottom">
-                            <em class="icon-link icon-lg pull-left"></em>
-                            <div>
-                                <span>{{'rdf.data.from.url.label' | translate}}</span>
-                                <br>
-                                <small class="text-muted">{{'all.rdf.formats.label' | translate}}</span>
-                                </small>
+                            <div class="grid-container">
+                                <em class="icon-link icon-lg"></em>
+                                <div class="text">
+                                    <span>{{'rdf.data.from.url.label' | translate}}</span>
+                                    <small class="text-muted">{{'all.rdf.formats.label' | translate}}</small>
+                                </div>
                             </div>
                         </div>
                     </div>
                     <div class="col-xs-12 col-md-6 col-lg-4 mb-1">
-                        <div class="btn btn-outline-primary btn-lg text-xs-left d-block import-rdf-snippet-btn" role="button" ng-click="pasteData()"
+                        <div class="btn btn-outline-primary btn-lg text-xs-left d-block import-rdf-snippet-btn"
+                             role="button" ng-click="pasteData()"
                              uib-popover="{{'supported.import.formats.label' | translate}} {{textFileFormatsHuman}}"
                              popover-trigger="mouseenter"
                              popover-placement="bottom">
-                        <em class="icon-edit icon-lg pull-left"></em>
-                            <div>
-                                <span>{{'import.rdf.text.snippet.label' | translate}}</span>
-                                <br>
-                                <small class="text-muted">{{'type.paste.data.label' | translate}}</span>
-                                </small>
+                            <div class="grid-container">
+                                <em class="icon-edit icon-lg"></em>
+                                <div class="text">
+                                    <div>{{'import.rdf.text.snippet.label' | translate}}</div>
+                                    <small class="text-muted">{{'type.paste.data.label' | translate}}</small>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/test-cypress/integration/resource/resource.spec.js
+++ b/test-cypress/integration/resource/resource.spec.js
@@ -321,7 +321,12 @@ describe('Resource view', () => {
 
     context('Triple resource', () => {
 
-        it('should show triple resource', () => {
+        it('should show triple resource', {
+            retries: {
+                runMode: 1,
+                openMode: 0
+            }
+        }, () => {
             // When I visit resource view with triple resource.
             ResourceSteps.visit(`triple=${TRIPLE_RESOURCE}&role=subject`);
 


### PR DESCRIPTION
## What?
The bottom text in the buttons in the Import page is positioned to always start under the first letter of the top text.

## Why?
The bottom text would become misaligned in the first button when resizing the page.

## How?
I altered the template structure of the buttons and added new styling.

## Screenshots?
When resizing the page, the buttons look as follows:
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/4b1a919e-5a35-482e-ab60-5edf4b2bbc0b)
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/4a32b3f9-8d1d-456b-97be-a53c49428e9b)
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/b1eec5bd-4bc6-4a4b-a469-dd457f7942af)
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/7fdbe81b-adc1-490d-b407-42cf9d97d95c)


* GDB-9237 - reposition import button text, so it doesn't "jump" on resize

* GDB-9237 - change grey text position

* GDB-9237 - remove extra div and apply styling to its parent

* GDB-9237 - add retry to test

(cherry picked from commit 15822ab61721c3e96a8adf7ac2afae0b9a372bf4)