### PR TITLE
GDB-8681 - adjust width of "Explain" warning message in SPARQL editor

### DIFF
--- a/src/css/sparql-editor.css
+++ b/src/css/sparql-editor.css
@@ -47,3 +47,7 @@
 .sparql-editor-view #query-editor .yasgui-toolbar .btn-selected {
     color: #fff;
 }
+
+#toast-container .toast {
+    width: 470px;
+}


### PR DESCRIPTION
## What?
The "Explain only works with SELECT, CONSTRUCT or DESCRIBE queries." warning message will not wrap the text with too much empty space remaining in the toast container.

## Why?
The text would wrap in a way that left some empty space on one side of the container.

## How?
I changed the width for the container only for this view.

## Screenshots?
### Before:
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/19c09b8d-89f3-4ed6-88ab-a139d9e85a74)

### After (English and French):
![Screenshot from 2024-03-07 16-30-45](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/9feff8c7-7fab-45d4-92e7-7aff819a721b)
![Screenshot from 2024-03-07 16-48-25](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/10031dd8-310f-4ea7-8856-21c825a0893f)