### PR TITLE
Enable the import button for folders.

### DIFF
--- a/src/js/angular/rest/mappers/import-mapper.js
+++ b/src/js/angular/rest/mappers/import-mapper.js
@@ -87,6 +87,7 @@ const addResourceToTree = (root, resource) => {
         return importServerResource;
     } else {
         resourceParent.importResource = resource;
+        resourceParent.path = path.join('/');
         return resourceParent;
     }
 };
@@ -181,7 +182,7 @@ const setupImportedAndModifiedComparableProperties = (importResourceElement) => 
 };
 
 const isImportable = (importResource) => {
-    return importResource.isFile() && importResource.status !== ImportResourceStatus.IMPORTING && importResource.status !== ImportResourceStatus.UPLOADING && importResource.status !== ImportResourceStatus.PENDING && importResource.status !== ImportResourceStatus.INTERRUPTING;
+    return importResource.status !== ImportResourceStatus.IMPORTING && importResource.status !== ImportResourceStatus.UPLOADING && importResource.status !== ImportResourceStatus.PENDING && importResource.status !== ImportResourceStatus.INTERRUPTING;
 };
 
 const hasOngoingImport = (importResource) => {


### PR DESCRIPTION
What
Enable the import button for folders in the server view.

Why
To match the behavior of the old implementation.

How
Change the condition to determine whether the import button is visible. Field paths of directories are needed for the reset button functionality.