### PR TITLE
GDB-9126: Can't download json result from construct query

### DIFF
--- a/src/js/angular/rest/rdf4j.repositories.rest.service.js
+++ b/src/js/angular/rest/rdf4j.repositories.rest.service.js
@@ -130,7 +130,7 @@ function RDF4JRepositoriesRestService($http, $translate) {
     function downloadResultsAsFile(repositoryId, data, acceptHeader, linkHeader) {
         const properties = Object.entries(data)
             .filter(([property, value]) => value !== undefined)
-            .map(([property, value]) => `${property}=${value}`);
+            .map(([property, value]) => `${property}=${encodeURIComponent(value)}`);
         const payloadString = properties.join('&');
         return $http({
             method: 'POST',


### PR DESCRIPTION
## What
There is an error when try to export results of query, that contains data.

## Why
The service which is responsible for downloading results makes a POST call to BE with "Content-Type" "application/x-www-form-urlencoded". The queries which causes the issue includes a data, for instance "FILTER (xsd:dateTime(?dateOfBirth) > "1999-03-22T14:17:31.290+02:00"^^xsd:dateTime)". The browser replace the character "+" with " " because of value of content type and this is the reason error appeared in BE. It can't parse data correctly.

## How
Implemented query encoding before sending it to the backend. This encoding ensures correct parsing on the server side.