### PR TITLE
GDB-10263 Help box on inport page should be visible on empty state or otherwise when explicitly opened

### DIFF
--- a/src/js/angular/import/controllers/tab.controller.js
+++ b/src/js/angular/import/controllers/tab.controller.js
@@ -49,7 +49,17 @@ function TabController($scope, $location, ImportViewStorageService, ImportContex
             ImportViewStorageService.setHelpVisibility(true);
             shouldResetHelpVisibility = false;
         }
-        const isVisible = resources.getSize() === 0;
+        const viewPersistence = ImportViewStorageService.getImportViewSettings();
+        let isVisible = viewPersistence.isHelpVisible;
+        if (resources.getSize() === 0 && viewPersistence.isHelpVisible) {
+            isVisible = true;
+        } else if (resources.getSize() === 0 && !viewPersistence.isHelpVisible) {
+            isVisible = false;
+        } else if (viewPersistence.isHelpVisible) {
+            isVisible = true;
+        } else if (!viewPersistence.isHelpVisible) {
+            isVisible = false;
+        }
         ImportViewStorageService.setHelpVisibility(isVisible);
         setIsHelpVisible(isVisible);
     };


### PR DESCRIPTION
## WHAT
Help box on inport page should be visible on empty state or otherwise when explicitly opened

## WHY
It was decided that some changes are needed in order to further improve the UX in the import view.

## HOW
