### PR TITLE
GDB-10134 increase characters limit for importing text snippet

### DIFF
--- a/src/js/angular/import/controllers/import-text-snippet.controller.js
+++ b/src/js/angular/import/controllers/import-text-snippet.controller.js
@@ -27,7 +27,8 @@ function ImportTextSnippetController($scope, $uibModalInstance, text, format) {
     $scope.rdfText = text;
     $scope.importFormat = $scope.importFormats.find((formatModel) => formatModel.type === format);
     $scope.startImport = true;
-    $scope.sizeLimit = 4000;
+    // Total amount of characters that can be imported via the text snippet dialog
+    $scope.sizeLimit = 100000;
 
 
     // =========================


### PR DESCRIPTION
## What
Increased characters limit for importing text snippet to 100000 chars.

## Why
Previous limit was 4000 chars which appeared too low for real life application so it was decided to be increased.

## How
Increased the config value.