### PR TITLE
Gdb 9971 implement import resource file acitons

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -999,6 +999,10 @@
                 "NONE": "None",
                 "IMPORTED": "Imported",
                 "NOT_IMPORTED": "Not imported"
+            },
+            "action": {
+                "interrupt_import": "Interrupt import",
+                "abort": "Abort"
             }
         }
     },

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -999,6 +999,10 @@
                 "NONE": "Aucun",
                 "IMPORTED": "Importé",
                 "NOT_IMPORTED": "Non importé"
+            },
+            "action": {
+                "interrupt_import": "Interrompre l'importation",
+                "abort": "Abandonner"
             }
         }
     },

--- a/src/js/angular/import/controllers.js
+++ b/src/js/angular/import/controllers.js
@@ -319,8 +319,8 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             $scope.getSettings();
         };
 
-        $scope.onImport = (importResource) => {
-            console.log('The resource ', importResource, 'have to be imported');
+        $scope.onImport = (resource) => {
+            $scope.setSettingsFor(resource.importResource.name, false, resource.importResource.format);
         };
 
         $scope.onDelete = (importResource) => {

--- a/src/js/angular/import/controllers.js
+++ b/src/js/angular/import/controllers.js
@@ -323,6 +323,10 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             $scope.setSettingsFor(resource.importResource.name, false, resource.importResource.format);
         };
 
+        $scope.onStopImport = (resource) => {
+            $scope.stopImport(resource.importResource);
+        };
+
         $scope.onDelete = (importResource) => {
             console.log('The resource ', importResource, 'have to be deleted');
         };

--- a/src/js/angular/import/controllers.js
+++ b/src/js/angular/import/controllers.js
@@ -336,8 +336,8 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             removeEntry(resourceNames);
         };
 
