### PR TITLE
increase ontotext-yasgui component version to 1.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.3.10",
+                "ontotext-yasgui-web-component": "1.3.11",
                 "shepherd.js": "^11.2.0"
             },
             "devDependencies": {
@@ -10184,9 +10184,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.10.tgz",
-            "integrity": "sha512-nhxN4NtStqzMR7CBiSWmbgEuIMxMsk93Z+3rS5rA5ERKLnc8vCNaZJsEItztgM4AIi5hmjZpbNZ9nvoOQdVq/Q==",
+            "version": "1.3.11",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.11.tgz",
+            "integrity": "sha512-m/Hj5HOxNLiX01HbZuUbC+apyhI2pqB+JPD0wi4unk6QAA6Lz8TwbG0Fj26EUvaE7s9NqwlMocJoSqcQBuMNww==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -24754,9 +24754,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.10.tgz",
-            "integrity": "sha512-nhxN4NtStqzMR7CBiSWmbgEuIMxMsk93Z+3rS5rA5ERKLnc8vCNaZJsEItztgM4AIi5hmjZpbNZ9nvoOQdVq/Q==",
+            "version": "1.3.11",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.11.tgz",
+            "integrity": "sha512-m/Hj5HOxNLiX01HbZuUbC+apyhI2pqB+JPD0wi4unk6QAA6Lz8TwbG0Fj26EUvaE7s9NqwlMocJoSqcQBuMNww==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.3.10",
+        "ontotext-yasgui-web-component": "1.3.11",
         "shepherd.js": "^11.2.0"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Increase ontotext-yasgui component version to 1.3.11.

## Why
Changes coming with the new version:
* GDB-3107 extend datatable to allow sorting individual columns based on the values type

## How
Increased the dependency version.