### PR TITLE
Update yasgui component version to 1.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.2.4",
+                "ontotext-yasgui-web-component": "1.2.5",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10051,9 +10051,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.4.tgz",
-            "integrity": "sha512-dJzJDohwN1fWbgR+JCSDyGQlpOBWL/E4pTQPv+gEOiKwh4Ub40oUBt6rgBAcNhmnccNW0Nfl1cnJADocdUdCNg==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.5.tgz",
+            "integrity": "sha512-2ErPTYZ2yNhwqLf9GAzyBN9a6AN/OH5ez1aw9g9C5QYzrMCybedAvz7UGEIhQrioQH/MXZSzwAKj5FAogm1YtA==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24534,9 +24534,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.4.tgz",
-            "integrity": "sha512-dJzJDohwN1fWbgR+JCSDyGQlpOBWL/E4pTQPv+gEOiKwh4Ub40oUBt6rgBAcNhmnccNW0Nfl1cnJADocdUdCNg==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.5.tgz",
+            "integrity": "sha512-2ErPTYZ2yNhwqLf9GAzyBN9a6AN/OH5ez1aw9g9C5QYzrMCybedAvz7UGEIhQrioQH/MXZSzwAKj5FAogm1YtA==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.2.4",
+        "ontotext-yasgui-web-component": "1.2.5",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Update yasgui component version to 1.2.5

## Why
Includes fixes for:
* GDB-9678: The 'Abort' button doesn't get translated when there are multiple running queries.
* GDB-9578 fix triple escaping when copying link

## How
Updated version