### PR TITLE
GDB-9211 add jsonld import/export tests

### DIFF
--- a/src/js/angular/core/components/export-settings-modal/exportSettingsModal.html
+++ b/src/js/angular/core/components/export-settings-modal/exportSettingsModal.html
@@ -57,7 +57,7 @@
 </div>
 
 <div class="modal-footer">
-    <button type="button" class="btn btn-link pull-left" ng-click="reset()">{{'import.restore.defaults.btn' | translate}}</button>
+    <button type="button" class="btn btn-link pull-left restore-defaults" ng-click="reset()">{{'import.restore.defaults.btn' | translate}}</button>
     <button type="button" ng-click="cancel()" class="btn btn-secondary">{{'common.cancel.btn' | translate}}</button>
     <button id="wb-export-JSONLD" class="btn btn-primary" type="button"
             ng-click="exportJsonLD()">

--- a/src/pages/explore.html
+++ b/src/pages/explore.html
@@ -94,12 +94,12 @@
 
         <div class="btn-group" uib-dropdown is-open="isopen">
             <button type="button"
-                    class="btn btn-sm btn-secondary dropdown-toggle"
+                    class="btn btn-sm btn-secondary dropdown-toggle download-as"
                     ng-class="loading ? 'disabled' : ''"
                     uib-dropdown-toggle>
                 {{'download.as.label' | translate}}
             </button>
-            <ul class="dropdown-menu small" role="menu">
+            <ul class="dropdown-menu small download-options" role="menu">
                 <li ng-repeat="fileType in fileTypes">
                     <a href="javascript:" ng-click="openJSONLDExportSettings(fileType)" ng-if="fileType.name === 'JSON-LD'" class="dropdown-item">{{fileType.name}}</a>
                     <a href="javascript:" ng-click="downloadExport(fileType)" ng-if="fileType.name !== 'JSON-LD'" class="dropdown-item">{{fileType.name}}</a>

--- a/src/pages/export.html
+++ b/src/pages/export.html
@@ -146,7 +146,7 @@
 								<div class="btn-group" uib-dropdown>
 									<!-- Keep the closing button tag right after the closing span tag, otherwise
 										 an extra space is rendered in HTML -->
-									<button type="button" class="btn btn-link dropdown-toggle" uib-dropdown-toggle gdb-tooltip="{{'export.graph.label' | translate}}"
+									<button type="button" class="btn btn-link dropdown-toggle export-graph" uib-dropdown-toggle gdb-tooltip="{{'export.graph.label' | translate}}"
 											ng-disabled="!graph.contextID.uri">
 										<span class="icon-export"></span></button>
 									<ul class="dropdown-menu" role="menu">

--- a/test-cypress/integration/import/import.server.files.spec.js
+++ b/test-cypress/integration/import/import.server.files.spec.js
@@ -59,6 +59,30 @@ describe('Import screen validation - server files', () => {
             .verifyImportStatusDetails(JSONLD_FILE_FOR_IMPORT, [CONTEXT, BASE_URI, '"preserveBNodeIds": true,', JSONLD_CONTEXT]);
     });
 
