### PR TITLE
GDB-10160 redesign cluster visualization

### DIFF
--- a/src/css/clustermanagement.css
+++ b/src/css/clustermanagement.css
@@ -12,11 +12,11 @@
 }
 
 .cluster-view path.link {
-    stroke-width: 3px;
+    stroke-width: 5px;
 }
 
 .cluster-zone {
-    stroke: black;
+    stroke: var(--gray-color);
     fill: transparent;
 }
 

--- a/src/css/clustermanagement.css
+++ b/src/css/clustermanagement.css
@@ -1,29 +1,29 @@
 .cluster-view {
-  position: relative;
+    position: relative;
 }
 
 .cluster-view svg {
-  background-color: #FFF;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
-  user-select: none;
+    background-color: #FFF;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -o-user-select: none;
+    user-select: none;
 }
 
 .cluster-view path.link {
-  stroke-width: 3px;
+    stroke-width: 3px;
 }
 
 .cluster-zone {
-  stroke: black;
-  fill: transparent;
+    stroke: black;
+    fill: transparent;
 }
 
 .cluster-zone.no-cluster {
-  stroke: black;
-  fill: transparent;
-  transition: fill 0.2s, stroke 0.2s;
+    stroke: black;
+    fill: transparent;
+    transition: fill 0.2s, stroke 0.2s;
 }
 
 .cluster-zone.no-cluster.has-access {
@@ -31,225 +31,228 @@
 }
 
 .cluster-zone.no-cluster:hover {
-  stroke-width: 3 !important;
-  fill: #f7f7f7 !important;
-  height: 120%;
-  width: 120%;
+    stroke-width: 3 !important;
+    fill: #f7f7f7 !important;
+    height: 120%;
+    width: 120%;
 }
 
 .settings-icon {
-  font-size: 110px !important;
+    font-size: 110px !important;
 }
 
 .settings-icon.small {
-  font-size: 56px !important;
+    font-size: 56px !important;
 }
 
 .toggle-legend-icon {
-  font-size: 40px !important;
+    font-size: 40px !important;
 }
 
 .node {
-  cursor: pointer;
-  fill: var(--gray-color);
-  stroke: black;
+    cursor: pointer;
+    fill: var(--gray-color);
 }
 
 .node.leader {
-  fill: var(--primary-color)
+    fill: var(--primary-color);
+    stroke: var(--primary-color);
 }
 
 .node.follower {
-  fill: var(--secondary-color)
+    fill: var(--secondary-color);
+    stroke: var(--secondary-color);
 }
 
 .node.candidate {
-  fill: var(--tertiary-color)
+    fill: var(--tertiary-color);
+    stroke: var(--tertiary-color);
 }
 
 .node.other {
-  fill: var(--gray-color)
+    fill: var(--gray-color);
+    stroke: var(--gray-color);
 }
 
 #node-group.legend .node {
-  cursor: default;
-  stroke-width: 0.5;
+    cursor: default;
+    stroke-width: 0.5;
 }
 
 #node-group.legend .node-icon {
