### PR TITLE
GDB-9664 - Match Swagger link color to the rest of the text on page

### DIFF
--- a/src/res/swagger5/index.css
+++ b/src/res/swagger5/index.css
@@ -49,7 +49,7 @@ body {
     margin: 0.3em;
 }
 
-.swagger-section .swagger-ui-wrap h3, p {
+.swagger-section .swagger-ui-wrap h3, p, a {
     color: #999999 !important;
     padding: 2px !important;
 }


### PR DESCRIPTION
## What?
The links in the REST API view will appear the same color as the rest of the text.

## Why?
The link styling came from the Swagger stylesheet and did not match the old UI.

## How?
I made sure to override the link style in the main `.css`.