### PR TITLE
GDB-10135 move jsonld context field on the right place in import settings dialog

### DIFF
--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -1,5 +1,3 @@
-<link href="css/import-resource-tree.css?v=[AIV]{version}[/AIV]" rel="stylesheet">
-
 <div class="import-resource-tree mt-2" ng-if="resources && !resources.isEmpty()">
     <div class="import-resource-tree-header">
         <div class="import-resources-actions">

--- a/src/js/angular/import/templates/settingsModal.html
+++ b/src/js/angular/import/templates/settingsModal.html
@@ -66,26 +66,6 @@
                     </label>
                 </div>
             </div>
-            <div ng-show="settings.hasContextLink" class="form-group row contextLinkRow">
-                <label class="col-lg-3 col-form-label">
-                    {{'import.context.link' | translate}}
-                    <span class="btn btn-link p-0"
-                          uib-popover="{{'import.context.link.info' | translate}}"
-                          popover-trigger="mouseenter"
-                          popover-placement="right">
-                    <em class="icon icon-info"></em>
-                </span>
-                </label>
-                <div class="col-lg-9">
-                    <input validate-uri name="contextLink" type="text"
-                           ng-model="settings['contextLink']" class="form-control"
-                           placeholder="http://example.com/example.jsonld">
-                    <div class="alert alert-danger"
-                         ng-if="settingsForm.contextLink.$dirty && settingsForm.contextLink.$error.validateUri">
-                        {{'import.alert.not.valid.iri' | translate}}
-                    </div>
-                </div>
-            </div>
             <div class="form-group row" ng-show="enableReplace">
                 <label class="col-lg-3 col-form-label">
                     {{'import.replaced.graphs' | translate}}
@@ -162,6 +142,27 @@
                                ng-required="enableReplace">
                         <strong>{{'import.data.cleared.before.import' | translate}}</strong>
                     </label>
+                </div>
+            </div>
+
+            <div ng-show="settings.hasContextLink" class="form-group row contextLinkRow">
+                <label class="col-lg-3 col-form-label">
+                    {{'import.context.link' | translate}}
+                    <span class="btn btn-link p-0"
+                          uib-popover="{{'import.context.link.info' | translate}}"
+                          popover-trigger="mouseenter"
+                          popover-placement="right">
+                    <em class="icon icon-info"></em>
+                </span>
+                </label>
+                <div class="col-lg-9">
+                    <input validate-uri name="contextLink" type="text"
+                           ng-model="settings['contextLink']" class="form-control"
+                           placeholder="http://example.com/example.jsonld">
+                    <div class="alert alert-danger"
+                         ng-if="settingsForm.contextLink.$dirty && settingsForm.contextLink.$error.validateUri">
+                        {{'import.alert.not.valid.iri' | translate}}
+                    </div>
                 </div>
             </div>
 

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -1,4 +1,5 @@
 <link rel="stylesheet" type="text/css" href="css/import.css?v=[AIV]{version}[/AIV]">
+<link rel="stylesheet" type="text/css" href="css/import-resource-tree.css?v=[AIV]{version}[/AIV]">
 
 <div id="wb-import">
     <h1>


### PR DESCRIPTION
## What
Moved jsonld context field in import setting dialog below replace graphs section where it should be in order to not precede it when it's visible.

## Why
The field was initially put on the wrong place in the settings form.

## How
Just moved the field to be after the replace graph section.

* Additionally, moved the resource tree directive css to be loaded in the import template because it seems that webpack can't put it properly in the bundle otherwise.