### PR TITLE
GDB-10191 Added missing filtering for selected graphs, while exporting JSONLD and NDJSONLD

### DIFF
--- a/src/js/angular/export/controllers.js
+++ b/src/js/angular/export/controllers.js
@@ -261,6 +261,7 @@ exportCtrl.controller('ExportCtrl',
 
             $scope.openJSONLDExportSettingsForSelectedGraphs = function (format) {
                 const contextsArray = Object.keys($scope.selectedGraphs.exportGraphs)
+                    .filter((index) => $scope.selectedGraphs.exportGraphs[index])
                     .map((index) => $scope.graphsByValue[index].exportUri);
 
                 if (contextsArray) {


### PR DESCRIPTION
What?
When user selects more than one graph for export in Graphs View and afterwards deselect one or more this isn't reflected and all the deselected graphs are exported as well.

Why?


How?
I added filtering of selected graphs when exporting JSONLD & NDJSONLD.