### PR TITLE
(2.7 branch) GDB-10416 - Change label on import modal cancel button

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -908,6 +908,7 @@
         "forces.serial.statements": "Forces the use of the serial statements pipeline. Not recommended. Use for debugging only.",
         "force.serial.pipeline": "Force serial pipeline",
         "restore.defaults.btn": "Restore defaults",
+        "only.upload.btn": "Only upload",
         "abort.btn": "Abort",
         "no.files.found": "No files found",
         "enable.for.auto.start": "Enable this option to start the import when you click the Import button. If it is disabled the import will be added to the list but not started automatically.",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -916,6 +916,7 @@
         "forces.serial.statements": "Force l'utilisation du pipeline d'instructions en série. Non recommandé. A utiliser uniquement pour le débogage.",
         "force.serial.pipeline": "Forcer le pipeline série",
         "restore.defaults.btn": "Restaurer les valeurs par défaut",
+        "only.upload.btn": "Télécharger uniquement",
         "abort.btn": "Abandonner",
         "no.files.found": "Aucun fichier trouvé",
         "enable.for.auto.start": "Activez cette option pour lancer l'importation lorsque vous cliquez sur le bouton Importer. Si elle est désactivée, l'importation sera ajoutée à la liste mais ne démarrera pas automatiquement.",

--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -129,6 +129,9 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
                             },
                             isMultiple: function () {
                                 return !fileName;
+                            },
+                            activeTab: function () {
+                                return $scope.activeTabId;
                             }
                         },
                         size: 'lg'

--- a/src/js/angular/import/controllers/settings-modal.controller.js
+++ b/src/js/angular/import/controllers/settings-modal.controller.js
@@ -1,10 +1,11 @@
+import {TABS} from "../services/import-context.service";
 angular
     .module('graphdb.framework.impex.import.controllers.settings-modal', [])
     .controller('SettingsModalController', SettingsModalController);
 
-SettingsModalController.$inject = ['$scope', '$uibModalInstance', 'toastr', 'UriUtils', 'settings', 'hasParserSettings', 'defaultSettings', 'isMultiple', '$translate'];
+SettingsModalController.$inject = ['$scope', '$uibModalInstance', 'toastr', 'UriUtils', 'settings', 'hasParserSettings', 'defaultSettings', 'isMultiple', 'activeTab', '$translate'];
 
-function SettingsModalController($scope, $uibModalInstance, toastr, UriUtils, settings, hasParserSettings, defaultSettings, isMultiple, $translate) {
+function SettingsModalController($scope, $uibModalInstance, toastr, UriUtils, settings, hasParserSettings, defaultSettings, isMultiple, activeTab, $translate) {
 
     // =========================
     // Public variables
@@ -15,6 +16,8 @@ function SettingsModalController($scope, $uibModalInstance, toastr, UriUtils, se
     $scope.isMultiple = isMultiple;
     $scope.enableReplace = !!($scope.settings.replaceGraphs && $scope.settings.replaceGraphs.length);
     $scope.showAdvancedSettings = false;
+    $scope.activeTab = activeTab;
+    $scope.userTabId = TABS.USER;
 
     // =========================
     // Public functions

--- a/src/js/angular/import/templates/settingsModal.html
+++ b/src/js/angular/import/templates/settingsModal.html
@@ -310,7 +310,7 @@
         {{'import.restore.defaults.btn' | translate}}
     </button>
     <button type="button" class="btn btn-secondary cancel-import-button" ng-click="cancel()" guide-selector="import-settings-cancel-button">
-        {{'common.cancel.btn' | translate}}
+        {{activeTab === userTabId ? 'import.only.upload.btn' : 'common.cancel.btn' | translate}}
     </button>
     <button type="submit" form="settingsForm" ng-click="ok()" ng-disabled="settingsForm.$invalid"
             class="btn btn-primary import-settings-import-button"

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -908,6 +908,7 @@
         "forces.serial.statements": "Forces the use of the serial statements pipeline. Not recommended. Use for debugging only.",
         "force.serial.pipeline": "Force serial pipeline",
         "restore.defaults.btn": "Restore defaults",
+        "only.upload.btn": "Only upload",
         "abort.btn": "Abort",
         "no.files.found": "No files found",
         "enable.for.auto.start": "Enable this option to start the import when you click the Import button. If it is disabled the import will be added to the list but not started automatically.",


### PR DESCRIPTION
## What?
When uploading a file, the dialog window will show "Only upload" and "Import" as the two button options. There will be no "Cancel" option in the "User data" tab. The "Server files" tab will still have the "Cancel" button.

## Why?
The "Cancel" button was confusing, because the file would get uploaded either way.

## How?
I changed the label in the modal by giving it information about the current tab.

## Screenshots?
User Data tab:
![image](https://github.com/Ontotext-AD/graphdb-workbench/assets/158429017/89477e3c-46b5-4639-978e-acc51ed1eaf6)
