### PR TITLE
GDB-10327: Implement error dialog on import failure

### DIFF
--- a/src/css/import-resource-tree.css
+++ b/src/css/import-resource-tree.css
@@ -42,6 +42,17 @@
     padding-top: 8px;
 }
 
+.import-resource-table .even-row-start .cell,
+.import-resource-table .odd-row-start .cell {
+    padding-top: 12px;
+}
+
+.import-resource-table .even-row-end .cell,
+.import-resource-table .odd-row-end .cell {
+    padding-top: 4px;
+    padding-bottom: 12px;
+}
+
 .import-resource-tree .import-resource-table .header-cell {
     font-weight: 700;
     font-size: 14px;
@@ -55,7 +66,6 @@
 
 .import-resource-tree .import-resource-table .cell {
     line-height: 18px;
-    vertical-align: top;
 }
 
 .import-resource-tree .import-resource-table .cell-title {
@@ -132,6 +142,11 @@
 .import-resource-tree .import-resource-table .cell .import-resource-message .success-messages .success-message .import-counters .import-counter,
 .import-resource-tree .import-resource-table .cell .import-resource-message .success-messages .success-message .text-success {
     padding-left: 10px;
+}
+
+.import-resource-tree .import-resource-table .cell .import-resource-message .error-message {
+    display: flex;
+    align-items: center;
 }
 
 .import-resource-tree .import-resource-tree-header {

--- a/src/css/import.css
+++ b/src/css/import.css
@@ -72,3 +72,9 @@
 .copy-btn:focus {
     outline: none;
 }
+
+.import-resource-message-dialog .message{
+    color: #000000;
+    font-size: 15px;
+    resize: none;
+}

--- a/src/js/angular/import/controllers/import-resource-message-dialog.controller.js
+++ b/src/js/angular/import/controllers/import-resource-message-dialog.controller.js
@@ -1,0 +1,25 @@
+angular
+    .module('graphdb.framework.impex.import.controllers.import-resource-message-dialog', [])
+    .controller('ImportResourceMessageDialogController', ImportResourceMessageDialogController);
+
+ImportResourceMessageDialogController.$inject = ['$scope', '$uibModalInstance', '$translate', 'toastr', 'message'];
+
+function ImportResourceMessageDialogController($scope, $uibModalInstance, $translate, toastr, message) {
+
+    $scope.message = message;
+
+
+    $scope.close = () => {
+        $uibModalInstance.dismiss();
+    };
+
+    $scope.copyToClipboard = () => {
+        navigator.clipboard.writeText($scope.message)
+            .then(() => {
+                toastr.success($translate.instant('import.help.messages.copied_to_clipboard'));
+                $scope.close();
+            }, (err) => {
+                console.error('Could not copy text: ', err);
+            });
+    };
+}

--- a/src/js/angular/import/directives/import-resource-message.directive.js
+++ b/src/js/angular/import/directives/import-resource-message.directive.js
@@ -1,15 +1,16 @@
+import 'angular/import/controllers/import-resource-message-dialog.controller';
 import {ImportResourceStatus} from "../../models/import/import-resource-status";
 import * as stringUtils from "../../utils/string-utils";
 
-const modules = [];
+const modules = ['graphdb.framework.impex.import.controllers.import-resource-message-dialog'];
 
 angular
     .module('graphdb.framework.import.directives.import-resource-message', modules)
     .directive('importResourceMessage', importResourceMessageDirective);
 
-importResourceMessageDirective.$inject = [];
+importResourceMessageDirective.$inject = ['$uibModal'];
 
-function importResourceMessageDirective() {
+function importResourceMessageDirective($uibModal) {
     return {
         restrict: 'E',
         templateUrl: 'js/angular/import/templates/import-resource-message.html',
@@ -22,6 +23,25 @@ function importResourceMessageDirective() {
             $scope.hasReplacedGraphs = $scope.resource.importResource.numReplacedGraphs > 0;
             $scope.hasAddedStatements = $scope.resource.importResource.addedStatements > 0;
             $scope.hasRemovedStatements = $scope.resource.importResource.removedStatements > 0;
+
+            /**
+             *
+             * @param {ImportResourceTreeElement} resourceTreeElement
+             */
+            $scope.showMessage = (resourceTreeElement) => {
+                $uibModal.open({
+                    templateUrl: 'js/angular/import/templates/import-resource-message-dialog.html',
+                    controller: 'ImportResourceMessageDialogController',
+                    size: 'lg',
+                    windowClass: 'import-resource-message-dialog',
+                    backdrop: 'static',
+                    resolve: {
+                        message: function () {
+                            return resourceTreeElement ? resourceTreeElement.importResource.message : '';
+                        }
+                    }
+                });
+            }
         }
     };
 }

--- a/src/js/angular/import/services/import-resource-tree.service.js
+++ b/src/js/angular/import/services/import-resource-tree.service.js
@@ -6,6 +6,7 @@ export const INDENT = 30;
 const PREFIX_AND_SUFFIX_LENGTH = 30;
 const MAX_CONTEXT_LENGTH = PREFIX_AND_SUFFIX_LENGTH * 2 + 3;
 const MAX_NAME_LENGTH = PREFIX_AND_SUFFIX_LENGTH * 4 + 3;
+const MAX_MESSAGE_LENGTH = 150;
 
 
 export const serverImportResourceTypeToIconMapping = new Map();
@@ -155,12 +156,24 @@ export class ImportResourceTreeService {
             importResourceElement.canResetStatus = ImportResourceTreeService.canResetStatus(importResourceElement.importResource);
             importResourceElement.hasStatusInfo = importResourceElement.importResource.status === 'DONE' || importResourceElement.importResource.status === 'ERROR';
             importResourceElement.isEditable = importResourceElement.importResource.isText();
+            ImportResourceTreeService.setupShortenedMessage(importResourceElement);
             ImportResourceTreeService.setupShortenedContext(importResourceElement);
             ImportResourceTreeService.setupShortenedName(importResourceElement);
             ImportResourceTreeService.setupImportedAndModifiedComparableProperties(importResourceElement);
         }
         importResourceElement.directories.forEach((directory) => ImportResourceTreeService.setupAfterTreeInitProperties(directory));
         importResourceElement.files.forEach((file) => ImportResourceTreeService.setupAfterTreeInitProperties(file));
+    }
+
+    /**
+     * Setts shortedMessage property if message is too long.
+     * @param {ImportResourceTreeElement} importResourceElement
+     */
+    static setupShortenedMessage(importResourceElement) {
+        const message = importResourceElement.importResource ? importResourceElement.importResource.message : '' || '';
+        if (message.length > MAX_MESSAGE_LENGTH) {
+            importResourceElement.shortenedMessage = message.substring(0, MAX_MESSAGE_LENGTH) + '...';
+        }
     }
 
     /**

--- a/src/js/angular/import/templates/import-resource-message-dialog.html
+++ b/src/js/angular/import/templates/import-resource-message-dialog.html
@@ -1,0 +1,29 @@
+<div class="modal-header">
+    <button type="button" class="close" ng-click="close()"></button>
+</div>
+
+<div class="modal-body">
+    <form>
+        <div class="form-group">
+            <textarea class="form-control message" rows="30" ng-model="message" readonly
+                      ng-maxlength="sizeLimit-1"></textarea>
+        </div>
+    </form>
+</div>
+
+<div class="modal-footer">
+    <div>
+        <button
+            type="button"
+            class="btn btn-secondary close-btn"
+            ng-click="close()">
+            {{'common.close' | translate}}
+        </button>
+        <button
+            type="button"
+            class="btn btn-primary copy-to-clipboard-btn"
+            ng-click="copyToClipboard()">
+            {{'copy.to.clipboard.modal.ok.btn' | translate}}
+        </button>
+    </div>
+</div>

--- a/src/js/angular/import/templates/import-resource-message.html
+++ b/src/js/angular/import/templates/import-resource-message.html
@@ -31,10 +31,14 @@
             </span>
         </div>
     </div>
-    <span ng-if="resource.importResource.status === ImportResourceStatus.ERROR"
-          class="text-danger">
+    <span ng-if="resource.importResource.status === ImportResourceStatus.ERROR" class="text-danger error-message">
         <em class="icon-warning"></em>
-        <small>{{resource.importResource.message || ''}}</small>
+        <button ng-if="resource.shortenedMessage"
+                class="btn btn-link"
+                ng-click="showMessage(resource)">
+            <small>{{resource.shortenedMessage}}</small>
+        </button>
+        <small ng-if="!resource.shortenedMessage">{{resource.importResource.message || ''}}</small>
     </span>
     <span class="text-secondary import-status-loader"
           ng-if="resource.importResource.status === ImportResourceStatus.IMPORTING || resource.importResource.status === ImportResourceStatus.UPLOADING || resource.importResource.status === ImportResourceStatus.PENDING || resource.importResource.status === ImportResourceStatus.INTERRUPTING">

--- a/src/js/angular/models/import/import-resource-tree-element.js
+++ b/src/js/angular/models/import/import-resource-tree-element.js
@@ -84,6 +84,8 @@ export class ImportResourceTreeElement {
          * @type {string}
          */
         this.iconClass = '';
+
+        this.shortenedMessage = '';
     }
 
     /**

--- a/test-cypress/fixtures/graphdb-import/more-files-with-error/import-resource-with-long-error.rdf
+++ b/test-cypress/fixtures/graphdb-import/more-files-with-error/import-resource-with-long-error.rdf
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:ex="http://example.org/stuff/1.0/">
+
+	<rdf:Description rdf:about="http://www.w3.org/TR/rdf-syntax-grammar"
+		dc:title="RDF1.1 XML Syntax">
+		<ex:looooooooooooooooooooooooooooooooongTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaame>
+			</rdf:Description>
+		</ex:looooooooooooooooooooooooooooooooongTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaame>
+	</rdf:Description>
+
+</rdf:RDF>

--- a/test-cypress/integration/import/import-view.spec.js
+++ b/test-cypress/integration/import/import-view.spec.js
@@ -37,7 +37,7 @@ describe('Import view', () => {
         // When I switch to the server files tab
         ImportUserDataSteps.openServerFilesTab();
         // Then I should see the server files only
-        ImportServerFilesSteps.getResources().should('have.length', 17);
+        ImportServerFilesSteps.getResources().should('have.length', 18);
         // When I switch back to the user data tab
         ImportServerFilesSteps.openUserDataTab();
         // Then I should see the uploaded file
@@ -91,7 +91,7 @@ describe('Import view', () => {
         ImportUserDataSteps.getHelpMessage().should('exist');
 
         // When I go to server tab
-        ImportSteps.openServerFilesTab()
+        ImportSteps.openServerFilesTab();
 
         // Then help message mustn't be displayed because the resources are not empty.
         ImportServerFilesSteps.getHelpMessage().should('not.exist');

--- a/test-cypress/steps/import/import-resource-message-dialog.js
+++ b/test-cypress/steps/import/import-resource-message-dialog.js
@@ -1,0 +1,46 @@
+export class ImportResourceMessageDialog {
+
+    static getDialog() {
+        return cy.get('.import-resource-message-dialog');
+    }
+
+    static getDialogHeader() {
+        return ImportResourceMessageDialog.getDialog().find('.modal-header');
+    }
+
+    static getCornerCloseButton() {
+        return ImportResourceMessageDialog.getDialogHeader().find('.close');
+    }
+
+    static clickOnCornerCloseButton() {
+        ImportResourceMessageDialog.getCornerCloseButton().click();
+    }
+
+    static getDialogBody() {
+        return ImportResourceMessageDialog.getDialog().find('.modal-body');
+    }
+
+    static getDialogFooter() {
+        return ImportResourceMessageDialog.getDialog().find('.modal-footer');
+    }
+
+    static getCloseButton() {
+        return ImportResourceMessageDialog.getDialogFooter().find('.close-btn');
+    }
+
+    static clickOnCloseButton() {
+        ImportResourceMessageDialog.getCloseButton().click();
+    }
+
+    static getMessage() {
+        return this.getDialogBody().find('.message');
+    }
+
+    static getCopyToClipboard() {
+        return ImportResourceMessageDialog.getDialogFooter().find('.copy-to-clipboard-btn')
+    }
+
+    static copyToClipboard() {
+        ImportResourceMessageDialog.getCopyToClipboard().click();
+    }
+}

--- a/test-cypress/steps/import/import-steps.js
+++ b/test-cypress/steps/import/import-steps.js
@@ -189,6 +189,10 @@ class ImportSteps {
         return this.getResourceByName(name).next().find('import-resource-message');
     }
 
+    static openErrorDialog(name) {
+        this.getResourceStatus(name).find('.error-message .btn').click();
+    }
+
     static getImportedResourcesStates() {
         return this.getResources().find('.import-resource-message');
     }


### PR DESCRIPTION
What
When an import fails and the error message is lengthy, the view does not look good.

Why
In the WB, the server message returned for every import is displayed to the user as it is, without any modifications. When the message is too lengthy, it is displayed as simple text without formatting. This makes the error report unusable.

How
When the error message is too lengthy, we will show a small piece to the user as a button. When the user clicks it, a dialog with the full error message will open.