### PR TITLE
GDB-9971: Implement Three-State Checkbox

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -13,6 +13,7 @@ import 'angular/core/directives/angulartooltips/angular-tooltips.js';
 import 'angular/core/directives/uppercased.directive';
 import 'angular/core/directives/operations-statuses-monitor/operations-statuses-monitor.directive';
 import 'angular/core/directives/autocomplete/autocomplete.directive';
+import 'angular/core/directives/prop-indeterminate/prop-indeterminate.directive';
 import {defineCustomElements} from 'ontotext-yasgui-web-component/loader';
 
 // $translate.instant converts <b> from strings to &lt;b&gt
@@ -37,6 +38,7 @@ const modules = [
     'graphdb.framework.core.directives.copytoclipboard.copytoclipboard',
     'graphdb.framework.core.directives.angular-tooltips',
     'graphdb.framework.core.directives.uppercased',
+    'graphdb.framework.core.directives.prop-indeterminate',
     'graphdb.framework.guides.services',
     'graphdb.framework.core.directives.operationsstatusesmonitor',
     'graphdb.framework.core.directives.autocomplete',

--- a/src/js/angular/core/directives/prop-indeterminate/prop-indeterminate.directive.js
+++ b/src/js/angular/core/directives/prop-indeterminate/prop-indeterminate.directive.js
@@ -1,0 +1,52 @@
+/**
+ * @ngdoc directive
+ * @name propIndeterminate
+ * @module graphdb.framework.core.directives.prop-indeterminate
+ * @restrict A
+ *
+ * @description
+ * The `propIndeterminate` directive updates the `indeterminate` property of an HTMLInputElement.
+ * It allows for a third state in addition to checked and unchecked, where it's unclear whether the item is toggled on or off.
+ * This directive sets the `indeterminate` property via JavaScript, as it cannot be set using an HTML attribute.
+ *
+ * @param {string} propIndeterminate - The value to be set to the indeterminate property of the element.
+ *
+ * @example
+ * <input type="checkbox" prop-indeterminate="true">
+ */
+
+const modules = [];
+
+angular
+    .module('graphdb.framework.core.directives.prop-indeterminate', modules)
+    .directive('propIndeterminate', propIndeterminate);
+
+propIndeterminate.$inject = [];
+
+function propIndeterminate() {
+    return {
+        restrict: 'A',
+        scope: {
+            propIndeterminate: '='
+        },
+        link: ($scope, element, attributes) => {
+            const indeterminateChanged = () => {
+                element.prop('indeterminate', !!$scope.propIndeterminate);
+            };
+
+            // =========================
+            // Subscriptions
+            // =========================
+            const subscriptions = [];
+
+            subscriptions.push($scope.$watch('propIndeterminate', indeterminateChanged));
+
+            const removeAllSubscribers = () => {
+                subscriptions.forEach((subscription) => subscription());
+            };
+
+            // Deregister the watchers when the scope/directive is destroyed
+            $scope.$on('$destroy', removeAllSubscribers);
+        }
+    };
+}

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -10,7 +10,7 @@ const STATUS_OPTIONS = {
     'ALL': 'ALL',
     'NONE': 'NONE',
     'IMPORTED': 'IMPORTED',
-    'NOT_IMPORTED': 'NOT_IMPORTED',
+    'NOT_IMPORTED': 'NOT_IMPORTED'
 };
 
 const modules = [];
@@ -116,6 +116,7 @@ function importResourceTreeDirective($timeout) {
                         resourceByFullPath.selected = true;
                     }
                 });
+                $scope.resources.getRoot().updateSelectionState();
                 $scope.displayResources = $scope.resources.toList()
                     .filter(filterByType)
                     .filter(filterByName);

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -102,7 +102,7 @@
             class="import-resource-row"
             ng-class="{ 'even-row-start': $even, 'odd-row-start': $odd}">
             <td class="import-resource-cell import-resource-cell-select">
-                <input type="checkbox" ng-model="resource.selected" ng-click="selectionChanged(resource)">
+                <input type="checkbox" ng-model="resource.selected" ng-click="selectionChanged(resource)" prop-indeterminate="resource.partialSelected">
             </td>
             <td colspan="5"
                 ng-style="{'padding-left': (filterByType !== TYPE_FILTER_OPTIONS.FILE ? resource.indent : '8px')}"


### PR DESCRIPTION
## What
Implements an additional selection state for the "import-resource-tree" directive. This state is applied to directories indicates that not all children are selected.

## Why
To enhance user experience.

## How
Implemented a new "propIndeterminate" directive that marks a checkbox as indeterminate. The "import-resource-tree" directive utilizes this directive to mark directories where some, but not all, children are selected.