### PR TITLE
GDB-10369 JSONLD and NDJSONLD export improvements

### DIFF
--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -353,8 +353,9 @@ function yasguiComponentDirective(
                     });
 
                     modalInstance.result.then(function (data) {
+                        const relValue = data.currentMode.name === 'framed' ? 'frame' : 'context';
                         const acceptHeader = accept + ';profile=' + data.currentMode.link;
-                        const linkHeader = data.link ? '<' + data.link + '>' : '';
+                        const linkHeader = data.link ? `<${data.link}>; rel=http://www.w3.org/ns/json-ld#${relValue}` : '';
                         downloadAs(query, infer, sameAs, authToken, acceptHeader, linkHeader);
                     });
                 } else {

--- a/src/js/angular/export/controllers.js
+++ b/src/js/angular/export/controllers.js
@@ -229,7 +229,8 @@ exportCtrl.controller('ExportCtrl',
                 });
 
                 modalInstance.result.then(function (data) {
-                    const linkHeader = data.link ? '<' + data.link + '>' : '';
+                    const relValue = data.currentMode.name === 'framed' ? 'frame' : 'context';
+                    const linkHeader = data.link ? `<${data.link}>; rel=http://www.w3.org/ns/json-ld#${relValue}` : '';
                     downloadJSONLDExport(format, context, linkHeader, $repositories.getActiveRepositoryObject(), $scope.graphsByValue, data.currentMode);
                 });
             };


### PR DESCRIPTION
What
Current WB implementation of the Link header value in JSON-LD requests sent to GDB is missing the ; rel=http://www.w3.org/ns/json-ld#frame and ; rel=http://www.w3.org/ns/json-ld#context attributes. 
Why
These rel attributes are essential for indicating the relationship type of the linked resources as per the JSON-LD specifications.
How
Added rel attribute in Link header based on selected mode.