### PR TITLE
Fixed three time calling init function in import view

### DIFF
--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -471,10 +471,10 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
         // Initialization
         // =========================
         $scope.importViewControllerInit = () => {
-            loadDefaultSettings();
-            pollList();
             initSubscriptions();
             getAppData();
+            loadDefaultSettings();
+            pollList();
             onActiveTabChanged(ImportContextService.getActiveTabId());
         };
     }]);


### PR DESCRIPTION
# Fixes three-time initialization of main import service

## What
- When the import view is opened, the init method of the main controller is called three times;
- Both the import and server data controllers are initialized regardless of the selected tab

## Why
On Bootstrap, all import controllers are initialized because they are defined in one module.
- When the main controller initializes all fields and functions, the init method is called. Inside the controller declaration, it calls its own init() function.
- When the server import controller is initialized, it extends the main controller. After initializing the fields and functions:
  - The main controller's init() function is called for the second time (triggered because the server import controller extends the main controller).
  - When the server controller is initialized, it calls its init method regardless of which tab is chosen.
- When the user import controller is initialized, it extends the main controller. After initializing the fields and functions:
  - The main controller's init() function is called for the third time (triggered because the user import controller extends the main controller);
  - When the user controller is initialized, it calls its init method regardless of which tab is chosen.
### Summary
When the page is loaded:
- The init method of the main controller is called due to self-initialization (This is not OK because the main controller is an 'abstract' class and should not be self-initialized);
-The server import controller is called regardless of whether the user import tab is selected:
   - The main class init method is called (at this point, it is OK for the superclass logic to be initialized);
   - The init method of the server import controller is called (after the superclass is ready, it is OK to initialize the server import controller).
- The user import controller is called regardless of whether the server import tab is selected:
   - The main class init method is called (at this point, it is OK for the superclass logic to be initialized);
   - The init method of the user import controller is called (after the superclass is ready, it is OK to initialize the user import controller).

## How
- Remove the self-initialization of the main controller;
- Add a condition to prevent the server import controller from self-initializing if the user import tab is selected;
- Add a condition to prevent the user import controller from self-initializing if the server import tab is selected.

There is a random NPE in Cypress tests

What
Sometimes Cypress fails when trying to import RDF data from a URL or text snippet.

Why
This can happen when the setSettingsFor function is called before the default settings are loaded.

How
A getDefaultSettings function is implemented that returns a Promise with the default settings of the chosen repository. The function returns immediately if the settings are already loaded; otherwise, it loads them from the backend.