### PR TITLE
Cherry pick GDB-10354 - move tab styling from global theme to local stylesheet

### DIFF
--- a/src/css/bootstrap-graphdb-theme.css
+++ b/src/css/bootstrap-graphdb-theme.css
@@ -1412,7 +1412,6 @@ footer.footer .container-fluid.main-container p {
 -------------------------------------------------------------*/
 .nav-tabs {
     font-weight: 400;
-    display: inline-block;
 }
 
 .nav-tabs .nav-item {

--- a/src/css/explore.css
+++ b/src/css/explore.css
@@ -17,3 +17,7 @@
         padding-right: 20px;
     }
 }
+
+.nav-tabs {
+    display: inline-block;
+}


### PR DESCRIPTION
## What?
The tabs in the Resource view will have different styling, which won't be applied to other tabs in the app.

## Why?
With the fix in https://github.com/Ontotext-AD/graphdb-workbench/pull/1429, the styling of some other tabs was affected in an undesired way.

## How?
The styling was moved to the local stylesheet for the `explore` page.

(cherry picked from commit c00265cba7909ef6ef91bca88522089e8856c99e)