### PR TITLE
GDB-9657 - Set the Similarity search result type correctly

### DIFF
--- a/src/js/angular/models/similarity/similarity-result-type.js
+++ b/src/js/angular/models/similarity/similarity-result-type.js
@@ -1,5 +1,13 @@
 export const SimilarityResultType = {
     'TERM_RESULT': 'termResult',
     'DOCUMENT_RESULT': 'documentResult',
-    'ENTITY_RESULT': 'entityResult'
+    'ENTITY_RESULT': 'entityResult',
+
+    'isResultDocumentType': (type) => {
+        return SimilarityResultType.DOCUMENT_RESULT === type;
+    },
+
+    'isResultTermType': (type) => {
+        return SimilarityResultType.TERM_RESULT === type;
+    }
 };

--- a/src/js/angular/similarity/controllers/similarity-list.controller.js
+++ b/src/js/angular/similarity/controllers/similarity-list.controller.js
@@ -229,6 +229,10 @@ function SimilarityCtrl(
         $scope.searchType = searchType;
     };
 
+    $scope.updateResultType = (resultType) => {
+        $scope.resultType = resultType;
+    };
+
     $scope.editSimilarityIndex = (similarityIndex) => {
         navigateToEditPage(similarityIndex);
     };

--- a/src/pages/similarity-indexes.html
+++ b/src/pages/similarity-indexes.html
@@ -128,8 +128,8 @@
 								<span ng-if="similarityResultType.DOCUMENT_RESULT === resultType">{{'document' | translate}}</span>
 						  </button>
 						  <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-						    <a class="dropdown-item" ng-click="updateSearchType(similarityResultType.TERM_RESULT)">{{'term' | translate}}</a>
-						    <a class="dropdown-item" ng-click="updateSearchType(similarityResultType.DOCUMENT_RESULT)">{{'document' | translate}}</a>
+						    <a class="dropdown-item" ng-click="updateResultType(similarityResultType.TERM_RESULT)">{{'term' | translate}}</a>
+						    <a class="dropdown-item" ng-click="updateResultType(similarityResultType.DOCUMENT_RESULT)">{{'document' | translate}}</a>
 						  </div>
 						</div>
 					</div>

--- a/src/pages/similarity-indexes.html
+++ b/src/pages/similarity-indexes.html
@@ -107,11 +107,11 @@
 					<strong>{{'similarity.search.type' | translate}} </strong>
 					<div class="btn-group">
 						<div class="dropdown">
-						  <button class="btn btn-link dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+						  <button class="btn btn-link dropdown-toggle search-type-btn" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 						    <span ng-if="similaritySearchType.isSearchTermType(searchType)">{{'term' | translate}}</span>
 						    <span ng-if="similaritySearchType.isSearchDocumentType(searchType)">{{'document' | translate}}</span>
 						  </button>
-						  <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+						  <div class="dropdown-menu dropdown-search-type" aria-labelledby="dropdownMenuButton">
 						    <a class="dropdown-item" ng-click="updateSearchType(similaritySearchType.SEARCH_TERM)">{{'term' | translate}}</a>
 						    <a class="dropdown-item" ng-click="updateSearchType(similaritySearchType.SEARCH_DOCUMENT)">{{'document' | translate}}</a>
 						  </div>
@@ -123,11 +123,11 @@
 					<strong>{{'similarity.result.type' | translate}} </strong>
 					<div class="btn-group">
 						<div class="dropdown">
-						  <button class="btn btn-link dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-								<span ng-if="similarityResultType.isResultTermType(resultType)">{{'term' | translate}}</span>
-								<span ng-if="similarityResultType.isResultDocumentType(resultType)">{{'document' | translate}}</span>
+						  <button class="btn btn-link dropdown-toggle result-type-btn" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <span ng-if="similarityResultType.isResultTermType(resultType)">{{'term' | translate}}</span>
+                            <span ng-if="similarityResultType.isResultDocumentType(resultType)">{{'document' | translate}}</span>
 						  </button>
-						  <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+						  <div class="dropdown-menu dropdown-result-type" aria-labelledby="dropdownMenuButton">
 						    <a class="dropdown-item" ng-click="updateResultType(similarityResultType.TERM_RESULT)">{{'term' | translate}}</a>
 						    <a class="dropdown-item" ng-click="updateResultType(similarityResultType.DOCUMENT_RESULT)">{{'document' | translate}}</a>
 						  </div>

