### PR TITLE
GDB-10263 Send folder for import if it's selected via the checkbox

### DIFF
--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -277,7 +277,6 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
         $scope.importAll = (selectedResources, withoutChangingSettings) => {
             // mark all files as selected locally in order to have them after the import is confirmed via the modal
             selectedResources
-                .filter((resource) => resource.isFile())
                 .forEach((resource) => {
                     $scope.selectedForImportFiles[resource.path] = true;
                 });


### PR DESCRIPTION
## WHAT
Send folder for import if it's selected via the checkbox along with all the files within.

## WHY
This will ensure consistent behavior with the scenario where the folder is imported using the import button next to it.

## HOW
Removed the folders filtration before sending the import request.