### PR TITLE
GDB-10170: Issue with long names in the import-resource-tree component

### DIFF
--- a/src/css/import-resource-tree.css
+++ b/src/css/import-resource-tree.css
@@ -62,6 +62,7 @@
     display: flex;
     align-items: center;
     line-height: 18px;
+    word-break: break-all;
 }
 
 .import-resource-tree .import-resource-table .cell-title em {

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -157,10 +157,12 @@
                 <span class="cell-title">
                     <em ng-class="resource.iconClass"></em>
                     <div ng-if="onEditResource && resource.isEditable">
-                        <a href="#" ng-click="editResource(resource)"><strong>{{resource.name}}</strong></a>
+                        <a href="#" ng-click="editResource(resource)" title="{{resource.name}}">
+                            <strong>{{resource.shortenedName ? resource.shortenedName : resource.name}}</strong>
+                        </a>
                     </div>
-                    <div ng-if="!resource.isEditable">
-                        <strong>{{resource.name}}</strong>
+                    <div ng-if="!resource.isEditable" title="{{resource.name}}">
+                        <strong>{{resource.shortenedName ? resource.shortenedName : resource.name}}</strong>
                     </div>
                 </span>
             </td>
@@ -224,7 +226,7 @@
                    title="{{resource.importResource.context}}"
                    class="uri-link"
                    href="{{'resource?uri=' + resource.importResource.context + '&role=context'}}">
-                    {{resource.shorthedContext ? resource.shorthedContext : resource.importResource.context}}
+                    {{resource.shortenedContext ? resource.shortenedContext : resource.importResource.context}}
                 </a>
             </td>
         </tr>

--- a/src/js/angular/models/import/import-resource-tree-element.js
+++ b/src/js/angular/models/import/import-resource-tree-element.js
@@ -41,14 +41,19 @@ export class ImportResourceTreeElement {
          */
         this.name = '';
         /**
+         * If name is too long it have to be shortened with ellipses in the middle.
+         * @type {string}
+         */
+        this.shortenedName = '';
+        /**
          * @type {string}
          */
         this.path = '';
         /**
-         * If context link is too long it have to be shorted with ellipses in the middle.
+         * If context link is too long it have to be shortened with ellipses in the middle.
          * @type {string}
          */
-        this.shorthedContext = '';
+        this.shortenedContext = '';
         /**
          * @type {boolean}
          */

--- a/src/js/angular/rest/mappers/import-mapper.js
+++ b/src/js/angular/rest/mappers/import-mapper.js
@@ -8,8 +8,10 @@ export const toImportResource = (importResourcesServerData) => {
 };
 
 export const INDENT = 30;
-const PREFIX_AND_SUFFIX_CONTEXT_LENGTH = 30;
-const MAX_CONTEXT_LENGTH = PREFIX_AND_SUFFIX_CONTEXT_LENGTH * 2 + 3;
+const PREFIX_AND_SUFFIX_LENGTH = 30;
+const MAX_CONTEXT_LENGTH = PREFIX_AND_SUFFIX_LENGTH * 2 + 3;
+const MAX_NAME_LENGTH = PREFIX_AND_SUFFIX_LENGTH * 4 + 3;
+
 
 const serverImportResourceTypeToIconMapping = new Map();
 serverImportResourceTypeToIconMapping.set(ImportResourceType.DIRECTORY, 'icon-folder');
@@ -137,7 +139,8 @@ const setupAfterTreeInitProperties = (importResourceElement) => {
         importResourceElement.canResetStatus = canResetStatus(importResourceElement.importResource);
         importResourceElement.hasStatusInfo = importResourceElement.importResource.status === 'DONE' || importResourceElement.importResource.status === 'ERROR';
         importResourceElement.isEditable = importResourceElement.importResource.isText();
-        setupShortedContext(importResourceElement);
+        setupShortenedContext(importResourceElement);
+        setupShortenedName(importResourceElement);
         setupImportedAndModifiedComparableProperties(importResourceElement);
     }
     importResourceElement.directories.forEach((directory) => setupAfterTreeInitProperties(directory));
@@ -148,10 +151,21 @@ const setupAfterTreeInitProperties = (importResourceElement) => {
  * Setts shortedContext property if context is too long.
  * @param {ImportResourceTreeElement} importResourceElement
  */
-const setupShortedContext = (importResourceElement) => {
+const setupShortenedContext = (importResourceElement) => {
     const context = importResourceElement.importResource ? importResourceElement.importResource.context : '' || '';
     if (context.length > MAX_CONTEXT_LENGTH) {
-        importResourceElement.shorthedContext = context.substring(0, PREFIX_AND_SUFFIX_CONTEXT_LENGTH) + '...' + context.substring(context.length - PREFIX_AND_SUFFIX_CONTEXT_LENGTH);
+        importResourceElement.shortenedContext = context.substring(0, PREFIX_AND_SUFFIX_LENGTH) + '...' + context.substring(context.length - PREFIX_AND_SUFFIX_LENGTH);
+    }
+};
+
+/**
+ * Setts shortenedName property if name is too long.
+ * @param {ImportResourceTreeElement} importResourceElement
+ */
+const setupShortenedName = (importResourceElement) => {
+    const name = importResourceElement.name || '';
+    if (name.length > MAX_NAME_LENGTH) {
+        importResourceElement.shortenedName = name.substring(0, PREFIX_AND_SUFFIX_LENGTH) + '...' + name.substring(name.length - PREFIX_AND_SUFFIX_LENGTH);
     }
 };
 


### PR DESCRIPTION
## What
 In the User Data tab, the Import RDF files option allows files with extremely long file names, up to 255 characters, to be imported. As a result, the overview elements overlap each other, and each checkbox cannot be clicked.

## Why
 When the name is long and there is no space for it to break into a new line, the import-resource-tree component becomes larger than the workbench page, causing a horizontal scrollbar to appear. Moving the scrollbar to the right causes the checkboxes to move under the right panel menu. While they are visible, they are not clickable.

## How
 Added a property to the cell where the name is displayed that allows the browser to break the word anywhere.