### PR TITLE
GDB-10136 allow replace graph option when importing single file

### DIFF
--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -364,7 +364,12 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             if (withoutChangingSettings) {
                 $scope.importSelected(selectedResources, withoutChangingSettings);
             } else {
-                $scope.setSettingsFor('', withoutChangingSettings, undefined);
+                // For single file import we need to pass the name.
+                let fileName = '';
+                if (selectedResources.length === 1) {
+                    fileName = selectedResources[0].importResource.name;
+                }
+                $scope.setSettingsFor(fileName, withoutChangingSettings, undefined);
             }
         };
 
@@ -869,7 +874,11 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
                     $scope.selectedForImportFiles[file.name] = true;
                 });
                 // Provide an import rejected callback and do the upload instead.
-                $scope.setSettingsFor('', false, undefined, () => {
+                let fileName = '';
+                if ($scope.currentFiles.length === 1) {
+                    fileName = $scope.currentFiles[0].name;
+                }
+                $scope.setSettingsFor(fileName, false, undefined, () => {
                     $scope.currentFiles.forEach((file) => {
                         $scope.updateImport(file.name, false, false);
                         // reset these as we are just uploading here

--- a/test-cypress/integration/import/import-user-data-file-upload.spec.js
+++ b/test-cypress/integration/import/import-user-data-file-upload.spec.js
@@ -49,6 +49,17 @@ describe('Import user data: File upload', () => {
         ImportUserDataSteps.checkImportedResource(0, 'bnodes.ttl');
     });
 
+    it('Should allow replacing graph when uploading and importing single file', () => {
+        // Given there are no files uploaded yet
+        ImportUserDataSteps.getResourcesTable().should('be.hidden');
+        // When I start to upload a file
+        ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[0], bnodes));
+        // Then the import settings dialog should open automatically
+        ImportSettingsDialogSteps.getDialog().should('be.visible');
+        // And the option for replace graph should be active
+        ImportSettingsDialogSteps.getReplaceExistingDataCheckbox().should('be.enabled').and('not.be.checked');
+    });
+
     it('Should be able to upload and import files one after the other and then override them', () => {
         // Given there are no files uploaded yet
         ImportUserDataSteps.getResourcesTable().should('be.hidden');

--- a/test-cypress/steps/import/import-settings-dialog-steps.js
+++ b/test-cypress/steps/import/import-settings-dialog-steps.js
@@ -53,4 +53,8 @@ export class ImportSettingsDialogSteps extends ModalDialogSteps {
             cy.get('.contextLinkRow').invoke('attr', 'style', 'display: block !important');
         });
     }
+
+    static getReplaceExistingDataCheckbox() {
+        return this.getSettingsForm().find('input.existing-data-replacement');
+    }
 }


### PR DESCRIPTION
## What
Allow when a single file is selected for import to be allowed the graph replacement option.

## Why
This is the expected behavior which works in cases where the file is not selected but the import action is directly triggered for it, but doesn't work for cases where the file is selected via the checkbox and imported through the batch import option.

## How
Implemented a check if a single file is selected and if that is the case, pass the file name to the import settings modal which in turn is used to enable the replace graph option.