### PR TITLE
GDB-10064 Wrong translation in French of 'Save' button in WB

### DIFF
--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1312,7 +1312,7 @@
     "common.running.operation": "Opération en cours... {{timeHuman}}",
     "common.refreshing.namespaces": "Rafraîchir les espaces de noms",
     "common.extra.message": "Normalement, cette opération est rapide, mais elle peut prendre plus de temps si un dépôt plus important doit d'abord être initialisé.",
-    "common.save.btn": "Sauver",
+    "common.save.btn": "Enregistrer",
     "common.confirm": "Confirmer",
     "common.create.btn": "Créer",
     "common.add.known.prefixes.error": "Erreur! Impossible d'ajouter des préfixes connus",


### PR DESCRIPTION
## What?
Wrong translation in French of 'Save' button in WB

## Why?
The 'save'  button in french it's 'Enregistrer" (which is in the context of apps and saving progress , ..etc ) but in the WB app it's written "Sauver" (which is in the context of : Help , aid , "save a life" ).

## How?
Changed translation of "Save" button in French from Sauver to Enregistrer.