### PR TITLE
GDB-10263 Allow resource tree column labels to be customized

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1020,6 +1020,7 @@
                 "name": "Name",
                 "size": "Size",
                 "modified": "Modified",
+                "uploaded": "Uploaded",
                 "imported": "Imported",
                 "context": "Context"
             },

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1029,6 +1029,7 @@
                 "name": "Nom",
                 "size": "Taille",
                 "modified": "Modifié",
+                "uploaded": "Téléchargé",
                 "imported": "Importé",
                 "context": "Contexte"
             },

--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -465,6 +465,13 @@ importViewModule.controller('ImportCtrl', ['$scope', 'toastr', '$controller', '$
     // Public variables
     // =========================
 
+    $scope.columnKeys = {
+        'name': 'import.import_resource_tree.header.name',
+        'size': 'import.import_resource_tree.header.size',
+        'modified': 'import.import_resource_tree.header.modified',
+        'imported': 'import.import_resource_tree.header.imported',
+        'context': 'import.import_resource_tree.header.context'
+    };
     $scope.loader = true;
     angular.extend(this, $controller('ImportViewCtrl', {$scope: $scope}));
     $scope.defaultType = 'server';
@@ -538,6 +545,13 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
     // Public variables
     // =========================
 
+    $scope.columnKeys = {
+        'name': 'import.import_resource_tree.header.name',
+        'size': 'import.import_resource_tree.header.size',
+        'modified': 'import.import_resource_tree.header.uploaded',
+        'imported': 'import.import_resource_tree.header.imported',
+        'context': 'import.import_resource_tree.header.context'
+    };
     $scope.loader = true;
     angular.extend(this, $controller('ImportViewCtrl', {$scope: $scope}));
     $scope.defaultType = USER_DATA_TYPE.FILE;

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -32,7 +32,11 @@ function importResourceTreeDirective($timeout, ImportContextService) {
         restrict: 'E',
         templateUrl: 'js/angular/import/templates/import-resource-tree.html',
         scope: {
-
+            /**
+             * Contains mapping of the column names to label keys. Should contain
+             * keys for: name, size, imported, modified, context column names.
+             */
+            columnKeys: '=',
             /**
              * If the type filter buttons should be visible.
              */

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -110,35 +110,35 @@
                 'sorting_desc': SORTING_TYPES.NAME === sortedBy &&  !sortAsc,
                 'sorting_asc': SORTING_TYPES.NAME === sortedBy && sortAsc,
                 'sorting': SORTING_TYPES.NAME !== sortedBy
-                }">{{'import.import_resource_tree.header.name' | translate}}</span>
+                }">{{columnKeys.name | translate}}</span>
             </th>
             <th class="header-cell cell-size" ng-click="sort(SORTING_TYPES.SIZE)">
                 <span ng-class="{
                 'sorting_desc': SORTING_TYPES.SIZE === sortedBy &&  !sortAsc,
                 'sorting_asc': SORTING_TYPES.SIZE === sortedBy && sortAsc,
                 'sorting': SORTING_TYPES.SIZE !== sortedBy
-                }">{{'import.import_resource_tree.header.size' | translate}}</span>
+                }">{{columnKeys.size | translate}}</span>
             </th>
             <th class="header-cell cell-modified" ng-click="sort(SORTING_TYPES.MODIFIED)">
                 <span ng-class="{
                 'sorting_desc': SORTING_TYPES.MODIFIED === sortedBy &&  !sortAsc,
                 'sorting_asc': SORTING_TYPES.MODIFIED === sortedBy && sortAsc,
                 'sorting': SORTING_TYPES.MODIFIED !== sortedBy
-                }">{{'import.import_resource_tree.header.modified' | translate}}</span>
+                }">{{columnKeys.modified | translate}}</span>
             </th>
             <th class="header-cell cell-imported" ng-click="sort(SORTING_TYPES.IMPORTED)">
                 <span ng-class="{
                 'sorting_desc': SORTING_TYPES.IMPORTED === sortedBy &&  !sortAsc,
                 'sorting_asc': SORTING_TYPES.IMPORTED === sortedBy && sortAsc,
                 'sorting': SORTING_TYPES.IMPORTED !== sortedBy
-                }">{{'import.import_resource_tree.header.imported' | translate}}</span>
+                }">{{columnKeys.imported | translate}}</span>
             </th>
             <th class="header-cell cell-context" ng-click="sort(SORTING_TYPES.CONTEXT)">
                 <span ng-class="{
                 'sorting_desc': SORTING_TYPES.CONTEXT === sortedBy &&  !sortAsc,
                 'sorting_asc': SORTING_TYPES.CONTEXT === sortedBy && sortAsc,
                 'sorting': SORTING_TYPES.CONTEXT !== sortedBy
-                }">{{'import.import_resource_tree.header.context' | translate}}</span>
+                }">{{columnKeys.context | translate}}</span>
             </th>
             <th class="header-cell import-resource-action"></th>
         </tr>

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -123,6 +123,7 @@
                 </div>
                 <div class="ot-loader ot-main-loader" onto-loader size="50" ng-if="loader"></div>
                 <import-resource-tree ng-if ="!loader"
+                                      column-keys="columnKeys"
                                       show-type-filter="false"
                                       sort-by="SORTING_TYPES.MODIFIED"
                                       asc="false"
@@ -161,6 +162,7 @@
                 </div>
                 <div class="ot-loader ot-main-loader" onto-loader size="50" ng-if="loader"></div>
                 <import-resource-tree ng-if ="!loader"
+                                      column-keys="columnKeys"
                                       show-type-filter="true"
                                       sort-by="SORTING_TYPES.NAME"
                                       on-import="onImport(resource)"


### PR DESCRIPTION
## WHAT
Allow resource tree column labels to be customized.

## WHY
Modified column has no meaning in user data where files are actually uploaded by the user and not modified.

## HOW
Extended the resource tree with additional parameter holding the column label keys. And modified the template to use them.