### PR TITLE
Increase version of "ontotext-yasgui-web-component"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.2.2",
+                "ontotext-yasgui-web-component": "1.2.3",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10051,9 +10051,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.2.tgz",
-            "integrity": "sha512-prv1S3OOxtH/yNA55zZqCAkOt+Y4fXQOmCuTpm4/YNB4odnItkU0KKZUKnMuzNu0Tgb2nP/0qCIZv7xZbx1eBA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.3.tgz",
+            "integrity": "sha512-mZVtwOBwEUza/sst1QBPljqppVK/xqq6tUUZGa/jOVP9dnIvy3yB9t+3xmLPejmdsWyvs/6eVsd+eOZJUR2gVQ==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24534,9 +24534,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.2.tgz",
-            "integrity": "sha512-prv1S3OOxtH/yNA55zZqCAkOt+Y4fXQOmCuTpm4/YNB4odnItkU0KKZUKnMuzNu0Tgb2nP/0qCIZv7xZbx1eBA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.3.tgz",
+            "integrity": "sha512-mZVtwOBwEUza/sst1QBPljqppVK/xqq6tUUZGa/jOVP9dnIvy3yB9t+3xmLPejmdsWyvs/6eVsd+eOZJUR2gVQ==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.2.2",
+        "ontotext-yasgui-web-component": "1.2.3",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Increased the version of the "ontotext-yasgui-web-component".

## Why
- GDB-9242: Refactoring the compact view functionality;
- Fixes an issue related to [GDB-8247](https://ontotext.atlassian.net/browse/GDB-8247).

## How
The version of "ontotext-yasgui-web-component" has been increased.

[GDB-8247]: https://ontotext.atlassian.net/browse/GDB-8247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