### PR TITLE
GDB-9970 add third button for cancel in the file override dialog

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -996,9 +996,9 @@
                 "the_property": "property"
             },
             "on_file_size_limit": {
-                "file_size_limit_info": "To import larger than {{fileSizeLimit}} MB files, use the ",
+                "file_import_options_info_1": "Explore other file import options - ",
+                "file_import_options_info_2": "import (opens Server files tab) or ",
                 "server_files_link": "Server files",
-                "import_or_use": "import or use the",
                 "api_link": "API"
             }
         },

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -956,7 +956,11 @@
         "user_data": {
             "duplicates_confirmation": {
                 "title": "Confirm files overwrite",
-                "message": "Following files are already uploaded: <br/>{{duplicatedFiles}}<br/>Do you want to overwrite them?"
+                "message": "Following files are already uploaded: <br/>{{duplicatedFiles}}<br/>Do you want to overwrite them?",
+                "buttons": {
+                    "keep_both": "Keep both",
+                    "overwrite": "Overwrite"
+                }
             }
         },
         "help": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -995,9 +995,9 @@
                 "the_property": "propriété"
             },
             "on_file_size_limit": {
-                "file_size_limit_info": "Pour importer des fichiers de plus de {{fileSizeLimit}} Mo, utilisez l'importation de ",
-                "server_files_link": "Fichiers du serveur",
-                "import_or_use": "ou utilisez l'",
+                "file_import_options_info_1": "Explorez d'autres options d'importation de fichiers - Importation de ",
+                "file_import_options_info_2": "(ouvre l'onglet Fichiers serveur) ou ",
+                "server_files_link": "Fichiers serveur",
                 "api_link": "API"
             }
         },

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -955,7 +955,11 @@
         "user_data": {
             "duplicates_confirmation": {
                 "title": "Confirmer l'écrasement des fichiers",
-                "message": "Les fichiers suivants sont déjà téléchargés: <br/>{{duplicatedFiles}}<br/>Voulez-vous les écraser"
+                "message": "Les fichiers suivants sont déjà téléchargés: <br/>{{duplicatedFiles}}<br/>Voulez-vous les écraser",
+                "buttons": {
+                    "keep_both": "Garde les deux",
+                    "overwrite": "Écraser"
+                }
             }
         },
         "help": {

--- a/src/js/angular/guides/steps/complex/import-rdf-file/plugin.js
+++ b/src/js/angular/guides/steps/complex/import-rdf-file/plugin.js
@@ -103,14 +103,14 @@ PluginRegistry.add('guide.step', [
                     guideBlockName: 'clickable-element',
                     options: angular.extend({}, {
                         content: 'guide.step_plugin.import_rdf_file.confirm_duplicate_files_dialog.content',
-                        elementSelector: GuideUtils.getElementSelector('.confirm-duplicate-files-dialog .confirm-btn'),
+                        elementSelector: GuideUtils.getElementSelector('.confirm-duplicate-files-dialog .confirm-overwrite-btn'),
                         url: '/import',
                         placement: 'bottom',
                         class: 'import-file-button-guide-dialog',
                         skipFromHistory: true,
                         // Checks whether the confirm dialog is currently open.
                         showOn: () => GuideUtils.isVisible(GuideUtils.getElementSelector('.confirm-duplicate-files-dialog')),
-                        onNextClick: () => GuideUtils.clickOnElement('.confirm-duplicate-files-dialog .confirm-btn')(),
+                        onNextClick: () => GuideUtils.clickOnElement('.confirm-duplicate-files-dialog .confirm-overwrite-btn')(),
                         onPreviousClick: () => {
                             if (GuideUtils.isVisible(GuideUtils.getElementSelector('.confirm-duplicate-files-dialog'))) {
                                 return GuideUtils.clickOnElement('.confirm-duplicate-files-dialog .cancel-btn');

--- a/src/js/angular/import/controllers/file-override-confirmation.controller.js
+++ b/src/js/angular/import/controllers/file-override-confirmation.controller.js
@@ -1,0 +1,36 @@
+import {decodeHTML} from "../../../../app";
+
+angular
+    .module('graphdb.framework.impex.import.controllers.file-override-confirmation', [])
+    .controller('FileOverrideConfirmationController', FileOverrideConfirmationController);
+
+FileOverrideConfirmationController.$inject = ['$scope', '$uibModalInstance', '$translate', '$sce', 'duplicatedFiles'];
+
+function FileOverrideConfirmationController($scope, $uibModalInstance, $translate, $sce, duplicatedFiles) {
+
+    // =========================
+    // Public variables
+    // =========================
+
+    $scope.message = $sce.trustAsHtml(decodeHTML($translate.instant('import.user_data.duplicates_confirmation.message', {duplicatedFiles: duplicatedFiles})));
+
+    // =========================
+    // Public functions
+    // =========================
+
+    $scope.cancel = () => {
+        $uibModalInstance.dismiss();
+    };
+
+    $scope.keepBoth = () => {
+        $uibModalInstance.close({
+            overwrite: false
+        });
+    };
+
+    $scope.overwrite = () => {
+        $uibModalInstance.close({
+            overwrite: true
+        });
+    };
+}

--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -8,6 +8,7 @@ import 'angular/import/controllers/tab.controller';
 import 'angular/import/controllers/settings-modal.controller';
 import 'angular/import/controllers/import-url.controller';
 import 'angular/import/controllers/import-text-snippet.controller';
+import 'angular/import/controllers/file-override-confirmation.controller';
 import {FileFormats} from "../../models/import/file-formats";
 import * as stringUtils from "../../utils/string-utils";
 import {FileUtils} from "../../utils/file-utils";
@@ -34,7 +35,8 @@ const modules = [
     'graphdb.framework.impex.import.controllers.tab',
     'graphdb.framework.impex.import.controllers.settings-modal',
     'graphdb.framework.impex.import.controllers.import-url',
-    'graphdb.framework.impex.import.controllers.import-text-snippet'
+    'graphdb.framework.impex.import.controllers.import-text-snippet',
+    'graphdb.framework.impex.import.controllers.file-override-confirmation'
 ];
 
 const importViewModule = angular.module('graphdb.framework.impex.import.controllers', modules);
@@ -832,13 +834,17 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
 
     const openDuplicatedFilesConfirmDialog = (duplicatedFiles, uniqueFiles) => {
         const existingFilenames = duplicatedFiles.map((file) => file.name).join('<br/>');
-        return ModalService.openSimpleModal({
-            title: $translate.instant('import.user_data.duplicates_confirmation.title'),
-            message: decodeHTML($translate.instant('import.user_data.duplicates_confirmation.message', {duplicatedFiles: existingFilenames})),
-            dialogClass: "confirm-duplicate-files-dialog",
-            warning: true
-        }).result.then(
-            () => {
+        const modalInstance = $uibModal.open({
+            templateUrl: 'js/angular/import/templates/file-override-confirmation.html',
+            controller: 'FileOverrideConfirmationController',
+            windowClass: 'confirm-duplicate-files-dialog',
+            resolve: {
+                duplicatedFiles: () => existingFilenames
+            }
+        });
+
+        modalInstance.result.then((data) => {
+            if (data.overwrite) {
                 // on first upload, currentFiles would be empty
                 if (!$scope.currentFiles.length) {
                     $scope.currentFiles.push(...duplicatedFiles, ...uniqueFiles);
@@ -848,14 +854,13 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
                     $scope.currentFiles = [...duplicatedFiles, ...uniqueFiles];
                 }
                 isFileListInitialized = true;
-            },
-            () => {
+            } else {
                 // override rejected
                 const prefixedDuplicates = filesPrefixRegistry.prefixDuplicates(duplicatedFiles);
                 $scope.currentFiles = [...$scope.currentFiles, ...prefixedDuplicates, ...uniqueFiles];
                 isFileListInitialized = true;
             }
-        );
+        });
     };
 
     const uploadedFilesValidator = () => {

--- a/src/js/angular/import/templates/file-override-confirmation.html
+++ b/src/js/angular/import/templates/file-override-confirmation.html
@@ -1,0 +1,18 @@
+<div class="modal-header">
+    <button type="button" class="close" ng-click="cancel()"></button>
+    <h4 class="modal-title">{{'import.user_data.duplicates_confirmation.title' | translate}}</h4>
+</div>
+
+<div class="modal-body" ng-bind-html="message"></div>
+
+<div class="modal-footer">
+    <button type="button" ng-click="cancel()" class="btn btn-link cancel-btn text-muted">
+        {{'common.cancel.btn' | translate}}
+    </button>
+    <button type="button" ng-click="keepBoth()" class="btn btn-secondary keep-both-btn">
+        {{'import.user_data.duplicates_confirmation.buttons.keep_both' | translate}}
+    </button>
+    <button type="button" ng-click="overwrite()" class="btn btn-primary confirm-overwrite-btn">
+        {{'import.user_data.duplicates_confirmation.buttons.overwrite' | translate}}
+    </button>
+</div>

--- a/src/js/angular/import/templates/fileSizeLimitInfo.html
+++ b/src/js/angular/import/templates/fileSizeLimitInfo.html
@@ -1,6 +1,6 @@
 <div class="ot-view-info">
-    {{'import.help.on_file_size_limit.file_size_limit_info' | translate: {fileSizeLimit: maxUploadFileSizeMB} }}
+    {{'import.help.on_file_size_limit.file_import_options_info_1' | translate}}
     <a href ng-click="openTab('server')" class="server-files-tab-link">{{'import.help.on_file_size_limit.server_files_link' | translate}}</a>
-    {{'import.help.on_file_size_limit.import_or_use' | translate}}
+    {{'import.help.on_file_size_limit.file_import_options_info_2' | translate}}
     <a href="/webapi" class="api-link">{{'import.help.on_file_size_limit.api_link' | translate}}</a>
 </div>

--- a/src/js/angular/import/templates/textSnippet.html
+++ b/src/js/angular/import/templates/textSnippet.html
@@ -44,7 +44,7 @@
             </ul>
         </div>
         <button id="wb-import-importText" class="btn btn-primary" type="button"
-                ng-click="ok()">
+                ng-click="ok()" ng-disabled="snippetForm.$invalid">
             <em class="icon-import"></em>{{'common.import' | translate}}
         </button>
     </div>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -956,7 +956,11 @@
         "user_data": {
             "duplicates_confirmation": {
                 "title": "Confirm files overwrite",
-                "message": "Following files are already uploaded: <br/>{{duplicatedFiles}}<br/>Do you want to overwrite them?"
+                "message": "Following files are already uploaded: <br/>{{duplicatedFiles}}<br/>Do you want to overwrite them?",
+                "buttons": {
+                    "keep_both": "Keep both",
+                    "overwrite": "Overwrite"
+                }
             }
         },
         "help": {

--- a/test-cypress/integration/import/import-user-data-file-upload.spec.js
+++ b/test-cypress/integration/import/import-user-data-file-upload.spec.js
@@ -1,7 +1,7 @@
-import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
 import {ImportSettingsDialogSteps} from "../../steps/import/import-settings-dialog-steps";
 import {MainMenuSteps} from "../../steps/main-menu-steps";
 import {ImportUserDataSteps} from "../../steps/import/import-user-data-steps";
+import {FileOverwriteDialogSteps} from "../../steps/import/file-overwrite-dialog-steps";
 
 const bnodes = `_:node0 <http://purl.org/dc/elements/1.1/title> "A new book" ;
                     \t<http://purl.org/dc/elements/1.1/creator> "A.N.Other" .`;
@@ -76,7 +76,7 @@ describe('Import user data: File upload', () => {
         ImportUserDataSteps.checkImportedResource(1, 'bnodes.ttl');
         // When I override the first file
         ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[0], bnodes));
-        ModalDialogSteps.clickOnConfirmButton();
+        FileOverwriteDialogSteps.overwrite();
         ImportSettingsDialogSteps.import();
         // Then I should see the uploaded file - it becomes first in the list
         // TODO: timestamps currently seems to not be changed on reimport
@@ -84,7 +84,7 @@ describe('Import user data: File upload', () => {
         ImportUserDataSteps.checkImportedResource(1, 'bnodes.ttl');
         // When I override the second file
         ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[1], jsonld));
-        ModalDialogSteps.clickOnConfirmButton();
+        FileOverwriteDialogSteps.overwrite();
         ImportSettingsDialogSteps.import();
         // Then I should see the uploaded file - it becomes first in the list
         ImportUserDataSteps.checkImportedResource(0, 'jsonld.jsonld');
@@ -137,9 +137,9 @@ describe('Import user data: File upload', () => {
         // When I upload a file with the same name
         ImportUserDataSteps.selectFile(file1);
         // Then I should see a file override confirmation dialog
-        ModalDialogSteps.getDialog().should('be.visible');
+        FileOverwriteDialogSteps.getDialog().should('be.visible');
         // When I confirm the file override
-        ModalDialogSteps.clickOnConfirmButton();
+        FileOverwriteDialogSteps.overwrite();
         // Then the import settings dialog should open automatically
         ImportSettingsDialogSteps.import();
         // Then The file should be overridden
@@ -158,9 +158,9 @@ describe('Import user data: File upload', () => {
         // When I upload a file with the same name
         ImportUserDataSteps.selectFile(file1);
         // Then I should see a file override confirmation dialog
-        ModalDialogSteps.getDialog().should('be.visible');
+        FileOverwriteDialogSteps.getDialog().should('be.visible');
         // When I cancel the file override
-        ModalDialogSteps.clickOnCancelButton();
+        FileOverwriteDialogSteps.keepBoth();
         ImportSettingsDialogSteps.import();
         // Then The file should not be overridden but prefixed instead
         ImportUserDataSteps.getResources().should('have.length', 2);
@@ -169,8 +169,8 @@ describe('Import user data: File upload', () => {
         // When I upload two files, one with the same name and second new one
         const file2 = ImportUserDataSteps.createFile(testFiles[1], jsonld);
         ImportUserDataSteps.selectFile([file1, file2]);
-        ModalDialogSteps.getDialog().should('be.visible');
-        ModalDialogSteps.clickOnCancelButton();
+        FileOverwriteDialogSteps.getDialog().should('be.visible');
+        FileOverwriteDialogSteps.keepBoth();
         ImportSettingsDialogSteps.import();
         // Then The file should not be overridden but prefixed with increased index instead
         ImportUserDataSteps.getResources().should('have.length', 4);

--- a/test-cypress/steps/import/file-overwrite-dialog-steps.js
+++ b/test-cypress/steps/import/file-overwrite-dialog-steps.js
@@ -1,0 +1,16 @@
+import {ModalDialogSteps} from "../modal-dialog-steps";
+
+export class FileOverwriteDialogSteps extends ModalDialogSteps {
+
+    static overwrite() {
+        this.getDialog().find('.confirm-overwrite-btn').click();
+    }
+
+    static cancel() {
+        this.getDialog().find('.cancel-btn').click();
+    }
+
+    static keepBoth() {
+        this.getDialog().find('.keep-both-btn').click();
+    }
+}


### PR DESCRIPTION
## What
* Add third button for cancel in the file override dialog.
* Disable import button in text import dialog when text size limit is violated.

## Why
* There should be a cancel operation which should really cancel the file upload.
* Text snippet import should be forbidden if the text size is above the allowed limit.

## How
* Implemented new custom dialog for this, because the once we use for confirmation have only two buttons.
* Disable the import button when there is validation error.