### PR TITLE
Gdb 9971 implements import resources buttons

### DIFF
--- a/src/css/import-resource-tree.css
+++ b/src/css/import-resource-tree.css
@@ -67,7 +67,16 @@
     padding-right: 10px
 }
 
-.import-resources-actions {
+.import-resource-tree .import-resources-actions {
+    display: flex;
+}
+
+.import-resource-tree .import-resources-actions .import-resource-status-dropdown .import-resource-status-checkbox {
+    pointer-events: none;
+}
+
+.import-resource-tree .import-resources-actions .import-resource-status-dropdown,
+.import-resource-tree .import-resources-actions .import-resource-selected-actions {
     display: flex;
 }
 

--- a/src/css/import-resource-tree.css
+++ b/src/css/import-resource-tree.css
@@ -67,6 +67,10 @@
     padding-right: 10px
 }
 
+.import-resources-actions {
+    display: flex;
+}
+
 .import-resource-tree .import-resource-table .import-resource-actions {
     display: flex;
     align-items: stretch;

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -993,6 +993,12 @@
                 "modified": "Modified",
                 "imported": "Imported",
                 "context": "Context"
+            },
+            "status": {
+                "ALL": "All",
+                "NONE": "None",
+                "IMPORTED": "Imported",
+                "NOT_IMPORTED": "Not imported"
             }
         }
     },

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -993,6 +993,12 @@
                 "modified": "Modifié",
                 "imported": "Importé",
                 "context": "Contexte"
+            },
+            "status": {
+                "ALL": "Tous",
+                "NONE": "Aucun",
+                "IMPORTED": "Importé",
+                "NOT_IMPORTED": "Non importé"
             }
         }
     },

--- a/src/js/angular/import/controllers.js
+++ b/src/js/angular/import/controllers.js
@@ -339,6 +339,14 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             console.log('The resource ', importResource, 'have to be deleted');
         };
 
+        $scope.onRemove = (selectedResources) => {
+            console.log('The resources ', selectedResources, 'have to be removed');
+        };
+
+        $scope.onReset = (selectedResources) => {
+            console.log('The resources ', selectedResources, 'have to be reset');
+        };
+
         // TODO: temporary exposed in the scope because it is called via scope.parent from the child TabsCtrl which should be changed
         /**
          * @param {boolean} force - Force the files list to be replaced with the new data

--- a/src/js/angular/import/controllers.js
+++ b/src/js/angular/import/controllers.js
@@ -347,6 +347,10 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             console.log('The resources ', selectedResources, 'have to be reset');
         };
 
+        $scope.importAll = (selectedResources, withoutChangingSettings) => {
+            console.log('The resources ', selectedResources, ' have to be imported withoutChangingSettings: ' + withoutChangingSettings);
+        };
+
         // TODO: temporary exposed in the scope because it is called via scope.parent from the child TabsCtrl which should be changed
         /**
          * @param {boolean} force - Force the files list to be replaced with the new data

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -1,7 +1,16 @@
+import {ImportResourceStatus} from "../../models/import/import-resource-status";
+
 const TYPE_FILTER_OPTIONS = {
     'FILE': 'FILE',
     'DIRECTORY': 'DIRECTORY',
     'ALL': 'ALL'
+};
+
+const STATUS_OPTIONS = {
+    'ALL': 'ALL',
+    'NONE': 'NONE',
+    'IMPORTED': 'IMPORTED',
+    'NOT_IMPORTED': 'NOT_IMPORTED',
 };
 
 const modules = [];
@@ -37,6 +46,8 @@ function importResourceTreeDirective($timeout) {
             $scope.TYPE_FILTER_OPTIONS = TYPE_FILTER_OPTIONS;
             $scope.filterByType = TYPE_FILTER_OPTIONS.ALL;
             $scope.filterByFileName = '';
+            $scope.STATUS_OPTIONS = STATUS_OPTIONS;
+            $scope.selectedByStatus = undefined;
 
 
             // =========================
@@ -46,6 +57,22 @@ function importResourceTreeDirective($timeout) {
                 resource.setSelection(resource.selected);
                 $scope.selectedResources = $scope.resources.getAllSelected();
             });
+
+            $scope.selectResourceWithStatus = (resourceStatus) => {
+                $scope.selectedByStatus = resourceStatus;
+                $scope.resources.setSelection(false);
+
+                if (STATUS_OPTIONS.ALL === $scope.selectedByStatus) {
+                    $scope.resources.setSelection(true);
+                } else if (STATUS_OPTIONS.IMPORTED === $scope.selectedByStatus) {
+                    $scope.resources.selectAllWithStatus([ImportResourceStatus.DONE]);
+                } else if (STATUS_OPTIONS.NOT_IMPORTED === $scope.selectedByStatus) {
+                    $scope.resources.selectAllWithStatus([ImportResourceStatus.IMPORTING, ImportResourceStatus.NONE, ImportResourceStatus.ERROR, ImportResourceStatus.PENDING, ImportResourceStatus.INTERRUPTING]);
+                }
+
+                $scope.selectedResources = $scope.resources.getAllSelected();
+                updateListedImportResources();
+            };
 
             $scope.filterByTypeChanged = (newType) => {
                 $scope.filterByType = newType;

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -23,28 +23,27 @@ function importResourceTreeDirective($timeout) {
              */
             resources: '=',
             onImport: '&',