-  font-size: 25px;
+    font-size: 25px;
 }
 
 .legend .id-host {
-  font-size: 9px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-  text-align: center;
-  font-weight: 400;
-  color: black;
+    font-size: 9px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    text-align: center;
+    font-weight: 400;
+    color: black;
 }
 
 .legend-group .label-wrapper {
-  overflow: visible;
+    overflow: visible;
 }
 
 .toggle-legend-btn {
-  position: absolute;
-  bottom: 0;
+    position: absolute;
+    bottom: 0;
 }
 
 .legend-group.hidden {
-  visibility: hidden;
+    visibility: hidden;
 }
 
 .hidden {
-  display: none;
+    display: none;
 }
 
 text.node-icon {
-  fill: rgba(255, 255, 255, 0.5);
-  font-size: 40px;
+    fill: rgba(255, 255, 255, 0.5);
+    font-size: 40px;
 }
 
 .id-host-background, .node-info-background {
-  fill: #EEEEEE;
+    fill: #EEEEEE;
 }
 
 text.node-icon {
-  text-anchor: middle;
-  dominant-baseline: central;
+    text-anchor: middle;
+    dominant-baseline: central;
 }
 
 text {
-  font-family: var(--main-font) !important;
-  font-size: 12px;
-  pointer-events: none;
+    font-family: var(--main-font) !important;
+    font-size: 12px;
+    pointer-events: none;
 }
 
 text.id-host, .node-info-fo {
-  text-anchor: middle;
-  font-weight: 400;
+    text-anchor: middle;
+    font-weight: 400;
 }
 
 .node-info-fo {
-  cursor: pointer;
+    cursor: pointer;
 }
 
 .text-btn {
-  background: none;
-  border: none;
-  margin: 0;
-  padding-top: .1rem;
-  cursor: pointer;
+    background: none;
+    border: none;
+    margin: 0;
+    padding-top: .1rem;
+    cursor: pointer;
 }
 
 .text-btn:focus, .text-btn {
-  outline: none !important;
-  box-shadow: none
+    outline: none !important;
+    box-shadow: none
 }
 
 .no-margin-list ul {
-  margin-bottom: 0;
+    margin-bottom: 0;
 }
 
 div.nodetooltip {
-  z-index: 1000;
-  position: absolute;
-  padding: 10px;
-  padding-left: 30px;
-  font-size: 90%;
-  text-align: left;
-  background: rgba(235, 235, 235, 0.9);
-  width: 40%;
-  max-width: 400px;
+    z-index: 1000;
+    position: absolute;
+    padding: 10px;
+    padding-left: 30px;
+    font-size: 90%;
+    text-align: left;
+    background: rgba(235, 235, 235, 0.9);
+    width: 40%;
+    max-width: 400px;
 }
 
 .main-menu.collapsed ~ div .legend-container {
-  left: 90px;
+    left: 90px;
 }
 
 .cluster-loader {
-  position: relative;
-  z-index: 100000;
+    position: relative;
+    z-index: 100000;
 }
 
 .cluster-loader .ot-loader-new-content {
-  position: absolute;
-  z-index: 100000;
-  width: 100%;
-  height: calc(100vh - 120px);
-  padding-top: calc((100vh - 300px) / 2);
-  background-color: rgba(255, 255, 255, 0.66);
+    position: absolute;
+    z-index: 100000;
+    width: 100%;
+    height: calc(100vh - 120px);
+    padding-top: calc((100vh - 300px) / 2);
+    background-color: rgba(255, 255, 255, 0.66);
 }
 
 .create-cluster-loader {
-  position: absolute;
-  margin: auto;
-  display: flex;
-  z-index: 100000;
-  background-color: rgba(255, 255, 255, 0.66);
+    position: absolute;
+    margin: auto;
+    display: flex;
+    z-index: 100000;
+    background-color: rgba(255, 255, 255, 0.66);
 
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
 }
 
 .cluster-configuration-panel {
-  z-index: 1016 !important;
+    z-index: 1016 !important;
 }
 
 .locations-list {
-  border: 1px solid;
-  min-height: 8rem;
-  max-height: 18rem;
-  overflow: auto;
+    border: 1px solid;
+    min-height: 8rem;
+    max-height: 18rem;
+    overflow: auto;
 }
 
 .locations-list .location-item {
-  justify-content: space-between;
+    justify-content: space-between;
 }
 
 .location-item {
-  padding: 2px;
-  -webkit-user-select: none;
-  user-select: none;
-  word-break: break-all;
+    padding: 2px;
+    -webkit-user-select: none;
+    user-select: none;
+    word-break: break-all;
 
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
 }
 
 .location-item.hoverable:not(.list-group-item-danger):hover {
-  background-color: rgba(0, 0, 0, .05);
-  cursor: pointer;
+    background-color: rgba(0, 0, 0, .05);
+    cursor: pointer;
 }
 
 .location-item.hoverable.list-group-item-danger:hover {
-  cursor: not-allowed;
+    cursor: not-allowed;
 }
 
 .list-group-item-node {
-  cursor: pointer;
-  padding: 0;
+    cursor: pointer;
+    padding: 0;
 }
 
 .list-group-item-node a {
-  padding: 0.75rem 1.25rem;
+    padding: 0.75rem 1.25rem;
 }
 
 .logo-image {
-  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIxLjAuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA0NyA2Ny4yIiBzdHlsZT0iIiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRjA0RTIzO30KPC9zdHlsZT4KPHRpdGxlPmdyYXBoZGItbG9nby1uby10ZXh0PC90aXRsZT4KCTxnPgoJPHBhdGggY2xhc3M9InN0MCIgZD0iTTM5LjMsMjcuOGM0LjMsMC45LDcsNSw2LjEsOS4zYy0wLjksNC4zLTUsNy05LjMsNi4xYy00LjItMC45LTctNS02LjItOS4yYzAuOC00LjIsNC45LTcsOS4xLTYuMgoJCUMzOS4yLDI3LjcsMzkuMiwyNy43LDM5LjMsMjcuOCIvPgoJPHBhdGggY2xhc3M9InN0MCIgZD0iTTIzLDQwLjNjMi41LDAuNiw0LjEsMywzLjcsNS41Yy0wLjUsMi41LTMsNC4xLTUuNSwzLjZjLTIuNS0wLjUtNC4xLTIuOS0zLjctNS41QzE4LjEsNDEuNCwyMC41LDM5LjgsMjMsNDAuMwoJCSIvPgoJPHBhdGggY2xhc3M9InN0MCIgZD0iTTI5LjQsMThjMS43LDAuNCwyLjgsMiwyLjUsMy43Yy0wLjQsMS43LTIsMi44LTMuNywyLjVjLTEuNy0wLjQtMi44LTItMi41LTMuN2MwLDAsMCwwLDAsMAoJCUMyNiwxOC44LDI3LjcsMTcuNywyOS40LDE4QzI5LjQsMTgsMjkuNCwxOCwyOS40LDE4Ii8+Cgk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMjMuOSwxLjZjMy4yLDIuNSwzLjgsNywxLjMsMTAuM3MtNywzLjgtMTAuMywxLjNjLTMuMi0yLjUtMy44LTctMS4zLTEwLjJDMTYtMC4yLDIwLjYtMC44LDIzLjksMS42CgkJQzIzLjgsMS42LDIzLjgsMS42LDIzLjksMS42Ii8+Cgk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMTIuMyw0OS40YzIuNywyLjgsMi42LDcuMi0wLjIsOS44Yy0yLjgsMi43LTcuMiwyLjYtOS44LTAuMmMtMi43LTIuOC0yLjYtNy4yLDAuMi05LjhjMCwwLDAsMCwwLDAKCQlDNS4zLDQ2LjUsOS42LDQ2LjYsMTIuMyw0OS40Ii8+CjwvZz4KPC9zdmc+Cg==) no-repeat left center;
-  height: 25px;
-  width: 25px;
+    background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIxLjAuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA0NyA2Ny4yIiBzdHlsZT0iIiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRjA0RTIzO30KPC9zdHlsZT4KPHRpdGxlPmdyYXBoZGItbG9nby1uby10ZXh0PC90aXRsZT4KCTxnPgoJPHBhdGggY2xhc3M9InN0MCIgZD0iTTM5LjMsMjcuOGM0LjMsMC45LDcsNSw2LjEsOS4zYy0wLjksNC4zLTUsNy05LjMsNi4xYy00LjItMC45LTctNS02LjItOS4yYzAuOC00LjIsNC45LTcsOS4xLTYuMgoJCUMzOS4yLDI3LjcsMzkuMiwyNy43LDM5LjMsMjcuOCIvPgoJPHBhdGggY2xhc3M9InN0MCIgZD0iTTIzLDQwLjNjMi41LDAuNiw0LjEsMywzLjcsNS41Yy0wLjUsMi41LTMsNC4xLTUuNSwzLjZjLTIuNS0wLjUtNC4xLTIuOS0zLjctNS41QzE4LjEsNDEuNCwyMC41LDM5LjgsMjMsNDAuMwoJCSIvPgoJPHBhdGggY2xhc3M9InN0MCIgZD0iTTI5LjQsMThjMS43LDAuNCwyLjgsMiwyLjUsMy43Yy0wLjQsMS43LTIsMi44LTMuNywyLjVjLTEuNy0wLjQtMi44LTItMi41LTMuN2MwLDAsMCwwLDAsMAoJCUMyNiwxOC44LDI3LjcsMTcuNywyOS40LDE4QzI5LjQsMTgsMjkuNCwxOCwyOS40LDE4Ii8+Cgk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMjMuOSwxLjZjMy4yLDIuNSwzLjgsNywxLjMsMTAuM3MtNywzLjgtMTAuMywxLjNjLTMuMi0yLjUtMy44LTctMS4zLTEwLjJDMTYtMC4yLDIwLjYtMC44LDIzLjksMS42CgkJQzIzLjgsMS42LDIzLjgsMS42LDIzLjksMS42Ii8+Cgk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMTIuMyw0OS40YzIuNywyLjgsMi42LDcuMi0wLjIsOS44Yy0yLjgsMi43LTcuMiwyLjYtOS44LTAuMmMtMi43LTIuOC0yLjYtNy4yLDAuMi05LjhjMCwwLDAsMCwwLDAKCQlDNS4zLDQ2LjUsOS42LDQ2LjYsMTIuMyw0OS40Ii8+CjwvZz4KPC9zdmc+Cg==) no-repeat left center;
+    height: 25px;
+    width: 25px;
 }
 
 .action-buttons {
-  flex-grow: 1;
+    flex-grow: 1;
 }
 
 .advanced-options-toggle {
-  margin-right: 6px;
+    margin-right: 6px;
 }