+    it('Test import Server files successfully with JSONLD default settings', () => {
+        ImportSteps.selectServerFile(JSONLD_FILE_FOR_IMPORT)
+            .importServerFiles(true)
+            .fillBaseURI(BASE_URI)
+            .selectNamedGraph()
+            .fillNamedGraph(CONTEXT)
+            .expandAdvancedSettings()
+            .setContextLinkToBeVisible()
+            .enablePreserveBNodes()
+            .importFromSettingsDialog()
+            .verifyImportStatus(JSONLD_FILE_FOR_IMPORT, SUCCESS_MESSAGE)
+            .verifyImportStatusDetails(JSONLD_FILE_FOR_IMPORT, [CONTEXT, BASE_URI, '"preserveBNodeIds": true,']);
+    });
+
+    it('Test import Server file successfully with JSONLD, button on row, with settings', () => {
+        ImportSteps.clickImportOnRow(0)
+            .fillBaseURI(BASE_URI)
+            .expandAdvancedSettings()
+            .fillContextLink(JSONLD_CONTEXT)
+            .importFromSettingsDialog()
+            .verifyImportStatus(JSONLD_FILE_FOR_IMPORT, SUCCESS_MESSAGE)
+            .verifyImportStatusDetails(JSONLD_FILE_FOR_IMPORT, [BASE_URI, '"preserveBNodeIds": false,', JSONLD_CONTEXT]);
+    });
+
     it('Test import with resetting status of imported file', () => {
         ImportSteps
             .selectServerFile(FILE_FOR_IMPORT)

--- a/test-cypress/integration/resource/resource.spec.js
+++ b/test-cypress/integration/resource/resource.spec.js
@@ -6,6 +6,7 @@ import {SparqlEditorSteps} from "../../steps/sparql-editor-steps";
 import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
 import {YasrSteps} from "../../steps/yasgui/yasr-steps";
 import {YasguiSteps} from "../../steps/yasgui/yasgui-steps";
+import {JsonLdModalSteps} from "../../steps/json-ld-modal-steps";
 
 const FILE_TO_IMPORT = 'resource-test-data.ttl';
 const SUBJECT_RESOURCE = 'http:%2F%2Fexample.com%2Fontology%23CustomerLoyalty';
@@ -45,6 +46,8 @@ describe('Resource view', () => {
     it('should results contains/"not contains" depends on blank node flag', () => {
         // When I load a resource that takes part in a triple with a blank node.
         ResourceSteps.visit(`uri=${PREDICATE_SOURCE}&role=subject`);
+
+        cy.get('.ontotext-yasgui-loader').should('be.hidden');
 
         // When I click on "predicate" tab.
         ResourceSteps.selectPredicateRole();
@@ -357,6 +360,43 @@ describe('Resource view', () => {
             // and a describe query to be present
             YasqeSteps.getActiveTabQuery().should('contain', 'describe <<<http://example.com/resource/person/W6J1827> <http://example.com/ontology#hasAddress> <http://example.com/resource/person/W6J1827/address>>>');
             YasguiSteps.getCurrentTab().should('contain', 'Unnamed 1');
+        });
+    });
+
+    context('Download as', () => {
+        it('should download as JSON-LD and then restore defaults', () => {
+            // Given I am in the Resource view
+            ResourceSteps.visit(`uri=${SUBJECT_RESOURCE}&role=subject`);
+            ResourceSteps.verifyActiveRoleTab('subject');
+
+            // When I download as JSON-LD
+            ResourceSteps.clickDownloadAsOption(1);
+
+            // Then I should see a dialog appear
+            JsonLdModalSteps.getJSONLDModal().should('be.visible');
+
+            // And I type some example data into the form
+            JsonLdModalSteps.selectJSONLDMode(0);
+            JsonLdModalSteps.typeJSONLDFrame('https://w3c.github.io/json-ld-api/tests/compact/0007-context.jsonld');
+
+            // And export a file
+            JsonLdModalSteps.clickExportJSONLD();
+
+            // Then the dialog should disappear
+            JsonLdModalSteps.getJSONLDModal().should('not.exist');
+
+            // And the file should have downloaded
+            JsonLdModalSteps.verifyFileExists('statements.jsonld');
+
+            // When I select the same download as option again and the dialog appears with the prior data
+            ResourceSteps.clickDownloadAsOption(1);
+            JsonLdModalSteps.getJSONLDModal().should('be.visible');
+            JsonLdModalSteps.getSelectedJSONLDModeField().should('have.value', 'http://www.w3.org/ns/json-ld#framed');
+            JsonLdModalSteps.getJSONLDFrame().should('have.value', 'https://w3c.github.io/json-ld-api/tests/compact/0007-context.jsonld');
+
+            // Then clicking the 'Restore defaults' button should reset the data in the form
+            JsonLdModalSteps.clickRestoreDefaultsJSONLD();
+            JsonLdModalSteps.getSelectedJSONLDModeField().should('have.value', 'http://www.w3.org/ns/json-ld#expanded');
         });
     });
 });

--- a/test-cypress/integration/sparql-editor/yasr/download-as.spec.js
+++ b/test-cypress/integration/sparql-editor/yasr/download-as.spec.js
@@ -2,6 +2,8 @@ import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
 import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
 import {YasrSteps} from "../../../steps/yasgui/yasr-steps";
 import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {JsonLdModalSteps} from "../../../steps/json-ld-modal-steps";
+import {GraphsOverviewSteps} from "../../../steps/explore/graphs-overview-steps";
 
 describe('Download results', () => {
     let repositoryId;
@@ -50,5 +52,74 @@ describe('Download results', () => {
             YasrSteps.getDownloadAsOption(6).contains( 'TSV*');
             YasrSteps.getDownloadAsOption(7).contains( 'Binary RDF Results');
         });
+
+        it('should download as JSON-LD after a CONSTRUCT query', () => {
+            // Given I execute a CONSTRUCT query
+            pasteAndExecuteConstructQuery();
+            // And I open the download dropdown
+            YasrSteps.openDownloadAsDropdown();
+            // Then the second option should be JSON-LD
+            YasrSteps.getDownloadAsOption(1).contains( 'JSON-LD');
+            // When I select it
+            YasrSteps.selectDownloadAsOption(1);
+            // The dialog for download should appear
+            JsonLdModalSteps.getJSONLDModal().should('be.visible');
+            // Then I see the default settings
+            JsonLdModalSteps.getSelectedJSONLDModeField().should('have.value', 'http://www.w3.org/ns/json-ld#expanded');
+            // When I click to export
+            JsonLdModalSteps.clickExportJSONLD();
+            // Then the dialog should disappear
+            JsonLdModalSteps.getJSONLDModal().should('not.exist');
+            // And the file should have downloaded
+            // TODO: verify the file exists
+            // JsonLdModalSteps.verifyFileExists('query-result.jsonld');
+
+            // When I open the dialog again
+            YasrSteps.selectDownloadAsOption(1);
+            // And I change the JSON-LD form
+            GraphsOverviewSteps.selectJSONLDMode(0);
+            // And type in a context
+            JsonLdModalSteps.typeJSONLDFrame('https://w3c.github.io/json-ld-api/tests/compact/0007-context.jsonld');
+            // And export
+            JsonLdModalSteps.clickExportJSONLD();
+            JsonLdModalSteps.getJSONLDModal().should('not.exist');
+            // Then the file should have downloaded
+            // TODO: verify the file exists
+            // JsonLdModalSteps.verifyFileExists('query-result.jsonld');
+        });
+
+        it('should download as JSON-LD after a CONSTRUCT query, with context added', () => {
+            // Given I execute a CONSTRUCT query
+            pasteAndExecuteConstructQuery();
+            // And I open the download dropdown
+            YasrSteps.openDownloadAsDropdown();
+            // Then the second option should be JSON-LD
+            YasrSteps.getDownloadAsOption(1).contains( 'JSON-LD');
+            // When I select it
+            YasrSteps.selectDownloadAsOption(1);
+            // And I change the JSON-LD form
+            GraphsOverviewSteps.selectJSONLDMode(0);
+            // And type in a context
+            JsonLdModalSteps.typeJSONLDFrame('https://w3c.github.io/json-ld-api/tests/compact/0007-context.jsonld');
+            // And export
+            JsonLdModalSteps.clickExportJSONLD();
+            JsonLdModalSteps.getJSONLDModal().should('not.exist');
+            // Then the file should have downloaded
+            // TODO: verify the file exists
+            // JsonLdModalSteps.verifyFileExists('query-result.jsonld');
+        });
     });
 });
