### PR TITLE
GDB-10382 - Reinit Yasgui if the repo is changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.3.14",
+        "ontotext-yasgui-web-component": "1.3.15",
         "shepherd.js": "^11.2.0"
     },
     "resolutions": {

--- a/src/js/angular/models/ontotext-yasgui/ontotext-yasgui-config.js
+++ b/src/js/angular/models/ontotext-yasgui/ontotext-yasgui-config.js
@@ -154,6 +154,13 @@ export class OntotextYasguiConfig {
         this.immutableSameAs = undefined;
 
         /**
+         * If the Yasgui state should be cleared to the initial state. Default value is false.
+         *
+         * @type {boolean}
+         */
+        this.clearState = false;
+
+        /**
          * If the configured endpoint should be preconfigured to any new opened editor tab.
          *
          * @type {boolean}

--- a/src/js/angular/sparql-editor/controllers.js
+++ b/src/js/angular/sparql-editor/controllers.js
@@ -15,13 +15,13 @@ import {VIEW_SPARQL_EDITOR} from "../models/sparql/constants";
 import {CancelAbortingQuery} from "../models/sparql/cancel-aborting-query";
 import {QueryMode} from "../models/ontotext-yasgui/query-mode";
 import 'angular/core/services/event-emitter-service';
-import {YasguiResetFlags} from "../models/ontotext-yasgui/yasgui-reset-flags";
 
 const modules = [
     'ui.bootstrap',
     'graphdb.framework.rest.connectors.service',
     'graphdb.framework.externalsync.controllers',
-    'graphdb.framework.utils.event-emitter-service'
+    'graphdb.framework.utils.event-emitter-service',
+    'graphdb.framework.utils.localstorageadapter'
 ];
 
 angular
@@ -44,7 +44,9 @@ SparqlEditorCtrl.$inject = [
     'GuidesService',
     'ModalService',
     'MonitoringRestService',
-    'EventEmitterService'];
+    'EventEmitterService',
+    'LocalStorageAdapter',
+    'LSKeys'];
 
 function SparqlEditorCtrl($rootScope,
                           $scope,
@@ -61,13 +63,13 @@ function SparqlEditorCtrl($rootScope,
                           GuidesService,
                           ModalService,
                           MonitoringRestService,
-                          EventEmitterService) {
+                          EventEmitterService,
+                          LocalStorageAdapter,
+                          LSKeys) {
     this.repository = '';
 
     const QUERY_EDITOR_ID = '#query-editor';
-    // When the view is loaded the repository change watcher will be triggered. We need to have this flag to prevent
-    // resetting the yasgui on the first load. This flag will be set to false after the first repository change.
-    let initialRepoInitialization = true;
+    let activeRepository = $repositories.getActiveRepository();
 
     /**
      * @type {OntotextYasguiConfig}
@@ -84,7 +86,11 @@ function SparqlEditorCtrl($rootScope,
     // =========================
     // Public functions
     // =========================
-    $scope.updateConfig = () => {
+    /**
+     * Updates the Yasgui configuration
+     * @param {boolean} clearYasguiState if set to true, the Yasgui will reinitialize and clear all tab results. Queries will remain.
+     */
+    $scope.updateConfig = (clearYasguiState) => {
         $scope.yasguiConfig = {
             endpoint: getEndpoint,
             componentId: VIEW_SPARQL_EDITOR,
@@ -96,12 +102,13 @@ function SparqlEditorCtrl($rootScope,
             outputHandlers: new Map([
                 [EventDataType.QUERY_EXECUTED, queryExecutedHandler],
                 [EventDataType.REQUEST_ABORTED, requestAbortedHandler]
-            ])
+            ]),
+            clearState: clearYasguiState !== undefined ? clearYasguiState : false
         };
     };
 
     $scope.getActiveRepositoryNoError = () => {
-        return $repositories.getActiveRepository();
+        return activeRepository;
     };
 
     // =========================
@@ -124,8 +131,13 @@ function SparqlEditorCtrl($rootScope,
         return $repositories.resolveSparqlEndpoint(yasqe.getQueryMode());
     };
 
-    const initViewFromUrlParams = () => {
-        $scope.updateConfig();
+    /**
+     * Initializes the editor from the URL parameters.
+     * @param {boolean} clearYasguiState if set to true, the Yasgui will reinitialize and clear all tab results. Queries will remain.
+     * The default is false.
+     */
+    const initViewFromUrlParams = (clearYasguiState = false) => {
+        $scope.updateConfig(clearYasguiState);
         const queryParams = $location.search();
         if (queryParams.hasOwnProperty(RouteConstants.savedQueryName)) {
             // init new tab from shared saved query link
@@ -409,7 +421,7 @@ function SparqlEditorCtrl($rootScope,
     };
 
     // Initialization and bootstrap
-    const init = () => {
+    const init = (clearYasguiState) => {
         // This script check is required, because of the following scenario:
         // I am in the SPARQL view;
         // Then I go to a different view and change the language;
@@ -430,12 +442,12 @@ function SparqlEditorCtrl($rootScope,
                 return;
             }
         }
-        Promise.all([$jwtAuth.getPrincipal(), $repositories.getPrefixes($repositories.getActiveRepository())])
+        Promise.all([$jwtAuth.getPrincipal(), $repositories.getPrefixes(activeRepository)])
             .then(([principal, usedPrefixes]) => {
                 $scope.prefixes = usedPrefixes;
                 setInferAndSameAs(principal);
                 // check is there is a saved query or query url parameter and init the editor
-                initViewFromUrlParams();
+                initViewFromUrlParams(clearYasguiState);
             });
         // TODO: we should also watch for changes in namespaces
         // scope.$watch('namespaces', function () {});
@@ -446,24 +458,13 @@ function SparqlEditorCtrl($rootScope,
     // =========================
     const subscriptions = [];
 
-    const reInitYasgui = (flags) => {
-        YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(QUERY_EDITOR_ID)
-            .then((yasguiComponent) => {
-                return yasguiComponent.reInitYasgui(flags);
-            })
-            .catch(() => {
-                console.error('Failed to reset yasr results');
-            });
-    };
-
-    const repositoryChangedHandler = (activeRepo) => {
-        if (activeRepo) {
-            if (!initialRepoInitialization) {
-                const flags = new YasguiResetFlags(true, true, true, true);
-                reInitYasgui(flags);
-            }
-            init();
-            initialRepoInitialization = false;
+    const repositoryChangedHandler = () => {
+        activeRepository= $repositories.getActiveRepository();
+        if (LocalStorageAdapter.get(LSKeys.SPARQL_LAST_REPO) !== activeRepository) {
+            init(true);
+            persistLasstUsedRepository();
+        } else {
+            init(false);
         }
     };
 
@@ -538,6 +539,25 @@ function SparqlEditorCtrl($rootScope,
         window.removeEventListener('beforeunload', beforeunloadHandler);
     };
 
+    const finalizeAndDestroy = () => {
+        persistLasstUsedRepository();
+        removeAllListeners();
+    };
+
+    const persistLasstUsedRepository = () => {
+        // The active repository is set when the controller is initialized and when the repository is changed.
+        // It holds the actual repository when the YASGUI is initialized. DON'T use runtime fetching of the actual repository here, because there is a scenario:
+        // 1. Open a tab with the SPARQL view open;
+        // 2. Open the SPARQL view in another tab and execute a query;
+        // 3. Switch to the repositories view and change the repository;
+        // 4. Switch back to the SPARQL view, and the YASR is not cleared.
+        // The problem occurs because of the second tab. When the repository is changed, its ID is persisted to local storage, which triggers the "storage" event to be fired.
+        // In the main controller, a listener has been registered to listen to that event and refresh the page outside of the Angular scope.
+        // Reloading the page triggers the destruction of the component and persistence of the active repository. The reloading of the page is out of the Angular scope, so the "activeRepository"
+        // holds the real repository when the YASGUI is created. If we use $$repositories.getActiveRepository(), the new value will be fetched, which in this case will be incorrect.
+        LocalStorageAdapter.set(LSKeys.SPARQL_LAST_REPO, activeRepository);
+    }
+
     subscriptions.push(
         $scope.$on('language-changed', function () {
             location.reload();
@@ -561,7 +581,7 @@ function SparqlEditorCtrl($rootScope,
         ));
 
     // Deregister the watcher when the scope/directive is destroyed
-    $scope.$on('$destroy', removeAllListeners);
+    subscriptions.push($scope.$on('$destroy', finalizeAndDestroy));
 
     // Wait until the active repository object is set, otherwise "canWriteActiveRepo()" may return a wrong result and the "ontotext-yasgui"
     // readOnly configuration may be incorrect.

--- a/src/js/angular/utils/local-storage-adapter.js
+++ b/src/js/angular/utils/local-storage-adapter.js
@@ -27,7 +27,8 @@ angular
         'REPOSITORY_ID': 'repository-id',
         'REPOSITORY_LOCATION': 'repository-location',
         'JSONLD_EXPORT_SETTINGS': 'jsonld-export-settings',
-        'IMPORT_VIEW': 'import-view'
+        'IMPORT_VIEW': 'import-view',
+        'SPARQL_LAST_REPO': 'sparql-last-repo'
     });
 
 LocalStorageAdapter.$inject = ['localStorageService', 'LSKeys'];


### PR DESCRIPTION
## What?
If the repository is changed, the Yasgui will clear the results and set the inference correctly for virtual repos.

## Why?
When running a query in a local repo without infer, then going to the repository menu and switching to a virtual repo, the Sparql editor would keep the infer off and the user won't be able to toggle it. The inference should always be on for virtual repositories.

## How?
I save the current repo in the local storage. When opening the Sparql page, the current and local store repositories are compared. If they are different, the component is reinitialized with a new flag in its config (to reset the state).

## Dependencies?
Depends on Yasgui MR:  https://github.com/Ontotext-AD/ontotext-yasgui/pull/274