### PR TITLE
GDB-9548 - Add color in dark theme for keyboard shortcut text

### DIFF
--- a/src/css/bootstrap-graphdb-theme-dark-auto.css
+++ b/src/css/bootstrap-graphdb-theme-dark-auto.css
@@ -38,3 +38,7 @@ option {
     background-color: var(--html-background);
     color: var(--gray-color);
 }
+
+.hotkeys-text, .keyboard-shortcut-description-item-description {
+    color: var(--keyboard-shortcuts);
+}

--- a/src/themes/default/plugin.js
+++ b/src/themes/default/plugin.js
@@ -58,7 +58,8 @@ PluginRegistry.add('themes', {
             'primary-color-lightness': '60%',
             'secondary-color-saturation': '70%',
             'color-warning-light': 'hsla(var(--primary-color-hsl), 0.15)',
-            'logo-color': 'var(--primary-color-dark)'
+            'logo-color': 'var(--primary-color-dark)',
+            'keyboard-shortcuts': 'var(--secondary-color)'
         },
         // CSS properties, "foo: bar" becomes "foo: bar"
         'properties': {


### PR DESCRIPTION
## What?
The keyboard shortcuts in dark theme on the Visual graph view and SPARQL view will match the color of the main menu text.

## Why?
The keyboard shortcuts would remain the same color as they were in the light theme.

## How?
I added a new variable in the dark theme for the shortcut text.

## Screenshots?
**Both views in dark mode:**

![Screenshot from 2024-02-23 11-49-06](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/e25e3816-e2df-40f9-8c0e-36b2504a32d8)
![Screenshot from 2024-02-23 11-48-48](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/ca049ca3-a7a1-46fd-8d14-fac5b5132225)