--- a/src/pages/similarity-indexes.html
+++ b/src/pages/similarity-indexes.html
@@ -124,8 +124,8 @@
 					<div class="btn-group">
 						<div class="dropdown">
 						  <button class="btn btn-link dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-								<span ng-if="similarityResultType.TERM_RESULT === resultType">{{'term' | translate}}</span>
-								<span ng-if="similarityResultType.DOCUMENT_RESULT === resultType">{{'document' | translate}}</span>
+								<span ng-if="similarityResultType.isResultTermType(resultType)">{{'term' | translate}}</span>
+								<span ng-if="similarityResultType.isResultDocumentType(resultType)">{{'document' | translate}}</span>
 						  </button>
 						  <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
 						    <a class="dropdown-item" ng-click="updateResultType(similarityResultType.TERM_RESULT)">{{'term' | translate}}</a>

--- a/test-cypress/integration/explore/similarity.spec.js
+++ b/test-cypress/integration/explore/similarity.spec.js
@@ -204,6 +204,9 @@ describe('Similarity screen validation', () => {
             cy.get('.index-search-panel').should('be.visible');
             cy.get('.selected-index').should('be.visible').and('contain', `Search in ${INDEX_NAME}`);
             getSearchIndexInput().should('be.visible');
+            // The search and result types should both be set to Term
+            SimilarityIndexesSteps.getSearchTypeButton().should('contain.text', 'Term');
+            SimilarityIndexesSteps.getResultTypeButton().should('contain.text', 'Term');
 
             // When I search for "Neal" in the index
             searchIndex('Neal');
@@ -211,6 +214,21 @@ describe('Similarity screen validation', () => {
             // Then I expect search results to be displayed
             // And showing 20 results
             YasrSteps.getResults().should('have.length', 20);
+
+            // When I select Document as the search type
+            SimilarityIndexesSteps.selectSearchTypeOption('Document');
+
+            // The result type should remain Term
+            SimilarityIndexesSteps.getResultTypeButton().should('contain.text', 'Term');
+
+            // When I select Document as the result type
+            SimilarityIndexesSteps.selectResultTypeOption('Document');
+
+            // The search type should remain Document
+            SimilarityIndexesSteps.getSearchTypeButton().should('contain.text', 'Document');
+
+            // The result type should be Document
+            SimilarityIndexesSteps.getResultTypeButton().should('contain.text', 'Document');
         });
     });
 
@@ -468,7 +486,7 @@ describe('Similarity screen validation', () => {
                 getIndexLinks().should('be.visible');
                 cy.waitUntil(() =>
                     cy.get('.edit-query-btn')
-                            .then(editBtn => editBtn));
+                            .then((editBtn) => editBtn));
             });
     }
 
@@ -501,7 +519,7 @@ describe('Similarity screen validation', () => {
         cy.waitUntil(() =>
             cy.get('#indexes-table')
                 .find('.index-row')
-                .then(indexes => indexes.length === 2))
+                .then((indexes) => indexes.length === 2));
 
         cy.url().should('contain', Cypress.config('baseUrl') + '/similarity'); //Should change the 'contain' method to 'eq' once GDB-3699 is resolved
     }

--- a/test-cypress/steps/explore/similarity-indexes-steps.js
+++ b/test-cypress/steps/explore/similarity-indexes-steps.js
@@ -15,4 +15,30 @@ export class SimilarityIndexesSteps {
     static getEditButton(similarityIndexName) {
         return SimilarityIndexesSteps.getSimilarityIndexRow(similarityIndexName).find('.edit-query-btn');
     }
+
+    static getSearchTypeButton() {
+        return cy.get('.search-type-btn');
+    }
+
+    static getResultTypeButton() {
+        return cy.get('.result-type-btn');
+    }
+
+    static clickSearchTypeDropdown() {
+        this.getSearchTypeButton().click();
+    }
+
+    static clickResultTypeDropdown() {
+        this.getResultTypeButton().click();
+    }
+
+    static selectSearchTypeOption(type) {
+        this.clickSearchTypeDropdown();
+        cy.get('.dropdown-search-type .dropdown-item').contains(type).click();
+    }
+
+    static selectResultTypeOption(type) {
+        this.clickResultTypeDropdown();
+        cy.get('.dropdown-result-type .dropdown-item').contains(type).click();
+    }
 }


### PR DESCRIPTION
## What?
When doing a similarity search and selecting a `result type`, the `search type` field will retain its value.

## Why?
There was a bug the on `result type` selection, the `search type` would disappear and could not be selected again.

## How?
I added a method to set the `result type` whenever it's selected.

## Screenshots?
The working version allows the `result type` to be changed.
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/638efd9f-8309-4d24-b705-574853760a66)