--- a/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
+++ b/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
@@ -10,7 +10,7 @@ import 'angular/clustermanagement/controllers/add-nodes.controller';
 import 'angular/clustermanagement/controllers/replace-nodes.controller';
 import {isString} from "lodash";
 import {LinkState, NodeState} from "../../models/clustermanagement/states";
-import {CLICK_IN_VIEW, DELETE_CLUSTER, MODEL_UPDATED, NODE_SELECTED, UPDATE_CLUSTER} from "../events";
+import {CLICK_IN_VIEW, CREATE_CLUSTER, DELETE_CLUSTER, MODEL_UPDATED, NODE_SELECTED, UPDATE_CLUSTER} from "../events";
 
 const modules = [
     'ui.bootstrap',
@@ -451,6 +451,9 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
         }));
         subscriptions.push($scope.$on(NODE_SELECTED, (event, data) => {
             selectNode(data);
+        }));
+        subscriptions.push($scope.$on(CREATE_CLUSTER, () => {
+            $scope.showCreateClusterDialog();
         }));
     };
 

--- a/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
+++ b/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
@@ -419,9 +419,9 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
     };
 
     /**
-     * @param {HTMLElement} targetEl The element which is the target of the click event.
+     * @param {HTMLElement} targetEl The element which is the event target.
      */