+
+function pasteAndExecuteConstructQuery() {
+    YasqeSteps.clearEditor();
+    YasqeSteps.pasteQuery('PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>' +
+        'PREFIX onto: <http://www.ontotext.com/>' +
+        'CONSTRUCT {' +
+        '?source rdf:type ?destination .' +
+        '}  WHERE {' +
+        '?bag rdf:type ?source .' +
+        '?flight rdf:type ?destination' +
+        '}');
+    YasqeSteps.executeQuery();
+}

--- a/test-cypress/steps/explore/graphs-overview-steps.js
+++ b/test-cypress/steps/explore/graphs-overview-steps.js
@@ -21,4 +21,36 @@ export class GraphsOverviewSteps {
     static openGraph(row = 0) {
         GraphsOverviewSteps.getResult(row).find('td ').eq(1).find('a').click();
     }
+
+    static selectRow(row) {
+        cy.get('.form-check-input').eq(row).click();
+    }
+
+    static getExportRepositoryButtonOnRow(index) {
+        return cy.get('.export-graph').eq(index);
+    }
+
+    static downloadAsFromRowButton(index) {
+        this.getExportRepositoryButtonOnRow(index).click();
+    }
+
+    static selectJSONLDFromRowDropdown() {
+        cy.get('.dropdown-menu').find('.export-repo-format-JSON-LD').eq(1).click();
+    }
+
+    static getExportRepositoryButton() {
+        return cy.get('.export-repository-btn');
+    }
+
+    static exportRepository() {
+        this.getExportRepositoryButton().click();
+    }
+
+    static selectJSONLDOption() {
+        cy.get('.export-repo-format-JSONLD').click();
+    }
+
+    static selectJSONLDMode(option) {
+        cy.get('[id=wb-JSONLD-mode]').select(option);
+    }
 }

