### PR TITLE
GDB-10354 - Move tabs in Resource view together when window resized

### DIFF
--- a/src/css/bootstrap-graphdb-theme.css
+++ b/src/css/bootstrap-graphdb-theme.css
@@ -1412,6 +1412,7 @@ footer.footer .container-fluid.main-container p {
 -------------------------------------------------------------*/
 .nav-tabs {
     font-weight: 400;
+    display: inline-block;
 }
 
 .nav-tabs .nav-item {


### PR DESCRIPTION
## What?
When resizing the window, the tabs in the Resource view will move down together, to make space for the button group on the right.

## Why?
The previous behavior was odd, because each tab would move down separately.

## How?
I changed the styling of the tabs.

## Screenshots?
On resize after the suggested improvement to the styling:
![Screenshot from 2024-06-17 10-13-02](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/71df899a-462b-44f8-9914-f25c5c680eba)
