### PR TITLE
GDB-8254: Import tab quickly flashes a wrong message

### DIFF
--- a/src/js/angular/core/directives.js
+++ b/src/js/angular/core/directives.js
@@ -140,8 +140,6 @@ function coreErrors($timeout) {
 
             scope.setAttrs(attrs);
 
-            scope.setRestricted();
-
             let previousElement;
 
             scope.showRemoteLocations = false;

--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -221,8 +221,6 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
          * !!!This should be public because it's used by the upload and import controllers
          */
         $scope.onRepositoryChange = () => {
-            // Update restricted on repositoryIsSet
-            $scope.setRestricted();
             if ($scope.isRestricted) {
                 return;
             }


### PR DESCRIPTION
## What
Some of the WB view depends on the selected repository. These views used the "core-error" directive inform users, that they must choose a repository before continue. However, when users refresh these views, the error directive is displayed briefly, regardless of whether a repository has already been chosen.

## Why
In the initial implementation of the core error directive, each view that used it called the 'setRestricted' function of the main controller.  This function calculated a value based on how the directive was configured and set the result to the global variable 'isRestricted.' Over time, the function grew more complex, and at one point, the result began to depend on the selected repository. As a result, the function was modified, and the flow was changed so that all function calls were moved from the views to the main controller within a hook triggered when the repository is selected. However, for some reason, the calls from the directive and import view were not removed [MR](https://github.com/Ontotext-AD/graphdb-workbench/pull/499). After this modification, the error directive started blinking when the views were refreshed.

When a page is refreshed, the error directive initializes. At this point, 'setRestricted' is called, but it calculates the wrong result because the repository is not set yet, leading to the display of the error message. Once the repository is set and 'setRestricted' is called for the second time, 'isRestricted' is calculated correctly, and the error message is hidden.

## How
Removes forbidden and unnecessary calls of "setRestricted" from error directive and import-view controller.