### PR TITLE
GDB-7884 optimize cluster view requests when no cluster is configured

### DIFF
--- a/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
+++ b/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
@@ -127,6 +127,10 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
                     $scope.clusterModel.nodes = [];
                     $scope.clusterModel.links = [];
                     $scope.clusterConfiguration = null;
+                    // Return from the local catch to allow error propagation furter
+                    // in the promise chain, because we actually want to skip the next
+                    // requests in the chain.
+                    return Promise.reject(error);
                 }
             });
     };

--- a/test-cypress/integration/cluster/cluster-management.spec.js
+++ b/test-cypress/integration/cluster/cluster-management.spec.js
@@ -119,7 +119,6 @@ describe('Cluster management', () => {
         ClusterPageSteps.previewClusterConfig();
         ClusterConfigurationSteps.getClusterConfig().should('be.visible');
         ClusterConfigurationSteps.deleteCluster();
-        // ClusterConfigurationSteps.closeConfigurationPanel();
         // Then I expect a confirmation dialog to appear
         DeleteClusterDialogSteps.getDialog().should('be.visible');
         // When I confirm
@@ -131,8 +130,6 @@ describe('Cluster management', () => {
         ClusterStubs.stubNoClusterConfig();
         RemoteLocationStubs.stubRemoteLocationStatusNotCluster();
         DeleteClusterDialogSteps.getDialog().should('not.exist');
-        ClusterPageSteps.previewClusterConfig();
-        ClusterConfigurationSteps.getDeleteClusterButton().should('be.hidden');
         ClusterPageSteps.getRemoveNodesButton().should('not.exist');
         ClusterPageSteps.getAddNodesButton().should('not.exist');
         ClusterPageSteps.getReplaceNodesButton().should('not.exist');


### PR DESCRIPTION
## What
Optimize cluster view requests when no cluster is configured.

## Why
Currently there is a flaw in the request promise chain where when the first request for the cluster status fails with 404 and is caught in the catch clause there is no return from there which makes the next request in the promise to advance and to actually be executed although there is no need from that.

## How
Added a return with rejection from the cluster status promise catch in order to allow the error to be propagated to the parent promise catch and next requests to be skipped.