### PR TITLE
fixes for GDB-9409 and GDB-9578

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.3.1",
+                "ontotext-yasgui-web-component": "1.3.2",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -9895,9 +9895,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.1.tgz",
-            "integrity": "sha512-rv9D7jBILFFIo7HSJdR31QugQdGX5/onbspB7VcrgjCF+QEqU7VRDhmFx10lbw4sxDz3GxR0fkl1N0QD2vR5tQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.2.tgz",
+            "integrity": "sha512-r8RLR8XTeFUS4tRPpcAVBOUeQv9EUjXrcBM5EZS61CqjzzEhIx66Q7i4eJKpOKUeHL+TdDs/SypSDkeekDDkgA==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24182,9 +24182,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.1.tgz",
-            "integrity": "sha512-rv9D7jBILFFIo7HSJdR31QugQdGX5/onbspB7VcrgjCF+QEqU7VRDhmFx10lbw4sxDz3GxR0fkl1N0QD2vR5tQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.2.tgz",
+            "integrity": "sha512-r8RLR8XTeFUS4tRPpcAVBOUeQv9EUjXrcBM5EZS61CqjzzEhIx66Q7i4eJKpOKUeHL+TdDs/SypSDkeekDDkgA==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.3.1",
+        "ontotext-yasgui-web-component": "1.3.2",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Increase the version of "ontotext-yasgui-web-component".

## Why
There are fixes for:
 - GDB-9409 Change background color of yasr error plugin
 - GDB-9578 Invalid RDF-star triple on copy link in SPARQL editor.

## How
The version has been increased.