### PR TITLE
GDB-9570 - show message when invalid custom role is written in User c…

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -484,6 +484,7 @@
     "security.count.all.results": "Count all SPARQL results",
     "security.read.write.access": "Repositories read/write access",
     "security.user.rights": "Users should have rights to at least one repository!",
+    "security.user.role.too.short": "Must be at least 2 symbols long",
     "security.no.active.location": "There is no active location.",
     "security.repository.title": "Repository",
     "security.tooltip.read": "Read",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -487,6 +487,7 @@
     "security.count.all.results": "Compter tous les résultats SPARQL",
     "security.read.write.access": "Accès en lecture/écriture aux dépôts\n",
     "security.user.rights": "Les utilisateurs doivent avoir des droits sur au moins un dépôt !",
+    "security.user.role.too.short": "Doit contenir au moins 2 symboles",
     "security.no.active.location": "Il n'y a pas de dépôt actif.",
     "security.repository.title": "Dépôt",
     "security.tooltip.read": "Lire",

--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -484,30 +484,30 @@ securityCtrl.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 'toa
             return $scope.user && !$scope.user.appSettings.DEFAULT_INFERENCE;
         };
 
-        $scope.isRoleValid = false;
+        $scope.showRoleValidationError = false;
         const minTagLength = 2;
 
         $scope.addCustomRole = function (role) {
-            $scope.isRoleValid = false;
+            $scope.showRoleValidationError = false;
             role.text = role.text.toUpperCase();
             return role;
         };
 
         $scope.validateTag = function (tag) {
-            $scope.isRoleValid = tag.text.length < minTagLength;
-            return !$scope.isRoleValid;
+            $scope.showRoleValidationError = tag.text.length < minTagLength;
+            return !$scope.showRoleValidationError;
         };
 
         $scope.checkForBackspace = function(event) {
             // If the key pressed is the backspace or delete key, the tag error message will be hidden
             if (event.keyCode === 8 || event.keyCode === 46) {
-                $scope.isRoleValid = false;
+                $scope.showRoleValidationError = false;
             }
         };
 
         $scope.removeErrorOnCut = function() {
             // If the user cuts text from the field, the tag error message will be hidden
-            $scope.isRoleValid = false;
+            $scope.showRoleValidationError = false;
         };
     }]);
 

--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -484,28 +484,30 @@ securityCtrl.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 'toa
             return $scope.user && !$scope.user.appSettings.DEFAULT_INFERENCE;
         };
 
-        $scope.showTagError = false;
+        $scope.isRoleValid = false;
+        const minTagLength = 2;
 
         $scope.addCustomRole = function (role) {
-            $scope.showTagError = false;
+            $scope.isRoleValid = false;
             role.text = role.text.toUpperCase();
             return role;
         };
 
         $scope.validateTag = function (tag) {
-            if (tag.text.length < 2 ) {
-                $scope.showTagError = true;
-                return false;
-            }
-            $scope.showTagError = false;
-            return true;
+            $scope.isRoleValid = tag.text.length < minTagLength;
+            return !$scope.isRoleValid;
         };
 
         $scope.checkForBackspace = function(event) {
             // If the key pressed is the backspace or delete key, the tag error message will be hidden
             if (event.keyCode === 8 || event.keyCode === 46) {
-                $scope.showTagError = false;
+                $scope.isRoleValid = false;
             }
+        };
+
+        $scope.removeErrorOnCut = function() {
+            // If the user cuts text from the field, the tag error message will be hidden
+            $scope.isRoleValid = false;
         };
     }]);
 

--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -484,30 +484,54 @@ securityCtrl.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 'toa
             return $scope.user && !$scope.user.appSettings.DEFAULT_INFERENCE;
         };
 
-        $scope.showRoleValidationError = false;
+        /**
+         * The validity of the last user typed custom role.
+         * @type {boolean}
+         */
+        $scope.isRoleValid = true;
         const minTagLength = 2;
 
+        /**
+         * Adds the user typed custom role and sets role validity flag to true.
+         *
+         * @param {{text: string}} role the user input
+         * @return {{text: string}} the user input in uppercase
+         */
         $scope.addCustomRole = function (role) {
-            $scope.showRoleValidationError = false;
+            $scope.isRoleValid = true;
             role.text = role.text.toUpperCase();
             return role;
         };
 
