### PR TITLE
GDB-9502 - add newest yasgui version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.3.9",
+                "ontotext-yasgui-web-component": "1.3.10",
                 "shepherd.js": "^11.2.0"
             },
             "devDependencies": {
@@ -10184,9 +10184,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.9",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.9.tgz",
-            "integrity": "sha512-ffupuf0tX17X2bU6iiJRoDsWEvjD9vAfSvcfOY/ghefgONZd5d/Q1BYnmWECvE6JP44wy6Khh4sbMIlYiVLTEQ==",
+            "version": "1.3.10",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.10.tgz",
+            "integrity": "sha512-nhxN4NtStqzMR7CBiSWmbgEuIMxMsk93Z+3rS5rA5ERKLnc8vCNaZJsEItztgM4AIi5hmjZpbNZ9nvoOQdVq/Q==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24754,9 +24754,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.3.9",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.9.tgz",
-            "integrity": "sha512-ffupuf0tX17X2bU6iiJRoDsWEvjD9vAfSvcfOY/ghefgONZd5d/Q1BYnmWECvE6JP44wy6Khh4sbMIlYiVLTEQ==",
+            "version": "1.3.10",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.10.tgz",
+            "integrity": "sha512-nhxN4NtStqzMR7CBiSWmbgEuIMxMsk93Z+3rS5rA5ERKLnc8vCNaZJsEItztgM4AIi5hmjZpbNZ9nvoOQdVq/Q==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.3.9",
+        "ontotext-yasgui-web-component": "1.3.10",
         "shepherd.js": "^11.2.0"
     },
     "resolutions": {


### PR DESCRIPTION
## What?
Update YASGUI component version to 1.3.10.

## Why?
A new YASGUI component version was released with the following improvement:
- Google chart width will take up the full window width

## How?
Package.json was updated.