### PR TITLE
GDB-10397 fix for the selection of files for import

### DIFF
--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -464,6 +464,11 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
             subscriptions.push($scope.$on('repositoryIsSet', $scope.onRepositoryChange));
             subscriptions.push($scope.$on('$destroy', () => $interval.cancel(listPollingHandler)));
             subscriptions.push(ImportContextService.onActiveTabIdUpdated((newActiveTabId) => onActiveTabChanged(newActiveTabId)));
+            subscriptions.push(ImportContextService.onSelectedFilesNamesUpdated(() => {
+                $scope.selectedForImportFiles = ImportContextService.getSelectedFilesNames()
+                    .map((name) => ({[name]: true}))
+                    .reduce((acc, val) => Object.assign(acc, val), {});
+            }));
             $scope.$on('$destroy', removeAllListeners);
         };
 

--- a/src/js/angular/models/import/import-resource-tree-element.js
+++ b/src/js/angular/models/import/import-resource-tree-element.js
@@ -261,7 +261,7 @@ export class ImportResourceTreeElement {
         const allSelected = [];
         const isRoot = this.isRoot();
         // If this is not the root, and it is selected, then push it to the list. This can be a file or directory which
-        // is has all files in it selected.
+        // has all files in it selected.
         if (!isRoot && this.selected) {
             allSelected.push(this);
         }


### PR DESCRIPTION
## What
Fix for the selection of files for import.

## Why
It appears that there are cases where files list maintained in the import view controller is not properly updated when a selection is made through the checkboxes in the resource tree which leads to wrong files sent for import.

## How
Added subscription for the selectedFileNamesUpdated event and updated the selectedForImportFiles list in the import view controller.

(cherry picked from commit 704d62b6e36e338b210c5688526dea60ad17c80c)