-            onDelete: '&'
+            onDelete: '&',
+            onReset: '&',
+            onRemove: '&'
         },
         link: ($scope, element, attrs) => {
             // =========================
             // Public variables
             // =========================
             $scope.displayResources = [];
+            $scope.selectedResources = [];
             $scope.TYPE_FILTER_OPTIONS = TYPE_FILTER_OPTIONS;
             $scope.filterByType = TYPE_FILTER_OPTIONS.ALL;
             $scope.filterByFileName = '';
 
-            // =========================
-            // Private variables
-            // =========================
-            let selectedResources = [];
 
             // =========================
             // Public functions
             // =========================
             $scope.selectionChanged = ((resource) => {
                 resource.setSelection(resource.selected);
-                selectedResources = $scope.resources.getAllSelected();
+                $scope.selectedResources = $scope.resources.getAllSelected();
             });
 
             $scope.filterByTypeChanged = (newType) => {
@@ -57,6 +56,18 @@ function importResourceTreeDirective($timeout) {
                 debounce(updateListedImportResources, 100);
             };
 
+            $scope.onResetStatus = () => {
+                if ($scope.selectedResources && $scope.selectedResources.length > 0) {
+                    $scope.onReset({selectedResources: $scope.selectedResources});
+                }
+            };
+
+            $scope.onRemoveResources = () => {
+                if ($scope.selectedResources && $scope.selectedResources.length > 0) {
+                    $scope.onRemove({selectedResources: $scope.selectedResources()});
+                }
+            };
+
             // =========================
             // Private functions
             // =========================
@@ -65,7 +76,7 @@ function importResourceTreeDirective($timeout) {
             };
 
             const updateListedImportResources = () => {
-                selectedResources.forEach((resource) => {
+                $scope.selectedResources.forEach((resource) => {
                     const resourceByFullPath = $scope.resources.getResourceByName(resource.importResource.name);
                     if (resourceByFullPath) {
                         resourceByFullPath.selected = true;

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -23,6 +23,7 @@ function importResourceTreeDirective($timeout) {
              */
             resources: '=',
             onImport: '&',
+            onImportAll: '&',
             onDelete: '&',
             onReset: '&',
             onRemove: '&'
@@ -65,6 +66,12 @@ function importResourceTreeDirective($timeout) {
             $scope.onRemoveResources = () => {
                 if ($scope.selectedResources && $scope.selectedResources.length > 0) {
                     $scope.onRemove({selectedResources: $scope.selectedResources()});
+                }
+            };
+
+            $scope.importAll = (withoutChangingSettings) => {
+                if ($scope.selectedResources && $scope.selectedResources.length > 0) {
+                    $scope.onImportAll({selectedResources: $scope.selectedResources, withoutChangingSettings});
                 }
             };
 

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -4,6 +4,25 @@
     <div class="import-resource-tree-header">
         <div class="import-resources-actions">
             <div ng-if="selectedResources && selectedResources.length > 0">
+                <div class="btn-group" uib-dropdown
+                     uib-popover="{{'import.selected.items' | translate}}"
+                     popover-trigger="mouseenter"
+                     popover-placement="top">
+                    <button type="button" class="btn btn-primary" ng-click="importAll(false)">
+                        <span class="icon-import"></span>
+                        {{'common.import' | translate}}
+                    </button>
+                    <button type="button" class="btn btn-primary dropdown-toggle-split dropdown-toggle" uib-dropdown-toggle>
+                        <span class="sr-only"></span>
+                    </button>
+                    <ul class="dropdown-menu" role="menu">
+                        <li>
+                            <button type="button" class="dropdown-item import-without-change-btn" ng-click="importAll(true)">
+                                {{'import.without.changing.settings' | translate}}
+                            </button>
+                        </li>
+                    </ul>
+                </div>
                 <button class="btn btn-secondary" type="button" ng-click="onResetStatus()"
                         uib-popover="{{'import.reset.last.imported' | translate}}"
                         popover-trigger="mouseenter"

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -3,7 +3,20 @@
 <div class="import-resource-tree mt-2" ng-if="resources && !resources.isEmpty()">
     <div class="import-resource-tree-header">
         <div class="import-resources-actions">
-Imports will be here
+            <div ng-if="selectedResources && selectedResources.length > 0">
+                <button class="btn btn-secondary" type="button" ng-click="onResetStatus()"
+                        uib-popover="{{'import.reset.last.imported' | translate}}"
+                        popover-trigger="mouseenter"
+                        popover-placement="top">
+                    {{'import.reset.status' | translate}}
+                </button>
+                <button class="btn btn-secondary" type="button" ng-click="onRemoveResources()"
+                        uib-popover="{{'import.remove.selected' | translate}}"
+                        popover-trigger="mouseenter"
+                        popover-placement="top">
+                    {{'import.remove.btn' | translate}}
+                </button>
+            </div>
         </div>
         <div class="import-resource-tree-filter btn-group">
             <button class="btn btn-secondary"

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -3,7 +3,29 @@
 <div class="import-resource-tree mt-2" ng-if="resources && !resources.isEmpty()">
     <div class="import-resource-tree-header">
         <div class="import-resources-actions">
-            <div ng-if="selectedResources && selectedResources.length > 0">
+            <div class="import-resource-status-dropdown btn-group" uib-dropdown>
+                <button type="button" class="btn btn-secondary dropdown-toggle" uib-dropdown-toggle>
+                    <input type="checkbox">
+                    {{selectedByStatus ? (('import.import_resource_tree.status.' + selectedByStatus) | translate) : ' '}}
+                </button>
+                <ul class="dropdown-menu" role="menu">
+                    <li>
+                        <button type="button" class="dropdown-item" ng-click="selectResourceWithStatus(STATUS_OPTIONS.ALL)">
+                            {{'import.import_resource_tree.status.ALL' | translate}}
+                        </button>
+                        <button type="button" class="dropdown-item" ng-click="selectResourceWithStatus(STATUS_OPTIONS.NONE)">
+                            {{'import.import_resource_tree.status.NONE' | translate}}
+                        </button>
+                        <button type="button" class="dropdown-item" ng-click="selectResourceWithStatus(STATUS_OPTIONS.IMPORTED)">
+                            {{'import.import_resource_tree.status.IMPORTED' | translate}}
+                        </button>
+                        <button type="button" class="dropdown-item" ng-click="selectResourceWithStatus(STATUS_OPTIONS.NOT_IMPORTED)">
+                            {{'import.import_resource_tree.status.NOT_IMPORTED' | translate}}
+                        </button>
+                    </li>
+                </ul>
+            </div>
+            <div class="import-resource-selected-actions btn-group" ng-if="selectedResources && selectedResources.length > 0">
                 <div class="btn-group" uib-dropdown
                      uib-popover="{{'import.selected.items' | translate}}"
                      popover-trigger="mouseenter"

--- a/src/js/angular/models/import/import-resource-tree-element.js
+++ b/src/js/angular/models/import/import-resource-tree-element.js
@@ -1,3 +1,5 @@
+import {ImportResourceStatus} from "./import-resource-status";
+
 /**
  * Resources have parent-child relations. This class represents one resource element from the parent-child relation tree.
  */
@@ -104,6 +106,21 @@ export class ImportResourceTreeElement {
         this.selected = selected;
         this.files.forEach((file) => file.setSelection(selected));
         this.directories.forEach((directory) => directory.setSelection(selected));
+    }
+
+    selectAllWithStatus(statuses) {
+
+        if (this.importResource) {
+            console.log(statuses);
+            console.log(this.importResource.status);
+            console.log(statuses.indexOf(this.importResource.status) > -1);
+        }
+
+        if (this.importResource && statuses.indexOf(this.importResource.status) > -1) {
+            this.selected = true;
+        }
+        this.files.forEach((file) => file.selectAllWithStatus(statuses));
+        this.directories.forEach((directory) => directory.selectAllWithStatus(statuses));
     }
 
     getAllSelected() {

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -147,7 +147,10 @@
                 <import-resource-tree ng-if="serverImportTree"
                                       resources="serverImportTree"
                                       on-delete="onDelete(resource)"
-                                      on-import="onImport(resource)"></import-resource-tree>
+                                      on-import="onImport(resource)"
+                                      on-remove="onRemove(selectedResources)"
+                                      on-reset="onReset(selectedResources)">
+                </import-resource-tree>
                 <div class="mt-2" files-table></div>
             </div>
         </div>

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -149,7 +149,8 @@
                                       on-delete="onDelete(resource)"
                                       on-import="onImport(resource)"
                                       on-remove="onRemove(selectedResources)"
-                                      on-reset="onReset(selectedResources)">
+                                      on-reset="onReset(selectedResources)"
+                                      on-import-all="importAll(selectedResources, withoutChangingSettings)">
                 </import-resource-tree>
                 <div class="mt-2" files-table></div>
             </div>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -985,6 +985,21 @@
                 "import_or_use": "import or use the",
                 "api_link": "API"
             }
+        },
+        "import_resource_tree": {
+            "header": {
+                "name": "Name",
+                "size": "Size",
+                "modified": "Modified",
+                "imported": "Imported",
+                "context": "Context"
+            },
+            "status": {
+                "ALL": "All",
+                "NONE": "None",
+                "IMPORTED": "Imported",
+                "NOT_IMPORTED": "Not imported"
+            }
         }
     },
     "text.snippet.text.aria.placeholder": "# Example: rdf:predicate a rdf:Property .",


### PR DESCRIPTION
## What
- Added "Reset Status" and "Remove" buttons to the import-resource-tree directive;
- Added the "Import" button to the import-resource-tree directive;
- Added a dropdown menu for selecting files based on their status.

## Why
- This addition provides users with the ability to reset the status of imported resources and to remove files if they were uploaded by the user;
- This addition provides users with the ability to trigger the import of files with or without changing settings
- This addition provides users with the ability to select files based on their status.