### PR TITLE
GDB-10004 Fixed issues in export.rest.service.js related with the additional encoding by us. Also fixed issue when multiple graphs are selected for export in both formats.

### DIFF
--- a/src/js/angular/export/controllers.js
+++ b/src/js/angular/export/controllers.js
@@ -146,9 +146,8 @@ exportCtrl.controller('ExportCtrl',
              *
              * @method downloadJSONLDExport
              * @param {String} data format
-             * @param {String} string context if there is any (or string from multiple contexts if there are multiple selected graphs)
+             * @param [String] array of string contexts if multiple graphs were selected or single graph object
              * @param {String} context/frame link
-             * @param {Boolean} true if the method is invoked for export of multiple selected graphs
              * @param {Object} current repository
              * @param {Object} graphsByValue
              * @param {Object} JSONLDMode (name and mode link)

--- a/src/js/angular/export/controllers.js
+++ b/src/js/angular/export/controllers.js
@@ -153,13 +153,13 @@ exportCtrl.controller('ExportCtrl',
              * @param {Object} graphsByValue
              * @param {Object} JSONLDMode (name and mode link)
              */
-            function downloadJSONLDExport(format, context, link, forSelectedGraphs, repo, graphsByValue, JSONLDMode) {
+            function downloadJSONLDExport(format, context, link, repo, graphsByValue, JSONLDMode) {
                 const acceptHeader = format.type + ';profile=' + JSONLDMode.link;
                 const headers = {
                     'accept': acceptHeader,
                     'link': link
                 };
-                ExportRestService.getExportedStatementsAsJSONLD(context, forSelectedGraphs, repo, graphsByValue, AuthTokenService.getAuthToken(), headers)
+                ExportRestService.getExportedStatementsAsJSONLD(context, repo, graphsByValue, AuthTokenService.getAuthToken(), headers)
                     .then(function ({data, filename}) {
                         saveAs(data, filename);
                     })
@@ -216,7 +216,7 @@ exportCtrl.controller('ExportCtrl',
              * @param {String} string context if there is any (or string from multiple contexts if there are multiple selected graphs for export)
              * @param {Boolean} true if the method is invoked for multiple selected graphs export
              */
-            $scope.openJSONLDExportSettings = function (format, context, forSelectedGraphs) {
+            $scope.openJSONLDExportSettings = function (format, context) {
                 const modalInstance = $uibModal.open({
                     templateUrl: 'js/angular/core/components/export-settings-modal/exportSettingsModal.html',
                     controller: ExportSettingsCtrl,
@@ -231,7 +231,7 @@ exportCtrl.controller('ExportCtrl',
 
                 modalInstance.result.then(function (data) {
                     const linkHeader = data.link ? '<' + data.link + '>' : '';
-                    downloadJSONLDExport(format, context, linkHeader, forSelectedGraphs, $repositories.getActiveRepositoryObject(), $scope.graphsByValue, data.currentMode);
+                    downloadJSONLDExport(format, context, linkHeader, $repositories.getActiveRepositoryObject(), $scope.graphsByValue, data.currentMode);
                 });
             };
 
@@ -261,12 +261,11 @@ exportCtrl.controller('ExportCtrl',
             };
 
             $scope.openJSONLDExportSettingsForSelectedGraphs = function (format) {
-                const contextStr = Object.keys($scope.selectedGraphs.exportGraphs)
-                    .map((index) => 'context=' + $scope.graphsByValue[index].exportUri)
-                    .join('&');
+                const contextsArray = Object.keys($scope.selectedGraphs.exportGraphs)
+                    .map((index) => $scope.graphsByValue[index].exportUri);
 
-                if (contextStr) {
-                    $scope.openJSONLDExportSettings(format, contextStr, true);
+                if (contextsArray) {
+                    $scope.openJSONLDExportSettings(format, contextsArray);
                 } else {
                       ModalService.openSimpleModal({
                           title: $translate.instant('export.multiple.graph'),

--- a/src/js/angular/rest/export.rest.service.js
+++ b/src/js/angular/rest/export.rest.service.js
@@ -20,41 +20,37 @@ function ExportRestService($http, $repositories, $translate) {
      * @param {Object} authentication token
      * @param {Object} request Accept and Link headers
      */
-    function getExportedStatementsAsJSONLD(context, forSelectedGraphs, repo, graphsByValue, auth, headers) {
+    function getExportedStatementsAsJSONLD(context, repo, graphsByValue, auth, headers) {
         const url = `${REPOSITORIES_ENDPOINT}/${repo.id}/statements?infer=false`;
-        let contextParam = null;
-        let locationParam = null;
-        let authTokenParam = null;
+        const params = {
+            location: repo.location
+        };
 
-        if (forSelectedGraphs) {
-            contextParam += context;
+        const httpHeaders = {
+            accept: headers.accept
+        };
+
+        if (Array.isArray(context)) {
+            params.context = context.map((value) => decodeURIComponent(value));
         } else {
             if (context) {
-                contextParam = graphsByValue[context.value].exportUri;
+                params.context = decodeURIComponent(graphsByValue[context.value].exportUri);
             }
-            locationParam = encodeURIComponent(repo.location);
         }
 
         if (auth) {
-            authTokenParam = encodeURIComponent(auth);
+            params.authToken = auth;
         }
 
-        if (headers.link === undefined) {
-            headers.link = '';
+        if (headers.link && headers.link !== '') {
+            httpHeaders.link = headers.link;
         }
 
         return $http({
             url: url,
             method: 'GET',
-            params: {
-                context: contextParam,
-                location: locationParam,
-                authToken: authTokenParam
-            },
-            headers: {
-                'Accept': headers.accept,
-                'Link': headers.link
-            },
+            params: params,
+            headers: httpHeaders,
             responseType: 'blob'
         }).then(function (res) {
             const data = res.data;

--- a/src/pages/export.html
+++ b/src/pages/export.html
@@ -62,7 +62,7 @@
                         </button>
                         <ul class="dropdown-menu">
                             <li ng-repeat="format in exportFormats">
-                                <a href="javascript:" ng-click="openJSONLDExportSettings(format, false, false)"
+                                <a href="javascript:" ng-click="openJSONLDExportSettings(format, false)"
                                    ng-if="format.name === 'JSON-LD' || format.name === 'NDJSON-LD'"
                                    class="dropdown-item export-repo-format-{{format.name}}">{{format.name}}</a>
                                 <a href="javascript:" ng-click="exportRepo(format, false)"


### PR DESCRIPTION
What?
Fixed bug in exporting multiple graphs. Also removed additional encoding.

Why?
This update was done, because the passed parameters were encoded once by us and afterwards they are encoded by http method. Also when multiple graphs were selected for export instead of passing array of the selected items we were passing concatenated string of the graphs with &context=, which is totally wrong.

How?
I decode the already encoded value(s) of the context(s) and do not encode location. Also instead of concatenating the selected contexts I return array of the values.