### PR TITLE
GDB-9549 fix sparql query endpoint resolving

### DIFF
--- a/src/js/angular/core/services/repositories.service.js
+++ b/src/js/angular/core/services/repositories.service.js
@@ -452,12 +452,12 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
          * @return {string} The resolved REST endpoint for sparql queries.
          */
         this.resolveSparqlEndpoint = (queryMode) => {
-            // if query mode is 'query' -> '/repositories/repo-name'
-            // if query mode is 'update' -> '/repositories/repo-name/statements'
+            // if query mode is 'query' -> 'repositories/repo-name'
+            // if query mode is 'update' -> 'repositories/repo-name/statements'
             if (queryMode === QueryMode.UPDATE) {
-                return `/repositories/${this.getActiveRepository()}/statements`;
+                return `repositories/${this.getActiveRepository()}/statements`;
             } else if (queryMode === QueryMode.QUERY) {
-                return `/repositories/${this.getActiveRepository()}`;
+                return `repositories/${this.getActiveRepository()}`;
             }
         };
 


### PR DESCRIPTION
## What
Fix sparql query endpoint resolving.

## Why
When GDB WB is deployed behind a context path requests to all endpoints which the WB calls should start without `/` otherwise this might brake the request routing.

## How
Removed the leading `/` from the sparql query endpoint used by the sparql editor and also by the download as feature.