### PR TITLE
Update ontotext-yasgui-web-component version to 1.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.3.4",
+                "ontotext-yasgui-web-component": "1.3.5",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -797,6 +797,7 @@
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/angular-translate/-/angular-translate-2.19.0.tgz",
             "integrity": "sha512-Z/Fip5uUT2N85dPQ0sMEe1JdF5AehcDe4tg/9mWXNDVU531emHCg53ZND9Oe0dyNiGX5rWcJKmsL1Fujus1vGQ==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
             "dependencies": {
                 "angular": "^1.8.0"
             },
@@ -808,6 +809,7 @@
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/angular-translate-loader-static-files/-/angular-translate-loader-static-files-2.19.0.tgz",
             "integrity": "sha512-B0LiFzn+rHGgL0okl+uAcQKtmySskTlhw6vsnQODUqARV0IcgMUi2tl9RhybgGy3MbGmdF1JjJFjITCbXzWZQA==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
             "dependencies": {
                 "angular-translate": "~2.19.0"
             }
@@ -2582,6 +2584,7 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+            "deprecated": "Please upgrade to v0.1.7",
             "dev": true,
             "dependencies": {
                 "kind-of": "^3.0.2"
@@ -2606,6 +2609,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+            "deprecated": "Please upgrade to v0.1.5",
             "dev": true,
             "dependencies": {
                 "kind-of": "^3.0.2"
@@ -5428,6 +5432,7 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+            "deprecated": "Please upgrade to v0.1.7",
             "dev": true,
             "dependencies": {
                 "kind-of": "^3.0.2"
@@ -5452,6 +5457,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+            "deprecated": "Please upgrade to v0.1.5",
             "dev": true,
             "dependencies": {
                 "kind-of": "^3.0.2"
@@ -5926,6 +5932,7 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
             "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
+            "deprecated": "This module is no longer supported.",
             "dev": true
         },
         "node_modules/figures": {
@@ -6257,6 +6264,20 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
         },
         "node_modules/function-bind": {
             "version": "1.1.1",
@@ -7478,6 +7499,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
             "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+            "deprecated": "Please upgrade to v1.0.1",
             "dev": true,
             "dependencies": {
                 "kind-of": "^6.0.0"
@@ -7610,6 +7632,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
             "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+            "deprecated": "Please upgrade to v1.0.1",
             "dev": true,
             "dependencies": {
                 "kind-of": "^6.0.0"
@@ -9861,6 +9884,7 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+            "deprecated": "Please upgrade to v0.1.7",
             "dev": true,
             "dependencies": {
                 "kind-of": "^3.0.2"
@@ -9873,6 +9897,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+            "deprecated": "Please upgrade to v0.1.5",
             "dev": true,
             "dependencies": {
                 "kind-of": "^3.0.2"
@@ -10082,9 +10107,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.4.tgz",
-            "integrity": "sha512-W/x5Sa9imrngf/ReMuCLUXK6zm0hJfA6a47pcQkXoQBE935BbJR96wEEGOks12EBNyimgzUdaeWu2CDXrOZNKA==",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.5.tgz",
+            "integrity": "sha512-JI7+UdKW0t9f5zLFS2++/o5jBpOb4qlWPrLbkUjzYnRJ08d1vgUQOS2yzEMtvUOjYFHQfRxp9iLfMRLy/ZxMgg==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -11458,7 +11483,7 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz",
             "integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
-            "deprecated": "< 19.4.0 is no longer supported",
+            "deprecated": "< 21.5.0 is no longer supported",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -12767,6 +12792,7 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+            "deprecated": "Please upgrade to v0.1.7",
             "dev": true,
             "dependencies": {
                 "kind-of": "^3.0.2"
@@ -12791,6 +12817,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+            "deprecated": "Please upgrade to v0.1.5",
             "dev": true,
             "dependencies": {
                 "kind-of": "^3.0.2"
@@ -13360,6 +13387,7 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+            "deprecated": "Please upgrade to v0.1.7",
             "dev": true,
             "dependencies": {
                 "kind-of": "^3.0.2"
@@ -13384,6 +13412,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+            "deprecated": "Please upgrade to v0.1.5",
             "dev": true,
             "dependencies": {
                 "kind-of": "^3.0.2"
@@ -15150,6 +15179,25 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/watchpack-chokidar2/node_modules/fsevents": {
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+            "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+            "deprecated": "The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "dependencies": {
+                "bindings": "^1.5.0",
+                "nan": "^2.12.1"
+            },
+            "engines": {
+                "node": ">= 4.0"
+            }
+        },
         "node_modules/watchpack-chokidar2/node_modules/is-binary-path": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -15803,6 +15851,25 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/fsevents": {
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+            "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+            "deprecated": "The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "dependencies": {
+                "bindings": "^1.5.0",
+                "nan": "^2.12.1"
+            },
+            "engines": {
+                "node": ">= 4.0"
             }
         },
         "node_modules/webpack-dev-server/node_modules/is-absolute-url": {
@@ -21534,6 +21601,13 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
+        "fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "optional": true
+        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -24510,9 +24584,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.4.tgz",
-            "integrity": "sha512-W/x5Sa9imrngf/ReMuCLUXK6zm0hJfA6a47pcQkXoQBE935BbJR96wEEGOks12EBNyimgzUdaeWu2CDXrOZNKA==",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.5.tgz",
+            "integrity": "sha512-JI7+UdKW0t9f5zLFS2++/o5jBpOb4qlWPrLbkUjzYnRJ08d1vgUQOS2yzEMtvUOjYFHQfRxp9iLfMRLy/ZxMgg==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -28576,6 +28650,17 @@
                         "to-regex-range": "^2.1.0"
                     }
                 },
+                "fsevents": {
+                    "version": "1.2.13",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+                    "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "bindings": "^1.5.0",
+                        "nan": "^2.12.1"
+                    }
+                },
                 "is-binary-path": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -29124,6 +29209,17 @@
                     "dev": true,
                     "requires": {
                         "locate-path": "^3.0.0"
+                    }
+                },
+                "fsevents": {
+                    "version": "1.2.13",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+                    "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "bindings": "^1.5.0",
+                        "nan": "^2.12.1"
                     }
                 },
                 "is-absolute-url": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.3.4",
+        "ontotext-yasgui-web-component": "1.3.5",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Update ontotext-yasgui-web-component version to 1.3.5

## Why
Includes fixes for:
* GDB-9430: workbench footer overlaps with yasgui when it is in two column layout.

## How
The version of ontotext-yasgui-web-component has been updated.