### PR TITLE
GDB-9233: YASQE - Different color styling of query

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -1,5 +1,12 @@
 @import "../common.css";
 
+/** Fixes the issue with the color of the sequence of < or > characters.
+This resolves the problem described in more detail in the issue tracker: "https://ontotext.atlassian.net/browse/GDB-9233"
+ */
+.CodeMirror-line span[class|="cm"]::after {
+    content: "\200c\200b"
+}
+
 /* Resets the default font-size for every tag in the yasgui */
 /* Omit the heading  tags */
 yasgui-component :not(h3,h4,sup) {


### PR DESCRIPTION
## What
There is an issue with the color styling of the "<<<" or ">>>" sequences in Microsoft Edge, Firefox, and Chrome.

## Why
JetBrains Mono has contextual ligatures for sequences of < and > (e.g. <<, <<<, >>, >>>). Affected browsers use the ligatures even when CSS says individual characters should have different formatting (in our case color).

## How
Added zero-width characters via ::after