### PR TITLE
Update ontotext-yasgui-web-component version to 1.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.3.4",
+                "ontotext-yasgui-web-component": "1.3.6",
                 "shepherd.js": "^11.1.1"
             },
             "devDependencies": {
@@ -10082,9 +10082,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.4.tgz",
-            "integrity": "sha512-W/x5Sa9imrngf/ReMuCLUXK6zm0hJfA6a47pcQkXoQBE935BbJR96wEEGOks12EBNyimgzUdaeWu2CDXrOZNKA==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.6.tgz",
+            "integrity": "sha512-YBxh/wVjeIkKAnVujyajN2QbXY4e44ndlRZFAoL6QthdJoXdEPfKb7OtOyqVgTNsoS94SEbMHYmM3quioLsYdQ==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24510,9 +24510,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.4.tgz",
-            "integrity": "sha512-W/x5Sa9imrngf/ReMuCLUXK6zm0hJfA6a47pcQkXoQBE935BbJR96wEEGOks12EBNyimgzUdaeWu2CDXrOZNKA==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.6.tgz",
+            "integrity": "sha512-YBxh/wVjeIkKAnVujyajN2QbXY4e44ndlRZFAoL6QthdJoXdEPfKb7OtOyqVgTNsoS94SEbMHYmM3quioLsYdQ==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.3.4",
+        "ontotext-yasgui-web-component": "1.3.6",
         "shepherd.js": "^11.1.1"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Update ontotext-yasgui-web-component version to 1.3.6

## Why
Includes fixes for:
- GDB-9430: Workbench footer overlaps with yasgui when it is in two column layout;
- GDB-9946: Workbench should allow to copy any long (truncated) value.

## How
The version of ontotext-yasgui-web-component has been updated.