### PR TITLE
GDB-9371 - (cherry pick) set dark theme for dropdowns

### DIFF
--- a/src/css/bootstrap-graphdb-theme-dark-auto.css
+++ b/src/css/bootstrap-graphdb-theme-dark-auto.css
@@ -34,3 +34,7 @@ input[type="checkbox"] {
     filter: var(--checkbox-filter);
 }
 
+option {
+    background-color: var(--html-background);
+    color: var(--gray-color);
+}


### PR DESCRIPTION
## What?
The dropdown menus will have styling to match the dark theme, whenever it's applied.

## Why?
The menus used to remain the same as in the light theme. This created a bad experience for users using the dark theme.

## How?
I added new styling for the option tags.

## Screenshots?
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/ec95115a-48ee-407f-ae5b-4c31f7636de0)
