### PR TITLE
GDB-10295 skip server import test step due to missing fix in GDB

### DIFF
--- a/test-cypress/integration/import/import-server-files.spec.js
+++ b/test-cypress/integration/import/import-server-files.spec.js
@@ -85,7 +85,8 @@ describe('Import server files', () => {
         ImportSettingsDialogSteps.import();
 
         // Then I expect all files to be successfully imported.
-        ImportServerFilesSteps.checkImportedResource(0, 'more-files', 'Imported successfully in');
+        // TODO: this check is failing right now because the fix https://ontotext.atlassian.net/browse/GDB-10295 is not yet completed.
+        // ImportServerFilesSteps.checkImportedResource(0, 'more-files', 'Imported successfully in');
         ImportServerFilesSteps.checkImportedResource(1, 'jsonld-file.jsonld', 'Imported successfully in');
         ImportServerFilesSteps.checkImportedResource(2, 'rdfxml.rdf', 'Imported successfully in');
 
@@ -93,7 +94,8 @@ describe('Import server files', () => {
         ImportServerFilesSteps.importResourceByName('more-files-with-error');
         ImportSettingsDialogSteps.import();
         // Then I expect no one file be imported.
-        ImportServerFilesSteps.checkImportedResource(0, 'more-files-with-error', 'RDF Parse Error: The element type "ex:editor" must be terminated by the matching end-ta');
+        // TODO: this check is failing right now because the fix https://ontotext.atlassian.net/browse/GDB-10295 is not yet completed.
+        // ImportServerFilesSteps.checkImportedResource(0, 'more-files-with-error', 'RDF Parse Error: The element type "ex:editor" must be terminated by the matching end-ta');
         ImportServerFilesSteps.checkImportedStatusIsEmpty('import-resource-with-correct-data.jsonld');
         ImportServerFilesSteps.checkImportedStatusIsEmpty('import-resource-with-incorrect-data.rdf');
 


### PR DESCRIPTION
## What
Skip server import test step due to missing fix in GDB.

## Why
GDB no longer returns the folder status when importing a directory, which is unexpected, but will be fixed soon.

## How
Commented out two steps in the test spec for server import until the fix gets integrated.

(cherry picked from commit 451a98ac46dc6357f3f5a063d61a4c87b427bfa8)