### PR TITLE
GDB-9970 properly toggle batch operation buttons

### DIFF
--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -197,6 +197,8 @@ function importResourceTreeDirective($timeout, ImportContextService) {
                     }
                 });
                 $scope.resources.getRoot().updateSelectionState();
+                // update selected resources because we keep cloned resources and not live references
+                $scope.selectedResources = $scope.resources.getAllSelected();
                 sortResources();
                 $scope.displayResources = $scope.resources.toList()
                     .filter(filterByType)
@@ -301,6 +303,7 @@ function importResourceTreeDirective($timeout, ImportContextService) {
             const onResourcesUpdatedHandler = (resources) => {
                 $scope.resources = resources;
                 updateListedImportResources();
+                setCanResetResourcesFlag();
             };
 
             // =========================

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -172,12 +172,13 @@
                     <button role="button" class="btn btn-link btn-sm secondary import-resource-action-reset-btn"
                             ng-click="resetStatus(resource)"
                             ng-if="resource.canResetStatus"
-                            ng-disabled="selectedResources.length > 1"
+                            ng-disabled="selectedResources.length > 0"
                             gdb-tooltip="{{'import.reset.status' | translate}}">
                         <span class="icon-close"></span>
                     </button>
                     <button ng-if="canRemoveResource"
                             class="btn btn-link btn-sm secondary import-resource-action-remove-btn"
+                            ng-disabled="selectedResources.length > 0"
                             ng-click="removeResource(resource)"
                             gdb-tooltip="{{'import.remove.btn' | translate}}">
                         <em class="icon-trash"></em>
@@ -185,6 +186,7 @@
                     <button class="btn btn-primary btn-sm import-resource-action-import-btn"
                             ng-if="resource.isImportable"
                             ng-click="onImport({resource: resource})"
+                            ng-disabled="selectedResources.length > 0"
                             gdb-tooltip="{{'import.import.btn' | translate}}">
                         <span class="icon-import"></span>
                     </button>

--- a/src/js/angular/models/import/import-resource-tree-element.js
+++ b/src/js/angular/models/import/import-resource-tree-element.js
@@ -232,7 +232,9 @@ export class ImportResourceTreeElement {
         this.files.forEach((file) => allSelected.push(...file.getAllSelected()));
         this.directories.forEach((directory) => allSelected.push(...directory.getAllSelected()));
 
-        return allSelected;
+        // clone them to ensure that upcoming from the server changes in the resources
+        // will not interfere with the selected resources list
+        return _.cloneDeep(allSelected);
     }
 
     deselectAll() {


### PR DESCRIPTION
## What
Properly toggle batch operation buttons.

## Why
When an operation like reset for example is made, the resource status is changed, but the batch reset button remains active. This is due to the way the selected resources were kept in the scope as live references linked to the resources three.

## How
Detached the selected resources from the resources tree and properly updated the selection status after each resources update cycle.

Additionally, disabled the local for any resource operation button when there are selected resources.