### PR TITLE
GDB-10126 - Save the selected theme mode when the user clicks 'Save'

### DIFF
--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -792,6 +792,7 @@ securityCtrl.controller('ChangeUserPasswordSettingsCtrl', ['$scope', 'toastr', '
         $scope.showWorkbenchSettings = true;
         /** @type {WorkbenchSettingsModel} */
         $scope.workbenchSettings = WorkbenchSettingsStorageService.getWorkbenchSettings();
+        $scope.selectedThemeMode = $scope.workbenchSettings.mode;
         $scope.saveButtonText = $translate.instant('common.save.btn');
         $scope.pageTitle = $translate.instant('view.settings.title');
         $scope.passwordPlaceholder = $translate.instant('security.new.password');
@@ -907,7 +908,7 @@ securityCtrl.controller('ChangeUserPasswordSettingsCtrl', ['$scope', 'toastr', '
             if (!$scope.validateForm()) {
                 return false;
             }
-
+            ThemeService.toggleThemeMode($scope.selectedThemeMode);
             $scope.updateUserHttp();
         };
 
@@ -916,7 +917,7 @@ securityCtrl.controller('ChangeUserPasswordSettingsCtrl', ['$scope', 'toastr', '
         };
 
         $scope.setThemeMode = function () {
-            ThemeService.toggleThemeMode($scope.workbenchSettings.mode);
+            $scope.selectedThemeMode = $scope.workbenchSettings.mode;
         };
 
         /**


### PR DESCRIPTION
## What?
The selected 'light' or 'dark' theme will be saved when the user clicks to save the changes in settings.

## Why?
The theme would be saved and applied even if the user clicked 'Cancel'.

## How?
I moved the theme application logic to the submit function.