### PR TITLE
GDB-9516 clear the rule highlighting on tab switch

### DIFF
--- a/src/js/angular/aclmanagement/controllers.js
+++ b/src/js/angular/aclmanagement/controllers.js
@@ -228,8 +228,12 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
      */
     $scope.moveUp = (scope, index) => {
         $scope.rulesModel.moveUp(scope, index);
-        $scope.selectedRule = index - 1;
         setModelDirty(scope);
+        if ($scope.modelIsDirty) {
+            $scope.selectedRule = index - 1;
+        } else {
+            $scope.selectedRule = undefined;
+        }
     };
 
     /**
@@ -239,8 +243,12 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
      */
     $scope.moveDown = (scope, index) => {
         $scope.rulesModel.moveDown(scope, index);
-        $scope.selectedRule = index + 1;
         setModelDirty(scope);
+        if ($scope.modelIsDirty) {
+            $scope.selectedRule = index + 1;
+        } else {
+            $scope.selectedRule = undefined;
+        }
     };
 
     /**
@@ -285,9 +293,9 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
             event.preventDefault();
             return;
         }
+        $scope.selectedRule = undefined;
         $scope.activeTabScope = scope;
         $scope.ruleKeys = $scope.rulesModel.getRuleKeysByScope($scope.activeTabScope);
-
     };
 
     /**
@@ -374,6 +382,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
     };
 
     const resetPageState = () => {
+        $scope.selectedRule = undefined;
         $scope.editedRuleIndex = undefined;
         $scope.editedRuleScope = undefined;
         $scope.modelIsDirty = false;


### PR DESCRIPTION
## What
Clear the rule highlighting on tab switch.

## Why
It's annoying bug where the selected rule index remains uncleared in the controller when tab is switched which causes a flickering of previously moved rule.

## How
* Cleared the selected rule index in the controller to prevent flickering on tab switch.
* Clear the selected rule property when moving rules up/down and the model appears to be pristine.