### PR TITLE
Gdb 9971 fixses loader functionality

### DIFF
--- a/src/js/angular/import/controllers.js
+++ b/src/js/angular/import/controllers.js
@@ -75,7 +75,6 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
         $scope.fileFormatsHuman = FileFormats.getFileFormatsHuman() + $translate.instant('import.gz.zip');
         $scope.textFileFormatsHuman = FileFormats.getTextFileFormatsHuman();
         $scope.maxUploadFileSizeMB = 0;
-        $scope.resources = new ImportResourceTreeElement();
         $scope.SORTING_TYPES = SortingType;
 
         // =========================
@@ -247,7 +246,7 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
          * @return {string[]}
          */
         $scope.getSelectedFiles = () => {
-            return $scope.resources.getAllSelectedFilesNames();
+            return ImportContextService.getResources().getAllSelectedFilesNames();
         };
 
         $scope.importSelected = (overrideSettings) => {
@@ -415,9 +414,9 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             filesLoader($repositories.getActiveRepository()).success(function (data) {
 
                 if (TABS.SERVER === $scope.activeTabId) {
-                    $scope.resources = toImportServerResource(toImportResource(data));
+                    ImportContextService.updateResources(toImportServerResource(toImportResource(data)));
                 } else if (TABS.USER === $scope.activeTabId) {
-                    $scope.resources = toImportUserDataResource(toImportResource(data));
+                    ImportContextService.updateResources(toImportUserDataResource(toImportResource(data)));
                 }
 
                 // reload all files
@@ -503,7 +502,7 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             subscriptions.push($scope.$on('$destroy', () => $interval.cancel(listPollingHandler)));
             subscriptions.push(ImportContextService.onActiveTabIdUpdated((newActiveTabId) => {
                 $scope.activeTabId = newActiveTabId;
-                $scope.resources = undefined;
+                ImportContextService.updateResources(new ImportResourceTreeElement());
                 $scope.updateListHttp(true);
             }));
             $scope.$on('$destroy', removeAllListeners);
@@ -1057,9 +1056,7 @@ importViewModule.controller('TabCtrl', ['$scope', '$location', 'ImportViewStorag
 
     subscriptions.push(ImportContextService.onFilesUpdated(onFilesUpdated));
 
-    const removeAllListeners = () => {
-        subscriptions.forEach((subscription) => subscription());
-    };
+    const removeAllListeners = () => subscriptions.forEach((subscription) => subscription());
 
     $scope.$on('$destroy', removeAllListeners);
 

--- a/src/js/angular/import/controllers.js
+++ b/src/js/angular/import/controllers.js
@@ -455,8 +455,6 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
                 $scope.savedSettings = _.mapKeys(_.filter($scope.files, 'parserSettings'), 'name');
             }).error(function (data) {
                 toastr.warning($translate.instant('import.error.could.not.get.files', {data: getError(data)}));
-            }).finally(() => {
-                $scope.loader = false;
             });
         };
 
@@ -521,7 +519,7 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
         init();
     }]);
 
