### PR TITLE
GDB-10161 Redesign cluster configuration panel

### DIFF
--- a/src/css/clustermanagement.css
+++ b/src/css/clustermanagement.css
@@ -196,7 +196,7 @@ div.nodetooltip {
   right: 0;
 }
 
-.rdf-info-side-panel {
+.cluster-configuration-panel {
   z-index: 1016 !important;
 }
 

--- a/src/js/angular/clustermanagement/app.js
+++ b/src/js/angular/clustermanagement/app.js
@@ -2,6 +2,7 @@ import 'angular/core/services';
 import 'angular/core/directives';
 import 'angular/clustermanagement/controllers/cluster-management.controller';
 import 'angular/clustermanagement/directives/cluster-graphical-view.directive';
+import 'angular/clustermanagement/directives/cluster-configuration.directive';
 import 'angular/core/services/repositories.service';
 import 'lib/d3.patch.js';
 import 'angular-pageslide-directive/dist/angular-pageslide-directive';
@@ -10,7 +11,8 @@ const modules = [
     'ngAnimate',
     'toastr',
     'graphdb.framework.clustermanagement.controllers.cluster-management',
-    'graphdb.framework.clustermanagement.directives.cluster-graphical-view'
+    'graphdb.framework.clustermanagement.directives.cluster-graphical-view',
+    'graphdb.framework.clustermanagement.directives.cluster-configuration'
 ];
 
 angular.module('graphdb.framework.clustermanagement', modules);

--- a/src/js/angular/clustermanagement/directives/cluster-configuration.directive.js
+++ b/src/js/angular/clustermanagement/directives/cluster-configuration.directive.js
@@ -1,0 +1,64 @@
+import {DELETE_CLUSTER, UPDATE_CLUSTER} from "../events";
+
+const modules = [];
+
+angular
+    .module('graphdb.framework.clustermanagement.directives.cluster-configuration', modules)
+    .directive('clusterConfiguration', ClusterConfiguration);
+
+ClusterConfiguration.$inject = ['$jwtAuth', '$uibModal', '$translate', 'toastr', 'ClusterViewContextService', 'ClusterRestService'];
+
+function ClusterConfiguration($jwtAuth, $uibModal, $translate, toastr, ClusterViewContextService, ClusterRestService) {
+    return {
+        restrict: 'E',
+        templateUrl: 'js/angular/clustermanagement/templates/cluster-configuration.html',
+        scope: {
+            currentNode: '=',
+            clusterModel: '=',
+            clusterConfiguration: '='
+        },
+        link: ($scope) => {
+
+            $scope.isAdmin = false;
+
+            $scope.closeClusterConfigurationPanel = () => {
+                ClusterViewContextService.hideClusterConfigurationPanel();
+            };
+
+            $scope.showEditConfigurationDialog = () => {
+                const modalInstance = $uibModal.open({
+                    templateUrl: 'js/angular/clustermanagement/templates/modal/cluster-edit-dialog.html',
+                    controller: 'EditClusterCtrl',
+                    size: 'lg',
+                    resolve: {
+                        data: () => {
+                            return {
+                                clusterConfiguration: $scope.clusterConfiguration
+                            };
+                        }
+                    }
+                });
+
+                modalInstance.result.finally(function () {
+                    $scope.$emit(UPDATE_CLUSTER, {force: true});
+                });
+            };
+
+            $scope.showDeleteDialog = () => {
+                const modalInstance = $uibModal.open({
+                    templateUrl: 'js/angular/clustermanagement/templates/modal/cluster-delete-dialog.html',
+                    controller: 'DeleteClusterCtrl'
+                });
+
+                modalInstance.result.then((forceDelete) => {
+                    $scope.$emit(DELETE_CLUSTER, {force: forceDelete});
+                });
+            };
+
+            const init = () => {
+                $scope.isAdmin = $jwtAuth.isAuthenticated() && $jwtAuth.isAdmin();
+            };
+            init();
+        }
+    };
+}

--- a/src/js/angular/clustermanagement/events.js
+++ b/src/js/angular/clustermanagement/events.js
@@ -1,0 +1,2 @@
+export const UPDATE_CLUSTER = 'updateCluster';
+export const DELETE_CLUSTER = 'deleteCluster';

--- a/src/js/angular/clustermanagement/services/cluster-view-context.service.js
+++ b/src/js/angular/clustermanagement/services/cluster-view-context.service.js
@@ -1,0 +1,38 @@
+angular
+    .module('graphdb.framework.clustermanagement.services.cluster-view-context-service', [])
+    .factory('ClusterViewContextService', ClusterViewContextService);
+
+ClusterViewContextService.$inject = ['EventEmitterService'];
+
+function ClusterViewContextService(EventEmitterService) {
+    let _showClusterConfigurationPanel = false;
+
+    function getShowClusterConfigurationPanel() {
+        return _showClusterConfigurationPanel;
+    }
+
+    function setShowClusterConfigurationPanel(showClusterConfigurationPanel) {
+        _showClusterConfigurationPanel = showClusterConfigurationPanel;
+        EventEmitterService.emit('showClusterConfigurationPanel', getShowClusterConfigurationPanel());
+    }
+
+    function showClusterConfigurationPanel() {
+        setShowClusterConfigurationPanel(true);
+    }
+
+    function hideClusterConfigurationPanel() {
+        setShowClusterConfigurationPanel(false);
+    }
+
+    function onShowClusterConfigurationPanel(callback) {
+        return EventEmitterService.subscribe('showClusterConfigurationPanel', () => callback(getShowClusterConfigurationPanel()));
+    }
+
+    return {
+        getShowClusterConfigurationPanel,
+        setShowClusterConfigurationPanel,
+        showClusterConfigurationPanel,
+        hideClusterConfigurationPanel,
+        onShowClusterConfigurationPanel
+    };
+}

--- a/src/js/angular/clustermanagement/templates/cluster-configuration.html
+++ b/src/js/angular/clustermanagement/templates/cluster-configuration.html
@@ -1,0 +1,89 @@
+<div class="cluster-configuration break-word-alt p-1 pt-2">
+    <button class="close mb-1 ml-1" ng-click="closeClusterConfigurationPanel()"></button>
+    <h3 class="hovered-parent">
+        {{'cluster_management.cluster_configuration.label' | translate}}
+    </h3>
+    <div class="mb-2" ng-if="isAdmin">
+        <button type="button" class="btn btn-secondary delete-cluster-btn mr-1"
+                ng-click="showDeleteDialog()"
+                gdb-tooltip="{{'cluster_management.buttons.delete_cluster_tooltip' | translate}}"
+                tooltip-placement="bottom">
+            <span class="icon-trash"></span> {{'cluster_management.buttons.delete_cluster' | translate}}
+        </button>
+        <button type="button" class="btn btn-primary edit-cluster-configuration"
+                ng-click="showEditConfigurationDialog()"
+                gdb-tooltip="{{'cluster_management.buttons.edit_cluster_tooltip' | translate}}"
+                tooltip-placement="bottom">
+            <span class="icon-edit mr-1"></span>{{'cluster_management.buttons.edit_cluster' | translate}}
+        </button>
+    </div>
+    <div class="datasource mb-1">
+        <div class="item clearfix break-word-alt small">
+            {{'cluster_management.cluster_configuration_properties.election_min_timeout' | translate}}
+            <em class="icon-info text-primary"
+                gdb-tooltip="{{'cluster_management.cluster_configuration_properties.election_min_timeout_tooltip' | translate}}"></em>
+        </div>
+        <div class="data-value">
+            <span>{{clusterConfiguration.electionMinTimeout | number}}</span>
+        </div>
+    </div>
+    <div class="datasource mb-1">
+        <div class="item clearfix break-word-alt small">
+            {{'cluster_management.cluster_configuration_properties.election_range_timeout' | translate}}
+            <em class="icon-info text-primary"
+                gdb-tooltip="{{'cluster_management.cluster_configuration_properties.election_range_timeout_tooltip' | translate}}"></em>
+        </div>
+        <div class="data-value">
+            <span>{{clusterConfiguration.electionRangeTimeout | number}}</span>
+        </div>
+    </div>
+    <div class="datasource mb-1">
+        <div class="item clearfix break-word-alt small">
+            {{'cluster_management.cluster_configuration_properties.heartbeat_interval' | translate}}
+            <em class="icon-info text-primary"
+                gdb-tooltip="{{'cluster_management.cluster_configuration_properties.heartbeat_interval_tooltip' | translate}}"></em>
+        </div>
+        <div class="data-value">
+            <span>{{clusterConfiguration.heartbeatInterval | number}}</span>
+        </div>
+    </div>
+    <div class="datasource mb-1">
+        <div class="item clearfix break-word-alt small">
+            {{'cluster_management.cluster_configuration_properties.message_size_kb' | translate}}
+            <em class="icon-info text-primary"
+                gdb-tooltip="{{'cluster_management.cluster_configuration_properties.message_size_kb_tooltip' | translate}}"></em>
+        </div>
+        <div class="data-value">
+            <span>{{clusterConfiguration.messageSizeKB | number}}</span>
+        </div>
+    </div>
+    <div class="datasource mb-1">
+        <div class="item clearfix break-word-alt small">
+            {{'cluster_management.cluster_configuration_properties.verification_timeout' | translate}}
+            <em class="icon-info text-primary"
+                gdb-tooltip="{{'cluster_management.cluster_configuration_properties.verification_timeout_tooltip' | translate}}"></em>
+        </div>
+        <div class="data-value">
+            <span>{{clusterConfiguration.verificationTimeout | number}}</span>
+        </div>
+    </div>
+    <div class="datasource mb-1">
+        <div class="item clearfix break-word-alt small">
+            {{'cluster_management.cluster_configuration_properties.transaction_log_maximum_size_gb' | translate}}
+            <em class="icon-info text-primary"
+                gdb-tooltip="{{'cluster_management.cluster_configuration_properties.transaction_log_maximum_size_gb_tooltip' | translate}}"></em>
+        </div>
+        <div class="data-value">
+            <span>{{clusterConfiguration.transactionLogMaximumSizeGB | number}}</span>
+        </div>
+    </div>
+    <h4>{{'cluster_management.cluster_configuration.nodes_list_label' | translate}}</h4>
+    <ul>
+        <li ng-repeat="node in clusterModel.nodes">
+            <a class="data-value" href="{{node.endpoint}}" target="_blank">{{node.endpoint}}</a>
+            <div class="small">{{ 'cluster_management.cluster_status.node.rpc_address' | translate }}: <span class="data-value">{{node.address}}</span>
+            </div>
+            <div class="small">{{ 'cluster_management.cluster_status.node.state' | translate }}: <span class="data-value">{{node.nodeState}}</span></div>
+        </li>
+    </ul>
+</div>

--- a/src/pages/cluster-management/clusterInfo.html
+++ b/src/pages/cluster-management/clusterInfo.html
@@ -24,31 +24,25 @@
 <div class="clearfix mb-2 d-flex" ng-if="!loader && clusterConfiguration">
     <div class="action-buttons">
         <div ng-if="isAdmin()" class="buttons-wrapper">
-            <button type="button" class="btn btn-secondary delete-cluster-btn mr-2"
-                    ng-click="showDeleteDialog()"
-                    gdb-tooltip="{{'cluster_management.buttons.delete_cluster_tooltip' | translate}}"
-                    tooltip-placement="bottom">
-                <span class="icon-trash"></span> {{'cluster_management.buttons.delete_cluster' | translate}}
-            </button>
             <button type="button" class="btn btn-secondary remove-node-btn" ng-if="currentLeader"
                     ng-click="showRemoveNodesFromClusterDialog()"
                     gdb-tooltip="{{'cluster_management.buttons.remove_nodes_btn_tooltip' | translate}}" tooltip-placement="bottom">
                 <span class="icon-minus"></span> {{'cluster_management.buttons.remove_nodes_btn' | translate}}
+            </button>
+            <button type="button" class="btn btn-secondary replace-nodes-btn" ng-if="currentLeader"
+                    ng-click="showReplaceNodesDialog()"
+                    gdb-tooltip="{{'cluster_management.buttons.replace_nodes_btn_tooltip' | translate}}" tooltip-placement="bottom">
+                <span class="icon-exchange"></span> {{'cluster_management.buttons.replace_nodes_btn' | translate}}
             </button>
             <button type="button" class="btn btn-primary add-node-btn" ng-if="currentLeader"
                     ng-click="showAddNodeToClusterDialog()"
                     gdb-tooltip="{{'cluster_management.buttons.add_nodes_btn_tooltip' | translate}}" tooltip-placement="bottom">
                 <span class="icon-plus"></span> {{'cluster_management.buttons.add_nodes_btn' | translate}}
             </button>
-            <button type="button" class="btn btn-primary replace-nodes-btn mr-2" ng-if="currentLeader"
-                    ng-click="showReplaceNodesDialog()"
-                    gdb-tooltip="{{'cluster_management.buttons.replace_nodes_btn_tooltip' | translate}}" tooltip-placement="bottom">
-                <span class="icon-exchange"></span> {{'cluster_management.buttons.replace_nodes_btn' | translate}}
-            </button>
         </div>
     </div>
     <button class="btn btn-link preview-cluster-config-btn"
-            ng-click="toggleSidePanel()"
+            ng-click="openClusterConfigurationPanel()"
             gdb-tooltip="{{'cluster_management.buttons.show_cluster_settings_tooltip' | translate}}"
             tooltip-placement="left"><span class="icon-settings settings-icon small"></span></button>
 </div>
@@ -91,95 +85,14 @@
 </div>
 
 <pageslide ng-show="clusterConfiguration"
-           ps-class="rdf-info-side-panel"
-           ps-open="shouldShowClusterSettingsPanel"
+           ps-class="cluster-configuration-panel rdf-info-side-panel"
+           ps-open="showClusterConfigurationPanel"
            onopen="onopen"
            onclose="onclose"
            ps-side="right"
            ps-custom-height="calc(100vh - 55px)"
            ps-size="25vw">
-    <div class="rdf-side-panel-content break-word-alt p-1 pt-2">
-        <button class="close mb-1 ml-1" ng-click="toggleSidePanel()"></button>
-        <h3 class="hovered-parent">
-            {{'cluster_management.cluster_configuration.label' | translate}}
-        </h3>
-        <div class="mb-2" ng-if="isAdmin()">
-            <button type="button" class="btn btn-primary edit-cluster-configuration"
-                    ng-if="currentNode.nodeState === NodeState.LEADER"
-                    ng-click="showEditConfigurationDialog()"
-                    gdb-tooltip="{{'cluster_management.buttons.edit_cluster_tooltip' | translate}}"
-                    tooltip-placement="bottom">
-                <span class="icon-edit mr-1"></span>{{'cluster_management.buttons.edit_cluster' | translate}}
-            </button>
-        </div>
-        <div class="datasource mb-1">
-            <div class="item clearfix break-word-alt small">
-                {{'cluster_management.cluster_configuration_properties.election_min_timeout' | translate}}
-                <em class="icon-info text-primary"
-                    gdb-tooltip="{{'cluster_management.cluster_configuration_properties.election_min_timeout_tooltip' | translate}}"></em>
-            </div>
-            <div class="data-value">
-                <span>{{clusterConfiguration.electionMinTimeout | number}}</span>
-            </div>
-        </div>
-        <div class="datasource mb-1">
-            <div class="item clearfix break-word-alt small">
-                {{'cluster_management.cluster_configuration_properties.election_range_timeout' | translate}}
-                <em class="icon-info text-primary"
-                    gdb-tooltip="{{'cluster_management.cluster_configuration_properties.election_range_timeout_tooltip' | translate}}"></em>
-            </div>
-            <div class="data-value">
-                <span>{{clusterConfiguration.electionRangeTimeout | number}}</span>
-            </div>
-        </div>
-        <div class="datasource mb-1">
-            <div class="item clearfix break-word-alt small">
-                {{'cluster_management.cluster_configuration_properties.heartbeat_interval' | translate}}
-                <em class="icon-info text-primary"
-                    gdb-tooltip="{{'cluster_management.cluster_configuration_properties.heartbeat_interval_tooltip' | translate}}"></em>
-            </div>
-            <div class="data-value">
-                <span>{{clusterConfiguration.heartbeatInterval | number}}</span>
-            </div>
-        </div>
-        <div class="datasource mb-1">
-            <div class="item clearfix break-word-alt small">
-                {{'cluster_management.cluster_configuration_properties.message_size_kb' | translate}}
-                <em class="icon-info text-primary"
-                    gdb-tooltip="{{'cluster_management.cluster_configuration_properties.message_size_kb_tooltip' | translate}}"></em>
-            </div>
-            <div class="data-value">
-                <span>{{clusterConfiguration.messageSizeKB | number}}</span>
-            </div>
-        </div>
-        <div class="datasource mb-1">
-            <div class="item clearfix break-word-alt small">
-                {{'cluster_management.cluster_configuration_properties.verification_timeout' | translate}}
-                <em class="icon-info text-primary"
-                    gdb-tooltip="{{'cluster_management.cluster_configuration_properties.verification_timeout_tooltip' | translate}}"></em>
-            </div>
-            <div class="data-value">
-                <span>{{clusterConfiguration.verificationTimeout | number}}</span>
-            </div>
-        </div>
-        <div class="datasource mb-1">
-            <div class="item clearfix break-word-alt small">
-                {{'cluster_management.cluster_configuration_properties.transaction_log_maximum_size_gb' | translate}}
-                <em class="icon-info text-primary"
-                    gdb-tooltip="{{'cluster_management.cluster_configuration_properties.transaction_log_maximum_size_gb_tooltip' | translate}}"></em>
-            </div>
-            <div class="data-value">
-                <span>{{clusterConfiguration.transactionLogMaximumSizeGB | number}}</span>
-            </div>
-        </div>
-        <h4>{{'cluster_management.cluster_configuration.nodes_list_label' | translate}}</h4>
-        <ul>
-            <li ng-repeat="node in clusterModel.nodes">
-                <a class="data-value" href="{{node.endpoint}}" target="_blank">{{node.endpoint}}</a>
-                <div class="small">{{ 'cluster_management.cluster_status.node.rpc_address' | translate }}: <span class="data-value">{{node.address}}</span>
-                </div>
-                <div class="small">{{ 'cluster_management.cluster_status.node.state' | translate }}: <span class="data-value">{{node.nodeState}}</span></div>
-            </li>
-        </ul>
-    </div>
+    <cluster-configuration current-node="currentNode"
+                           cluster-configuration="clusterConfiguration"
+                           cluster-model="clusterModel"></cluster-configuration>
 </pageslide>

--- a/test-cypress/integration/cluster/cluster-management.spec.js
+++ b/test-cypress/integration/cluster/cluster-management.spec.js
@@ -7,7 +7,7 @@ import {RemoteLocationStubs} from "../../stubs/cluster/remote-location-stubs";
 import {DeleteClusterDialogSteps} from "../../steps/cluster/delete-cluster-dialog-steps";
 import {ReplaceNodesDialogSteps} from "../../steps/cluster/replace-nodes-dialog-steps";
 import {ApplicationSteps} from "../../steps/application-steps";
-import {ClusterViewSteps} from "../../steps/cluster/cluster-view-steps";
+import {ClusterConfigurationSteps} from "../../steps/cluster/cluster-configuration-steps";
 
 describe('Cluster management', () => {
 
@@ -96,7 +96,6 @@ describe('Cluster management', () => {
         RemoteLocationStubs.stubRemoteLocationFilter();
         RemoteLocationStubs.stubRemoteLocationStatusInCluster();
         // And cluster management actions should be accessible
-        ClusterPageSteps.getClusterDeleteButton().should('be.visible');
         ClusterPageSteps.getRemoveNodesButton().should('be.visible');
         ClusterPageSteps.getAddNodesButton().should('be.visible');
         ClusterPageSteps.getReplaceNodesButton().should('be.visible');
@@ -117,7 +116,10 @@ describe('Cluster management', () => {
         ClusterPageSteps.getClusterPage().should('be.visible');
         ClusterPageSteps.getCreateClusterButton().should('not.have.class', 'no-cluster');
         // When I click on delete cluster
-        ClusterPageSteps.deleteCluster();
+        ClusterPageSteps.previewClusterConfig();
+        ClusterConfigurationSteps.getClusterConfig().should('be.visible');
+        ClusterConfigurationSteps.deleteCluster();
+        // ClusterConfigurationSteps.closeConfigurationPanel();
         // Then I expect a confirmation dialog to appear
         DeleteClusterDialogSteps.getDialog().should('be.visible');
         // When I confirm
@@ -129,100 +131,13 @@ describe('Cluster management', () => {
         ClusterStubs.stubNoClusterConfig();
         RemoteLocationStubs.stubRemoteLocationStatusNotCluster();
         DeleteClusterDialogSteps.getDialog().should('not.exist');
-        ClusterPageSteps.getClusterDeleteButton().should('not.exist');
+        ClusterPageSteps.previewClusterConfig();
+        ClusterConfigurationSteps.getDeleteClusterButton().should('be.hidden');
         ClusterPageSteps.getRemoveNodesButton().should('not.exist');
         ClusterPageSteps.getAddNodesButton().should('not.exist');
         ClusterPageSteps.getReplaceNodesButton().should('not.exist');
         ClusterPageSteps.getPreviewClusterConfigButton().should('not.exist');
         ClusterPageSteps.getCreateClusterButton().should('have.class', 'no-cluster');
-    });
-
-    it('Should be display correct message for "waiting-for-snapshot" recovery state', () => {
-        // Given I have opened the cluster management page
-        ClusterPageSteps.visit();
-
-        // Given there is an existing cluster created
-        ClusterStubs.stubClusterConfig();
-        // and two nodes have a "waiting-for-snapshot" recovery status. One of them is without an affected node.
-        ClusterStubs.stubClusterWithRecoveryStatusGroupStatus('waiting-for-snapshot');
-        ClusterStubs.stubClusterNodeStatus();
-        RemoteLocationStubs.stubRemoteLocationFilter();
-        RemoteLocationStubs.stubRemoteLocationStatusInCluster();
-
-        // Then I expect to see cluster view with 3 nodes,
-        ClusterViewSteps.getNodes().should('have.length', 3);
-        // The first, with corresponding for "waiting-for-snapshot" status message without affected nodes,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7200').should('have.text', 'Waiting for snapshot');
-        // The second, with corresponding for "waiting-for-snapshot" status message followed with affected nodes,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7201').should('have.text', 'Waiting for snapshot from node http://pc...');
-        // The third, without message,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7202').should('have.text', '');
-    });
-
-    it('Should be display correct message for "building-snapshot" recovery state', () => {
-        // Given I have opened the cluster management page
-        ClusterPageSteps.visit();
-
-        // Given there is an existing cluster created
-        ClusterStubs.stubClusterConfig();
-        // and two nodes have a "building-snapshot" recovery status. One of them is without an affected node.
-        ClusterStubs.stubClusterWithRecoveryStatusGroupStatus('building-snapshot');
-        ClusterStubs.stubClusterNodeStatus();
-        RemoteLocationStubs.stubRemoteLocationFilter();
-        RemoteLocationStubs.stubRemoteLocationStatusInCluster();
-
-        // Then I expect to see cluster view with 3 nodes,
-        ClusterViewSteps.getNodes().should('have.length', 3);
-        // The first, with corresponding for "building-snapshot" status message without affected nodes,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7200').should('have.text', 'Building a snapshot');
-        // The second, with corresponding for "building-snapshot" status message followed with affected nodes,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7201').should('have.text', 'Building a snapshot for http://pc-deskto...');
-        // The third, without message,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7202').should('have.text', '');
-    });
-
-    it('Should be display correct message for "sending-snapshot" recovery state', () => {
-        // Given I have opened the cluster management page
-        ClusterPageSteps.visit();
-
-        // Given there is an existing cluster created
-        ClusterStubs.stubClusterConfig();
-        // and two nodes have a "sending-snapshot" recovery status. One of them is without an affected node.
-        ClusterStubs.stubClusterWithRecoveryStatusGroupStatus('sending-snapshot');
-        ClusterStubs.stubClusterNodeStatus();
-        RemoteLocationStubs.stubRemoteLocationFilter();
-        RemoteLocationStubs.stubRemoteLocationStatusInCluster();
-
-        // Then I expect to see cluster view with 3 nodes,
-        ClusterViewSteps.getNodes().should('have.length', 3);
-        // The first, with corresponding for "sending-snapshot" status message without affected nodes,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7200').should('have.text', 'Sending a snapshot');
-        // The second, with corresponding for "sending-snapshot" status message followed with affected nodes,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7201').should('have.text', 'Sending a snapshot to node http://pc-des...');
-        // The third, without message,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7202').should('have.text', '');
-    });
-
-    it('Should be display correct message for "receiving-snapshot" recovery state', () => {
-        // Given I have opened the cluster management page
-        ClusterPageSteps.visit();
-
-        // Given there is an existing cluster created
-        ClusterStubs.stubClusterConfig();
-        // and two nodes have a "receiving-snapshot" recovery status. One of them is without an affected node.
-        ClusterStubs.stubClusterWithRecoveryStatusGroupStatus('receiving-snapshot');
-        ClusterStubs.stubClusterNodeStatus();
-        RemoteLocationStubs.stubRemoteLocationFilter();
-        RemoteLocationStubs.stubRemoteLocationStatusInCluster();
-
-        // Then I expect to see cluster view with 3 nodes,
-        ClusterViewSteps.getNodes().should('have.length', 3);
-        // The first, with corresponding for "receiving-snapshot" status message without affected nodes,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7200').should('have.text', 'Receiving a snapshot');
-        // The second, with corresponding for "receiving-snapshot" status message followed with affected nodes,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7201').should('have.text', 'Receiving a snapshot from node http://pc...');
-        // The third, without message,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7202').should('have.text', '');
     });
 
     it('Should be able to replace nodes in cluster', () => {

--- a/test-cypress/integration/cluster/cluster-states.spec.js
+++ b/test-cypress/integration/cluster/cluster-states.spec.js
@@ -1,0 +1,103 @@
+import {ClusterPageSteps} from "../../steps/cluster/cluster-page-steps";
+import {ClusterStubs} from "../../stubs/cluster/cluster-stubs";
+import {RemoteLocationStubs} from "../../stubs/cluster/remote-location-stubs";
+import {ClusterViewSteps} from "../../steps/cluster/cluster-view-steps";
+import {GlobalOperationsStatusesStub} from "../../stubs/global-operations-statuses-stub";
+
+describe('Cluster states', () => {
+
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'cluster-repo' + Date.now();
+        GlobalOperationsStatusesStub.stubNoOperationsResponse(repositoryId);
+    });
+
+    it('Should be display correct message for "waiting-for-snapshot" recovery state', () => {
+        // Given I have opened the cluster management page
+        ClusterPageSteps.visit();
+
+        // Given there is an existing cluster created
+        ClusterStubs.stubClusterConfig();
+        // and two nodes have a "waiting-for-snapshot" recovery status. One of them is without an affected node.
+        ClusterStubs.stubClusterWithRecoveryStatusGroupStatus('waiting-for-snapshot');
+        ClusterStubs.stubClusterNodeStatus();
+        RemoteLocationStubs.stubRemoteLocationFilter();
+        RemoteLocationStubs.stubRemoteLocationStatusInCluster();
+
+        // Then I expect to see cluster view with 3 nodes,
+        ClusterViewSteps.getNodes().should('have.length', 3);
+        // The first, with corresponding for "waiting-for-snapshot" status message without affected nodes,
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7200').should('have.text', 'Waiting for snapshot');
+        // The second, with corresponding for "waiting-for-snapshot" status message followed with affected nodes,
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7201').should('have.text', 'Waiting for snapshot from node http://pc...');
+        // The third, without message,
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7202').should('have.text', '');
+    });
+
+    it('Should be display correct message for "building-snapshot" recovery state', () => {
+        // Given I have opened the cluster management page
+        ClusterPageSteps.visit();
+
+        // Given there is an existing cluster created
+        ClusterStubs.stubClusterConfig();
+        // and two nodes have a "building-snapshot" recovery status. One of them is without an affected node.
+        ClusterStubs.stubClusterWithRecoveryStatusGroupStatus('building-snapshot');
+        ClusterStubs.stubClusterNodeStatus();
+        RemoteLocationStubs.stubRemoteLocationFilter();
+        RemoteLocationStubs.stubRemoteLocationStatusInCluster();
+
+        // Then I expect to see cluster view with 3 nodes,
+        ClusterViewSteps.getNodes().should('have.length', 3);
+        // The first, with corresponding for "building-snapshot" status message without affected nodes,
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7200').should('have.text', 'Building a snapshot');
+        // The second, with corresponding for "building-snapshot" status message followed with affected nodes,
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7201').should('have.text', 'Building a snapshot for http://pc-deskto...');
+        // The third, without message,
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7202').should('have.text', '');
+    });
+
+    it('Should be display correct message for "sending-snapshot" recovery state', () => {
+        // Given I have opened the cluster management page
+        ClusterPageSteps.visit();
+
+        // Given there is an existing cluster created
+        ClusterStubs.stubClusterConfig();
+        // and two nodes have a "sending-snapshot" recovery status. One of them is without an affected node.
+        ClusterStubs.stubClusterWithRecoveryStatusGroupStatus('sending-snapshot');
+        ClusterStubs.stubClusterNodeStatus();
+        RemoteLocationStubs.stubRemoteLocationFilter();
+        RemoteLocationStubs.stubRemoteLocationStatusInCluster();
+
+        // Then I expect to see cluster view with 3 nodes,
+        ClusterViewSteps.getNodes().should('have.length', 3);
+        // The first, with corresponding for "sending-snapshot" status message without affected nodes,
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7200').should('have.text', 'Sending a snapshot');
+        // The second, with corresponding for "sending-snapshot" status message followed with affected nodes,
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7201').should('have.text', 'Sending a snapshot to node http://pc-des...');
+        // The third, without message,
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7202').should('have.text', '');
+    });
+
+    it('Should be display correct message for "receiving-snapshot" recovery state', () => {
+        // Given I have opened the cluster management page
+        ClusterPageSteps.visit();
+
+        // Given there is an existing cluster created
+        ClusterStubs.stubClusterConfig();
+        // and two nodes have a "receiving-snapshot" recovery status. One of them is without an affected node.
+        ClusterStubs.stubClusterWithRecoveryStatusGroupStatus('receiving-snapshot');
+        ClusterStubs.stubClusterNodeStatus();
+        RemoteLocationStubs.stubRemoteLocationFilter();
+        RemoteLocationStubs.stubRemoteLocationStatusInCluster();
+
+        // Then I expect to see cluster view with 3 nodes,
+        ClusterViewSteps.getNodes().should('have.length', 3);
+        // The first, with corresponding for "receiving-snapshot" status message without affected nodes,
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7200').should('have.text', 'Receiving a snapshot');
+        // The second, with corresponding for "receiving-snapshot" status message followed with affected nodes,
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7201').should('have.text', 'Receiving a snapshot from node http://pc...');
+        // The third, without message,
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7202').should('have.text', '');
+    });
+});

--- a/test-cypress/steps/cluster/cluster-configuration-steps.js
+++ b/test-cypress/steps/cluster/cluster-configuration-steps.js
@@ -1,0 +1,17 @@
+export class ClusterConfigurationSteps {
+    static getClusterConfig() {
+        return cy.get('.cluster-configuration-panel');
+    }
+
+    static closeConfigurationPanel() {
+        this.getClusterConfig().find('.close').click();
+    }
+
+    static getDeleteClusterButton() {
+        return this.getClusterConfig().find('.delete-cluster-btn');
+    }
+
+    static deleteCluster() {
+        this.getDeleteClusterButton().click();
+    }
+}

--- a/test-cypress/steps/cluster/cluster-page-steps.js
+++ b/test-cypress/steps/cluster/cluster-page-steps.js
@@ -15,14 +15,6 @@ export class ClusterPageSteps {
         this.getCreateClusterButton().click();
     }
 
-    static getClusterDeleteButton() {
-        return cy.get('.delete-cluster-btn');
-    }
-
-    static deleteCluster() {
-        this.getClusterDeleteButton().click();
-    }
-
     static getRemoveNodesButton() {
         return cy.get('.remove-node-btn');
     }


### PR DESCRIPTION
## What
Redesign cluster configuration panel.

## Why
Hide the delete cluster button inside and simplify the main cluster-management.controller.js by extracting the cluster configuration in separate component.

## How
Extract cluster configuration in separate component and use it in the cluster view side panel. Introduced cluster-view-context.service.js for storing some context variables and allow inter-component communication.