-        $scope.validateTag = function (tag) {
-            $scope.showRoleValidationError = tag.text.length < minTagLength;
-            return !$scope.showRoleValidationError;
+        /**
+         * Checks if the input text is valid or not.
+         *
+         * @param {{text: string}} fieldValue the user input
+         * @return {boolean} true if valid, otherwise false
+         */
+        $scope.isCustomRoleValid = function (fieldValue) {
+            $scope.isRoleValid = fieldValue.text.length >= minTagLength;
+            return $scope.isRoleValid;
         };
 
+        /**
+         * Checks if the user pressed the 'Backspace' or 'Delete' key and sets the role validity flag accordingly.
+         *
+         * @param {Object} event
+         */
         $scope.checkForBackspace = function(event) {
             // If the key pressed is the backspace or delete key, the tag error message will be hidden
             if (event.keyCode === 8 || event.keyCode === 46) {
-                $scope.showRoleValidationError = false;
+                $scope.isRoleValid = true;
             }
         };
 
+        /**
+         * Sets the role validity flag to true.
+         */
         $scope.removeErrorOnCut = function() {
             // If the user cuts text from the field, the tag error message will be hidden
-            $scope.showRoleValidationError = false;
+            $scope.isRoleValid = true;
         };
     }]);
 

--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -484,9 +484,28 @@ securityCtrl.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 'toa
             return $scope.user && !$scope.user.appSettings.DEFAULT_INFERENCE;
         };
 
+        $scope.showTagError = false;
+
         $scope.addCustomRole = function (role) {
+            $scope.showTagError = false;
             role.text = role.text.toUpperCase();
             return role;
+        };
+
+        $scope.validateTag = function (tag) {
+            if (tag.text.length < 2 ) {
+                $scope.showTagError = true;
+                return false;
+            }
+            $scope.showTagError = false;
+            return true;
+        };
+
+        $scope.checkForBackspace = function(event) {
+            // If the key pressed is the backspace or delete key, the tag error message will be hidden
+            if (event.keyCode === 8 || event.keyCode === 46) {
+                $scope.showTagError = false;
+            }
         };
     }]);
 

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -209,7 +209,7 @@
                     <div class="card-block">
                         <h3>{{'security.user.custom_role' | translate}}</h3>
                         <div class="input-group">
-                            <tags-input class="wb-tags-input" ng-model="customRoles" min-length="2"
+                            <tags-input name="customRoleTag" class="wb-tags-input" ng-model="customRoles" min-length="2"
                                         ng-disabled="!isUser() || mode === 'settings'"
                                         use-strings="true"
                                         add-on-space="true"
@@ -219,6 +219,9 @@
                                         paste-split-pattern="[\s+]"
                                         on-tag-added="addCustomRole($tag)"
                                         placeholder="{{'security.user.add.custom_role.msg' | translate}}"></tags-input>
+                            <div class="small" ng-if="form.customRoleTag.$touched && !form.customRoleTag.$valid">
+                                <small>{{'security.user.role.too.short' | translate}}</small>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -269,7 +272,7 @@
 
 		<div class="text-right">
             <button id="wb-user-goBack" class="btn btn-secondary" type="button" ng-click="goBack()">{{'common.cancel.btn' | translate}}</button>
-            <button id="wb-user-submit" class="btn btn-primary" type="submit">{{saveButtonText}}</button>
+            <button id="wb-user-submit" class="btn btn-primary" type="submit" ng-disabled="form.customRoleTag.$touched && !form.customRoleTag.$valid">{{saveButtonText}}</button>
 		</div>
 	</form>
 </div>

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -220,8 +220,9 @@
                                         on-tag-adding="validateTag($tag)"
                                         on-tag-added="addCustomRole($tag)"
                                         ng-keydown="checkForBackspace($event)"
+                                        ng-cut="removeErrorOnCut()"
                                         placeholder="{{'security.user.add.custom_role.msg' | translate}}"></tags-input>
-                            <div class="small" ng-show="showTagError">
+                            <div class="small" ng-show="isRoleValid">
                                 <small>{{'security.user.role.too.short' | translate}}</small>
                             </div>
                         </div>
@@ -274,7 +275,7 @@
 
 		<div class="text-right">
             <button id="wb-user-goBack" class="btn btn-secondary" type="button" ng-click="goBack()">{{'common.cancel.btn' | translate}}</button>
-            <button id="wb-user-submit" class="btn btn-primary" type="submit" ng-disabled="showTagError">{{saveButtonText}}</button>
+            <button id="wb-user-submit" class="btn btn-primary" type="submit" ng-disabled="isRoleValid">{{saveButtonText}}</button>
 		</div>
 	</form>
 </div>

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -219,7 +219,7 @@
                                         paste-split-pattern="[\s+]"
                                         on-tag-added="addCustomRole($tag)"
                                         placeholder="{{'security.user.add.custom_role.msg' | translate}}"></tags-input>
