### PR TITLE
Gdb 9387 remove yasqe resizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.2.3",
+                "ontotext-yasgui-web-component": "1.2.4",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10051,9 +10051,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.3.tgz",
-            "integrity": "sha512-mZVtwOBwEUza/sst1QBPljqppVK/xqq6tUUZGa/jOVP9dnIvy3yB9t+3xmLPejmdsWyvs/6eVsd+eOZJUR2gVQ==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.4.tgz",
+            "integrity": "sha512-dJzJDohwN1fWbgR+JCSDyGQlpOBWL/E4pTQPv+gEOiKwh4Ub40oUBt6rgBAcNhmnccNW0Nfl1cnJADocdUdCNg==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24534,9 +24534,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.3.tgz",
-            "integrity": "sha512-mZVtwOBwEUza/sst1QBPljqppVK/xqq6tUUZGa/jOVP9dnIvy3yB9t+3xmLPejmdsWyvs/6eVsd+eOZJUR2gVQ==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.4.tgz",
+            "integrity": "sha512-dJzJDohwN1fWbgR+JCSDyGQlpOBWL/E4pTQPv+gEOiKwh4Ub40oUBt6rgBAcNhmnccNW0Nfl1cnJADocdUdCNg==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.2.3",
+        "ontotext-yasgui-web-component": "1.2.4",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {

--- a/src/css/create-similarity-index.css
+++ b/src/css/create-similarity-index.css
@@ -10,3 +10,7 @@
 yasgui-component .CodeMirror {
     height: 330px !important;
 }
+
+.keyboard-shortcuts-dialog-wrapper {
+    margin-top: -21px;
+}

--- a/src/css/graphs-config.css
+++ b/src/css/graphs-config.css
@@ -70,6 +70,10 @@ yasgui-component .CodeMirror {
     background-color:  hsla(var(--primary-color-hsl), 0.15)
 }
 
+.keyboard-shortcuts-dialog-wrapper {
+    margin-top: -21px;
+}
+
 @media (max-width: 1270px) {
     .image-label {
         flex-direction: column;

--- a/src/css/jdbc-create.css
+++ b/src/css/jdbc-create.css
@@ -6,3 +6,7 @@
 yasgui-component .CodeMirror {
     height: 330px !important;
 }
+
+.keyboard-shortcuts-dialog-wrapper {
+    margin-top: -21px;
+}

--- a/src/css/sparql-templates.css
+++ b/src/css/sparql-templates.css
@@ -1,3 +1,7 @@
 yasgui-component .CodeMirror {
     height: 330px !important;
 }
+
+.keyboard-shortcuts-dialog-wrapper {
+    margin-top: -21px;
+}

--- a/src/js/angular/graphexplore/controllers/graphs-config.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-config.controller.js
@@ -497,6 +497,7 @@ function GraphConfigCtrl(
         componentId: 'graphs-config',
         render: RenderingMode.YASQE,
         maxPersistentResponseSize: 0,
+        showYasqeResizer: false,
         yasqeMode: YasqeMode.PROTECTED,
         infer: $scope.newConfig.startQueryIncludeInferred,
         sameAs: $scope.newConfig.startQuerySameAs

--- a/src/js/angular/jdbc/controllers.js
+++ b/src/js/angular/jdbc/controllers.js
@@ -369,6 +369,7 @@ function JdbcCreateCtrl(
             showQueryButton: false,
             showResultInfo: false,
             downloadAsOn: false,
+            showYasqeResizer: false,
             initialQuery: $scope.jdbcConfigurationInfo.query,
             componentId: 'jdbc-component',
             prefixes: $scope.prefixes,

--- a/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/src/js/angular/similarity/controllers/create-index.controller.js
@@ -526,6 +526,7 @@ function CreateSimilarityIdxCtrl(
             showQueryButton: false,
             downloadAsOn: false,
             showResultInfo: false,
+            showYasqeResizer: false,
             pageSize: 100,
             prefixes: usedPrefixes,
             render: $scope.similarityIndexInfo.getSelectedYasguiRenderMode(),

--- a/src/js/angular/sparql-template/controllers.js
+++ b/src/js/angular/sparql-template/controllers.js
@@ -179,6 +179,7 @@ function SparqlTemplateCreateCtrl(
             showToolbar: false,
             showResultTabs: false,
             showYasqeActionButtons: false,
+            showYasqeResizer: false,
             yasqeActionButtons: DISABLE_YASQE_BUTTONS_CONFIGURATION,
             showQueryButton: false,
             initialQuery: $scope.sparqlTemplateInfo.query,


### PR DESCRIPTION
## What
- Remove the non-functioning resize bar in the "Create similarity index";
- Remove the non-functioning resize bar in the "Create visual graph config";
- Remove the non-functioning resize bar in the "SQL table configuration";
- Remove the non-functioning resize bar in the "Create SPARQL Templates".

## Why
The height is set programmatically, and we don't want to change it.

## How
The YASQE resizer has been hidden.

#Additional work
## What
- GDB-9318: Turn off double click or YASQE resizer;
- GDB-9628 properly switch yasgui modes when tabs are switched or opened;

## Why
- GDB-9318: We don't want this behavior, when the component is used with other components in a view, this behavior can make the view look strange;
- GDB-9628:
  - When switching to editor only mode, then changing to another tab or opening a new tab won't preserve the selected mode;
  - When switching to horizontal layout (2-columns), then yasqe spans the entire available page height, but when opening new tab or switching to another opened one, then yasqe shrinks to its default height.

## How
- The version of "ontotext-yasgui-web-component" has been increased.