### PR TITLE
Add npm install step before validation in Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,25 +19,26 @@ pipeline {
 
   stages {
 
-  stage('Validate translations') {
-    steps {
-        sh 'node scripts/validate-translations.js || exit 1'
-    }
-  }
-
-  stage('Print Branch Name') {
-    steps {
-      script {
-        echo "Building branch: ${env.BRANCH_NAME}"
-      }
-    }
-  }
-
     stage('Install') {
       steps {
         sh "npm install"
       }
     }
+
+    stage('Validate translations') {
+     steps {
+       sh 'node scripts/validate-translations.js || exit 1'
+     }
+    }
+
+    stage('Print Branch Name') {
+      steps {
+        script {
+          echo "Building branch: ${env.BRANCH_NAME}"
+        }
+      }
+    }
+
 
 //     stage('Test') {
 //       steps {


### PR DESCRIPTION
To ensure all node.js dependencies are properly installed before validation, the 'npm install' step has been added prior to the 'Validate translations' stage in the Jenkinsfile. This change aims to prevent errors related to missing node modules.