--- a/test-cypress/steps/import-steps.js
+++ b/test-cypress/steps/import-steps.js
@@ -145,6 +145,12 @@ class ImportSteps {
         return ImportSteps;
     }
 
+    static clickImportOnRow(row) {
+        this.getImportFileRow(row).find('.pull-right').contains('Import').click();
+
+        return ImportSteps;
+    }
+
     static importFromSettingsDialog() {
         // Dialog should disappear
         ImportSteps.getModal().
@@ -199,13 +205,21 @@ class ImportSteps {
         return ImportSteps;
     }
 
+    static setContextLinkToBeVisible() {
+        ImportSteps.getSettingsForm().within(() => {
+            cy.get('.contextLinkRow').invoke('attr', 'style', 'display: block !important');
+        });
+
+        return ImportSteps;
+    }
+
     static resetStatusOfUploadedFiles() {
         // Button should disappear
         cy.get('#import-server #wb-import-clearStatuses')
             .click()
             .then((el) => {
                 cy.waitUntil(() => cy.wrap(el).should('not.be.visible'));
-            })
+            });
 
         return ImportSteps;
     }

--- a/test-cypress/steps/json-ld-modal-steps.js
+++ b/test-cypress/steps/json-ld-modal-steps.js
@@ -1,0 +1,41 @@
+export class JsonLdModalSteps {
+    static getJSONLDModal() {
+        return cy.get('.modal-content');
+    }
+
+    static selectJSONLDMode(option) {
+        cy.get('[id=wb-JSONLD-mode]').select(option);
+    }
+
+    static getSelectedJSONLDModeField() {
+        return cy.get('#wb-JSONLD-mode option:checked');
+    }
+
+    static getJSONLDFrame() {
+        return cy.get('[id=wb-JSONLD-frame]');
+    }
+
+    static getJSONLDContext() {
+        return cy.get('[id=wb-JSONLD-context]');
+    }
+
+    static typeJSONLDFrame(text) {
+        this.getJSONLDFrame().type(text);
+    }
+
+    static typeJSONLDContext(text) {
+        this.getJSONLDContext().type(text);
+    }
+
+    static clickExportJSONLD() {
+        cy.get('[id=wb-export-JSONLD]').click();
+    }
+
+    static clickRestoreDefaultsJSONLD() {
+        cy.get('.restore-defaults').click();
+    }
+
+    static verifyFileExists(fileName) {
+        cy.readFile('cypress/downloads/' + fileName);
+    }
+}

--- a/test-cypress/steps/resource/resource-steps.js
+++ b/test-cypress/steps/resource/resource-steps.js
@@ -53,7 +53,12 @@ export class ResourceSteps {
     }
 
     static getDownloadAsDropdown() {
-        return cy.get('.dropdown-toggle');
+        return cy.get('.download-as');
+    }
+
+    static clickDownloadAsOption(option) {
+        this.getDownloadAsDropdown().click();
+        cy.get('.download-options li').eq(option).click();
     }
 
     static getVisualGraphButton() {
@@ -97,7 +102,7 @@ export class ResourceSteps {
     }
 
     static selectRole(role) {
-        ResourceSteps.getRoleTab(role).click();
+        ResourceSteps.getRoleTab(role).click({force: false});
     }
 
     static selectSubjectRole() {

--- a/test-cypress/steps/yasgui/yasr-steps.js
+++ b/test-cypress/steps/yasgui/yasr-steps.js
@@ -86,6 +86,11 @@ export class YasrSteps {
         return this.getDownloadAsDropdown().find('.ontotext-dropdown-menu-item').eq(number);
     }
 
+    static selectDownloadAsOption(number) {
+        // Click with force: true, because the repository dropdown at the top of the page hides the option
+        this.getDownloadAsOption(number).click({force: true});
+    }
+
     static getPagination() {
         return YasrSteps.getYasr().find('.ontotext-pagination');
     }


### PR DESCRIPTION
## What
Add jsonld import/export tests.

## Why
To improve the code test coverage and prevent regressions.

## How