### PR TITLE
Update yasgui component version to 1.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.3.3",
+                "ontotext-yasgui-web-component": "1.3.4",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -9895,9 +9895,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.3.tgz",
-            "integrity": "sha512-4Ni442SxHoJmAvxsqb3thVOmDOPci62XKRUW2sYh3h1w04FGzA6+cPkB7mEnY9QztEKoIE6sMyjSYPHkfa4w4g==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.4.tgz",
+            "integrity": "sha512-W/x5Sa9imrngf/ReMuCLUXK6zm0hJfA6a47pcQkXoQBE935BbJR96wEEGOks12EBNyimgzUdaeWu2CDXrOZNKA==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24182,9 +24182,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.3.tgz",
-            "integrity": "sha512-4Ni442SxHoJmAvxsqb3thVOmDOPci62XKRUW2sYh3h1w04FGzA6+cPkB7mEnY9QztEKoIE6sMyjSYPHkfa4w4g==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.4.tgz",
+            "integrity": "sha512-W/x5Sa9imrngf/ReMuCLUXK6zm0hJfA6a47pcQkXoQBE935BbJR96wEEGOks12EBNyimgzUdaeWu2CDXrOZNKA==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.3.3",
+        "ontotext-yasgui-web-component": "1.3.4",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Update yasgui component version to 1.3.4

## Why
Includes fixes for:
* GDB-9719: Add loader when rendering result table after compact view toggled;
* GDB-9848: Missing error in the result after abort query.

## How
Updated version