### PR TITLE
Gdb 9970 add opportunity to user to change rdf text snipets

### DIFF
--- a/src/js/angular/import/controllers.js
+++ b/src/js/angular/import/controllers.js
@@ -4,7 +4,6 @@ import 'angular/rest/import.rest.service';
 import 'angular/rest/upload.rest.service';
 import 'angular/import/import-context.service';
 import 'angular/import/import-view-storage.service';
-import {FILE_STATUS} from "../models/import/file-status";
 import {FileFormats} from "../models/import/file-formats";
 import * as stringUtils from "../utils/string-utils";
 import {FileUtils} from "../utils/file-utils";
@@ -14,6 +13,7 @@ import {ImportResourceTreeElement} from "../models/import/import-resource-tree-e
 import {decodeHTML} from "../../../app";
 import {FilePrefixRegistry} from "./file-prefix-registry";
 import {SortingType} from "../models/import/sorting-type";
+import {ImportResourceStatus} from "../models/import/import-resource-status";
 
 const modules = [
     'ui.bootstrap',
@@ -427,7 +427,7 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
                     ImportContextService.updateFiles($scope.files);
                 }
                 $scope.showClearStatuses = _.filter($scope.files, function (file) {
-                    return file.status === FILE_STATUS.DONE || file.status === FILE_STATUS.ERROR;
+                    return file.status === ImportResourceStatus.DONE || file.status === ImportResourceStatus.ERROR;
                 }).length > 0;
 
                 $scope.savedSettings = _.mapKeys(_.filter($scope.files, 'parserSettings'), 'name');
@@ -660,8 +660,8 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
 
         modalInstance.result.then((data) => {
             if (file) {
-                if ((file.data !== data.text || file.format !== data.format) && file.status !== FILE_STATUS.NONE) {
-                    file.status = FILE_STATUS.NONE;
+                if ((file.data !== data.text || file.format !== data.format) && file.status !== ImportResourceStatus.NONE) {
+                    file.status = ImportResourceStatus.NONE;
                     file.message = $translate.instant('import.text.snippet.not.imported');
                 }
                 file.data = data.text;
@@ -720,7 +720,7 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
         $scope.settings.type = file.type;
         $scope.settings.data = file.data;
         $scope.settings.format = file.format;
-        file.status = FILE_STATUS.PENDING;
+        file.status = ImportResourceStatus.PENDING;
 
         const importer = startImport ? ImportRestService.importTextSnippet : ImportRestService.updateTextSnippet;
         importer($repositories.getActiveRepository(), $scope.settings)
@@ -728,7 +728,7 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
                 $scope.updateList();
             }).error(function (data) {
             toastr.error($translate.instant('import.could.not.send.data', {data: getError(data)}));
-            file.status = FILE_STATUS.ERROR;
+            file.status = ImportResourceStatus.ERROR;
             file.message = getError(data);
         }).finally(nextCallback || function () {});
     };
@@ -749,7 +749,7 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
         $scope.settings.type = file.type;
         $scope.settings.data = file.data;
         $scope.settings.format = file.format;
-        file.status = FILE_STATUS.PENDING;
+        file.status = ImportResourceStatus.PENDING;
 
         const importer = startImport ? ImportRestService.importFromUrl : ImportRestService.updateFromUrl;
         importer($repositories.getActiveRepository(), $scope.settings).success(function () {
@@ -767,7 +767,7 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
             $scope.updateList();
         }).catch((data) => {
             toastr.error($translate.instant('import.could.not.upload.file', {data: getError(data)}));
-            file.status = FILE_STATUS.ERROR;
+            file.status = ImportResourceStatus.ERROR;
             file.message = getError(data);
         }).finally(nextCallback || function () {});
     };

--- a/src/js/angular/import/controllers.js
+++ b/src/js/angular/import/controllers.js
@@ -355,6 +355,17 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             $scope.setSettingsFor('', withoutChangingSettings, undefined);
         };
 
+        /**
+         * Edits the <code>resource</code>.
+         *
+         * @param {ImportResourceTreeElement} resource - the resource to be edited.
+         */
+        $scope.onEditResource = (resource) => {
+            if (resource.importResource.isText()) {
+                $scope.openTextSnippetDialog(resource.importResource);
+            }
+        };
+
         // =========================
         // Private functions
         // =========================
