### PR TITLE
GDB-9304 - Translate labels in Google chart config and Pivot table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.3.8",
+                "ontotext-yasgui-web-component": "1.3.9",
                 "shepherd.js": "^11.2.0"
             },
             "devDependencies": {
@@ -10184,9 +10184,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.8.tgz",
-            "integrity": "sha512-Gy5ugoE7at/3NoBqd113Kg2592fJX89Rnh8iAeq1tj6EVJBkDOG7MG38XvzHyeAUjU1jgXszLF9ZHfFCFvEOow==",
+            "version": "1.3.9",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.9.tgz",
+            "integrity": "sha512-ffupuf0tX17X2bU6iiJRoDsWEvjD9vAfSvcfOY/ghefgONZd5d/Q1BYnmWECvE6JP44wy6Khh4sbMIlYiVLTEQ==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24754,9 +24754,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.8.tgz",
-            "integrity": "sha512-Gy5ugoE7at/3NoBqd113Kg2592fJX89Rnh8iAeq1tj6EVJBkDOG7MG38XvzHyeAUjU1jgXszLF9ZHfFCFvEOow==",
+            "version": "1.3.9",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.9.tgz",
+            "integrity": "sha512-ffupuf0tX17X2bU6iiJRoDsWEvjD9vAfSvcfOY/ghefgONZd5d/Q1BYnmWECvE6JP44wy6Khh4sbMIlYiVLTEQ==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.3.7",
+                "ontotext-yasgui-web-component": "1.3.8",
                 "shepherd.js": "^11.2.0"
             },
             "devDependencies": {
@@ -10184,9 +10184,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.7.tgz",
-            "integrity": "sha512-jwyVTebXRL+0gjTA3Fa+5Z7tyv1AKkbrq9FCotpbjUBGUt5d8rQFq0JuxKo8o3r49KQEwdKJ06DRyDrGWyA23A==",
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.8.tgz",
+            "integrity": "sha512-Gy5ugoE7at/3NoBqd113Kg2592fJX89Rnh8iAeq1tj6EVJBkDOG7MG38XvzHyeAUjU1jgXszLF9ZHfFCFvEOow==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24754,9 +24754,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.7.tgz",
-            "integrity": "sha512-jwyVTebXRL+0gjTA3Fa+5Z7tyv1AKkbrq9FCotpbjUBGUt5d8rQFq0JuxKo8o3r49KQEwdKJ06DRyDrGWyA23A==",
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.8.tgz",
+            "integrity": "sha512-Gy5ugoE7at/3NoBqd113Kg2592fJX89Rnh8iAeq1tj6EVJBkDOG7MG38XvzHyeAUjU1jgXszLF9ZHfFCFvEOow==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.3.8",
+        "ontotext-yasgui-web-component": "1.3.9",
         "shepherd.js": "^11.2.0"
     },
     "resolutions": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.3.7",
+        "ontotext-yasgui-web-component": "1.3.8",
         "shepherd.js": "^11.2.0"
     },
     "resolutions": {

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -804,6 +804,8 @@
     "query.editor.automatically.execute.update.warning": "This is an update and it may change the data in the repository.<br>Are you sure you want to execute it automatically?",
     "query.editor.error.show.full.message": "Show full exception message",
     "query.editor.error.show.less.message": "Show less exception message",
+    "query.editor.language.change.warning.title": "Change language",
+    "query.editor.reload.page.warning": "Changing the language will reload the page. Are you sure you want to continue?",
     "sparql.tab.directive.unnamed.tab.title": "Unnamed",
     "search.resource.current.page.msg": "Use <b>View resource</b> on this page",
     "search.resources.msg": "Search RDF resources",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -803,6 +803,8 @@
     "query.editor.automatically.execute.update.warning": "Il s'agit d'une mise à jour et elle peut modifier les données du dépôt. <br>Êtes-vous sûr de vouloir l'exécuter automatiquement ?",
     "query.editor.error.show.full.message": "Afficher le message d'exception complet",
     "query.editor.error.show.less.message": "Afficher moins de détails sur l'exception",
+    "query.editor.language.change.warning.title": "Changer la langue",
+    "query.editor.reload.page.warning": "Changer la langue rechargera la page. Es-tu sur de vouloir continuer?",
     "sparql.tab.directive.unnamed.tab.title": "Anonyme",
     "search.resource.current.page.msg": "Use <b>View resource</b> on this page",
     "search.resources.msg": "Rechercher des ressources RDF",

--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -14,10 +14,12 @@ import {YasguiComponentDirectiveUtil} from "./yasgui-component-directive.util";
 import {KeyboardShortcutName} from "../../../models/ontotext-yasgui/keyboard-shortcut-name";
 import {YasguiPersistenceMigrationService} from "./yasgui-persistence-migration.service";
 import {ExportSettingsCtrl} from "../../components/export-settings-modal/controller";
+import 'angular/core/services/event-emitter-service';
 
 const modules = [
     'graphdb.framework.core.services.translation-service',
-    'graphdb.framework.sparql-editor.share-query.service'];
+    'graphdb.framework.sparql-editor.share-query.service',
+    'graphdb.framework.utils.event-emitter-service'];
 angular
     .module('graphdb.framework.core.directives.yasgui-component', modules)
     .directive('yasguiComponent', yasguiComponentDirective);
