### PR TITLE
GDB-9968 - Stop the query editor from scrolling up on paste

### DIFF
--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -443,7 +443,6 @@ function yasguiComponentDirective(
                     .then(SparqlRestService.addKnownPrefixes)
                     .then((response) => {
                         queryString = response.data;
-                        ontotextYasguiElement.setQuery(queryString);
                     })
                     .then(() => {
                         emitQueryChanged(JSON.stringify(queryString));


### PR DESCRIPTION
## What?
If the user expands the query editor using the control bar at the bottom, and is writing a long query. While scrolled to the end and the beginning of the query is not visible, pasting new text will not cause the editor to scroll up to the cursor position. It will remain where the end of the query is visible.

## Why?
In the above described case, when scrolled to the bottom of a long query, pasting text made the scroll reposition higher up. The user would lose sight of the end of the query.

## How?
I removed a function call in the `codeMirrorPasteHandler` for setting the query in the editor after it has been pasted. 

## Anything else?
Example query tested with:
```
SELECT ?s ?p ?o
WHERE {
	?s1 ?p1 ?o1 .
    ?s1 ?p2 ?o2 .
    ?s1 ?p3 ?o3 .
    ?s1 ?p4 ?o4 .
    ?s1 ?p5 ?o5 .
    ?s1 ?p6 ?o6 .
    ?s1 ?p7 ?o7 .
    ?s1 ?p8 ?o8 .
    ?s1 ?p9 ?o9 .
    ?s1 ?p10 ?o10 .
    ?s1 ?p11 ?o11 .
    ?s1 ?p12 ?o12 .
    
    ?s1 ?p13 ?o13 .
    
    ?s1 ?p14 ?o14 .
    ?s1 ?p15 ?o15 .
    ?s1 ?p16 ?o16 .
    ?s1 ?p17 ?o17 .
    ?s1 ?p18 ?o18 .
    ?s1 ?p19 ?o19 .
    ?s1 ?p20 ?o20 .
    ?s1 ?p21 ?o21 .
    ?s1 ?p22 ?o22 .
    ?s1 ?p23 ?o23 .
    ?s1 ?p24 ?o24 .
    ?s1 ?p24 ?o25 .
    ?s1 ?p24 ?o25 .
    ?s1 ?p24 ?o25 .
    ?s1 ?p24 ?o25 .
    ?s1 ?p24 ?o25 .
    ?s1 ?p24 ?o26 .
    ?s1 ?p24 ?o26 .
    ?s1 ?p24 ?o26 .
    
    
    
}
```

When pasting between the last line and the closing bracket, the bracket remains within view.
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/6d200325-c286-4116-afc0-fc5b3abc0a3e)
