### PR TITLE
GDB-9238 - hide remote locations already added to cluster node list

### DIFF
--- a/src/js/angular/clustermanagement/controllers/add-nodes.controller.js
+++ b/src/js/angular/clustermanagement/controllers/add-nodes.controller.js
@@ -7,12 +7,12 @@ angular
 AddNodesDialogCtrl.$inject = ['$scope', '$uibModalInstance', 'data', '$uibModal', 'RemoteLocationsService'];
 
 function AddNodesDialogCtrl($scope, $uibModalInstance, data, $uibModal, RemoteLocationsService) {
-    const clusterConfiguration = _.cloneDeep(data.clusterConfiguration);
     const clusterModel = _.cloneDeep(data.clusterModel);
     $scope.nodes = [];
 
     $scope.clusterNodes = clusterModel.nodes.map((node) => ({rpcAddress: node.address, endpoint: node.endpoint}));
-    $scope.locations = clusterModel.locations.filter((location) => !clusterConfiguration.nodes.includes(location.rpcAddress));
+    const clusterEndpoints = $scope.clusterNodes.map((node) => node.endpoint);
+    $scope.locations = clusterModel.locations.filter((location) => !clusterEndpoints.includes(location.endpoint));
     $scope.locations.forEach((location) => location.isNew = true);
 
     $scope.deleteLocation = function (event, location) {

--- a/src/js/angular/clustermanagement/controllers/replace-nodes.controller.js
+++ b/src/js/angular/clustermanagement/controllers/replace-nodes.controller.js
@@ -8,7 +8,6 @@ angular
 ReplaceNodesDialogCtrl.$inject = ['$scope', '$uibModalInstance', '$timeout', 'toastr', '$translate', 'data', '$uibModal', '$rootScope', 'RemoteLocationsService'];
 
 function ReplaceNodesDialogCtrl($scope, $uibModalInstance, $timeout, toastr, $translate, data, $uibModal, $rootScope, RemoteLocationsService) {
-    const clusterConfiguration = _.cloneDeep(data.clusterConfiguration);
     const clusterModel = _.cloneDeep(data.clusterModel);
     // Nodes to be used as replacements
     $scope.replacementNodes = [];
@@ -20,7 +19,8 @@ function ReplaceNodesDialogCtrl($scope, $uibModalInstance, $timeout, toastr, $tr
     $scope.leftNodesMajority = false;
 
     $scope.clusterNodes = clusterModel.nodes.map((node) => ({rpcAddress: node.address, endpoint: node.endpoint, shouldReplace: false}));
-    $scope.locations = clusterModel.locations.filter((location) => !clusterConfiguration.nodes.includes(location.rpcAddress));
+    const clusterEndpoints = $scope.clusterNodes.map((node) => node.endpoint);
+    $scope.locations = clusterModel.locations.filter((location) => !clusterEndpoints.includes(location.endpoint));
     $scope.locations.forEach((location) => location.isNew = true);
 
     $scope.addLocation = () => {


### PR DESCRIPTION
## What?
If a node goes offline, the add/replace node dialogs won't show it as an available remote location, until the node is removed first.

## Why?
Previously, the node would appear as both added to the cluster and as an available location, which would cause some confusion.

## How?
The RPC address was checked previously and nodes without connection had no RPC address, meaning they didn't match the cluster node list and appeared as an available location.
I used an array to extract just the cluster node endpoints and used them to compare the locations against.