-        $scope.onReset = (selectedResources) => {
-            console.log('The resources ', selectedResources, 'have to be reset');
+        $scope.onReset = (resources = []) => {
+            resetStatusOrRemoveEntry(resources.map((resource) => resource.importResource.name), false);
         };
 
         $scope.importAll = (selectedResources, withoutChangingSettings) => {
@@ -429,6 +429,9 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
         };
 
         const resetStatusOrRemoveEntry = (names, remove) => {
+            if (!names || names.length < 1) {
+                return;
+            }
             const resetService = $scope.viewUrl === OPERATION.UPLOAD ? ImportRestService.resetUserDataStatus : ImportRestService.resetServerFileStatus;
             resetService($repositories.getActiveRepository(), names, remove).success(function () {
                 $scope.updateList(true);

--- a/src/js/angular/import/controllers.js
+++ b/src/js/angular/import/controllers.js
@@ -380,9 +380,9 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             const filesLoader = $scope.viewUrl === OPERATION.UPLOAD ? ImportRestService.getUploadedFiles : ImportRestService.getServerFiles;
             filesLoader($repositories.getActiveRepository()).success(function (data) {
 
-                // Commented during development. When everything is ready this functionality have to change current one.
                 if (TABS.SERVER === $scope.viewType) {
-                    $scope.serverImportTree = toImportServerResource(toImportResource(data));
+                    // Commented during development. When everything is ready this functionality have to change current one.
+                    // $scope.serverImportTree = toImportServerResource(toImportResource(data));
                 } else if (TABS.USER === $scope.viewType) {
                     $scope.userData = toImportUserDataResource(toImportResource(data));
                 }

--- a/src/js/angular/import/controllers.js
+++ b/src/js/angular/import/controllers.js
@@ -327,16 +327,12 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             $scope.stopImport(resource.importResource);
         };
 
-        $scope.onDelete = (importResource) => {
-            console.log('The resource ', importResource, 'have to be deleted');
-        };
-
         /**
          * Triggers a remove operation in the backend for selected resources.
-         * @param {ImportResourceTreeElement[]} selectedResources - The resources to be removed.
+         * @param {ImportResourceTreeElement[]} resources - The resources to be removed.
          */
-        $scope.onRemove = (selectedResources) => {
-            const resourceNames = selectedResources.map((resource) => resource.name);
+        $scope.onRemove = (resources) => {
+            const resourceNames = resources.map((resource) => resource.name);
             removeEntry(resourceNames);
         };
 

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -57,6 +57,7 @@ function importResourceTreeDirective($timeout) {
             $scope.filterByFileName = '';
             $scope.STATUS_OPTIONS = STATUS_OPTIONS;
             $scope.selectedByStatus = undefined;
+            $scope.ImportResourceStatus = ImportResourceStatus;
 
             // =========================
             // Public functions
@@ -93,13 +94,17 @@ function importResourceTreeDirective($timeout) {
             };
 
             $scope.onResetStatus = () => {
-                if ($scope.selectedResources && $scope.selectedResources.length > 0) {
-                    $scope.onReset({selectedResources: $scope.selectedResources});
+                if (!$scope.selectedResources) {
+                    return;
+                }
+                const files = $scope.selectedResources.filter((resource) => !resource.isDirectory());
+                if (files.length > 0) {
+                    $scope.onReset({resources: files});
                 }
             };
 
             $scope.resetStatus = (importResource) => {
-                $scope.onReset({selectedResources: [importResource]});
+                $scope.onReset({resources: [importResource]});
             };
 
             $scope.onRemoveResources = () => {

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -40,7 +40,8 @@ function importResourceTreeDirective($timeout) {
             onImportAll: '&',
             onDelete: '&',
             onReset: '&',
-            onRemove: '&'
+            onRemove: '&',
+            onStopImport: '&'
         },
         link: ($scope, element, attrs) => {
 
@@ -117,6 +118,10 @@ function importResourceTreeDirective($timeout) {
                 if ($scope.selectedResources && $scope.selectedResources.length > 0) {
                     $scope.onImportAll({selectedResources: $scope.selectedResources, withoutChangingSettings});
                 }
+            };
+
+            $scope.stopImport = (importResource) => {
+                $scope.onStopImport({resource: importResource});
             };
 
             // =========================

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -38,7 +38,6 @@ function importResourceTreeDirective($timeout) {
             showTypeFilter: '=',
             onImport: '&',
             onImportAll: '&',
-            onDelete: '&',
             onReset: '&',
             onRemove: '&',
             onStopImport: '&'
@@ -59,6 +58,7 @@ function importResourceTreeDirective($timeout) {
             $scope.STATUS_OPTIONS = STATUS_OPTIONS;
             $scope.selectedByStatus = undefined;
             $scope.ImportResourceStatus = ImportResourceStatus;
+            $scope.canRemoveResource = angular.isDefined(attrs.onRemove);
 
             // =========================
             // Public functions
@@ -110,8 +110,12 @@ function importResourceTreeDirective($timeout) {
 
             $scope.onRemoveResources = () => {
                 if ($scope.selectedResources && $scope.selectedResources.length > 0) {
-                    $scope.onRemove({selectedResources: $scope.selectedResources});
+                    $scope.onRemove({resources: $scope.selectedResources});
                 }
+            };
+
+            $scope.removeResource = (resource) => {
+                $scope.onRemove({resources: [resource]});
             };
 
             $scope.importAll = (withoutChangingSettings) => {

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -154,6 +154,7 @@
                         <em class="icon-trash"></em>
                     </button>
                     <button class="btn btn-primary btn-sm import-resource-action-import"
+                            ng-if="resource.isFile() && resource.importResource.status !== ImportResourceStatus.IMPORTING && resource.importResource.status !== ImportResourceStatus.UPLOADING && resource.importResource.status !== ImportResourceStatus.PENDING && resource.importResource.status !== ImportResourceStatus.INTERRUPTING"
                             ng-click="onImport({resource: resource})">
                         <span class="icon-import"></span>
                     </button>

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -144,7 +144,7 @@
                     </button>
                     <button role="button" class="btn btn-link btn-inline secondary pr-0"
                             ng-click="resetStatus(resource)"
-                            ng-show="resource.importResource.status === ImportResourceStatus.DONE || resource.importResource.status === ImportResourceStatus.ERROR"
+                            ng-if="resource.canResetStatus"
                             ng-disabled="selectedResources.length > 1"
                             gdb-tooltip="{{'import.reset.status' | translate}}">
                         <span class="icon-close"></span>
@@ -154,14 +154,14 @@
                         <em class="icon-trash"></em>
                     </button>
                     <button class="btn btn-primary btn-sm import-resource-action-import"
-                            ng-if="resource.isFile() && resource.importResource.status !== ImportResourceStatus.IMPORTING && resource.importResource.status !== ImportResourceStatus.UPLOADING && resource.importResource.status !== ImportResourceStatus.PENDING && resource.importResource.status !== ImportResourceStatus.INTERRUPTING"
+                            ng-if="resource.isImportable"
                             ng-click="onImport({resource: resource})">
                         <span class="icon-import"></span>
                     </button>
                     <button class="btn btn-sm"
                             ng-click="stopImport(resource)"
                             ng-disabled="resource.importResource.status === ImportResourceStatus.INTERRUPTING"
-                            ng-show="resource.importResource.status === ImportResourceStatus.IMPORTING || resource.importResource.status === ImportResourceStatus.UPLOADING || resource.importResource.status === ImportResourceStatus.PENDING || resource.importResource.status === ImportResourceStatus.INTERRUPTING"
+                            ng-if="resource.hasOngoingImport"
                             gdb-tooltip="{{'import.import_resource_tree.action.interrupt_import' | translate}}">
                         <span class="icon-close"></span>
                         {{'import.import_resource_tree.action.abort' | translate}}

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -158,6 +158,14 @@
                             ng-click="onImport({resource: resource})">
                         <span class="icon-import"></span>
                     </button>
+                    <button class="btn btn-sm"
+                            ng-click="stopImport(resource)"
+                            ng-disabled="resource.importResource.status === ImportResourceStatus.INTERRUPTING"
+                            ng-show="resource.importResource.status === ImportResourceStatus.IMPORTING || resource.importResource.status === ImportResourceStatus.UPLOADING || resource.importResource.status === ImportResourceStatus.PENDING || resource.importResource.status === ImportResourceStatus.INTERRUPTING"
+                            gdb-tooltip="{{'import.import_resource_tree.action.interrupt_import' | translate}}">
+                        <span class="icon-close"></span>
+                        {{'import.import_resource_tree.action.abort' | translate}}
+                    </button>
                 </div>
             </td>
         </tr>

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -59,7 +59,7 @@
                         popover-placement="top">
                     {{'import.reset.status' | translate}}
                 </button>
-                <button class="btn btn-secondary remove-resources-btn" type="button" ng-click="onRemoveResources()"
+                <button ng-if="canRemoveResource" class="btn btn-secondary remove-resources-btn" type="button" ng-click="onRemoveResources()"
                         uib-popover="{{'import.remove.selected' | translate}}"
                         popover-trigger="mouseenter"
                         popover-placement="top">
@@ -149,8 +149,8 @@
                             gdb-tooltip="{{'import.reset.status' | translate}}">
                         <span class="icon-close"></span>
                     </button>
-                    <button class="btn btn-link btn-sm secondary import-resource-action-remove"
-                            ng-click="onDelete({resource: resource})">
+                    <button ng-if="canRemoveResource" class="btn btn-link btn-sm secondary import-resource-action-remove"
+                            ng-click="removeResource(resource)">
                         <em class="icon-trash"></em>
                     </button>
                     <button class="btn btn-primary btn-sm import-resource-action-import"

--- a/src/js/angular/models/import/import-resource-tree-element.js
+++ b/src/js/angular/models/import/import-resource-tree-element.js
@@ -74,7 +74,7 @@ export class ImportResourceTreeElement {
      * @return {ImportResourceTreeElement} - the root resource of the paren-child tree.
      */
     getRoot() {
-        if (this.parent === undefined) {
+        if (this.isRoot()) {
             return this;
         }
         return this.parent.getRoot();
@@ -183,6 +183,10 @@ export class ImportResourceTreeElement {
         }
         this.files.forEach((file) => file.selectAllWithStatus(statuses));
         this.directories.forEach((directory) => directory.selectAllWithStatus(statuses));
+    }
+
+    isRoot() {
+        return this.parent === undefined;
     }
 
     getAllSelected() {

--- a/src/js/angular/models/import/import-resource-tree-element.js
+++ b/src/js/angular/models/import/import-resource-tree-element.js
@@ -19,6 +19,19 @@ export class ImportResourceTreeElement {
          * @type {number}
          */
         this.indent = 0;
+
+        /**
+         * @type {boolean}
+         */
+        this.isImportable = false;
+        /**
+         * @type {boolean}
+         */
+        this.hasOngoingImport = false;
+        /**
+         * @type {boolean}
+         */
+        this.canResetStatus = false;
         /**
          * @type {string}
          */
@@ -99,7 +112,7 @@ export class ImportResourceTreeElement {
      * @return {boolean} true if the resource contains rdf data.
      */
     isFile() {
-        return this.importResource.isFile();
+        return !this.isRoot() && this.importResource.isFile();
     }
 
     /**

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -128,6 +128,7 @@
                                       on-delete="onDelete(resource)"
                                       on-import="onImport(resource)"
                                       on-remove="onRemove(selectedResources)"
+                                      on-stop-import="onStopImport(resource)"
                                       on-reset="onReset(selectedResources)"
                                       on-import-all="importAll(selectedResources, withoutChangingSettings)">
                 </import-resource-tree>
@@ -157,6 +158,7 @@
                                       show-type-filter="true"
                                       on-delete="onDelete(resource)"
                                       on-import="onImport(resource)"
+                                      on-stop-import="onStopImport(resource)"
                                       on-remove="onRemove(selectedResources)"
                                       on-reset="onReset(resources)"
                                       on-import-all="importAll(selectedResources, withoutChangingSettings)">

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -125,11 +125,10 @@
                 <import-resource-tree ng-if="userData"
                                       resources="userData"
                                       show-type-filter="false"
-                                      on-delete="onDelete(resource)"
                                       on-import="onImport(resource)"
-                                      on-remove="onRemove(selectedResources)"
+                                      on-remove="onRemove(resources)"
                                       on-stop-import="onStopImport(resource)"
-                                      on-reset="onReset(selectedResources)"
+                                      on-reset="onReset(resources)"
                                       on-import-all="importAll(selectedResources, withoutChangingSettings)">
                 </import-resource-tree>
 <!--                <div class="mt-2" files-table></div>-->
@@ -156,10 +155,8 @@
                 <import-resource-tree ng-if="serverImportTree"
                                       resources="serverImportTree"
                                       show-type-filter="true"
-                                      on-delete="onDelete(resource)"
                                       on-import="onImport(resource)"
                                       on-stop-import="onStopImport(resource)"
-                                      on-remove="onRemove(selectedResources)"
                                       on-reset="onReset(resources)"
                                       on-import-all="importAll(selectedResources, withoutChangingSettings)">
                 </import-resource-tree>

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -158,7 +158,7 @@
                                       on-delete="onDelete(resource)"
                                       on-import="onImport(resource)"
                                       on-remove="onRemove(selectedResources)"
-                                      on-reset="onReset(selectedResources)"
+                                      on-reset="onReset(resources)"
                                       on-import-all="importAll(selectedResources, withoutChangingSettings)">
                 </import-resource-tree>
                 <div class="mt-2" files-table></div>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -999,6 +999,10 @@
                 "NONE": "None",
                 "IMPORTED": "Imported",
                 "NOT_IMPORTED": "Not imported"
+            },
+            "action": {
+                "interrupt_import": "Interrupt import",
+                "abort": "Abort"
             }
         }
     },

--- a/test-cypress/integration/import/import-server-files.spec.js
+++ b/test-cypress/integration/import/import-server-files.spec.js
@@ -72,8 +72,7 @@ describe('Import server files', () => {
         ImportSteps.verifyImportStatusDetails(JSONLD_FILE_FOR_IMPORT, [CONTEXT, BASE_URI, '"preserveBNodeIds": true,']);
     });
 
-    // TODO: will be fixed with next MR
-    it.skip('Test import Server file successfully with JSONLD, button on row, with settings', () => {
+    it('Test import Server file successfully with JSONLD, button on row, with settings', () => {
         ImportSteps.clickImportOnRow(0);
         ImportSteps.expandAdvancedSettings();
         ImportSteps.fillBaseURI(BASE_URI);

--- a/test-cypress/steps/import/import-steps.js
+++ b/test-cypress/steps/import/import-steps.js
@@ -326,7 +326,7 @@ class ImportSteps {
     }
 
     static clickImportOnRow(row) {
-        this.getImportFileRow(row).find('.pull-right').contains('Import').click();
+        cy.get('.import-file-btn').contains('Import').click();
 
         return ImportSteps;
     }


### PR DESCRIPTION
## What:
- Implements the action to reset the import status of a single or multiple resources;
- Implements import single RDF resource;
- Implements interrupt single rdf resource import;
- Hides the "Delete" button when the server tab is active.

## Why:
- This allows users to clear the status of either a single imported resource or all imported resources;
- This gives the user the opportunity to import a single RDF resource;
- This gives the user the opportunity to abort a rdf import if it is not finished yet;
- Server files can't be deleted from the workbench.

## How:
- Added a BE call to reset the status of either specified or all resources when the user clicks the "Reset status" button;
- Added a BE call to import a single RDF resource when the user clicks the "Import" button;
- Added BE call to abort a single rdf resource import when the user clicks on the "Abort" button;
- Added a check to see if the "onDelete" function is passed. If not, the button is hidden. Removed the "onDelete" function from the "import-resource-tree" directive when it's instantiated for server import.