### PR TITLE
GDB-10211: Cluster configuration menu irregular behavior on zoom-out

### DIFF
--- a/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
+++ b/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
@@ -60,6 +60,7 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
     $scope.leaderChanged = false;
     $scope.currentLeader = null;
     $scope.showClusterConfigurationPanel = false;
+    $scope.clusterConfigurationPanelSize = undefined;
 
     // =========================
     // Public functions
@@ -459,8 +460,13 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
         subscriptions.forEach((subscription) => subscription());
     };
 
+    const updateClusterConfigurationPanelSize = () => {
+        $scope.clusterConfigurationPanelSize = 0.25 * window.innerWidth + 'px';
+    };
+
     const subscribeHandlers = () => {
         subscriptions.push(ClusterViewContextService.onShowClusterConfigurationPanel((show) => {
+            updateClusterConfigurationPanelSize();
             $scope.showClusterConfigurationPanel = show;
         }));
         subscriptions.push($scope.$on(UPDATE_CLUSTER, (event, data) => {
@@ -490,6 +496,7 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
 
     const init = () => {
         subscribeHandlers();
+        updateClusterConfigurationPanelSize();
         $scope.showClusterConfigurationPanel = ClusterViewContextService.getShowClusterConfigurationPanel();
 
         loadInitialData()

--- a/src/pages/cluster-management/clusterInfo.html
+++ b/src/pages/cluster-management/clusterInfo.html
@@ -84,7 +84,7 @@
            onclose="onclose"
            ps-side="right"
            ps-custom-height="calc(100vh - 55px)"
-           ps-size="25vw">
+           ps-size="{{ clusterConfigurationPanelSize }}">
     <cluster-configuration current-node="currentNode"
                            cluster-configuration="clusterConfiguration"
                            cluster-model="clusterModel"></cluster-configuration>


### PR DESCRIPTION
## What
In Cluster management - the Cluster configuration menu pops-out  unexpectedly, when a zoom-out ( ctrl+mouse scroll ) action is performed in the browser.

## Why
It seems like the issue is related to the way the page slide panel (<pageslide>) is being sized using viewport units (vw). When the window is resizing by pressing control and scrolling, this might cause the page slide panel to momentarily appear or reposition due to the change in its size.

## How
Added a fixed size for the panel width, which is calculated before the panel is opened.