### PR TITLE
GDB-9972 change file upload workflow

### DIFF
--- a/src/css/import.css
+++ b/src/css/import.css
@@ -13,6 +13,17 @@
     text-overflow: ellipsis;
 }
 
+/* Remove the padding from the large button and move it to the nested link below . This allows the click over the button
+   to work in the entire button area. */
+.upload-buttons .upload-rdf-files-btn {
+    padding: 0;
+}
+
+.upload-buttons .upload-rdf-files-btn > a {
+    width: 100%;
+    padding: 0.75em 1.2em;
+}
+
 .grid-container {
     display: flex;
     align-items: center;

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -941,6 +941,12 @@
         "context.link": "JSON-LD context",
         "context.link.info": "Specifies external JSON-LD context as a URL. Only whitelisted URLs can be used.",
         "file.upload.progress": "{{progress}} % uploaded",
+        "user_data": {
+            "duplicates_confirmation": {
+                "title": "Confirm files overwrite",
+                "message": "Following files are already uploaded: <br/>{{duplicatedFiles}}<br/>Do you want to overwrite them?"
+            }
+        },
         "help": {
             "buttons": {
                 "toggle_help": {
@@ -948,6 +954,9 @@
                 },
                 "copy_file_size_prop": {
                     "tooltip": "Copy max file size property"
+                },
+                "copy_import_directory_prop": {
+                    "tooltip": "Copy import directory property"
                 }
             },
             "messages": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -941,6 +941,12 @@
         "context.link": "Contexte JSON-LD",
         "context.link.info": "Spécifie le contexte JSON-LD externe en tant qu'URL. Seules les URL figurant sur la liste blanche peuvent être utilisées",
         "file.upload.progress": "{{progress}} % téléchargé",
+        "user_data": {
+            "duplicates_confirmation": {
+                "title": "Confirmer l'écrasement des fichiers",
+                "message": "Les fichiers suivants sont déjà téléchargés: <br/>{{duplicatedFiles}}<br/>Voulez-vous les écraser"
+            }
+        },
         "help": {
             "buttons": {
                 "toggle_help": {
@@ -948,6 +954,9 @@
                 },
                 "copy_file_size_prop": {
                     "tooltip": "Copier la propriété de taille maximale du fichier"
+                },
+                "copy_import_directory_prop": {
+                    "tooltip": "Copier la propriété du répertoire d'importation"
                 }
             },
             "messages": {

--- a/src/js/angular/import/file-prefix-registry.js
+++ b/src/js/angular/import/file-prefix-registry.js
@@ -1,0 +1,79 @@
+import {FileUtils} from "../utils/file-utils";
+
+/**
+ * This is a stateful utility class which maintains a registry of filenames mapped to numerical indices.
+ */
+export class FilePrefixRegistry {
+    constructor() {
+        this.filesPrefixRegistry = {};
+    }
+
+    /**
+     * Builds a registry of filenames mapped to numerical indices.
+     * The registry is in format <code>{filename: index}</code>.
+     * @param {[object]} files - list of files to be used when building the registry.
+     */
+    buildPrefixesRegistry(files) {
+        files.filter((file) => file.type === 'file')
+            .forEach((file) => {
+                // file name is in format file-name-123.txt
+                const fileNameOnly = FileUtils.getFilenameAndExtension(file.name).filename;
+
+                const suffixSeparatorIndex = fileNameOnly.lastIndexOf('-');
+                let index = suffixSeparatorIndex < 0 ? 0 : fileNameOnly.substring(suffixSeparatorIndex + 1);
+                let filename = fileNameOnly.substring(0, suffixSeparatorIndex);
+                if (suffixSeparatorIndex < 0) {
+                    index = 0;
+                    filename = fileNameOnly;
+                } else {
+                    index = fileNameOnly.substring(suffixSeparatorIndex + 1);
+                    filename = fileNameOnly.substring(0, suffixSeparatorIndex);
+                }
+
+                if (index) {
+                    index = parseInt(index);
+                    const currentIndex = this.filesPrefixRegistry[filename] || 0;
+                    this.filesPrefixRegistry[filename] = currentIndex < index ? index : currentIndex;
+                } else {
+                    this.filesPrefixRegistry[filename] = 0;
+                }
+            });
+    }
+
+    /**
+     * Prefixes all the duplicated files with a numeric index.
+     * The prefixed file names are in the form of: <originalFileName>-<index>.
+     *
+     * @param {[object]} files - Array with new files which are selected by the user from the file system.
+     * @return {[object]} - The same array with prefixed files.
+     */
+    prefixDuplicates(files) {
+        return files.map((file) => {
+            const {filename, extension} = FileUtils.getFilenameAndExtension(file.name);
+            const prefixedName = `${filename}-${this.getIndexForFile(filename)}.${extension}`;
+            // This is the way how the File name can be changed. It is not possible to change the file name by just
+            // calling <code>file.name = 'newName'</code> because the File object is immutable.
+            return new File([file], prefixedName, {
+                type: file.type,
+                lastModified: file.lastModified
+            });
+        });
+    }
+
+    /**
+     * Finds the index for the given file name. If the file name is already in the registry, it returns the next index,
+     * otherwise it creates a new index for the file name.
+     * @param {string} filename - The filename to find the index for.
+     * @return {*|number} - The index for the given file name.
+     */
+    getIndexForFile(filename) {
+        let index = this.filesPrefixRegistry[filename];
+        if (index !== undefined) {
+            index++;
+        } else {
+            index = 0;
+        }
+        this.filesPrefixRegistry[filename] = index;
+        return index;
+    }
+}

--- a/src/js/angular/utils/file-utils.js
+++ b/src/js/angular/utils/file-utils.js
@@ -7,4 +7,17 @@ export class FileUtils {
     static convertBytesToMegabytes(bytes) {
         return Math.floor(bytes / (1024 * 1024));
     }
+
+    /**
+     * Parses a file name and returns the filename and the extension.
+     * @param {string} fileName The file name to parse
+     * @return {{extension: string, filename: string}}
+     */
+    static getFilenameAndExtension(fileName) {
+        const extensionSeparatorIndex = fileName.lastIndexOf('.');
+        return {
+            filename: fileName.substring(0, extensionSeparatorIndex),
+            extension: fileName.substring(extensionSeparatorIndex + 1)
+        };
+    }
 }

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -42,11 +42,12 @@
                              popover-trigger="mouseenter"
                              popover-placement="bottom"
                              guide-selector="uploadRdfFileButton">
-                            <a id="wb-import-uploadFile" ngf-select="showToast(rejFiles)" ng-model="currentFiles"
-                               ngf-multiple="true"
-                               class="pointer clearfix"
+                            <a id="wb-import-uploadFile" class="pointer clearfix"
                                accept="{{fileFormatsExtended}}"
-                               ngf-change="fileSelected($files, $file, $newFiles, $duplicateFiles, $invalidFiles, $event)"
+                               ngf-multiple="true"
+                               ngf-select
+                               ngf-keep="false"
+                               ngf-change="fileSelected($files, $file, $newFiles, $duplicateFiles, $invalidFiles)"
                                ngf-max-size="maxUploadFileSizeMB + 'MB'">
                                 <div class="grid-container">
                                     <em class="icon-upload icon-lg"></em>
@@ -138,7 +139,7 @@
                             {{'import.help.on_server_import.put_files_into' | translate}}.<br>
                             {{'import.help.on_server_import.directory_can_be_changed' | translate}}
                             <strong class="server-import-directory-prop copyable">graphdb.workbench.importDirectory</strong>
-                            <copy-to-clipboard tooltip-text="import.help.buttons.copy_file_size_prop.tooltip"></copy-to-clipboard>
+                            <copy-to-clipboard tooltip-text="import.help.buttons.copy_import_directory_prop.tooltip"></copy-to-clipboard>
                             {{'import.help.on_server_import.the_property' | translate}}.
                         </p>
                     </div>

--- a/test-cypress/fixtures/graphdb-import/sample-jsonld.json
+++ b/test-cypress/fixtures/graphdb-import/sample-jsonld.json
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "ab": "http://learningsparql.com/ns/addressbook#"
+  },
+  "@id": "ab:richard",
+  "ab:homeTel": "(229)276-5135",
+  "ab:email": "richard491@hotmail.com"
+}

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -941,6 +941,12 @@
         "context.link": "JSON-LD context",
         "context.link.info": "Specifies external JSON-LD context as a URL. Only whitelisted URLs can be used.",
         "file.upload.progress": "{{progress}} % uploaded",
+        "user_data": {
+            "duplicates_confirmation": {
+                "title": "Confirm files overwrite",
+                "message": "Following files are already uploaded: <br/>{{duplicatedFiles}}<br/>Do you want to overwrite them?"
+            }
+        },
         "help": {
             "buttons": {
                 "toggle_help": {
@@ -948,6 +954,9 @@
                 },
                 "copy_file_size_prop": {
                     "tooltip": "Copy max file size property"
+                },
+                "copy_import_directory_prop": {
+                    "tooltip": "Copy import directory property"
                 }
             },
             "messages": {
@@ -971,7 +980,7 @@
                 "the_property": "property"
             },
             "on_file_size_limit": {
-                "file_size_limit_info": "To import larger than {{fileSizeLimit}} files, use the ",
+                "file_size_limit_info": "To import larger than {{fileSizeLimit}} MB, use the ",
                 "server_files_link": "Server files",
                 "import_or_use": "import or use the",
                 "api_link": "API"

--- a/test-cypress/integration-flaky/import/import.server.files.spec.js
+++ b/test-cypress/integration-flaky/import/import.server.files.spec.js
@@ -1,4 +1,4 @@
-import ImportSteps from '../../steps/import-steps';
+import ImportSteps from "../../steps/import/import-steps";
 
 describe('Import screen validation - server files', () => {
 

--- a/test-cypress/integration-flaky/setup/sparql-template-create.js
+++ b/test-cypress/integration-flaky/setup/sparql-template-create.js
@@ -1,6 +1,6 @@
 import {SparqlCreateUpdateSteps} from "../../steps/setup/sparql-create-update-steps";
 import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
-import ImportSteps from "../../steps/import-steps";
+import ImportSteps from "../../steps/import/import-steps";
 import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
 import {MainMenuSteps} from "../../steps/main-menu-steps";
 import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";

--- a/test-cypress/integration/import/import-file-upload.spec.js
+++ b/test-cypress/integration/import/import-file-upload.spec.js
@@ -1,0 +1,105 @@
+import ImportSteps from "../../steps/import/import-steps";
+import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
+
+const bnodes = `_:node0 <http://purl.org/dc/elements/1.1/title> "A new book" ;
+                    \t<http://purl.org/dc/elements/1.1/creator> "A.N.Other" .`;
+const jsonld = JSON.stringify({
+    "@context": {
+        "ab": "http://learningsparql.com/ns/addressbook#"
+    },
+    "@id": "ab:richard",
+    "ab:homeTel": "(229)276-5135",
+    "ab:email": "richard491@hotmail.com"
+});
+
+describe('Import user data: File upload', () => {
+
+    let repositoryId;
+    const testFiles = [
+        'bnodes.ttl',
+        'jsonld.json'
+    ];
+
+    beforeEach(() => {
+        repositoryId = 'user-import-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        ImportSteps.visitImport('user', repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteUploadedFile(repositoryId, testFiles);
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should be able to upload a single unique file', () => {
+        // Given there are no files uploaded yet
+        ImportSteps.getUserDataUploadedFilesTable().should('be.hidden');
+        // When I upload a file
+        ImportSteps.selectFile(ImportSteps.createFile(testFiles[0], bnodes));
+        // Then I should see the uploaded file
+        ImportSteps.getUserDataUploadedFiles().should('have.length', 1);
+        ImportSteps.getUserDataUploadedFile(0).should('contain', 'bnodes.ttl');
+    });
+
+    it('Should be able to upload multiple unique file', () => {
+        // Given there are no files uploaded yet
+        ImportSteps.getUserDataUploadedFilesTable().should('be.hidden');
+        // When I upload a file
+        const file1 = ImportSteps.createFile(testFiles[0], bnodes);
+        const file2 = ImportSteps.createFile(testFiles[1], jsonld);
+        ImportSteps.selectFile([file1, file2]);
+        // Then I should see the uploaded file
+        ImportSteps.getUserDataUploadedFiles().should('have.length', 2);
+        ImportSteps.getUserDataUploadedFile(0).should('contain', 'bnodes.ttl');
+        ImportSteps.getUserDataUploadedFile(1).should('contain', 'jsonld.json');
+    });
+
+    it('Should be able to override a single file', () => {
+        // Given I have uploaded a file
+        ImportSteps.getUserDataUploadedFilesTable().should('be.hidden');
+        const file1 = ImportSteps.createFile(testFiles[0], bnodes);
+        ImportSteps.selectFile(file1);
+        ImportSteps.getUserDataUploadedFiles().should('have.length', 1);
+        ImportSteps.getUserDataUploadedFile(0).should('contain', 'bnodes.ttl');
+        // When I upload a file with the same name
+        ImportSteps.selectFile(file1);
+        // Then I should see a file override confirmation dialog
+        ModalDialogSteps.getDialog().should('be.visible');
+        // When I confirm the file override
+        ModalDialogSteps.clickOnConfirmButton();
+        // Then The file should be overridden
+        ImportSteps.getUserDataUploadedFiles().should('have.length', 1);
+        ImportSteps.getUserDataUploadedFile(0).should('contain', 'bnodes.ttl');
+    });
+
+    it('Should be able to upload file with same name and preserve the existing file', () => {
+        // Given I have uploaded a file
+        ImportSteps.getUserDataUploadedFilesTable().should('be.hidden');
+        const file1 = ImportSteps.createFile(testFiles[0], bnodes);
+        ImportSteps.selectFile(file1);
+        ImportSteps.getUserDataUploadedFiles().should('have.length', 1);
+        ImportSteps.getUserDataUploadedFile(0).should('contain', 'bnodes.ttl');
+        // When I upload a file with the same name
+        ImportSteps.selectFile(file1);
+        // Then I should see a file override confirmation dialog
+        ModalDialogSteps.getDialog().should('be.visible');
+        // When I cancel the file override
+        ModalDialogSteps.clickOnCancelButton();
+        // Then The file should not be overridden but prefixed instead
+        ImportSteps.getUserDataUploadedFiles().should('have.length', 2);
+        ImportSteps.getUserDataUploadedFile(0).should('contain', 'bnodes.ttl');
+        ImportSteps.getUserDataUploadedFile(1).should('contain', 'bnodes-0.ttl');
+        // When I upload two files, one with the same name and second new one
+        const file2 = ImportSteps.createFile(testFiles[1], jsonld);
+        ImportSteps.selectFile([file1, file2]);
+        ModalDialogSteps.getDialog().should('be.visible');
+        ModalDialogSteps.clickOnCancelButton();
+        // Then The file should not be overridden but prefixed with increased index instead
+        ImportSteps.getUserDataUploadedFiles().should('have.length', 4);
+        ImportSteps.getUserDataUploadedFile(0).should('contain', 'bnodes.ttl');
+        ImportSteps.getUserDataUploadedFile(1).should('contain', 'bnodes-0.ttl');
+        ImportSteps.getUserDataUploadedFile(2).should('contain', 'bnodes-1.ttl');
+        ImportSteps.getUserDataUploadedFile(3).should('contain', 'jsonld.json');
+    });
+});

--- a/test-cypress/integration/import/import-from-url.spec.js
+++ b/test-cypress/integration/import/import-from-url.spec.js
@@ -1,4 +1,4 @@
-import ImportSteps from '../../steps/import-steps';
+import ImportSteps from "../../steps/import/import-steps";
 
 describe('Import user data: URL import', () => {
 

--- a/test-cypress/integration/import/import-server-files.spec.js
+++ b/test-cypress/integration/import/import-server-files.spec.js
@@ -1,4 +1,4 @@
-import ImportSteps from '../../steps/import-steps';
+import ImportSteps from "../../steps/import/import-steps";
 
 describe('Import screen validation - server files', () => {
 
@@ -25,9 +25,9 @@ describe('Import screen validation - server files', () => {
 
     it('Test import Server files successfully without changing settings', () => {
         ImportSteps.selectServerFile(FILE_FOR_IMPORT);
-        // ImportSteps.importServerFiles();
-        // ImportSteps.verifyImportStatus(FILE_FOR_IMPORT, SUCCESS_MESSAGE);
-        // ImportSteps.verifyImportStatusDetails(FILE_FOR_IMPORT, '"preserveBNodeIds": false,');
+        ImportSteps.importServerFiles();
+        ImportSteps.verifyImportStatus(FILE_FOR_IMPORT, SUCCESS_MESSAGE);
+        ImportSteps.verifyImportStatusDetails(FILE_FOR_IMPORT, '"preserveBNodeIds": false,');
     });
 
     it('Test import Server files successfully with changing settings', () => {
@@ -98,6 +98,7 @@ describe('Import screen validation - server files', () => {
             .verifyImportStatus(TTLS_FOR_IMPORT, SUCCESS_MESSAGE)
             .verifyImportStatusDetails(TTLS_FOR_IMPORT, '"preserveBNodeIds": false,');
     });
+
     it('Test import trigstar from Server files successfully without changing settings', () => {
         ImportSteps
             .selectServerFile(TRIGS_FOR_IMPORT)

--- a/test-cypress/integration/import/import-text-snippet.spec.js
+++ b/test-cypress/integration/import/import-text-snippet.spec.js
@@ -1,4 +1,4 @@
-import ImportSteps from '../../steps/import-steps';
+import ImportSteps from "../../steps/import/import-steps";
 
 describe('Import user data: Import text snippet', () => {
 

--- a/test-cypress/integration/import/import-user-data-tab.spec.js
+++ b/test-cypress/integration/import/import-user-data-tab.spec.js
@@ -1,4 +1,4 @@
-import ImportSteps from '../../steps/import-steps';
+import ImportSteps from "../../steps/import/import-steps";
 import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
 
 const RDF_TEXT_SNIPPET = '@prefix ab:<http://learningsparql.com/ns/addressbook#>.\n\n' +

--- a/test-cypress/integration/import/import-view.spec.js
+++ b/test-cypress/integration/import/import-view.spec.js
@@ -1,0 +1,42 @@
+import ImportSteps from "../../steps/import/import-steps";
+
+const bnodes = `_:node0 <http://purl.org/dc/elements/1.1/title> "A new book" ;
+                    \t<http://purl.org/dc/elements/1.1/creator> "A.N.Other" .`;
+
+describe('Import view', () => {
+
+    let repositoryId;
+    const testFiles = [
+        'bnodes.ttl',
+        'jsonld.json'
+    ];
+
+    beforeEach(() => {
+        repositoryId = 'user-import-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        ImportSteps.visitImport('user', repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteUploadedFile(repositoryId, testFiles);
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should be able to toggle between user data and server files tabs', () => {
+        // Given I have opened the user data tab and uploaded a single file
+        ImportSteps.getUserDataUploadedFilesTable().should('be.hidden');
+        ImportSteps.selectFile(ImportSteps.createFile(testFiles[0], bnodes));
+        ImportSteps.getUserDataUploadedFiles().should('have.length', 1);
+        ImportSteps.getUserDataUploadedFile(0).should('contain', 'bnodes.ttl');
+        // When I switch to the server files tab
+        ImportSteps.openServerFilesTab();
+        // Then I should see the server files only
+        ImportSteps.getServerFiles().should('have.length', 11);
+        // When I switch back to the user data tab
+        ImportSteps.openUserDataTab();
+        // Then I should see the uploaded file
+        ImportSteps.getUserDataUploadedFiles().should('have.length', 1);
+        ImportSteps.getUserDataUploadedFile(0).should('contain', 'bnodes.ttl');
+    });
+});

--- a/test-cypress/integration/monitor/global-operation-statuses-component.spec.js
+++ b/test-cypress/integration/monitor/global-operation-statuses-component.spec.js
@@ -1,6 +1,6 @@
 import HomeSteps from "../../steps/home-steps";
 import {OperationsStatusesComponentSteps} from "../../steps/operations-statuses-component-steps";
-import ImportSteps from "../../steps/import-steps";
+import ImportSteps from "../../steps/import/import-steps";
 import {GlobalOperationsStatusesStub} from "../../stubs/global-operations-statuses-stub";
 
 describe('Operations Status Component', () => {

--- a/test-cypress/integration/repository/repositories.spec.js
+++ b/test-cypress/integration/repository/repositories.spec.js
@@ -1,5 +1,5 @@
 import HomeSteps from "../../steps/home-steps";
-import ImportSteps from "../../steps/import-steps";
+import ImportSteps from "../../steps/import/import-steps";
 import {RepositorySteps} from "../../steps/repository-steps";
 import {ToasterSteps} from "../../steps/toaster-steps";
 import {GlobalOperationsStatusesStub} from "../../stubs/global-operations-statuses-stub";

--- a/test-cypress/integration/setup/sparql-template-create.js
+++ b/test-cypress/integration/setup/sparql-template-create.js
@@ -1,6 +1,6 @@
 import {SparqlCreateUpdateSteps} from "../../steps/setup/sparql-create-update-steps";
 import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
-import ImportSteps from "../../steps/import-steps";
+import ImportSteps from "../../steps/import/import-steps";
 import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
 import {MainMenuSteps} from "../../steps/main-menu-steps";
 import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";

--- a/test-cypress/steps/guides/guide-steps.js
+++ b/test-cypress/steps/guides/guide-steps.js
@@ -3,7 +3,7 @@ import {MainMenuSteps} from "../main-menu-steps";
 import {RepositorySteps} from "../repository-steps";
 import {RepositorySelectorSteps} from "../repository-selector-steps";
 import {AutocompleteSteps} from "../autocomplete-steps";
-import ImportSteps from "../import-steps";
+import ImportSteps from "../import/import-steps";
 
 export class GuideSteps {
     static visit() {

--- a/test-cypress/steps/import/import-steps.js
+++ b/test-cypress/steps/import/import-steps.js
@@ -1,9 +1,18 @@
-import {ModalDialogSteps} from "./modal-dialog-steps";
+import {ModalDialogSteps} from "../modal-dialog-steps";
 
 /**
  * Reusable functions for interacting with the import page.
  */
 class ImportSteps {
+
+    static createFile(filename, content) {
+        return {
+            contents: Cypress.Buffer.from(content),
+            fileName: filename,
+            mimeType: 'text/plain',
+            lastModified: Date.now()
+        };
+    }
 
     static visit() {
         cy.visit('/import');
@@ -71,6 +80,7 @@ class ImportSteps {
     }
 
     static openUserDataTab() {
+        cy.get('.ot-loader').should('not.be.visible');
         return ImportSteps.getTabs().eq(0).click();
     }
 
@@ -80,6 +90,11 @@ class ImportSteps {
 
     static getServerFilesTab() {
         return ImportSteps.getView().find('#import-server');
+    }
+
+    static openServerFilesTab() {
+        cy.get('.ot-loader').should('not.be.visible');
+        return ImportSteps.getTabs().eq(1).click();
     }
 
     static getUploadRdfFilesButton() {
@@ -123,7 +138,7 @@ class ImportSteps {
     }
 
     static getUserDataUploadedFilesTable() {
-        return ImportSteps.getView().find('#wb-import-fileInFiles');
+        return ImportSteps.getView().find('#import-user table');
     }
 
     static getUserDataUploadedFiles() {
@@ -136,6 +151,37 @@ class ImportSteps {
 
     static deleteUploadedFile(index) {
         ImportSteps.getUserDataUploadedFile(index).find('.remove-file-btn').click();
+    }
+
+    static getServerFilesTable() {
+        return ImportSteps.getView().find('#import-server table');
+    }
+
+    static getServerFiles() {
+        return ImportSteps.getServerFilesTable().find('.import-file-row');
+    }
+
+    static getServerFile(index) {
+        return ImportSteps.getServerFiles().eq(index);
+    }
+
+    static openFileUploadDialog() {
+        this.getUploadRdfFilesButton().find('#wb-import-uploadFile').click();
+    }
+
+    static selectFile(files) {
+        cy.get('input[type=file]').selectFile(files, {force: true});
+    }
+
+    static uploadFile(filePath) {
+        const filePathsList = Array.isArray(filePath)? filePath : [filePath];
+        // cy.fixture(`/graphdb-import/${fileName}`).as('file1');
+        cy.fixtures(filePathsList).then((files) => {
+            const aliases = filePathsList.map((filePath, i) => `@file-${i}`);
+            console.log(`%cfixture files:`, 'background: plum', files, aliases);
+            // with force because the field is hidden
+            cy.get('input[type=file]').selectFile(aliases, {force: true});
+        });
     }
 
     static openImportURLDialog(importURL) {

--- a/test-cypress/support/commands.js
+++ b/test-cypress/support/commands.js
@@ -6,6 +6,29 @@ import './settings-commands';
 import './visual-graph-commands';
 import 'cypress-wait-until';
 
+/**
+ * Loads fixtures from the given paths recursively and returns them as an array.
+ *
+ * Emits an alias in form file-0, file-1, file-2, etc. for each fixture file loaded.
+ *
+ * @param {[string]} remainingPaths - file paths to load
+ * @param {[object]} loadedContents - array of already loaded contents
+ * @return {Cypress.Chainable<unknown>}
+ */
+function loadFixtures(remainingPaths, loadedContents) {
+    return cy.fixture(remainingPaths[0]).as(`file-${loadedContents.length}`).then((contents) => {
+        loadedContents.push(contents);
+        if (remainingPaths.length > 1) {
+            return loadFixtures(remainingPaths.slice(1), loadedContents);
+        }
+        return cy.wrap(loadedContents);
+    });
+}
+
+// defined as: fixtures<Contents = unknown>(paths: string[]): Chainable<Contents[]>;
+Cypress.Commands.add('fixtures', (paths) => {
+    return loadFixtures(paths, []);
+});
 
 /**
  * Cypress cannot directly work with iframes due to https://github.com/cypress-io/cypress/issues/136

--- a/test-cypress/support/import-commands.js
+++ b/test-cypress/support/import-commands.js
@@ -32,6 +32,16 @@ Cypress.Commands.add('importServerFile', (repositoryId, fileName, importSettings
     waitServerOperation(SERVER_URL, repositoryId, fileName);
 });
 
+Cypress.Commands.add('deleteUploadedFile', (repositoryId, fileName) => {
+    const fileNames = Array.isArray(fileName)? fileName : [fileName];
+    cy.request({
+        method: 'DELETE',
+        url: `${REPOSITORIES_URL}${repositoryId}/import/upload/status?remove=true`,
+        body: fileNames,
+        headers: {'Content-type': 'application/json;charset=utf-8'}
+    }).should((response) => expect(response.status).to.equal(200));
+});
+
 function waitServerOperation(url, repositoryId, fileName) {
     cy.request({
         method: 'GET',


### PR DESCRIPTION
## What
Change the upload files workflow in the user data tab on the import view.

## Why
The new upload workflow allows the user to decide if newly selected for upload files should override existing ones if filename collision occurs. If override is rejected, then all duplicated filenames are prefixed with a numerical index.

## How
* Extended the import controller  and template so that when new files are selected to check for duplications and open a confirmation modal.
* Implemented additional utilities to calculate the file prefixes.
* Added new tests