### PR TITLE
GDB-10046 - show full recovery message on mouseover

### DIFF
--- a/src/js/angular/clustermanagement/directives.js
+++ b/src/js/angular/clustermanagement/directives.js
@@ -62,6 +62,7 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
                 });
                 scope.$on("$destroy", function () {
                     legendTooltip.destroy();
+                    CDS.removeEventListeners();
                 });
                 function updateTranslations(translationMapObject, translationAppend = '') {
                     Object.keys(translationMapObject).forEach((key) => {

--- a/src/js/angular/clustermanagement/services/cluster-drawing.service.js
+++ b/src/js/angular/clustermanagement/services/cluster-drawing.service.js
@@ -294,6 +294,23 @@ function calculateElementSizeByText(text) {
     return {height, width};
 }
 
+function addRecoveryLabelListeners(object, message, width, height, displayMessage) {
+    object.on('mouseover.tooltip', () => {
+        object
+            .attr('width', calculateElementSizeByText(message).width)
+            .attr('height', calculateElementSizeByText(message).height)
+            .attr('x', -calculateElementSizeByText(message).width / 2)
+            .html(`<div>${message}</div>`);
+    });
+    object.on('mouseout.tooltip', () => {
+        object
+            .attr('width', width)
+            .attr('height', height)
+            .attr('x', -width / 2)
+            .html(`<div>${displayMessage}</div>`);
+    });
+}
+
 function resizeLabelDynamic(nodes) {
     nodes.select('.node-info-fo')
         .each(function (d) {
@@ -307,6 +324,12 @@ function resizeLabelDynamic(nodes) {
             const displayMessage = isShorten ? message : d.recoveryStatus.message;
             const width = calculateElementSizeByText(displayMessage).width;
             const height = calculateElementSizeByText(displayMessage).height;
+            object.on('.tooltip', null);
+            if (isShorten) {
+                addRecoveryLabelListeners(object, d.recoveryStatus.message, width, height, displayMessage);
+            }
+
+            // Set initial size and text
             object
                 .attr('width', width)
                 .attr('height', height)
@@ -422,4 +445,8 @@ function createHexagon(nodeGroup, radius) {
         .append("path")
         .attr('class', 'node member')
         .attr("d", d3.line());
+}
+
+export function removeEventListeners() {
+    d3.select(document).selectAll('.node-info-fo').on('.tooltip', null);
 }

--- a/src/js/angular/clustermanagement/services/cluster-drawing.service.js
+++ b/src/js/angular/clustermanagement/services/cluster-drawing.service.js
@@ -294,19 +294,19 @@ function calculateElementSizeByText(text) {
     return {height, width};
 }
 
-function addRecoveryLabelListeners(object, message, width, height, displayMessage) {
+function addRecoveryLabelListeners(object, message, truncatedSize, displayMessage, fullSize) {
     object.on('mouseover.tooltip', () => {
         object
-            .attr('width', calculateElementSizeByText(message).width)
-            .attr('height', calculateElementSizeByText(message).height)
-            .attr('x', -calculateElementSizeByText(message).width / 2)
+            .attr('width', fullSize.width)
+            .attr('height', fullSize.height)
+            .attr('x', -fullSize.width / 2)
             .html(`<div>${message}</div>`);
     });
     object.on('mouseout.tooltip', () => {
         object
-            .attr('width', width)
-            .attr('height', height)
-            .attr('x', -width / 2)
+            .attr('width', truncatedSize.width)
+            .attr('height', truncatedSize.height)
+            .attr('x', -truncatedSize.width / 2)
             .html(`<div>${displayMessage}</div>`);
     });
 }
@@ -319,21 +319,22 @@ function resizeLabelDynamic(nodes) {
                 object.attr('width', 0);
                 return;
             }
-            const message = extractShortMessageFromNode(d);
-            const isShorten = d.recoveryStatus.message && d.recoveryStatus.message.length > shortMessageLimit && message !== d.recoveryStatus.message;
-            const displayMessage = isShorten ? message : d.recoveryStatus.message;
-            const width = calculateElementSizeByText(displayMessage).width;
-            const height = calculateElementSizeByText(displayMessage).height;
+            const shortMessage = extractShortMessageFromNode(d);
+            const isShorten = d.recoveryStatus.message && d.recoveryStatus.message.length > shortMessageLimit && shortMessage !== d.recoveryStatus.message;
+            const displayMessage = isShorten ? shortMessage : d.recoveryStatus.message;
+            const truncatedSize = calculateElementSizeByText(shortMessage);
+            const fullSize = calculateElementSizeByText(d.recoveryStatus.message);
             object.on('.tooltip', null);
+
             if (isShorten) {
-                addRecoveryLabelListeners(object, d.recoveryStatus.message, width, height, displayMessage);
+                addRecoveryLabelListeners(object, d.recoveryStatus.message, truncatedSize, displayMessage, fullSize);
             }
 
             // Set initial size and text
             object
-                .attr('width', width)
-                .attr('height', height)
-                .attr('x', -width / 2)
+                .attr('width', truncatedSize.width)
+                .attr('height', truncatedSize.height)
+                .attr('x', -truncatedSize.width / 2)
                 .html(`<div>${displayMessage}</div>`);
         });
 }


### PR DESCRIPTION
## What?
The shortened recovery messages in the cluster view will appear full length on `mouseover`. They will become shortened on `mouseout`.

## Why?
There was no way to see the full recovery message. 

## How?
I added event listeners in the service and used the original message size in the calculations.

## Screenshots?
On mouse over:
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/93fa1d44-d414-4d1c-b0a5-28c7a7326689)
