### PR TITLE
GDB-3698 increase zoom-out level in visual graph

### DIFF
--- a/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -769,7 +769,7 @@ function GraphsVisualizationsCtrl(
     let colorIndex = 0;
     const nodeLabelMinFontSize = 16; // in pixels
     // define zoom and drag behavior; keep this out of draw() to preserve state when nodes are added/removed
-    const zoomLayout = d3.zoom().scaleExtent([0.5, 10]);
+    const zoomLayout = d3.zoom().scaleExtent([0.1, 10]);
     let container;
     const INITIAL_CONTAINER_TRANSFORM = d3.zoomIdentity.translate(0, -70).scale(1);
 


### PR DESCRIPTION
## What
Increase zoom-out level in visual graph.

## Why
This will greatly increase the usability of the graph visualization by the data engineers.

## How
Changed the lower bound of the zoom level.

Current zoom out level
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/51084653/0add47ad-c3a9-4c33-83c4-a50e94c58890)

New zoom out level
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/51084653/f54a27b0-deb5-4001-8610-7661cb0bd254)