### PR TITLE
GDB-9971: Fixes a popover issue

### DIFF
--- a/src/js/angular/import/directives/import-resource-status-info.directive.js
+++ b/src/js/angular/import/directives/import-resource-status-info.directive.js
@@ -4,9 +4,9 @@ angular
     .module('graphdb.framework.import.import-resource-status-info', modules)
     .directive('importResourceStatusInfo', importResourceStatusInfoDirective);
 
-importResourceStatusInfoDirective.$inject = [];
+importResourceStatusInfoDirective.$inject = ['$rootScope'];
 
-function importResourceStatusInfoDirective() {
+function importResourceStatusInfoDirective($rootScope) {
     return {
         restrict: 'E',
         templateUrl: 'js/angular/import/templates/import-resource-status-info.html',
@@ -29,14 +29,29 @@ function importResourceStatusInfoDirective() {
             // =========================
             // Public functions
             // =========================
-            $scope.openPopover = () => {
+            $scope.open = () => {
+                $scope.closeAllDialogs();
                 $scope.popoverIsOpen = true;
             };
 
-            $scope.closePopover = () => {
+            $scope.closeAllDialogs = () => {
+                $rootScope.$broadcast('closePopovers');
+            };
+
+            $scope.close = () => {
                 $scope.popoverIsOpen = false;
             };
 
+            // =========================
+            // Subscriptions
+            // =========================
+            $scope.$on('closePopovers', $scope.close);
+
+            const removeAllSubscribers = () => {
+                $scope.$off('closePopovers', $scope.close);
+            };
+
+            $scope.$on('$destroy', removeAllSubscribers);
         }
     };
 }

--- a/src/js/angular/import/templates/import-resource-status-info.html
+++ b/src/js/angular/import/templates/import-resource-status-info.html
@@ -4,14 +4,14 @@
       popover-trigger="none"
       popover-is-open="popoverIsOpen"
       popover-placement="left"
-      ng-mouseover="openPopover()"
-      ng-mouseleave="closePopover()"
+      ng-mouseover="open()"
       popover-append-to-body="true">
 </span>
 
 
 <script type="text/ng-template" id="resourceStatusInfoTemplate.html">
-    <div class="import-resource-status-info-popover" ng-mouseleave="closePopover()" ng-mouseover="openPopover()">
+    <sup class="pull-right btn btn-sm close" ng-click="close()"></sup>
+    <div class="import-resource-status-info-popover">
         <h4>{{'import.status-info.last_import_settings' | translate}}</h4>
 
         <table class="table table-sm m-0">


### PR DESCRIPTION
## What
When the popover dialog displaying an imported resource appears at the bottom of the window, it causes the window to flicker.

## Why
The popover is initially positioned to the left of the icon, but if the content exceeds the available space and a vertical scrollbar appears, it causes the hovered icons to move. This movement triggers the popover to close and reopen under the cursor, leading to a flickering effect.

## How
This fix removes the automatic closure of the popover when the mouse leaves the button. Now, the popover can only be closed by the user clicking on the close button, which appears in the top-left corner of the popover.