@@ -38,6 +40,7 @@ yasguiComponentDirective.$inject = [
     'MonitoringRestService',
     'SparqlRestService',
     'ShareQueryLinkService',
+    'EventEmitterService',
     'ModalService'
 ];
 
@@ -74,6 +77,7 @@ function yasguiComponentDirective(
     MonitoringRestService,
     SparqlRestService,
     ShareQueryLinkService,
+    eventEmitterService,
     ModalService
 ) {
 
@@ -87,6 +91,7 @@ function yasguiComponentDirective(
         },
         link: ($scope, element, attrs) => {
             $scope.classToApply = attrs.class || '';
+            $scope.language = undefined;
             const downloadAsPluginNameToEventHandler = new Map();
             const outputHandlers = $scope.yasguiConfig && $scope.yasguiConfig.outputHandlers ? new Map($scope.yasguiConfig.outputHandlers) : new Map();
             // The initial query value which is set in the yasqe editor. This is used for dirty checking while the user
@@ -369,6 +374,27 @@ function yasguiComponentDirective(
             const subscriptions = [];
 
             const init = (newVal, oldValue) => {
+                // This script check is required, because of the following scenario:
+                // I am in the SPARQL view;
+                // Then I go to a different view and change the language;
+                // Then I return to the SPARQL view. I will see that the Google chart and Pivot table will have their
+                // original scripts loaded still.
+                // THE FIX: Get all the scripts (if there are none, the correct language will be loaded). If there are
+                // scripts, and they don't match those, which are loaded already, the page needs to reload when opening
+                // the SPARQL view, otherwise the Google chart and Pivot table configs will be in the old language.
+                const googleScripts = document.querySelectorAll(`script[src*="https://www.gstatic.com/"]`);
+                if (googleScripts.length > 0) {
+                    const currentLang = $languageService.getLanguage();
+                    let searchTerm = 'module.js';
+                    if ('en' !== currentLang) {
+                        searchTerm = `module__${currentLang}.js`;
+                    }
+                    if (!Array.prototype.some.call(googleScripts, (script) => script.src.includes(searchTerm))) {
+                        location.reload();
+                        return;
+                    }
+                }
+                $scope.language = $languageService.getLanguage();
                 if (!$scope.ontotextYasguiConfig && newVal || newVal && !isEqual(newVal, oldValue)) {
                     const virtualRepository = $repositories.isActiveRepoOntopType();
                     const config = {
@@ -480,9 +506,26 @@ function yasguiComponentDirective(
             };
 
             subscriptions.push(
-                $scope.$on('language-changed', function (event, args) {
-                    $scope.language = args.locale;
-                }));
+                $scope.$on('language-changed', function () {
+                    location.reload();
+                })
+            );
+            subscriptions.push(
+                eventEmitterService.subscribe('before-language-change', function (args) {
+                    return new Promise((resolve) => {
+                        ModalService.openSimpleModal({
+                            title: $translate.instant('query.editor.language.change.warning.title'),
+                            message: $translate.instant('query.editor.reload.page.warning'),
+                            warning: true
+                        }).result.then(function () {
+                            resolve(args);
+                        }, function () {
+                            args.cancel = true;
+                            resolve(args);
+                        });
+                    });
+                }
+            ));
 
             const removeAllSubscribers = () => {
                 subscriptions.forEach((subscription) => subscription());

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -803,6 +803,8 @@
     "query.editor.automatically.execute.update.warning": "This is an update and it may change the data in the repository.<br>Are you sure you want to execute it automatically?",
     "query.editor.error.show.full.message": "Show full exception message",
     "query.editor.error.show.less.message": "Show less exception message",
+    "query.editor.language.change.warning.title": "Change language",
+    "query.editor.reload.page.warning": "Changing the language will reload the page. Are you sure you want to continue?",
     "sparql.tab.directive.unnamed.tab.title": "Unnamed",
     "search.resource.current.page.msg": "Use <b>View resource</b> on this page",
     "search.resources.msg": "Search RDF resources",

--- a/test-cypress/integration-flaky/import/import-user-data-batch-operations.spec.js
+++ b/test-cypress/integration-flaky/import/import-user-data-batch-operations.spec.js
@@ -127,7 +127,9 @@ describe('Import user data: Batch operations', {retries: {runMode: 2}}, () => {
         ImportUserDataSteps.selectFileByIndex(0);
         // And I delete the file
         ImportUserDataSteps.removeSelectedResources();
-        // Then I should see a confirmation dialog
+        // Then I force click the confirmation dialog, to hide the button popover, which covers it
+        ModalDialogSteps.getDialog().click({force: true});
+        // The dialog should be visible
         ModalDialogSteps.getDialog().should('be.visible');
         // When I confirm the deletion
         ModalDialogSteps.clickOnConfirmButton();

--- a/test-cypress/integration-flaky/sparql-editor/actions/share-query.spec.js
+++ b/test-cypress/integration-flaky/sparql-editor/actions/share-query.spec.js
@@ -32,7 +32,7 @@ describe('Share query', () => {
         ShareSavedQueryDialog.getDialog().should('be.visible');
         ShareSavedQueryDialog.getDialogTitle().should('contain', 'Copy URL to clipboard');
         ShareSavedQueryDialog.getShareLink().then((shareLink) => {
-            expect(shareLink).to.have.string(`/sparql?name=Unnamed&query=select%20*%20where%20%7B%20%20%0A%20%3Fs%20%3Fp%20%3Fo%20.%20%0A%20%7D%20limit%20100&infer=true&sameAs=true`);
+            expect(shareLink).to.have.string(`/sparql?name=Unnamed&query=select%20*%20where%20%7B%0A%20%20%20%20%3Fs%20%3Fp%20%3Fo%20.%0A%7D%20limit%20100&infer=true&sameAs=true`);
         });
         // When I cancel operation
         ShareSavedQueryDialog.closeDialog();

--- a/test-cypress/integration/sparql-editor/internationalization.spec.js
+++ b/test-cypress/integration/sparql-editor/internationalization.spec.js
@@ -1,14 +1,15 @@
 import {QueryStubs} from "../../stubs/yasgui/query-stubs";
-import {YasguiSteps} from "../../steps/yasgui/yasgui-steps";
+import {PluginTabs, YasguiSteps} from "../../steps/yasgui/yasgui-steps";
 import {LanguageSelectorSteps} from "../../steps/language-selector-steps";
 import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
 import {YasrSteps} from "../../steps/yasgui/yasr-steps";
 import {SparqlEditorSteps} from "../../steps/sparql-editor-steps";
+import {ImportUserDataSteps} from "../../steps/import/import-user-data-steps";
 
 describe('Internationalization of ontotext-yasgui-web-component', () => {
-
+    let repositoryId;
     beforeEach(() => {
-        const repositoryId = 'sparql-editor-' + Date.now();
+        repositoryId = 'sparql-editor-' + Date.now();
         QueryStubs.stubQueryCountResponse();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
@@ -16,26 +17,75 @@ describe('Internationalization of ontotext-yasgui-web-component', () => {
         SparqlEditorSteps.visitSparqlEditorPage();
     });
 
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
     it('Should translate labels when language is changed', () => {
-        // When I load page I expect all labels to be translated on the default English language.
+        // When I load page I expect all labels to be translated to the default English language.
         YasguiSteps.getYasguiModeButton().contains('Editor and results');
 
-        // When I execute a query I expect labels in table plugin to be translated on the default English language.
+        // When I execute a query I expect labels in table plugin to be translated to the default English language.
         YasqeSteps.executeQuery();
 
-        // Then I expect label in table plugin to be translated on the default English language.
+        // Then I expect label in table plugin to be translated to the default English language.
         YasrSteps.getResultFilter().invoke('attr', 'placeholder').should('contain', 'Filter query results');
 
-        // When I change language to French.
+        // When I change language to French
         LanguageSelectorSteps.switchToFr();
-        // Yasgui re-renders all DOM elements to shows the new labels. This includes the plugins of yasr which is time-consuming.
-        // We have to wait a bit because cypress is too fast and grabs the old element (with the old label) and the test fails.
-        cy.wait(500);
 
-        // Then I expect labels to be translated on French language.
+        // Then confirm the language change
+        LanguageSelectorSteps.confirmLanguageChange();
+
+        // Then I expect labels to be translated in French language
+        PluginTabs.getGoogleChartsTab().should('contain.text', 'Graphique Google');
         YasguiSteps.getYasguiModeButton().contains('Éditeur et résultats');
 
-        // And I expect label in table plugin to be translated on French language.
+        // And I expect label in table plugin to be translated in French language.
+        YasrSteps.getResultFilter().invoke('attr', 'placeholder').should('contain', 'Filtrer les résultats des requêtes');
+    });
+
+    it('Should not translate when language change is cancelled', () => {
+        // When I load page I expect all labels to be translated on the default English language
+        YasguiSteps.getYasguiModeButton().contains('Editor and results');
+
+        // When I execute a query I expect labels in table plugin to be translated in the default English language
+        YasqeSteps.executeQuery();
+
+        // Then I expect label in table plugin to be translated in the default English language
+        YasrSteps.getResultFilter().invoke('attr', 'placeholder').should('contain', 'Filter query results');
+
+        // When I change language to French
+        LanguageSelectorSteps.switchToFr();
+
+        // Then cancel the language change
+        LanguageSelectorSteps.cancelLanguageChange();
+
+        // Then I expect labels to be in English
+        YasguiSteps.getYasguiModeButton().contains('Editor and results');
+
+        // And I expect label in table plugin to remain in English
+        YasrSteps.getResultFilter().invoke('attr', 'placeholder').should('contain', 'Filter query results');
+    });
+
+    it('Should translate labels when language is changed in another view', () => {
+        // Given I open the Import page
+        ImportUserDataSteps.visitImport('user', repositoryId);
+
+        // When I change language to French
+        LanguageSelectorSteps.switchToFr();
+
+        // And return to the SPARQL view
+        SparqlEditorSteps.visitSparqlEditorPage();
+
+        // When I execute a query
+        YasqeSteps.executeQuery();
+
+        // Then I expect labels to be translated to French
+        PluginTabs.getGoogleChartsTab().should('contain.text', 'Graphique Google');
+        YasguiSteps.getYasguiModeButton().contains('Éditeur et résultats');
+
+        // And I expect label in table plugin to be translated to French
         YasrSteps.getResultFilter().invoke('attr', 'placeholder').should('contain', 'Filtrer les résultats des requêtes');
     });
 });

--- a/test-cypress/steps/language-selector-steps.js
+++ b/test-cypress/steps/language-selector-steps.js
@@ -19,4 +19,16 @@ export class LanguageSelectorSteps {
     static switchToEn() {
         LanguageSelectorSteps.changeLanguage('en');
     }
+
+    static getLanguageChangeModal() {
+        return cy.get('.modal-dialog');
+    }
+
+    static confirmLanguageChange() {
+        this.getLanguageChangeModal().find('.confirm-btn').click();
+    }
+
+    static cancelLanguageChange() {
+        this.getLanguageChangeModal().find('.cancel-btn').click();
+    }
 }

--- a/test-cypress/steps/sparql-steps.js
+++ b/test-cypress/steps/sparql-steps.js
@@ -72,7 +72,7 @@ class SparqlSteps {
     }
 
     static getQueryArea() {
-        return cy.get('#queryEditor .CodeMirror');
+        return cy.get('#query-editor .CodeMirror');
     }
 
     static waitUntilQueryIsVisible() {

--- a/test-cypress/steps/yasgui/yasgui-steps.js
+++ b/test-cypress/steps/yasgui/yasgui-steps.js
@@ -176,6 +176,12 @@ export class YasguiSteps {
     }
 }
 
+export class PluginTabs {
+    static getGoogleChartsTab() {
+        return cy.get('.select_charts');
+    }
+}
+
 export class TabContextMenu {
     static getContextMenu() {
         return cy.get('.yasgui .context-menu');

--- a/test-cypress/support/sparql-commands.js
+++ b/test-cypress/support/sparql-commands.js
@@ -45,7 +45,7 @@ function clearQuery() {
 }
 
 function getQueryArea() {
-    return cy.get('#queryEditor .CodeMirror');
+    return cy.get('#query-editor .CodeMirror');
 }
 
 function getQueryTextArea() {


### PR DESCRIPTION
## What?
When the user changes the language while in the SPARQL view, the page will require permission to reload.

## Why?
The configs are loaded with the language passed in during initialization, it cannot be changed afterwards. Hence, the page needs to reload in order to have the right labels in the config window.

## How?
I handle the dialog open and page reload in the `yasgui-component-directive`. If the user is on the SPARQL editor page, the dialog will appear.

**Dependency**: this MR depends on changes in the YASGUI component with MR https://github.com/Ontotext-AD/ontotext-yasgui/pull/265