### PR TITLE
GDB-10366 don't send for import children of folders that are completely selected

### DIFF
--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -458,7 +458,7 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             ImportContextService.updateResources([]);
             ImportContextService.updateShowLoader(true);
             $scope.updateListHttp(true).finally(() => ImportContextService.updateShowLoader(false));
-        }
+        };
 
         const initSubscriptions = () => {
             subscriptions.push($scope.$on('repositoryIsSet', $scope.onRepositoryChange));

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -152,8 +152,8 @@ function importResourceTreeDirective($timeout, ImportContextService) {
             };
 
             $scope.importAll = (withoutChangingSettings) => {
-                const selectedResources = $scope.resources.getAllSelected();
-                if (selectedResources && selectedResources.length > 0) {
+                const selectedResources = $scope.resources.getAllSelectedForImport();
+                if (selectedResources.length > 0) {
                     $scope.onImportAll({selectedResources: selectedResources, withoutChangingSettings});
                 }
             };
@@ -204,10 +204,10 @@ function importResourceTreeDirective($timeout, ImportContextService) {
             };
 
             const updateHasSelection = () => {
-                let allSelectedFilesNames = $scope.resources.getAllSelectedFilesNames();
+                const allSelectedFilesNames = $scope.resources.getAllSelectedFilesNames();
                 $scope.hasSelection = allSelectedFilesNames.length > 0;
                 ImportContextService.updateSelectedFilesNames(allSelectedFilesNames);
-            }
+            };
 
             const updateSelectByStateDropdownModel = () => {
                 const hasUnselectedDisplayedImportResource = $scope.displayResources.some((resource) => !resource.selected);

--- a/src/js/angular/models/import/import-resource.js
+++ b/src/js/angular/models/import/import-resource.js
@@ -8,6 +8,7 @@ import {ImportResourceType} from "./import-resource-type";
 export class ImportResource {
 
     constructor(importResourceServerData, hashGenerator) {
+        // we use hash as a key to tell angular that the object has changed, and it should update the view
         this.hash = hashGenerator(JSON.stringify(importResourceServerData));
         this.name = importResourceServerData ? importResourceServerData.name : undefined;
         this.status = importResourceServerData ? importResourceServerData.status : ImportResourceStatus.NONE;


### PR DESCRIPTION
## What
Don't send for import children of folders that are completely selected. Meaning that all children are selected as well.

## Why
Sending the children of selected folders forces the backend to import them twice, once when the folder is imported and second for each individual resource sent for import.

## How
Implemented separate method in the resource tree that allows collecting all selected resources but if the selected resource is a directory, then it's children is not collected for import.