-    const mousedownHandler = function (targetEl) {
+    const deselectNode = function (targetEl) {
         const nodeTooltipElement = document.getElementById('nodeTooltip');
         if ($scope.selectedNode && nodeTooltipElement !== targetEl && !nodeTooltipElement.contains(targetEl)) {
             selectNode(null);
@@ -447,7 +447,7 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
             deleteCluster(data.force);
         }));
         subscriptions.push($scope.$on(CLICK_IN_VIEW, (event, data) => {
-            mousedownHandler(data);
+            deselectNode(data);
         }));
         subscriptions.push($scope.$on(NODE_SELECTED, (event, data) => {
             selectNode(data);

--- a/src/js/angular/clustermanagement/directives/cluster-configuration.directive.js
+++ b/src/js/angular/clustermanagement/directives/cluster-configuration.directive.js
@@ -6,9 +6,9 @@ angular
     .module('graphdb.framework.clustermanagement.directives.cluster-configuration', modules)
     .directive('clusterConfiguration', ClusterConfiguration);
 
-ClusterConfiguration.$inject = ['$jwtAuth', '$uibModal', '$translate', 'toastr', 'ClusterViewContextService', 'ClusterRestService'];
+ClusterConfiguration.$inject = ['$jwtAuth', '$uibModal', '$translate', 'toastr', 'ClusterViewContextService'];
 
-function ClusterConfiguration($jwtAuth, $uibModal, $translate, toastr, ClusterViewContextService, ClusterRestService) {
+function ClusterConfiguration($jwtAuth, $uibModal, $translate, toastr, ClusterViewContextService) {
     return {
         restrict: 'E',
         templateUrl: 'js/angular/clustermanagement/templates/cluster-configuration.html',

--- a/src/js/angular/clustermanagement/directives/cluster-graphical-view.directive.js
+++ b/src/js/angular/clustermanagement/directives/cluster-graphical-view.directive.js
@@ -3,7 +3,7 @@ import * as CDS from "../services/cluster-drawing.service";
 import {LinkState, NodeState, RecoveryState} from "../../models/clustermanagement/states";
 import d3tip from 'lib/d3-tip/d3-tip-patch';
 import {cloneDeep, get, isEmpty} from "lodash";
-import {CLICK_IN_VIEW, MODEL_UPDATED, NODE_SELECTED} from "../events";
+import {CLICK_IN_VIEW, CREATE_CLUSTER, MODEL_UPDATED, NODE_SELECTED} from "../events";
 
 const navigationBarWidthFull = 240;
 const navigationBarWidthCollapsed = 70;
@@ -207,6 +207,19 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
 
                     linksGroup = svg.append('g').attr('id', 'links-group');
                     nodesGroup = svg.append('g').attr('id', 'nodes-group');
+
+                    svg.append("svg:defs").append("svg:marker")
+                        .attr("id", "arrowhead")
+                        .attr("viewBox", "0 0 10 10")
+                        .attr("refX", 5)
+                        .attr("refY", 5)
+                        .attr("markerWidth", 5)
+                        .attr("markerHeight", 5)
+                        .attr("orient", "auto-start-reverse")
+                        .append("path")
+                        .attr("d", "M 0 0 L 10 5 L 0 10 z")
+                        .style("fill", "var(--secondary-color)");
+
                     createLegendGroup();
                 }
 
@@ -309,7 +322,6 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
                     // Position node/link state labels
                     nodeStateLabel.attr('x', legendPadding + legendWidth / 2);
                     linkStateLabel.attr('x', legendPadding + legendWidth / 2);
-
 
                     const linkWidth = legendWidth / 3;
 
@@ -425,16 +437,11 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
 
                 function setClusterZoneType(hasCluster) {
                     CDS.setCreateClusterZone(hasCluster, clusterZone, translationsMap, hasAccess);
-                    let mouseupCallback;
                     if (!hasCluster && hasAccess) {
-                        mouseupCallback = () => {
-                            scope.$apply(function () {
-                                scope.showCreateClusterDialog();
-                            });
-                        };
+                        clusterZone.on('mouseup', () => {
+                            scope.$emit(CREATE_CLUSTER);
+                        });
                     }
-                    clusterZone
-                        .on('mouseup', mouseupCallback);
                 }
 
                 function getNodesModel() {

--- a/src/js/angular/clustermanagement/directives/cluster-graphical-view.directive.js
+++ b/src/js/angular/clustermanagement/directives/cluster-graphical-view.directive.js
@@ -8,7 +8,7 @@ import {CLICK_IN_VIEW, MODEL_UPDATED, NODE_SELECTED} from "../events";
 const navigationBarWidthFull = 240;
 const navigationBarWidthCollapsed = 70;
 let navigationBarWidth = navigationBarWidthFull;
-const nodeRadius = 50;
+const nodeRadius = 45;
 const legendNodeRadius = 25;
 
 // Labels in translation map is dynamically translated and reassigned. It contains defaults

--- a/src/js/angular/clustermanagement/events.js
+++ b/src/js/angular/clustermanagement/events.js
@@ -16,6 +16,12 @@ export const CLICK_IN_VIEW = 'clickInView';
 export const NODE_SELECTED = 'nodeSelected';
 
 /**
+ * Event fired when the cluster zone visualization is clicked while there is no cluster yet.
+ * @type {string}
+ */
+export const CREATE_CLUSTER = 'createCluster';
+
+/**
  * Event fired from the cluster management view component down to the child visualization informing it that the model
  * was updated.
  * @type {string}

--- a/src/js/angular/clustermanagement/events.js
+++ b/src/js/angular/clustermanagement/events.js
@@ -1,2 +1,23 @@
 export const UPDATE_CLUSTER = 'updateCluster';
 export const DELETE_CLUSTER = 'deleteCluster';
+
+/**
+ * Event fired from the cluster-graphical-view component up to its parent when user clicks somewhere in the view.
+ * The payload is the event target HTMLElement.
+ * @type {string}
+ */
+export const CLICK_IN_VIEW = 'clickInView';
+
+/**
+ * Event fired from the cluster-graphical-view component up to its parent when user selects a node from the visualization.
+ * The payload is the selected node.
+ * @type {string}
+ */
+export const NODE_SELECTED = 'nodeSelected';
+
+/**
+ * Event fired from the cluster management view component down to the child visualization informing it that the model
+ * was updated.
+ * @type {string}
+ */
+export const MODEL_UPDATED = 'modelUpdated';

--- a/src/js/angular/clustermanagement/services/cluster-drawing.service.js
+++ b/src/js/angular/clustermanagement/services/cluster-drawing.service.js
@@ -8,6 +8,24 @@ const clusterColors = {
     ontoGrey: 'var(--gray-color)'
 };
 
+const linkStateColors = {
+    [LinkState.IN_SYNC]: clusterColors.ontoBlue,
+    [LinkState.SYNCING]: clusterColors.ontoBlue,
+    [LinkState.OUT_OF_SYNC]: clusterColors.ontoGrey,
+    [LinkState.RECEIVING_SNAPSHOT]: clusterColors.ontoBlue
+};
+
+const linkStateStyle = {
+    // solid line
+    [LinkState.IN_SYNC]: 'none',
+    // dashed line
+    [LinkState.SYNCING]: '10 10',
+    // dashed line
+    [LinkState.OUT_OF_SYNC]: '10 10',
+    // dashed line
+    [LinkState.RECEIVING_SNAPSHOT]: '10 10'
+};
+
 const font = {
     FONT_AWESOME: 'FONT_AWESOME',
     ICOMOON: 'ICOMOON'
@@ -372,6 +390,11 @@ export function createLinks(linksDataBinding) {
 
 export function updateLinks(linksDataBinding, nodes) {
     linksDataBinding
+        .attr('class', (link) => {
+            // add the link id as a css class for testing purposes
+            const idClass = link.id.replaceAll(':', '-');
+            return `link ${idClass}`;
+        })
         .attr('stroke', setLinkColor)
         .style('stroke-dasharray', setLinkStyle)
         .style("marker-mid", addArrow)
@@ -379,29 +402,19 @@ export function updateLinks(linksDataBinding, nodes) {
 }
 
 function addArrow(link) {
-    if (link.status === LinkState.SYNCING) {
+    if (link.status === LinkState.RECEIVING_SNAPSHOT) {
         return "url(#arrowhead)";
     }
 }
 
 export function setLinkColor(link) {
-    if (link.status === LinkState.IN_SYNC) {
-        return clusterColors.ontoBlue;
-    } else if (link.status === LinkState.SYNCING) {
-        return clusterColors.ontoBlue;
-    } else if (link.status === LinkState.OUT_OF_SYNC) {
-        return clusterColors.ontoGrey;
-    }
-    return 'none';
+    const linkColor = linkStateColors[link.status];
+    return linkColor || 'none';
 }
 
 export function setLinkStyle(link) {
-    if (link.status === LinkState.OUT_OF_SYNC || link.status === LinkState.SYNCING) {
-        return '10 10';
-    } else if (link.status === LinkState.IN_SYNC) {
-        return 'none';
-    }
-    return 'none';
+    const linkStyle = linkStateStyle[link.status];
+    return linkStyle || 'none';
 }
 
 function getLinkCoordinates(link, nodes) {

--- a/src/js/angular/clustermanagement/services/cluster-drawing.service.js
+++ b/src/js/angular/clustermanagement/services/cluster-drawing.service.js
@@ -184,6 +184,14 @@ const iconMap = {
     [RecoveryState.RECOVERY_OPERATION_FAILURE_WARNING]: {icon: '\ue920', font: font.ICOMOON}
 };
 
+const nodeStateIcons = {
+    [NodeState.CANDIDATE]: {icon: '\ue914', font: font.ICOMOON},
+    [NodeState.NO_CONNECTION]: {icon: '\ue931', font: font.ICOMOON},
+    [NodeState.OUT_OF_SYNC]: {icon: '\ue920', font: font.ICOMOON},
+    [NodeState.READ_ONLY]: {icon: '\ue95c', font: font.ICOMOON},
+    [NodeState.RESTRICTED]: {icon: '\ue933', font: font.ICOMOON}
+};
+
 function getNodeInfoIconType(node) {
     const status = node.recoveryStatus;
 
@@ -195,22 +203,8 @@ function getNodeInfoIconType(node) {
 }
 
 function getNodeIconType(node) {
-    if (node.nodeState === NodeState.LEADER) {
-        return {icon: '\ue935', font: font.ICOMOON};
-    } else if (node.nodeState === NodeState.FOLLOWER) {
-        return {icon: '\ue963', font: font.ICOMOON};
-    } else if (node.nodeState === NodeState.CANDIDATE) {
-        return {icon: '\ue914', font: font.ICOMOON};
-    } else if (node.nodeState === NodeState.NO_CONNECTION) {
-        return {icon: '\ue931', font: font.ICOMOON};
-    } else if (node.nodeState === NodeState.OUT_OF_SYNC) {
-        return {icon: '\ue920', font: font.ICOMOON};
-    } else if (node.nodeState === NodeState.READ_ONLY) {
-        return {icon: '\ue95c', font: font.ICOMOON};
-    } else if (node.nodeState === NodeState.RESTRICTED) {
-        return {icon: '\ue933', font: font.ICOMOON};
-    }
-    return {icon: '', font: ''};
+    const iconType = nodeStateIcons[node.nodeState];
+    return iconType ? iconType : {icon: '', font: ''};
 }
 
 function updateNodesInfoText(nodes) {
@@ -446,6 +440,8 @@ function createHexagon(nodeGroup, radius) {
         .enter()
         .append("path")
         .attr('class', 'node member')
+        .attr("stroke-width", "10")
+        .attr("stroke-linejoin", "round")
         .attr("d", d3.line());
 }
 

--- a/src/js/angular/clustermanagement/services/cluster-drawing.service.js
+++ b/src/js/angular/clustermanagement/services/cluster-drawing.service.js
@@ -1,4 +1,5 @@
 import {LinkState, NodeState, RecoveryState} from "../../models/clustermanagement/states";
+import {isEmpty} from "lodash";
 
 const clusterColors = {
     ontoOrange: 'var(--primary-color)',
@@ -170,7 +171,7 @@ function updateNodesIcon(nodes) {
 }
 
 function hasRecoveryState(node) {
-    return !_.isEmpty(node.recoveryStatus);
+    return !isEmpty(node.recoveryStatus);
 }
 
 const iconMap = {
@@ -225,7 +226,7 @@ function updateNodesInfoText(nodes) {
         })
         .append('foreignObject')
         .attr('width', function (d) {
-            if (_.isEmpty(d.recoveryStatus)) {
+            if (isEmpty(d.recoveryStatus)) {
                 return 0;
             }
             const shortMessage = extractShortMessageFromNode(d);
@@ -235,7 +236,7 @@ function updateNodesInfoText(nodes) {
             return objectWidth;
         })
         .attr('height', function (d) {
-            if (_.isEmpty(d.recoveryStatus)) {
+            if (isEmpty(d.recoveryStatus)) {
                 return 0;
             }
             return objectHeight;
@@ -247,7 +248,7 @@ function updateNodesInfoText(nodes) {
             return 78;
         })
         .classed('hidden', function (d) {
-            return _.isEmpty(d.recoveryStatus);
+            return isEmpty(d.recoveryStatus);
         })
         .style('font-size', '12px')
         .style('font-weight', '400')
@@ -315,7 +316,7 @@ function resizeLabelDynamic(nodes) {
     nodes.select('.node-info-fo')
         .each(function (d) {
             const object = d3.select(this);
-            if (_.isEmpty(d.recoveryStatus)) {
+            if (isEmpty(d.recoveryStatus)) {
                 object.attr('width', 0);
                 return;
             }

--- a/src/js/angular/clustermanagement/services/cluster-drawing.service.js
+++ b/src/js/angular/clustermanagement/services/cluster-drawing.service.js
@@ -130,12 +130,12 @@ function addHostnameToNodes(nodeElements, nodeRadius, isLegend) {
 
         nodeTextHost
             .append('text')
-            .attr('y', nodeRadius + 15)
+            .attr('y', nodeRadius + 25)
             .attr('class', 'id id-host');
 
         nodeTextHost
             .append('text')
-            .attr('y', nodeRadius + 45)
+            .attr('y', nodeRadius + 55)
             .attr('class', 'node-info-text');
     }
 }

--- a/src/js/angular/models/clustermanagement/states.js
+++ b/src/js/angular/models/clustermanagement/states.js
@@ -23,5 +23,7 @@ export const LinkState = {
     IN_SYNC: 'IN_SYNC',
     OUT_OF_SYNC: 'OUT_OF_SYNC',
     SYNCING: 'SYNCING',
-    NO_CONNECTION: 'NO_CONNECTION'
+    NO_CONNECTION: 'NO_CONNECTION',
+    // complimentary state, built based on the recovery state of two nodes when one is receiving snapshot to the other
+    RECEIVING_SNAPSHOT: 'RECEIVING_SNAPSHOT'
 };

--- a/src/pages/cluster-management/clusterInfo.html
+++ b/src/pages/cluster-management/clusterInfo.html
@@ -73,15 +73,7 @@
 </div>
 
 <div ng-if="!loader" class="cluster-view">
-    <div cluster-graphical-view></div>
-    <div id="toggle-legend-button" class="toggle-legend-btn">
-        <button class="btn btn-link"
-                ng-click="toggleLegend()"
-                gdb-tooltip="{{'cluster_management.cluster_page.toggle_legend_btn' | translate}}"
-                tooltip-placement="right">
-            <span class="icon-help toggle-legend-icon"></span>
-        </button>
-    </div>
+    <cluster-graphical-view cluster-model="clusterModel" legend-visible=""></cluster-graphical-view>
 </div>
 
 <pageslide ng-show="clusterConfiguration"

--- a/test-cypress/fixtures/cluster/3-nodes-cluster-group-status-receiving-snapshot.json
+++ b/test-cypress/fixtures/cluster/3-nodes-cluster-group-status-receiving-snapshot.json
@@ -8,7 +8,7 @@
         "lastLogIndex": 0,
         "endpoint": "http://pc-desktop:7200",
         "recoveryStatus": {
-            "affectedNodes": [],
+            "affectedNodes": ["http://pc-desktop:7202"],
             "state": "RECEIVING_SNAPSHOT"
         }
     },
@@ -17,16 +17,13 @@
         "nodeState": "LEADER",
         "term": 2,
         "syncStatus": {
-            "pc-desktop:7300": "IN_SYNC",
+            "pc-desktop:7300": "OUT_OF_SYNC",
             "pc-desktop:7302": "IN_SYNC"
         },
         "lastLogTerm": 0,
         "lastLogIndex": 0,
         "endpoint": "http://pc-desktop:7201",
-        "recoveryStatus": {
-            "affectedNodes": ["http://pc-desktop:7200"],
-            "state": "RECEIVING_SNAPSHOT"
-        }
+        "recoveryStatus": {}
     },
     {
         "address": "pc-desktop:7302",
@@ -36,6 +33,9 @@
         "lastLogTerm": 0,
         "lastLogIndex": 0,
         "endpoint": "http://pc-desktop:7202",
-        "recoveryStatus": {}
+        "recoveryStatus": {
+            "affectedNodes": ["http://pc-desktop:7200"],
+            "state": "SENDING_SNAPSHOT"
+        }
     }
 ]

--- a/test-cypress/integration/cluster/cluster-states.spec.js
+++ b/test-cypress/integration/cluster/cluster-states.spec.js
@@ -13,7 +13,7 @@ describe('Cluster states', () => {
         GlobalOperationsStatusesStub.stubNoOperationsResponse(repositoryId);
     });
 
-    it('Should be display correct message for "waiting-for-snapshot" recovery state', () => {
+    it('Should display correct message for "waiting-for-snapshot" recovery state', () => {
         // Given I have opened the cluster management page
         ClusterPageSteps.visit();
 
@@ -35,7 +35,7 @@ describe('Cluster states', () => {
         ClusterViewSteps.getNodeInfoText('pc-desktop:7202').should('have.text', '');
     });
 
-    it('Should be display correct message for "building-snapshot" recovery state', () => {
+    it('Should display correct message for "building-snapshot" recovery state', () => {
         // Given I have opened the cluster management page
         ClusterPageSteps.visit();
 
@@ -57,7 +57,7 @@ describe('Cluster states', () => {
         ClusterViewSteps.getNodeInfoText('pc-desktop:7202').should('have.text', '');
     });
 
-    it('Should be display correct message for "sending-snapshot" recovery state', () => {
+    it('Should display correct message for "sending-snapshot" recovery state', () => {
         // Given I have opened the cluster management page
         ClusterPageSteps.visit();
 
@@ -79,7 +79,7 @@ describe('Cluster states', () => {
         ClusterViewSteps.getNodeInfoText('pc-desktop:7202').should('have.text', '');
     });
 
-    it('Should be display correct message for "receiving-snapshot" recovery state', () => {
+    it('Should display correct message for "receiving-snapshot" recovery state', () => {
         // Given I have opened the cluster management page
         ClusterPageSteps.visit();
 
@@ -94,10 +94,24 @@ describe('Cluster states', () => {
         // Then I expect to see cluster view with 3 nodes,
         ClusterViewSteps.getNodes().should('have.length', 3);
         // The first, with corresponding for "receiving-snapshot" status message without affected nodes,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7200').should('have.text', 'Receiving a snapshot');
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7200').should('have.text', 'Receiving a snapshot from node http://pc...');
         // The second, with corresponding for "receiving-snapshot" status message followed with affected nodes,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7201').should('have.text', 'Receiving a snapshot from node http://pc...');
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7202').should('have.text', 'Sending a snapshot to node http://pc-des...');
         // The third, without message,
-        ClusterViewSteps.getNodeInfoText('pc-desktop:7202').should('have.text', '');
+        ClusterViewSteps.getNodeInfoText('pc-desktop:7201').should('have.text', '');
+
+        // Then I expect receiving snapshot link between the node which is sending and the one which is receiving a snapshot
+        ClusterViewSteps.getLink('pc-desktop-7300-pc-desktop-7302').should('have.css', 'stroke-dasharray', '10px, 10px')
+            .and('have.css', 'marker-mid', 'url("#arrowhead")')
+            .invoke('attr', 'stroke')
+            .should('eq', 'var(--secondary-color)');
+        // And I expect an out of sync link between the leader and the out of sync node (the one receiving the snapshot)
+        ClusterViewSteps.getLink('pc-desktop-7301-pc-desktop-7300').should('have.css', 'stroke-dasharray', '10px, 10px')
+            .invoke('attr', 'stroke')
+            .should('eq', 'var(--gray-color)');
+        // And I expect to have an in sync link between the leader and the node sending the snapshot
+        ClusterViewSteps.getLink('pc-desktop-7301-pc-desktop-7302').should('have.css', 'stroke-dasharray', 'none')
+            .invoke('attr', 'stroke')
+            .should('eq', 'var(--secondary-color)');
     });
 });

--- a/test-cypress/steps/cluster/cluster-view-steps.js
+++ b/test-cypress/steps/cluster/cluster-view-steps.js
@@ -1,14 +1,18 @@
 export class ClusterViewSteps {
 
-   static getNodes() {
+    static getNodes() {
         return cy.get('.id-host-background').parent().parent();
     }
 
     static getNode(host) {
-       return ClusterViewSteps.getNodes().contains(host).parent().parent();
+        return ClusterViewSteps.getNodes().contains(host).parent().parent();
     }
 
     static getNodeInfoText(host) {
         return ClusterViewSteps.getNode(host).find('.node-info-fo');
+    }
+
+    static getLink(id) {
+        return cy.get(`path.link.${id}`);
     }
 }


### PR DESCRIPTION
## What
Redesign cluster visualization.

## Why
Allow better perceiving and improved interraction with the cluster view from the users.

## How
* Make cluster node hexagons having rounded corners.
* Make node links thiker.
* Changed color of the cluster zone circle and also thiker.
* Add arrowhead to links in receiving snapshot state.
* Removed artificial childContext shared between cluster-management.controller and cluster-graphical-view.directive which was needless and used to introduce tight coupling between them. Replaced interaction with events. Also moved some code from the controller to directive where it belongs. 
* Simplified some of the functions in the cluster-drawing.service by replacing conditional logic with static resolution from predefined mappings.
* Added test to verify the receiving snapshot link is properly rendered.

NOTE: This merge request removes the legend link. It'll be back with the next MR.