### PR TITLE
GDB-10242: Creating a visual graph config throws 404 when a preview is requested

### DIFF
--- a/src/js/angular/graphexplore/controllers/graphs-config.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-config.controller.js
@@ -482,7 +482,7 @@ function GraphConfigCtrl(
     }
 
     const getQueryEndpoint = () => {
-        return `/repositories/${$repositories.getActiveRepository()}`;
+        return `repositories/${$repositories.getActiveRepository()}`;
     };
 
     const defaultYasguiConfig = {

--- a/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/src/js/angular/similarity/controllers/create-index.controller.js
@@ -541,7 +541,7 @@ function CreateSimilarityIdxCtrl(
     }
 
     const getQueryEndpoint = () => {
-        return `/repositories/${$repositories.getActiveRepository()}`;
+        return `repositories/${$repositories.getActiveRepository()}`;
     };
 
     /**


### PR DESCRIPTION
## What
When GraphDB is behind a reverse proxy and there is a context path:
 - the previewing the visual graph query fail to load.
 - the test query of similarity index fail to load.

## Why
There were a slash in the beginning of relative urls

## How
The slashes has been removed