-                            <div class="small" ng-if="form.customRoleTag.$touched && !form.customRoleTag.$valid">
+                            <div class="small" ng-show="form.customRoleTag.$invalid">
                                 <small>{{'security.user.role.too.short' | translate}}</small>
                             </div>
                         </div>

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -209,7 +209,7 @@
                     <div class="card-block">
                         <h3>{{'security.user.custom_role' | translate}}</h3>
                         <div class="input-group">
-                            <tags-input name="customRoleTag" class="wb-tags-input" ng-model="customRoles" min-length="2"
+                            <tags-input name="customRoleTag" class="wb-tags-input" ng-model="customRoles" min-length="1"
                                         ng-disabled="!isUser() || mode === 'settings'"
                                         use-strings="true"
                                         add-on-space="true"
@@ -217,9 +217,11 @@
                                         add-on-paste="true"
                                         replace-spaces-with-dashes="false"
                                         paste-split-pattern="[\s+]"
+                                        on-tag-adding="validateTag($tag)"
                                         on-tag-added="addCustomRole($tag)"
+                                        ng-keydown="checkForBackspace($event)"
                                         placeholder="{{'security.user.add.custom_role.msg' | translate}}"></tags-input>
-                            <div class="small" ng-show="form.customRoleTag.$invalid">
+                            <div class="small" ng-show="showTagError">
                                 <small>{{'security.user.role.too.short' | translate}}</small>
                             </div>
                         </div>
@@ -272,7 +274,7 @@
 
 		<div class="text-right">
             <button id="wb-user-goBack" class="btn btn-secondary" type="button" ng-click="goBack()">{{'common.cancel.btn' | translate}}</button>
-            <button id="wb-user-submit" class="btn btn-primary" type="submit" ng-disabled="form.customRoleTag.$touched && !form.customRoleTag.$valid">{{saveButtonText}}</button>
+            <button id="wb-user-submit" class="btn btn-primary" type="submit" ng-disabled="showTagError">{{saveButtonText}}</button>
 		</div>
 	</form>
 </div>

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -222,7 +222,7 @@
                                         ng-keydown="checkForBackspace($event)"
                                         ng-cut="removeErrorOnCut()"
                                         placeholder="{{'security.user.add.custom_role.msg' | translate}}"></tags-input>
-                            <div class="small" ng-show="isRoleValid">
+                            <div class="small" ng-show="showRoleValidationError">
                                 <small>{{'security.user.role.too.short' | translate}}</small>
                             </div>
                         </div>
@@ -275,7 +275,7 @@
 
 		<div class="text-right">
             <button id="wb-user-goBack" class="btn btn-secondary" type="button" ng-click="goBack()">{{'common.cancel.btn' | translate}}</button>
-            <button id="wb-user-submit" class="btn btn-primary" type="submit" ng-disabled="isRoleValid">{{saveButtonText}}</button>
+            <button id="wb-user-submit" class="btn btn-primary" type="submit" ng-disabled="showRoleValidationError">{{saveButtonText}}</button>
 		</div>
 	</form>
 </div>

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -217,12 +217,12 @@
                                         add-on-paste="true"
                                         replace-spaces-with-dashes="false"
                                         paste-split-pattern="[\s+]"
-                                        on-tag-adding="validateTag($tag)"
+                                        on-tag-adding="isCustomRoleValid($tag)"
                                         on-tag-added="addCustomRole($tag)"
                                         ng-keydown="checkForBackspace($event)"
                                         ng-cut="removeErrorOnCut()"
                                         placeholder="{{'security.user.add.custom_role.msg' | translate}}"></tags-input>
-                            <div class="small" ng-show="showRoleValidationError">
+                            <div class="small" ng-hide="isRoleValid">
                                 <small>{{'security.user.role.too.short' | translate}}</small>
                             </div>
                         </div>
@@ -275,7 +275,7 @@
 
 		<div class="text-right">
             <button id="wb-user-goBack" class="btn btn-secondary" type="button" ng-click="goBack()">{{'common.cancel.btn' | translate}}</button>
-            <button id="wb-user-submit" class="btn btn-primary" type="submit" ng-disabled="showRoleValidationError">{{saveButtonText}}</button>
+            <button id="wb-user-submit" class="btn btn-primary" type="submit" ng-disabled="!isRoleValid">{{saveButtonText}}</button>
 		</div>
 	</form>
 </div>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -484,6 +484,7 @@
     "security.count.all.results": "Count all SPARQL results",
     "security.read.write.access": "Repositories read/write access",
     "security.user.rights": "Users should have rights to at least one repository!",