@@ -638,42 +649,42 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
 
     /**
      * Opens a modal dialog where the user can paste a rdf text snippet and import it.
-     * @param {{object}|undefined} file
+     * @param {{ImportResource}|undefined} importResource
      */
-    $scope.openTextSnippetDialog = (file) => {
+    $scope.openTextSnippetDialog = (importResource) => {
         const scope = {};
-        if (file) {
-            scope.rdfText = file.data;
+        if (importResource) {
+            scope.rdfText = importResource.data;
         }
         const modalInstance = $uibModal.open({
             templateUrl: 'js/angular/import/templates/textSnippet.html',
             controller: 'TextCtrl',
             resolve: {
                 text: function () {
-                    return file ? file.data : '';
+                    return importResource ? importResource.data : '';
                 },
                 format: function () {
-                    return file ? file.format : 'text/turtle';
+                    return importResource ? importResource.format : 'text/turtle';
                 }
             }
         });
 
         modalInstance.result.then((data) => {
-            if (file) {
-                if ((file.data !== data.text || file.format !== data.format) && file.status !== ImportResourceStatus.NONE) {
-                    file.status = ImportResourceStatus.NONE;
-                    file.message = $translate.instant('import.text.snippet.not.imported');
+            if (importResource) {
+                if ((importResource.data !== data.text || importResource.format !== data.format) && importResource.status !== ImportResourceStatus.NONE) {
+                    importResource.status = ImportResourceStatus.NONE;
+                    importResource.message = $translate.instant('import.text.snippet.not.imported');
                 }
-                file.data = data.text;
-                file.format = data.format;
-                updateTextImport(file);
+                importResource.data = data.text;
+                importResource.format = data.format;
+                updateTextImport(importResource);
             } else {
-                file = {type: 'text', name: 'Text snippet ' + DateUtils.formatCurrentDateTime(), format: data.format, data: data.text};
-                $scope.files.unshift(file);
-                $scope.updateImport(file.name, false, false);
+                importResource = {type: 'text', name: 'Text snippet ' + DateUtils.formatCurrentDateTime(), format: data.format, data: data.text};
+                $scope.files.unshift(importResource);
+                $scope.updateImport(importResource.name, false, false);
             }
             if (data.startImport) {
-                $scope.setSettingsFor(file.name, false, file.format);
+                $scope.setSettingsFor(importResource.name, false, importResource.format);
             }
         });
     };

--- a/src/js/angular/import/directives/import-resource-status-info.directive.js
+++ b/src/js/angular/import/directives/import-resource-status-info.directive.js
@@ -45,10 +45,11 @@ function importResourceStatusInfoDirective($rootScope) {
             // =========================
             // Subscriptions
             // =========================
-            $scope.$on('closePopovers', $scope.close);
+            const subscribers = [];
+            subscribers.push($scope.$on('closePopovers', $scope.close));
 
             const removeAllSubscribers = () => {
-                $scope.$off('closePopovers', $scope.close);
+                subscribers.forEach((subscriber) => subscriber());
             };
 
             $scope.$on('$destroy', removeAllSubscribers);

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -50,7 +50,8 @@ function importResourceTreeDirective($timeout) {
             onImportAll: '&',
             onReset: '&',
             onRemove: '&',
-            onStopImport: '&'
+            onStopImport: '&',
+            onEditResource: '&'
         },
         link: ($scope, element, attrs) => {
 
@@ -170,6 +171,10 @@ function importResourceTreeDirective($timeout) {
                 }
                 $scope.sortedBy = sortedBy;
                 updateListedImportResources();
+            };
+
+            $scope.editResource = (resource) => {
+                $scope.onEditResource({resource});
             };
 
             // =========================

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -165,7 +165,12 @@
                 class="import-resource-cell">
                 <span class="import-resource-title">
                     <em ng-class="{'icon-folder': resource.isDirectory(), 'icon-file': resource.isFile()}"></em>
-                    <strong>{{resource.name}}</strong>
+                    <div ng-if="onEditResource && resource.isEditable">
+                        <a href="#" ng-click="editResource(resource)"><strong>{{resource.name}}</strong></a>
+                    </div>
+                    <div ng-if="!resource.isEditable">
+                        <strong>{{resource.name}}</strong>
+                    </div>
                 </span>
             </td>
             <td class="import-resource-cell">

--- a/src/js/angular/models/import/file-status.js
+++ b/src/js/angular/models/import/file-status.js
@@ -1,7 +1,0 @@
-export const FILE_STATUS = {
-    'UPLOADING': 'UPLOADING',
-    'PENDING': 'PENDING',
-    'ERROR': 'ERROR',
-    'DONE': 'DONE',
-    'NONE': 'NONE'
-};

--- a/src/js/angular/models/import/import-resource-tree-element.js
+++ b/src/js/angular/models/import/import-resource-tree-element.js
@@ -65,6 +65,10 @@ export class ImportResourceTreeElement {
          * @type {boolean}
          */
         this.isModifiedBiggerThanImported = false;
+        /**
+         * @type {boolean}
+         */
+        this.isEditable = false;
     }
 
     /**

--- a/src/js/angular/models/import/import-resource.js
+++ b/src/js/angular/models/import/import-resource.js
@@ -77,4 +77,8 @@ export class ImportResource {
     isURL() {
         return ImportResourceType.URL === this.type;
     }
+
+    isText() {
+        return ImportResourceType.TEXT === this.type;
+    }
 }

--- a/src/js/angular/rest/mappers/import-mapper.js
+++ b/src/js/angular/rest/mappers/import-mapper.js
@@ -114,6 +114,7 @@ const setupAfterTreeInitProperties = (importResourceElement) => {
         importResourceElement.hasOngoingImport = hasOngoingImport(importResourceElement.importResource);
         importResourceElement.canResetStatus = canResetStatus(importResourceElement.importResource);
         importResourceElement.hasStatusInfo = importResourceElement.importResource.status === 'DONE' || importResourceElement.importResource.status === 'ERROR';
+        importResourceElement.isEditable = importResourceElement.importResource.isText();
         setupShortedContext(importResourceElement);
         setupImportedAndModifiedComparableProperties(importResourceElement);
     }

--- a/src/js/angular/rest/upload.rest.service.js
+++ b/src/js/angular/rest/upload.rest.service.js
@@ -1,4 +1,4 @@
-import {FILE_STATUS} from "../models/import/file-status";
+import {ImportResourceStatus} from "../models/import/import-resource-status";
 
 angular
     .module('graphdb.framework.rest.upload.service', [])
@@ -62,12 +62,12 @@ function UploadRestService($http, Upload, $translate) {
     function reportProgress(evt, file) {
         if (file.file) {
             file.file = null;
-            file.status = FILE_STATUS.UPLOADING;
-        } else if (file.status !== FILE_STATUS.UPLOADING) {
-            file.status = FILE_STATUS.PENDING;
+            file.status = ImportResourceStatus.UPLOADING;
+        } else if (file.status !== ImportResourceStatus.UPLOADING) {
+            file.status = ImportResourceStatus.PENDING;
         }
 
-        if (file.status === FILE_STATUS.UPLOADING) {
+        if (file.status === ImportResourceStatus.UPLOADING) {
             const progressPercentage = parseInt(100.0 * evt.loaded / evt.total);
             file.message = $translate.instant('import.file.upload.progress', {progress: progressPercentage});
         }

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -131,7 +131,8 @@
                                       on-remove="onRemove(resources)"
                                       on-stop-import="onStopImport(resource)"
                                       on-reset="onReset(resources)"
-                                      on-import-all="importAll(selectedResources, withoutChangingSettings)">
+                                      on-import-all="importAll(selectedResources, withoutChangingSettings)"
+                                      on-edit-resource="onEditResource(resource)">
                 </import-resource-tree>
             </div>
             <div id="import-server" ng-hide="isS4()" class="tab-pane" ng-controller="ImportCtrl"


### PR DESCRIPTION
## What
Clicking on the name link of an RDF text resource in the import-resource-tree.directive now opens a dialog containing the resource data, enabling users to update the imported RDF text data.

## Why
This functionality allows users to make modifications to the imported RDF data.

## How
A listener for the "onEditResource" event from the import-resource-tree.directive has been added. When this event occurs, a dialog displaying the resource data is opened, allowing users to update the RDF data and import it into the GraphDB database.

# Additional work
- Fixes unsubscribing functionality of import-resource-status-info directive;
- Removes duplicated import resource status constants.
