### PR TITLE
Update yasgui component version to 1.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.3.2",
+                "ontotext-yasgui-web-component": "1.3.3",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -9895,9 +9895,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.2.tgz",
-            "integrity": "sha512-r8RLR8XTeFUS4tRPpcAVBOUeQv9EUjXrcBM5EZS61CqjzzEhIx66Q7i4eJKpOKUeHL+TdDs/SypSDkeekDDkgA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.3.tgz",
+            "integrity": "sha512-4Ni442SxHoJmAvxsqb3thVOmDOPci62XKRUW2sYh3h1w04FGzA6+cPkB7mEnY9QztEKoIE6sMyjSYPHkfa4w4g==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24182,9 +24182,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.2.tgz",
-            "integrity": "sha512-r8RLR8XTeFUS4tRPpcAVBOUeQv9EUjXrcBM5EZS61CqjzzEhIx66Q7i4eJKpOKUeHL+TdDs/SypSDkeekDDkgA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.3.tgz",
+            "integrity": "sha512-4Ni442SxHoJmAvxsqb3thVOmDOPci62XKRUW2sYh3h1w04FGzA6+cPkB7mEnY9QztEKoIE6sMyjSYPHkfa4w4g==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.3.2",
+        "ontotext-yasgui-web-component": "1.3.3",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Update yasgui component version to 1.3.3

## Why
Includes fixes for:
* GDB-9578: fix literal position in rdf star triple

## How
Updated version