### PR TITLE
GDB-9971: changes displayed context to be a link.

### DIFF
--- a/src/css/import-resource-tree.css
+++ b/src/css/import-resource-tree.css
@@ -85,7 +85,8 @@
 }
 
 .import-resource-tree .import-resource-table .import-resource-actions {
-    text-align: end;
+    display: flex;
+    justify-content: flex-end;
 }
 
 .import-resource-tree .import-resource-table .import-resource-actions .import-resource-action-import {
@@ -100,7 +101,7 @@
 
 .import-resource-tree .import-resource-table .import-resource-modified,
 .import-resource-tree .import-resource-table .import-resource-imported,
-.import-resource-tree .import-resource-table .import-resource-import-resource-size {
+.import-resource-tree .import-resource-table .import-resource-size {
     min-width: 120px;
 }
 

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -215,10 +215,14 @@
             <td class="import-resource-cell import-resource-imported">
                 {{ resource.importResource.importedOn | date:'yyyy-MM-dd, HH:mm' }}
             </td>
-            <td class="import-resource-cell">
-                {{ resource.importResource.context || ''}}
+            <td colspan="2" class="import-resource-cell">
+                <a if="resource.importResource.context"
+                   title="{{resource.importResource.context}}"
+                   class="uri-link"
+                   href="{{'resource?uri=' + resource.importResource.context + '&role=context'}}">
+                    {{resource.shorthedContext ? resource.shorthedContext : resource.importResource.context}}
+                </a>
             </td>
-            <td class="import-resource-cell import-resource-cell-action"></td>
         </tr>
         </tbody>
     </table>

--- a/src/js/angular/models/import/import-resource-tree-element.js
+++ b/src/js/angular/models/import/import-resource-tree-element.js
@@ -41,6 +41,11 @@ export class ImportResourceTreeElement {
          */
         this.name = '';
         /**
+         * If context link is too long it have to be shorted with ellipses in the middle.
+         * @type {string}
+         */
+        this.shorthedContext = '';
+        /**
          * @type {boolean}
          */
         this.selected = false;

--- a/src/js/angular/rest/mappers/import-mapper.js
+++ b/src/js/angular/rest/mappers/import-mapper.js
@@ -7,6 +7,8 @@ export const toImportResource = (importResourcesServerData) => {
 };
 
 export const INDENT = 30;
+const PREFIX_AND_SUFFIX_CONTEXT_LENGTH = 30;
+const MAX_CONTEXT_LENGTH = PREFIX_AND_SUFFIX_CONTEXT_LENGTH * 2 + 3;
 
 /**
  * Convert list with {@link ImportResource} to a list of {@link ImportResourceTreeElement}.
@@ -45,7 +47,7 @@ export const toImportServerResource = (importResources) => {
  */
 const addResourceToTree = (root, resource) => {
     const path = getPath(resource);
-    let directoryPath = [];
+    let directoryPath;
     if (resource.isDirectory()) {
         directoryPath = path;
     } else {
@@ -112,9 +114,21 @@ const setupAfterTreeInitProperties = (importResourceElement) => {
         importResourceElement.hasOngoingImport = hasOngoingImport(importResourceElement.importResource);
         importResourceElement.canResetStatus = canResetStatus(importResourceElement.importResource);
         importResourceElement.hasStatusInfo = importResourceElement.importResource.status === 'DONE' || importResourceElement.importResource.status === 'ERROR';
+        setupShortedContext(importResourceElement);
     }
     importResourceElement.directories.forEach((directory) => setupAfterTreeInitProperties(directory));
     importResourceElement.files.forEach((file) => setupAfterTreeInitProperties(file));
+};
+
+/**
+ * Setts shortedContext property if context is too long.
+ * @param {ImportResourceTreeElement} importResourceElement
+ */
+const setupShortedContext = (importResourceElement) => {
+    const context = importResourceElement.importResource ? importResourceElement.importResource.context : '' || '';
+    if (context.length > MAX_CONTEXT_LENGTH) {
+        importResourceElement.shorthedContext = context.substring(0, PREFIX_AND_SUFFIX_CONTEXT_LENGTH) + '...' + context.substring(context.length - PREFIX_AND_SUFFIX_CONTEXT_LENGTH);
+    }
 };
 
 const isImportable = (importResource) => {


### PR DESCRIPTION
## What
 Changed the displayed context to be a hyperlink that opens the resource view with the corresponding context.

## Why
 This will be useful for users to quickly view all related triples for the context where the RDF triples are imported.

## How
 The representation of context value has been changed to be a link.

# Additional work
Fixes resource button alignment for small windows.