### PR TITLE
GDB-10156 fix buttons height in yasr toolbar

### DIFF
--- a/src/css/lib/ontotext-yasgui-web-component.css
+++ b/src/css/lib/ontotext-yasgui-web-component.css
@@ -162,6 +162,11 @@ yasgui-component .yasr-toolbar {
     line-height: 1.25;
 }
 
+/* Make all buttons in the yasr toolbar having equal height same as the other WB buttons. */
+yasgui-component .yasr-toolbar .yasr-toolbar-element {
+    height: 38px;
+}
+
 yasgui-component .yasr-toolbar .explore-visual-graph-button {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## What
It appears that some of the buttons rendered in the yasr toolbar have greater height than expected.

## Why
For consistency with the other large buttons in the WB.

## How
Applied some explicit height for the buttons in the yasr toolbar.