### PR TITLE
Update yasgui component version to 1.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.2.7",
+                "ontotext-yasgui-web-component": "1.2.8",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10051,9 +10051,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.7.tgz",
-            "integrity": "sha512-CwfEerSaBl6RZVv6+Of4U1Y42EABtnpCH3Fl2c5BcCxl4bF1VV170YOPeIrtTtRUG57+sMJW9DiFSjGdnlX8gw==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.8.tgz",
+            "integrity": "sha512-pWztu60ato6TsSmC5PglKUjoulc8BsKoAeVZrl7kRat+eJJABpWkzZZ1uJjZMzk871hQKL+hYFDRREHylFWgsA==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24534,9 +24534,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.7.tgz",
-            "integrity": "sha512-CwfEerSaBl6RZVv6+Of4U1Y42EABtnpCH3Fl2c5BcCxl4bF1VV170YOPeIrtTtRUG57+sMJW9DiFSjGdnlX8gw==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.2.8.tgz",
+            "integrity": "sha512-pWztu60ato6TsSmC5PglKUjoulc8BsKoAeVZrl7kRat+eJJABpWkzZZ1uJjZMzk871hQKL+hYFDRREHylFWgsA==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.2.7",
+        "ontotext-yasgui-web-component": "1.2.8",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Update yasgui component version to 1.2.8

## Why
Includes fixes for:
* GDB-9848: Yasr - Missing error in the result after abort query

## How
Updated version