### PR TITLE
Update yasgui component version to 1.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.2.6",
+                "ontotext-yasgui-web-component": "1.2.7",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10051,9 +10051,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.6.tgz",
-            "integrity": "sha512-cyVOtEyCw2IU8CXG8iVQXaU1pDZrp/Za6nsRE3id0vrjmeFozhSeP2Fo6kZYY7fKbWlV2+7+q1C7exKOO0AhaQ==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.7.tgz",
+            "integrity": "sha512-CwfEerSaBl6RZVv6+Of4U1Y42EABtnpCH3Fl2c5BcCxl4bF1VV170YOPeIrtTtRUG57+sMJW9DiFSjGdnlX8gw==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24534,9 +24534,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.6.tgz",
-            "integrity": "sha512-cyVOtEyCw2IU8CXG8iVQXaU1pDZrp/Za6nsRE3id0vrjmeFozhSeP2Fo6kZYY7fKbWlV2+7+q1C7exKOO0AhaQ==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.7.tgz",
+            "integrity": "sha512-CwfEerSaBl6RZVv6+Of4U1Y42EABtnpCH3Fl2c5BcCxl4bF1VV170YOPeIrtTtRUG57+sMJW9DiFSjGdnlX8gw==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.2.6",
+        "ontotext-yasgui-web-component": "1.2.7",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Update yasgui component version to 1.2.7

## Why
Includes fixes for:
* GDB-9578: fix literal position in rdf star triple

## How
Updated version