+    "security.user.role.too.short": "Must be at least 2 symbols long",
     "security.no.active.location": "There is no active location.",
     "security.repository.title": "Repository",
     "security.tooltip.read": "Read",

--- a/test-cypress/integration/setup/user-and-access.spec.js
+++ b/test-cypress/integration/setup/user-and-access.spec.js
@@ -89,7 +89,7 @@ describe('User and Access', () => {
         // And the field should show an error
         UserAndAccessSteps.getFieldError().should('contain.text', 'Must be at least 2 symbols long');
         // When I add more text to the custom role tag
-        UserAndAccessSteps.addTextToCustomRoleField('A');
+        UserAndAccessSteps.addTextToCustomRoleField('A{enter}');
         // Then the 'create' button should be enabled
         UserAndAccessSteps.getConfirmUserCreateButton().should('be.enabled');
         // And the field error should not exist

--- a/test-cypress/integration/setup/user-and-access.spec.js
+++ b/test-cypress/integration/setup/user-and-access.spec.js
@@ -94,6 +94,15 @@ describe('User and Access', () => {
         UserAndAccessSteps.getConfirmUserCreateButton().should('be.enabled');
         // And the field error should not exist
         UserAndAccessSteps.getFieldError().should('not.be.visible');
+
+        // When I type an invalid tag
+        UserAndAccessSteps.addTextToCustomRoleField('B{enter}');
+        // And the field shows an error
+        UserAndAccessSteps.getFieldError().should('contain.text', 'Must be at least 2 symbols long');
+        // When I delete the invalid text
+        UserAndAccessSteps.addTextToCustomRoleField('{backspace}');
+        // Then the error should not be visible
+        UserAndAccessSteps.getFieldError().should('not.be.visible');
     });
 
     it('Warn users when setting no password when creating new user admin', () => {

--- a/test-cypress/integration/setup/user-and-access.spec.js
+++ b/test-cypress/integration/setup/user-and-access.spec.js
@@ -72,6 +72,32 @@ describe('User and Access', () => {
         testForUser(name, true);
     });
 
+    it('Create user with custom role', () => {
+        const name = "user";
+        // When I create a read/write user
+        getCreateNewUserButton().click();
+        getUsernameField().type(name);
+        getPasswordField().type(PASSWORD);
+        getConfirmPasswordField().type(PASSWORD);
+        getRoleRadioButton(ROLE_USER).click();
+        // And add a custom role of 1 letter
+        getCustomRoleField().type('A');
+        getRepoitoryRightsList().contains('Any data repository').nextUntil('.write').eq(1).within(() => {
+            cy.get('.write').click();
+        });
+
+        // Then the 'create' button should be disabled
+        getConfirmUserCreateButton().should('be.disabled');
+        // And the field should show an error
+        getFieldError().should('contain.text', 'Must be at least 2 symbols long');
+        // When I add more text to the custom role tag
+        getCustomRoleField().type('A');
+        // Then the 'create' button should be enabled
+        getConfirmUserCreateButton().should('be.enabled');
+        // And the field error should not exist
+        getFieldError().should('not.exist');
+    });
+
     function testForUser(name, isAdmin) {
         //enable security
         getToggleSecuritySwitch().click();
@@ -136,6 +162,10 @@ describe('User and Access', () => {
         return cy.get('#wb-user-confirmpassword');
     }
 
+    function getCustomRoleField() {
+        return cy.get('tags-input');
+    }
+
     function getConfirmUserCreateButton() {
         return cy.get('#wb-user-submit');
     }
@@ -146,6 +176,10 @@ describe('User and Access', () => {
 
     function getRepoitoryRightsList() {
         return cy.get('#user-repos');
+    }
+
+    function getFieldError() {
+        return cy.get('div.small');
     }
 
     function createUser(username, password, role) {

--- a/test-cypress/integration/setup/user-and-access.spec.js
+++ b/test-cypress/integration/setup/user-and-access.spec.js
@@ -1,3 +1,5 @@
+import {UserAndAccessSteps} from "../../steps/setup/user-and-access-steps";
+
 describe('User and Access', () => {
 
     const PASSWORD = "password";
@@ -7,21 +9,21 @@ describe('User and Access', () => {
     const DEFAULT_ADMIN_PASSWORD = "root";
 
     beforeEach(() => {
-        cy.visit('/users');
+        UserAndAccessSteps.visit();
         cy.window();
         // Users table should be visible
-        getUsersTable().should('be.visible');
+        UserAndAccessSteps.getUsersTable().should('be.visible');
     });
 
     after(() => {
-        cy.visit('/users');
-        getUsersTable().should('be.visible');
-        cy.get('#wb-users-userInUsers tr').then((table) => {
-            cy.get('table > tbody  > tr').each(($el, index, $list) => {
-                getUsersTable().should('be.visible');
+        UserAndAccessSteps.visit();
+        UserAndAccessSteps.getUsersTable().should('be.visible');
+        UserAndAccessSteps.getUsersTableRow().then((table) => {
+            UserAndAccessSteps.getTableRow().each(($el, index, $list) => {
+                UserAndAccessSteps.getUsersTable().should('be.visible');
                 const username = $el.find('.username').text();
                 if (username !=='admin') {
-                    deleteUser(username);
+                    UserAndAccessSteps.deleteUser(username);
                 }
             });
         });
@@ -29,26 +31,22 @@ describe('User and Access', () => {
 
     it('Initial state', () => {
         // Create new user button should be visible
-        getCreateNewUserButton().should('be.visible');
+        UserAndAccessSteps.getCreateNewUserButton().should('be.visible');
         // Security should be disabled
-        cy.get('#toggle-security').find('.security-switch-label').should('be.visible')
-            .and('contain', 'Security is OFF');
-        cy.get('#toggle-security').find('.switch:checkbox').should('not.be.checked');
+        UserAndAccessSteps.getSecuritySwitchLabel().should('be.visible').and('contain', 'Security is OFF');
+        UserAndAccessSteps.getSecurityCheckbox().should('not.be.checked');
         // Only admin user should be created by default
-        getUsersTable().find('tbody tr').should('have.length', 1);
-        findUserInTable('admin');
-        cy.get('@user').find('.user-type').should('be.visible')
-            .and('contain', 'Administrator');
+        UserAndAccessSteps.getTableRow().should('have.length', 1);
+        UserAndAccessSteps.findUserInTable('admin');
+        UserAndAccessSteps.getUserType().should('be.visible').and('contain', 'Administrator');
         // The admin should have unrestricted rights
-        cy.get('@user').find('.repository-rights').should('be.visible')
-            .and('contain', 'Unrestricted');
+        UserAndAccessSteps.getRepositoryRights().should('be.visible').and('contain', 'Unrestricted');
         // And can be edited
-        cy.get('@user').find('.edit-user-btn').should('be.visible')
-            .and('not.be.disabled');
+        UserAndAccessSteps.getEditUserButton().should('be.visible').and('not.be.disabled');
         // And cannot be deleted
-        cy.get('@user').find('.delete-user-btn').should('not.exist');
+        UserAndAccessSteps.getDeleteUserButton().should('not.exist');
         // Date created should be visible
-        cy.get('@user').find('.date-created').should('be.visible');
+        UserAndAccessSteps.getDateCreated().should('be.visible');
     });
 
     it('Create user', () => {
@@ -75,171 +73,90 @@ describe('User and Access', () => {
     it('Create user with custom role', () => {
         const name = "user";
         // When I create a read/write user
-        getCreateNewUserButton().click();
-        getUsernameField().type(name);
-        getPasswordField().type(PASSWORD);
-        getConfirmPasswordField().type(PASSWORD);
-        getRoleRadioButton(ROLE_USER).click();
+        UserAndAccessSteps.clickCreateNewUserButton();
+        UserAndAccessSteps.typeUsername(name);
+        UserAndAccessSteps.typePassword(PASSWORD);
+        UserAndAccessSteps.typeConfirmPasswordField(PASSWORD);
+        UserAndAccessSteps.selectRoleRadioButton(ROLE_USER);
         // And add a custom role of 1 letter
-        getCustomRoleField().type('A');
-        getRepoitoryRightsList().contains('Any data repository').nextUntil('.write').eq(1).within(() => {
-            cy.get('.write').click();
+        UserAndAccessSteps.addTextToCustomRoleField('A');
+        UserAndAccessSteps.getRepositoryRightsList().contains('Any data repository').nextUntil('.write').eq(1).within(() => {
+            UserAndAccessSteps.clickWriteAccess();
         });
 
         // Then the 'create' button should be disabled
-        getConfirmUserCreateButton().should('be.disabled');
+        UserAndAccessSteps.getConfirmUserCreateButton().should('be.disabled');
         // And the field should show an error
-        getFieldError().should('contain.text', 'Must be at least 2 symbols long');
+        UserAndAccessSteps.getFieldError().should('contain.text', 'Must be at least 2 symbols long');
         // When I add more text to the custom role tag
-        getCustomRoleField().type('A');
+        UserAndAccessSteps.addTextToCustomRoleField('A');
         // Then the 'create' button should be enabled
-        getConfirmUserCreateButton().should('be.enabled');
+        UserAndAccessSteps.getConfirmUserCreateButton().should('be.enabled');
         // And the field error should not exist
-        getFieldError().should('not.exist');
+        UserAndAccessSteps.getFieldError().should('not.be.visible');
     });
+
+    it('Warn users when setting no password when creating new user admin', () => {
+        UserAndAccessSteps.getUsersTable().should('be.visible');
+        createUser("adminWithNoPassword", PASSWORD, ROLE_CUSTOM_ADMIN);
+        UserAndAccessSteps.getUsersTable().should('be.visible');
+        UserAndAccessSteps.getSplashLoader().should('not.be.visible');
+        UserAndAccessSteps.deleteUser("adminWithNoPassword");
+    });
+
+    function createUser(username, password, role) {
+        UserAndAccessSteps.clickCreateNewUserButton();
+        UserAndAccessSteps.typeUsername(username);
+        UserAndAccessSteps.typePassword(password);
+        UserAndAccessSteps.typeConfirmPasswordField(password);
+        UserAndAccessSteps.selectRoleRadioButton(role);
+        if (role === "#roleUser") {
+            UserAndAccessSteps.getRepositoryRightsList().contains('Any data repository').nextUntil('.write').eq(1).within(() => {
+                UserAndAccessSteps.clickWriteAccess();
+            });
+            UserAndAccessSteps.confirmUserCreate();
+        } else if (role === "#roleAdmin" && username === "adminWithNoPassword") {
+            UserAndAccessSteps.getNoPasswordCheckbox().check()
+                .then(() => {
+                    UserAndAccessSteps.getNoPasswordCheckbox()
+                        .should('be.checked');
+                });
+            UserAndAccessSteps.getConfirmUserCreateButton().click()
+                .then(() => {
+                    UserAndAccessSteps.getDialogText().contains('If the password is unset and security is enabled, this administrator will not be ' +
+                        'able to log into GraphDB through the workbench. Are you sure that you want to continue?');
+                    UserAndAccessSteps.confirmInDialog();
+                });
+        } else {
+            UserAndAccessSteps.confirmUserCreate();
+        }
+        UserAndAccessSteps.getSplashLoader().should('not.be.visible');
+        UserAndAccessSteps.getUsersTable().should('contain', username);
+    }
 
     function testForUser(name, isAdmin) {
         //enable security
-        getToggleSecuritySwitch().click();
+        UserAndAccessSteps.toggleSecurity();
         //login new user
-        loginWithUser(name, PASSWORD);
+        UserAndAccessSteps.loginWithUser(name, PASSWORD);
         //verify permissions
-        cy.url().should('include', '/users');
+        UserAndAccessSteps.getUrl().should('include', '/users');
         if (isAdmin) {
-            getUsersTable().should('be.visible');
+            UserAndAccessSteps.getUsersTable().should('be.visible');
         } else {
-            cy.get('.alert-danger').should('contain',
+            UserAndAccessSteps.getError().should('contain',
                 'You have no permission to access this functionality with your current credentials.');
         }
-        logout();
+        UserAndAccessSteps.logout();
         //login with the admin
-        loginWithUser("admin", DEFAULT_ADMIN_PASSWORD);
-        cy.get('.ot-splash').should('not.be.visible');
-        getUsersTable().should('be.visible');
+        UserAndAccessSteps.loginWithUser("admin", DEFAULT_ADMIN_PASSWORD);
+        UserAndAccessSteps.getSplashLoader().should('not.be.visible');
+        UserAndAccessSteps.getUsersTable().should('be.visible');
         //delete new-user
-        deleteUser(name);
+        UserAndAccessSteps.deleteUser(name);
         //disable security
-        getToggleSecuritySwitch().click({force: true});
-        cy.get('#toggle-security').find('.security-switch-label').should('be.visible')
-            .and('contain', 'Security is OFF');
-        getUsersTable().should('be.visible');
-    }
-
-    it('Warn users when setting no password when creating new user admin', () => {
-        getUsersTable().should('be.visible');
-        createUser("adminWithNoPassword", PASSWORD, ROLE_CUSTOM_ADMIN);
-        getUsersTable().should('be.visible');
-        cy.get('.ot-splash').should('not.be.visible');
-        deleteUser("adminWithNoPassword");
-    });
-
-    function getCreateNewUserButton() {
-        return cy.get('#wb-users-userCreateLink');
-    }
-
-    function getToggleSecuritySwitch() {
-        return cy.get('#toggle-security span.switch');
-    }
-
-    function getUsersTable() {
-        return cy.get('#wb-users-userInUsers');
-    }
-
-    function findUserInTable(username) {
-        return getUsersTable().find(`tbody .username:contains(${username})`)
-            .closest('tr').as('user');
-    }
-
-    function getUsernameField() {
-        return cy.get('#wb-user-username');
-    }
-
-    function getPasswordField() {
-        return cy.get('#wb-user-password');
-    }
-
-    function getConfirmPasswordField() {
-        return cy.get('#wb-user-confirmpassword');
-    }
-
-    function getCustomRoleField() {
-        return cy.get('tags-input');
-    }
-
-    function getConfirmUserCreateButton() {
-        return cy.get('#wb-user-submit');
-    }
-
-    function getRoleRadioButton(userRole) {
-        return cy.get(userRole);
-    }
-
-    function getRepoitoryRightsList() {
-        return cy.get('#user-repos');
-    }
-
-    function getFieldError() {
-        return cy.get('div.small');
-    }
-
-    function createUser(username, password, role) {
-        getCreateNewUserButton().click();
-        getUsernameField().type(username);
-        getPasswordField().type(password);
-        getConfirmPasswordField().type(password);
-        getRoleRadioButton(role).click();
-        if (role === "#roleUser") {
-            getRepoitoryRightsList().contains('Any data repository').nextUntil('.write').eq(1).within(() => {
-                cy.get('.write').click();
-            });
-            getConfirmUserCreateButton().click();
-        } else if (role === "#roleAdmin" && username === "adminWithNoPassword") {
-            cy.get('#noPassword:checkbox').check()
-                .then(() => {
-                    cy.get('#noPassword:checkbox')
-                        .should('be.checked');
-                });
-            getConfirmUserCreateButton().click()
-                .then(() => {
-                    cy.get('.modal-dialog').find('.lead').contains('If the password is unset and security is enabled, this administrator will not be ' +
-                        'able to log into GraphDB through the workbench. Are you sure that you want to continue?');
-                    cy.get('.modal-dialog').find('.confirm-btn').click();
-                });
-        } else {
-            getConfirmUserCreateButton().click();
-        }
-        cy.get('.ot-splash').should('not.be.visible');
-        getUsersTable().should('contain', username);
-    }
-
-    function deleteUser(username) {
-        findUserInTable(username);
-        cy.get('@user')
-            .should('have.length', 1)
-            .within(() => {
-                cy.get('.delete-user-btn')
-                    .as('deleteBtn');
-            });
-        return cy.waitUntil(() =>
-            cy.get('@deleteBtn')
-                .then((deleteBtn) => deleteBtn && Cypress.dom.isAttached(deleteBtn) && deleteBtn.trigger('click')))
-            .then(() => {
-                cy.get('.confirm-btn').click();
-            });
-    }
-
-    function loginWithUser(username, password) {
-        cy.get('#wb-login-username').type(username);
-        cy.get('#wb-login-password').type(password);
-        cy.get('#wb-login-submitLogin').click();
-    }
-
-    function logout() {
-        cy.get('#btnGroupDrop2').click();
-        cy.get('.dropdown-item')
-            .contains('Logout')
-            .closest('a')
-            // Force the click because Cypress sometimes determines that the item has 0x0 dimensions
-            .click({force: true});
+        UserAndAccessSteps.toggleSecurity();//.click({force: true});
+        UserAndAccessSteps.getSecuritySwitchLabel().should('be.visible').and('contain', 'Security is OFF');
+        UserAndAccessSteps.getUsersTable().should('be.visible');
     }
 });

--- a/test-cypress/steps/setup/user-and-access-steps.js
+++ b/test-cypress/steps/setup/user-and-access-steps.js
@@ -1,0 +1,189 @@
+export class UserAndAccessSteps {
+    static visit() {
+        cy.visit('/users');
+    }
+
+    static getUrl() {
+        return cy.url();
+    }
+
+    static getSplashLoader() {
+        return cy.get('.ot-splash');
+    }
+
+    static getCreateNewUserButton() {
+        return cy.get('#wb-users-userCreateLink');
+    }
+
+    static clickCreateNewUserButton() {
+        this.getCreateNewUserButton().click();
+    }
+
+    static getToggleSecuritySwitch() {
+        return cy.get('#toggle-security span.switch');
+    }
+
+    static toggleSecurity() {
+        this.getToggleSecuritySwitch().click();
+    }
+
+    static getSecuritySwitchLabel() {
+        return cy.get('#toggle-security').find('.security-switch-label');
+    }
+
+    static getSecurityCheckbox() {
+        return cy.get('#toggle-security').find('.switch:checkbox');
+    }
+
+    static getUser() {
+        return cy.get('@user');
+    }
+
+    static getUserType() {
+        return this.getUser().find('.user-type');
+    }
+
+    static getRepositoryRights() {
+        return this.getUser().find('.repository-rights');
+    }
+
+    static getEditUserButton() {
+        return this.getUser().find('.edit-user-btn');
+    }
+
+    static getDeleteUserButton() {
+        return this.getUser().find('.delete-user-btn');
+    }
+
+    static getDateCreated() {
+        return this.getUser().find('.date-created');
+    }
+
+    static getUsersTable() {
+        return cy.get('#wb-users-userInUsers');
+    }
+
+    static getTableRow() {
+        return this.getUsersTable().find('tbody tr');
+    }
+
+    static getUsersTableRow() {
+        return cy.get('#wb-users-userInUsers tr');
+    }
+
+    static findUserInTable(username) {
+        return this.getUsersTable().find(`tbody .username:contains(${username})`)
+            .closest('tr').as('user');
+    }
+
+    static getUsernameField() {
+        return cy.get('#wb-user-username');
+    }
+
+    static typeUsername(text) {
+        this.getUsernameField().type(text);
+    }
+
+    static getPasswordField() {
+        return cy.get('#wb-user-password');
+    }
+
+    static typePassword(text) {
+        this.getPasswordField().type(text);
+    }
+
+    static getConfirmPasswordField() {
+        return cy.get('#wb-user-confirmpassword');
+    }
+
+    static typeConfirmPasswordField(text) {
+        this.getConfirmPasswordField().type(text);
+    }
+
+    static getNoPasswordCheckbox() {
+        return cy.get('#noPassword:checkbox');
+    }
+
+    static getCustomRoleField() {
+        return cy.get('tags-input');
+    }
+
+    static addTextToCustomRoleField(text) {
+        this.getCustomRoleField().type(text);
+    }
+
+    static getConfirmUserCreateButton() {
+        return cy.get('#wb-user-submit');
+    }
+
+    static confirmUserCreate() {
+        cy.get('#wb-user-submit').click();
+    }
+
+    static getRoleRadioButton(userRole) {
+        return cy.get(userRole);
+    }
+
+    static selectRoleRadioButton(role) {
+        this.getRoleRadioButton(role).click();
+    }
+
+    static getRepositoryRightsList() {
+        return cy.get('#user-repos');
+    }
+
+    static clickWriteAccess() {
+        cy.get('.write').click();
+    }
+
+    static getFieldError() {
+        return cy.get('div.small');
+    }
+
+    static getError() {
+        return cy.get('.alert-danger');
+    }
+
+    static getModal() {
+        return cy.get('.modal-dialog');
+    }
+
+    static getDialogText() {
+        return this.getModal().find('.lead');
+    }
+
+    static confirmInDialog() {
+        this.getModal().find('.confirm-btn').click();
+    }
+
+    static deleteUser(username) {
+        this.findUserInTable(username);
+        cy.get('@user')
+            .should('have.length', 1)
+            .within(() => {
+                cy.get('.delete-user-btn')
+                    .as('deleteBtn');
+            });
+        return cy.waitUntil(() =>
+            cy.get('@deleteBtn')
+                .then((deleteBtn) => deleteBtn && Cypress.dom.isAttached(deleteBtn) && deleteBtn.trigger('click')))
+            .then(() => {
+                cy.get('.confirm-btn').click();
+            });
+    }
+
+    static loginWithUser(username, password) {
+        cy.get('#wb-login-username').type(username);
+        cy.get('#wb-login-password').type(password);
+        cy.get('#wb-login-submitLogin').click();
+    }
+
+    static logout() {
+        cy.get('#btnGroupDrop2').click();
+        cy.get('.dropdown-item')
+            .contains('Logout')
+            .closest('a')
+            // Force the click because Cypress sometimes determines that the item has 0x0 dimensions
+            .click({force: true});
+    }
+}


### PR DESCRIPTION
## What?
When editing or creating a user, the Admin user will see an error if a `custom role` tag is typed, containing less than 2 characters.

## Why?
Previously, the field would be highlighted in red and the single letter typed would not turn into a tag. The Admin was not notified, but was allowed to save the changes. However, the invalid tag does not get saved.

## How?
I added an error message to the field and disabled the 'Save/Create' button, if the user has typed in the `custom role` field and the input is invalid.

## Testing?
I added a test for this validation.

## Screenshots?
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/381df633-f648-4690-8490-2eed4635f642)