-importViewModule.controller('ImportCtrl', ['$scope', 'toastr', '$controller', '$translate', '$repositories', 'ImportRestService', function ($scope, toastr, $controller, $translate, $repositories, ImportRestService) {
+importViewModule.controller('ImportCtrl', ['$scope', 'toastr', '$controller', '$translate', '$repositories', 'ImportRestService', 'ImportContextService', function ($scope, toastr, $controller, $translate, $repositories, ImportRestService, ImportContextService) {
 
     // =========================
     // Private variables
@@ -582,6 +580,10 @@ importViewModule.controller('ImportCtrl', ['$scope', 'toastr', '$controller', '$
     const init = function () {
         $scope.pollList();
         $scope.onRepositoryChange();
+        const onFirstResourceUpdatesHandler = ImportContextService.onResourcesUpdated(() => {
+            $scope.loader = false;
+            onFirstResourceUpdatesHandler();
+        });
     };
     init();
 }]);
@@ -906,6 +908,10 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
         subscriptions.push(ImportContextService.onFilesUpdated((files) => {
             filesPrefixRegistry.buildPrefixesRegistry(files);
         }));
+        const onFirstResourceUpdatesHandler = ImportContextService.onResourcesUpdated(() => {
+            $scope.loader = false;
+            onFirstResourceUpdatesHandler();
+        });
     };
     init();
 }]);

--- a/src/js/angular/import/controllers.js
+++ b/src/js/angular/import/controllers.js
@@ -32,11 +32,6 @@ const modules = [
 
 const importViewModule = angular.module('graphdb.framework.impex.import.controllers', modules);
 
-export const OPERATION = {
-    UPLOAD: 'upload',
-    SERVER: 'server'
-};
-
 const USER_DATA_TYPE = {
     FILE: 'file',
     TEXT: 'text',
@@ -462,7 +457,7 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             if (!names || names.length < 1) {
                 return;
             }
-            const resetService = $scope.activeTabId === OPERATION.UPLOAD ? ImportRestService.resetUserDataStatus : ImportRestService.resetServerFileStatus;
+            const resetService = $scope.activeTabId === TABS.USER ? ImportRestService.resetUserDataStatus : ImportRestService.resetServerFileStatus;
             resetService($repositories.getActiveRepository(), names, remove).success(function () {
                 $scope.updateList(true);
             }).error(function (data) {
@@ -1067,7 +1062,8 @@ importViewModule.controller('TabCtrl', ['$scope', '$location', 'ImportViewStorag
     $scope.$on('$destroy', removeAllListeners);
 
     // Updates the active tab id from tha url.
-    ImportContextService.updateActiveTabId($location.hash() || TABS.USER);
+    const activeTabId = $location.hash() || TABS.USER;
+    $scope.openTab(activeTabId);
 }]);
 
 importViewModule.controller('SettingsModalCtrl', ['$scope', '$uibModalInstance', 'toastr', 'UriUtils', 'settings', 'hasParserSettings', 'defaultSettings', 'isMultiple', '$translate',

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -25,18 +25,14 @@ angular
     .module('graphdb.framework.import.import-resource-tree', modules)
     .directive('importResourceTree', importResourceTreeDirective);
 
-importResourceTreeDirective.$inject = ['$timeout'];
+importResourceTreeDirective.$inject = ['$timeout', 'ImportContextService'];
 
-function importResourceTreeDirective($timeout) {
+function importResourceTreeDirective($timeout, ImportContextService) {
     return {
         restrict: 'E',
         templateUrl: 'js/angular/import/templates/import-resource-tree.html',
         scope: {
 
-            /**
-             * @type {ImportResourceTreeElement}
-             */
-            resources: '=',
             /**
              * If the type filter buttons should be visible.
              */
@@ -181,10 +177,6 @@ function importResourceTreeDirective($timeout) {
             // Private functions
             // =========================
 
-            const init = () => {
-                updateListedImportResources();
-            };
-
             /**
              * Sets the flag showing if any of the selected resources is already imported
              * and can have their states reset.
@@ -291,11 +283,20 @@ function importResourceTreeDirective($timeout) {
             };
 
             // =========================
+            // Subscription handlers
+            // =========================
+
+            const onResourcesUpdatedHandler = (resources) => {
+                $scope.resources = resources;
+                updateListedImportResources();
+            };
+
+            // =========================
             // Subscriptions
             // =========================
             const subscriptions = [];
 
-            subscriptions.push($scope.$watch('resources', init));
+            subscriptions.push(ImportContextService.onResourcesUpdated(onResourcesUpdatedHandler));
 
             const removeAllSubscribers = () => {
                 subscriptions.forEach((subscription) => subscription());

--- a/src/js/angular/import/import-context.service.js
+++ b/src/js/angular/import/import-context.service.js
@@ -1,4 +1,13 @@
+/**
+ * The import service is implemented using many controllers and directives that share common variables.
+ * The purpose of the ImportContextService is to hold data shared between them.
+ */
 import {cloneDeep} from "lodash";
+
+export const TABS = {
+    USER: 'user',
+    SERVER: 'server'
+};
 
 angular
     .module('graphdb.framework.importcontext.service', [])
@@ -7,6 +16,9 @@ angular
 ImportContextService.$inject = ['EventEmitterService'];
 
 function ImportContextService(EventEmitterService) {
+
+    let _activeTabId = TABS.USER;
+
     /**
      * @type {*[]}
      * @private
@@ -14,11 +26,37 @@ function ImportContextService(EventEmitterService) {
     let _files = [];
 
     return {
+        updateActiveTabId,
+        getActiveTabId,
+        onActiveTabIdUpdated,
         getFiles,
         addFile,
         updateFiles,
         onFilesUpdated
     };
+
+    /**
+     * Updates the active tab id of import page.
+     * @param {string} activeTabId - the new view of import page. Its value have to be one of {@link OPERATION}
+     */
+    function updateActiveTabId(activeTabId) {
+        _activeTabId = activeTabId;
+        EventEmitterService.emit('activeTabIdUpdated', getActiveTabId());
+    }
+
+    function getActiveTabId() {
+        return _activeTabId;
+    }
+
+    /**
+     * Subscribes to the 'activeTabUpdated' event.
+     * @param {function} callback - The callback to be called when the event is fired.
+     *
+     * @return unsubscribe function.
+     */
+    function onActiveTabIdUpdated(callback) {
+        return EventEmitterService.subscribe('activeTabIdUpdated', () => callback(getActiveTabId()));
+    }
 
     /**
      * Updates the list of files.
@@ -34,9 +72,11 @@ function ImportContextService(EventEmitterService) {
     /**
      * Subscribes to the 'filesUpdated' event.
      * @param {function} callback - The callback to be called when the event is fired.
+     *
+     * @return unsubscribe function.
      */
     function onFilesUpdated(callback) {
-        EventEmitterService.subscribe('filesUpdated', () => callback(getFiles()));
+        return EventEmitterService.subscribe('filesUpdated', () => callback(getFiles()));
     }
 
     /**

--- a/src/js/angular/import/import-context.service.js
+++ b/src/js/angular/import/import-context.service.js
@@ -18,6 +18,11 @@ ImportContextService.$inject = ['EventEmitterService'];
 function ImportContextService(EventEmitterService) {
 
     let _activeTabId = TABS.USER;
+    /**
+     * @type {ImportResourceTreeElement}
+     * @private
+     */
+    let _resources = undefined;
 
     /**
      * @type {*[]}
@@ -32,7 +37,10 @@ function ImportContextService(EventEmitterService) {
         getFiles,
         addFile,
         updateFiles,
-        onFilesUpdated
+        onFilesUpdated,
+        updateResources,
+        getResources,
+        onResourcesUpdated
     };
 
     /**
@@ -96,5 +104,34 @@ function ImportContextService(EventEmitterService) {
      */
     function getFiles() {
         return cloneDeep(_files);
+    }
+
+    /**
+     * Updates the resources.
+     * Emits the 'resourcesUpdated' event when the resources are updated.
+     * The 'filesUpdated' event contains the new resources.
+     * @param {ImportResourceTreeElement} resources
+     */
+    function updateResources(resources) {
+        _resources = resources;
+        EventEmitterService.emit('resourcesUpdated', getResources());
+    }
+
+    /**
+     * Gets the resources.
+     * @return {ImportResourceTreeElement} - The resources.
+     */
+    function getResources() {
+        return cloneDeep(_resources);
+    }
+
+    /**
+     * Subscribes to the 'resourcesUpdated' event.
+     * @param {function} callback - The callback to be called when the event is fired.
+     *
+     * @return the unsubscribe function.
+     */
+    function onResourcesUpdated(callback) {
+        return EventEmitterService.subscribe('resourcesUpdated', () => callback(getResources()));
     }
 }

--- a/src/js/angular/import/templates/filesTable.html
+++ b/src/js/angular/import/templates/filesTable.html
@@ -3,7 +3,7 @@
 
     <div ng-show="showTable()" class="mb-1 clearfix">
         <div class="pull-right form-inline">
-            <div class="btn-group d-inline mr-1" ng-show="viewType === 'server'">
+            <div class="btn-group d-inline mr-1" ng-show="activeTabId === 'server'">
                 <button type="button" class="btn btn-secondary" ng-model="showItems" uib-btn-radio="'file'" gdb-tooltip="{{'import.show.files.only' | translate}}">
                     <em class="icon-file"></em>
                 </button>
@@ -48,7 +48,7 @@
                 {{'import.reset.status' | translate}}
             </button>
             <button id="wb-import-removeEntries"
-                    ng-show="batch && viewType === 'user'"
+                    ng-show="batch && activeTabId === 'user'"
                     class="btn btn-secondary" type="button" ng-click="removeEntrySelected()"
                     uib-popover="{{'import.remove.selected' | translate}}"
                     popover-trigger="mouseenter"
@@ -86,9 +86,9 @@
                 <div class="d-inline-block" style="overflow: hidden; text-overflow: ellipsis;">
                     <div class="import-file-header">
                         <!-- no icon for server files -->
-                        <em class="icon-file" ng-show="viewType === 'server' && file.type === 'file'"></em>
+                        <em class="icon-file" ng-show="activeTabId === 'server' && file.type === 'file'"></em>
                         <em class="icon-folder" ng-show="file.type === 'directory'"></em>
-                        <em class="icon-upload" ng-show="viewType === 'user' && file.type === 'file'"></em>
+                        <em class="icon-upload" ng-show="activeTabId === 'user' && file.type === 'file'"></em>
                         <em class="icon-link" ng-show="file.type === 'url'"></em>
                         <em class="icon-edit" ng-show="file.type === 'text'"></em>
                         <strong ng-show="file.type !== 'text'">{{file.name}}</strong>
@@ -131,7 +131,7 @@
                     </div>
                 </div>
             </td>
-            <td width="25" ng-show="viewType === 'user'">
+            <td width="25" ng-show="activeTabId === 'user'">
                 <button class="btn btn-link secondary remove-file-btn" ng-click="removeEntry([file.name])" ng-disabled="batch || file.status === 'IMPORTING' || file.status === 'UPLOADING' || file.status === 'PENDING' || file.status === 'INTERRUPTING'">
                     <em class="icon-trash"></em>
                 </button>
@@ -143,7 +143,7 @@
                         ng-cloak
                         ng-hide="!importable(file) || file.status === 'IMPORTING' || file.status === 'UPLOADING' || file.status === 'PENDING' || file.status === 'INTERRUPTING'"
                         guide-selector="import-file-{{file.name}}"
-                        data-target="#{{viewType}}Modal">
+                        data-target="#{{activeTabId}}Modal">
                     <span class="icon-import"></span>
                     {{'common.import' | translate}}
                 </button>
@@ -159,7 +159,7 @@
             </td>
         </tr>
         </tbody>
-        <tbody ng-show="files.length == 0 && viewType == 'server'">
+        <tbody ng-show="files.length == 0 && activeTabId == 'server'">
         <tr>
             <td>{{'import.no.files.found' | translate}}</td>
         </tr>

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -122,7 +122,9 @@
                         </ul>
                     </div>
                 </div>
-                <import-resource-tree show-type-filter="false"
+                <div class="ot-loader ot-main-loader" onto-loader size="50" ng-if="loader"></div>
+                <import-resource-tree ng-if ="!loader"
+                                      show-type-filter="false"
                                       sort-by="SORTING_TYPES.MODIFIED"
                                       asc="false"
                                       on-import="onImport(resource)"
@@ -152,7 +154,9 @@
                         </p>
                     </div>
                 </div>
-                <import-resource-tree show-type-filter="true"
+                <div class="ot-loader ot-main-loader" onto-loader size="50" ng-if="loader"></div>
+                <import-resource-tree ng-if ="!loader"
+                                      show-type-filter="true"
                                       sort-by="SORTING_TYPES.NAME"
                                       on-import="onImport(resource)"
                                       on-stop-import="onStopImport(resource)"

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -122,9 +122,7 @@
                         </ul>
                     </div>
                 </div>
-                <import-resource-tree ng-if="resources"
-                                      resources="resources"
-                                      show-type-filter="false"
+                <import-resource-tree show-type-filter="false"
                                       sort-by="SORTING_TYPES.MODIFIED"
                                       asc="false"
                                       on-import="onImport(resource)"
@@ -154,9 +152,7 @@
                         </p>
                     </div>
                 </div>
-                <import-resource-tree ng-if="resources"
-                                      resources="resources"
-                                      show-type-filter="true"
+                <import-resource-tree show-type-filter="true"
                                       sort-by="SORTING_TYPES.NAME"
                                       on-import="onImport(resource)"
                                       on-stop-import="onStopImport(resource)"

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -16,11 +16,11 @@
 
         <ul class="nav nav-tabs mb-2">
             <li class="nav-item" id="wb-import-tabUpload">
-                <a class="nav-link" ng-class="viewType == 'user' ? 'active' : ''" href ng-click="openTab('user')"
+                <a class="nav-link" ng-class="activeTabId == 'user' ? 'active' : ''" href ng-click="openTab('user')"
                    data-toggle="tab">{{'user.data' | translate}}</a>
             </li>
             <li class="nav-item" id="wb-import-tabServer" ng-hide="isS4()">
-                <a class="nav-link" ng-class="viewType == 'server' ? 'active' : ''" href
+                <a class="nav-link" ng-class="activeTabId == 'server' ? 'active' : ''" href
                    ng-click="openTab('server')" data-toggle="tab">{{'server.files' | translate}}</a>
             </li>
             <li class="nav-item">
@@ -34,7 +34,7 @@
 
         <div class="tab-content">
             <div id="import-user" class="tab-pane" ng-controller="UploadCtrl"
-                 ng-class="$parent.viewType == 'user' ? 'active' : ''">
+                 ng-class="activeTabId == 'user' ? 'active' : ''">
                 <div class="row upload-buttons">
                     <div class="col-xs-12 col-md-6 col-lg-4 mb-2 fat-btn">
                         <div class="btn btn-outline-primary btn-lg text-xs-left upload-rdf-files-btn"
@@ -136,7 +136,7 @@
                 </import-resource-tree>
             </div>
             <div id="import-server" ng-hide="isS4()" class="tab-pane" ng-controller="ImportCtrl"
-                 ng-class="$parent.viewType == 'server' ? 'active' : ''">
+                 ng-class="activeTabId == 'server' ? 'active' : ''">
 
                 <div ng-if="isHelpVisible" class="alert alert-help server-files-import-help mb-0">
                     <button type="button" ng-click="toggleHelp()" gdb-tooltip="{{'common.close' | translate}}"

--- a/test-cypress/integration/import/import-user-data-batch-operations.spec.js
+++ b/test-cypress/integration/import/import-user-data-batch-operations.spec.js
@@ -70,7 +70,7 @@ describe('Import user data: Batch operations', () => {
         ImportUserDataSteps.getResourceByName('bnodes.ttl').should('be.visible');
     });
 
-    it('Should be able to batch import files', () => {
+    it('Should be able to batch import files', {retries: 2}, () => {
         uploadFiles([
             {name: testFiles[0], content: bnodes},
             {name: testFiles[1], content: jsonld},
@@ -174,9 +174,10 @@ function uploadFiles(data) {
     });
     ImportUserDataSteps.selectFile(createdFiles);
     ImportSettingsDialogSteps.cancelImport();
+    ImportSettingsDialogSteps.getDialog().should('not.exist');
     ImportUserDataSteps.getResources().should('have.length', data.length);
     // check them backwards because  latest uploaded/imported files are at the top
-    data.reverse().forEach((file, index) => {
+    data.forEach((file, index) => {
         ImportUserDataSteps.checkUserDataUploadedResource(index, file.name);
     });
 }


### PR DESCRIPTION
## What
Implemented a loader to display during the initialization of the import view.

## Why
After integration of the new resource list, the loader had to be changed to work again as expected.

## How
Introduced a 'loader' flag to control the display of the loader. Upon page initialization, the loader is set to true, causing it to be displayed while hiding the import-resource-tree.directive. Once resources are loaded for the first time, the loader is set to false, triggering the display of resources and hiding the loader.

# Additional work
- The 'viewType' parameter was renamed to 'activeTabId' and moved to the import context service;
- The 'resources' parameter was moved to the import context service.
