### PR TITLE
GDB-8247: Cells in YASR are centered vertically

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -303,6 +303,10 @@ yasgui-component .yasr .dataTable .nonUri sup {
     color: #666666;
 }
 
+yasgui-component .yasr .dataTables_wrapper .dataTable tbody tr {
+    vertical-align: top;
+}
+
 yasgui-component .yasr #explainPlanQuery {
     font-family: var(--mono-font);
 }


### PR DESCRIPTION
## What
GDB-8247: Cells in YASR are centered vertically.

## Why
This issue arises from the new YASGUI.

## How
Top alignment has been added to all results in the YASR result table.