### PR TITLE
GDB-9883: Misalignment on monitoring icons

### DIFF
--- a/src/css/operations-statuses-monitor.css
+++ b/src/css/operations-statuses-monitor.css
@@ -79,8 +79,9 @@
     width: 24px;
 }
 
-.operations-statuses .operation-status-label {
-    padding: 5px;
+
+.operations-statuses-content .operation-status-content .operation-status-label {
+    padding-left: 5px;
     line-height: 0;
     text-align: start;
 }


### PR DESCRIPTION
## What
The icons were not properly separated from the text, they were too close to each other.

## Why
The labels had a CSS declaration that set padding to 5 px, but there was another declaration with higher specificity that set padding to 0 px.

## How
The CSS selector has been modified to increase specificity scoring.