### PR TITLE
Gdb 9971 add stylint to import resource messages

### DIFF
--- a/src/css/import-resource-tree.css
+++ b/src/css/import-resource-tree.css
@@ -50,16 +50,12 @@
 }
 
 .import-resource-tree .import-resource-table .import-resource-cell {
-    font-size: 13px;
-    font-weight: 400;
     line-height: 18px;
 }
 
 .import-resource-tree .import-resource-table .import-resource-title {
     display: flex;
     align-items: center;
-    font-size: 14px;
-    font-weight: 400;
     line-height: 18px;
 }
 
@@ -99,7 +95,7 @@
 .import-resource-tree .import-resource-table .import-resource-modified,
 .import-resource-tree .import-resource-table .import-resource-imported,
 .import-resource-tree .import-resource-table .import-resource-import-resource-size {
-    width: 120px;
+    min-width: 120px;
 }
 
 .import-resource-tree .import-resource-table .import-resource-cell.import-resource-message,

--- a/src/js/angular/import/directives/import-resource-message.directive.js
+++ b/src/js/angular/import/directives/import-resource-message.directive.js
@@ -1,0 +1,25 @@
+import {ImportResourceStatus} from "../../models/import/import-resource-status";
+import * as stringUtils from "../../utils/string-utils";
+
+const modules = [];
+
+angular
+    .module('graphdb.framework.import.import-resource-message', modules)
+    .directive('importResourceMessage', importResourceMessageDirective);
+
+importResourceMessageDirective.$inject = [];
+
+function importResourceMessageDirective() {
+    return {
+        restrict: 'E',
+        templateUrl: 'js/angular/import/templates/import-resource-message.html',
+        scope: {
+            resource: '='
+        },
+        link: ($scope) => {
+            $scope.ImportResourceStatus = ImportResourceStatus;
+            $scope.toTitleCase = (str) => stringUtils.toTitleCase(str);
+        }
+
+    };
+}

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -1,4 +1,5 @@
 import {ImportResourceStatus} from "../../models/import/import-resource-status";
+import 'angular/import/directives/import-resource-message.directive';
 
 const TYPE_FILTER_OPTIONS = {
     'FILE': 'FILE',
@@ -13,7 +14,7 @@ const STATUS_OPTIONS = {
     'NOT_IMPORTED': 'NOT_IMPORTED'
 };
 
-const modules = [];
+const modules = ['graphdb.framework.import.import-resource-message'];
 
 angular
     .module('graphdb.framework.import.import-resource-tree', modules)

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -91,6 +91,10 @@ function importResourceTreeDirective($timeout) {
                 }
             };
 
+            $scope.resetStatus = (importResource) => {
+                $scope.onReset({selectedResources: [importResource]});
+            };
+
             $scope.onRemoveResources = () => {
                 if ($scope.selectedResources && $scope.selectedResources.length > 0) {
                     $scope.onRemove({selectedResources: $scope.selectedResources()});

--- a/src/js/angular/import/templates/import-resource-message.html
+++ b/src/js/angular/import/templates/import-resource-message.html
@@ -1,0 +1,19 @@
+<div class="import-resource-message">
+    <span ng-if="resource.importResource.status === ImportResourceStatus.NONE && resource.importResource.message"
+          class="text-info">
+                    <small>{{resource.importResource.message || ''}}</small>
+                </span>
+    <span ng-if="resource.importResource.status === ImportResourceStatus.DONE" class="text-success">
+                    <em class="icon-check"></em>
+                    <small>{{resource.importResource.message || ''}}</small>
+                </span>
+    <span ng-show="resource.importResource.status === ImportResourceStatus.ERROR" class="text-danger">
+                    <em class="icon-warning"></em>
+                    <small>{{resource.importResource.message || ''}}</small>
+                </span>
+    <span class="text-secondary import-status-loader"
+          ng-show="resource.importResource.status === ImportResourceStatus.IMPORTING || resource.importResource.status === ImportResourceStatus.UPLOADING || resource.importResource.status === ImportResourceStatus.PENDING || resource.importResource.status === ImportResourceStatus.INTERRUPTING">
+                    <em class="icon-reload loader"></em>
+                    <small>{{toTitleCase(resource.importResource.status)}}...</small>
+                </span>
+</div>

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -115,6 +115,13 @@
             <td class="import-resource-cell">
                 <div class="import-resource-actions">
                     <div class="icon-info text-tertiary import-resource-action-info"></div>
+                    <button role="button" class="btn btn-link btn-inline secondary pr-0"
+                            ng-click="resetStatus(resource)"
+                            ng-show="resource.importResource.status === ImportResourceStatus.DONE || resource.importResource.status === ImportResourceStatus.ERROR"
+                            ng-disabled="selectedResources.length > 1"
+                            gdb-tooltip="{{'import.reset.status' | translate}}">
+                        <span class="icon-close"></span>
+                    </button>
                     <button class="btn btn-link secondary import-resource-action-remove" ng-click="onDelete({resource: resource})">
                         <em class="icon-trash"></em>
                     </button>

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -109,7 +109,7 @@
                 class="import-resource-cell">
                 <span class="import-resource-title">
                     <em ng-class="{'icon-folder': resource.isDirectory(), 'icon-file': resource.isFile()}"></em>
-                    <span>{{resource.name}}</span>
+                    <strong>{{resource.name}}</strong>
                 </span>
             </td>
             <td class="import-resource-cell">
@@ -127,8 +127,8 @@
         <tr ng-repeat-end class="import-resource-row" ng-class="{ 'even-row-end': $even, 'odd-row-end': $odd}">
             <td class="import-resource-cell import-resource-cell-select"></td>
             <td ng-style="{'padding-left': (filterByType !== TYPE_FILTER_OPTIONS.FILE ? resource.indent : '8px')}"
-                class="import-resource-cell import-resource-message">
-                {{ resource.importResource.message || ''}}
+                class="import-resource-cell">
+                <import-resource-message resource="resource"></import-resource-message>
             </td>
             <td class="import-resource-cell import-resource-size">
                 {{ resource.importResource.size || ''}}

--- a/src/js/angular/models/import/import-resource-status.js
+++ b/src/js/angular/models/import/import-resource-status.js
@@ -8,6 +8,7 @@ export const ImportResourceStatus = {
      * Initial state. The rdf resources in this state are available in the server, but its data is not inserted into GraphDB.
      */
     'NONE': 'NONE',
+    'UPLOADING': 'UPLOADING',
     /**
      * The import of rdf resources in this state was not started because GraphDB was stopped.
      */


### PR DESCRIPTION
## What
- Icons and colors have been added to resource messages;
- Implemented a reset status button for each resource in the tree.

## Why
- To enhance the user experience;
- This provides users with the opportunity to reset the status of individual files without having to click on checkboxes and use the global reset button.

## How
- Different icons and colors have been applied to resource messages based on the import resource status. For example, errors are shown in red, successful operations in green, etc.
- The button has been added to each row in the import resource tree. When clicked, it calls the onReset function of the "import-resource-tree" directive client.