### PR TITLE
GDB-10263: Fixes Issue with Loader

### DIFF
--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -351,7 +351,8 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
         $scope.updateListHttp = (force) => {
             const filesLoader = $scope.activeTabId === TABS.USER ? ImportRestService.getUploadedFiles : ImportRestService.getServerFiles;
             const executedInTabId = $scope.activeTabId;
-            filesLoader($repositories.getActiveRepository()).success(function (data) {
+            return filesLoader($repositories.getActiveRepository())
+                .success(function (data) {
                 if (executedInTabId !== ImportContextService.getActiveTabId()) {
                     return;
                 }
@@ -393,7 +394,7 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
                 $scope.savedSettings = _.mapKeys(_.filter($scope.files, 'parserSettings'), 'name');
             }).error(function (data) {
                 toastr.warning($translate.instant('import.error.could.not.get.files', {data: getError(data)}));
-            }).finally(() => ImportContextService.updateShowLoader(false));
+            });
         };
 
         const resetStatusOrRemoveEntry = (names, remove) => {
@@ -437,10 +438,10 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             subscriptions.push($scope.$on('repositoryIsSet', $scope.onRepositoryChange));
             subscriptions.push($scope.$on('$destroy', () => $interval.cancel(listPollingHandler)));
             subscriptions.push(ImportContextService.onActiveTabIdUpdated((newActiveTabId) => {
-                ImportContextService.updateShowLoader(true);
                 $scope.activeTabId = newActiveTabId;
                 ImportContextService.updateResources(new ImportResourceTreeElement());
-                $scope.updateListHttp(true);
+                ImportContextService.updateShowLoader(true);
+                $scope.updateListHttp(true).finally(() => ImportContextService.updateShowLoader(false));
             }));
             $scope.$on('$destroy', removeAllListeners);
         };

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -76,6 +76,7 @@ function importResourceTreeDirective($timeout, ImportContextService) {
             $scope.SORTING_TYPES = SortingType;
             $scope.sortAsc = angular.isDefined(attrs.asc) ? $scope.asc : true;
             $scope.sortedBy = $scope.sortBy;
+            $scope.showLoader = ImportContextService.getShowLoader();
 
             // =========================
             // Public functions
@@ -316,6 +317,7 @@ function importResourceTreeDirective($timeout, ImportContextService) {
             const subscriptions = [];
 
             subscriptions.push(ImportContextService.onResourcesUpdated(onResourcesUpdatedHandler));
+            subscriptions.push(ImportContextService.onShowLoaderUpdated((showLoader) => $scope.showLoader = showLoader));
 
             const removeAllSubscribers = () => {
                 subscriptions.forEach((subscription) => subscription());

--- a/src/js/angular/import/services/import-context.service.js
+++ b/src/js/angular/import/services/import-context.service.js
@@ -30,6 +30,8 @@ function ImportContextService(EventEmitterService) {
      */
     let _files = [];
 
+    let _showLoader = true;
+
     return {
         updateActiveTabId,
         getActiveTabId,
@@ -40,8 +42,33 @@ function ImportContextService(EventEmitterService) {
         onFilesUpdated,
         updateResources,
         getResources,
-        onResourcesUpdated
+        onResourcesUpdated,
+        updateShowLoader,
+        getShowLoader,
+        onShowLoaderUpdated
     };
+
+    /**
+     * @param {boolean} showLoader
+     */
+    function updateShowLoader(showLoader) {
+        _showLoader = showLoader;
+        EventEmitterService.emit('showLoaderUpdated', getShowLoader());
+    }
+
+    function getShowLoader() {
+        return _showLoader;
+    }
+
+    /**
+     * Subscribes to the 'showLoaderUpdated' event.
+     * @param {function} callback - The callback to be called when the event is fired.
+     *
+     * @return unsubscribe function.
+     */
+    function onShowLoaderUpdated(callback) {
+        return EventEmitterService.subscribe('showLoaderUpdated', () => callback(getShowLoader()));
+    }
 
     /**
      * Updates the active tab id of import page.

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -1,4 +1,5 @@
-<div class="import-resource-tree mt-2" ng-if="resources && !resources.isEmpty()">
+<div class="ot-loader ot-main-loader" onto-loader size="50" ng-if="showLoader"></div>
+<div class="import-resource-tree mt-2" ng-if="!showLoader && resources && !resources.isEmpty()">
     <div class="import-resource-tree-header">
         <div class="import-resources-actions">
             <div class="import-resource-status-dropdown btn-group" uib-dropdown>

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -121,9 +121,7 @@
                         </ul>
                     </div>
                 </div>
-                <div class="ot-loader ot-main-loader" onto-loader size="50" ng-if="loader"></div>
-                <import-resource-tree ng-if ="!loader"
-                                      column-keys="columnKeys"
+                <import-resource-tree column-keys="columnKeys"
                                       show-type-filter="false"
                                       sort-by="SORTING_TYPES.MODIFIED"
                                       asc="false"
@@ -160,9 +158,7 @@
                         </ul>
                     </div>
                 </div>
-                <div class="ot-loader ot-main-loader" onto-loader size="50" ng-if="loader"></div>
-                <import-resource-tree ng-if ="!loader"
-                                      column-keys="columnKeys"
+                <import-resource-tree column-keys="columnKeys"
                                       show-type-filter="true"
                                       sort-by="SORTING_TYPES.NAME"
                                       on-import="onImport(resource)"


### PR DESCRIPTION
GDB-10263: Fixes Issue with Loader

What
Sometimes the loaders are not displayed when the import view is opened.

Why
The loader is included in the main import template, and its visibility is controlled by two controllers: one for user data and one for server files. The main controller uses three controllers with a shared variable that determines whether the loader should be displayed. There seems to be an issue with this variable, as both controllers extend the main import controller, leading to inconsistent behavior.

How
Moved the loader into the import-resource-tree directive. The variable that controls the visibility of the loader has been moved to the import context service, allowing it to be changed and used by all components. Additional Work
There is a possible issue when a REST service is called to fetch user data, and before it returns, the tab is changed. In this case, the resource tree might display incorrect results until updated again. To prevent this, a check has been added to ensure the response is processed only if the tab remains the same as it was before the request. If the tab has changed, the response is skipped.