### PR TITLE
(Cherry pick) GDB 10391 - Render menu labels faster

### DIFF
--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -23,6 +23,7 @@ import './guides/directives';
 import {GUIDE_PAUSE} from './guides/tour-lib-services/shepherd.service';
 import 'angular-pageslide-directive/dist/angular-pageslide-directive';
 import 'angularjs-slider/dist/rzslider.min';
+import {debounce} from "lodash";
 
 angular
     .module('graphdb.workbench.se.controllers', [
@@ -201,9 +202,9 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         $scope.initTutorial();
     });
 
-    $scope.checkMenu = function () {
+    $scope.checkMenu = debounce(function() {
         return $('.main-menu').hasClass('collapsed');
-    };
+    }, 250, {trailing: false});
 
     //Copy to clipboard popover options
     $scope.copyToClipboard = function (uri) {
@@ -514,6 +515,9 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 
     $scope.$on('$destroy', () => {
         window.removeEventListener('storage', localStoreChangeHandler);
+        if ($scope.checkMenu) {
+            $timeout.cancel($scope.checkMenu);
+        }
     });
 
     $scope.isAdmin = function () {

--- a/src/template.html
+++ b/src/template.html
@@ -120,7 +120,7 @@
         <a class="menu-element-root" ng-href="{{::item.hrefFun ? item.hrefFun(productInfo) : item.href}}" ng-if="!item.children.length"
            ng-click="select($index, $event, clicked)">
             <span ng-class=item.icon class="menu-item-icon"></span>
-            <span class="menu-item" ng-if="!checkMenu()">{{item.label}}</span>
+            <span class="menu-item" ng-show="!checkMenu()">{{item.label}}</span>
         </a>
         <ul ng-if="item.children.length" class="sub-menu">
             <li class="submenu-title">{{item.label}}</li>


### PR DESCRIPTION
## What?
The "Import" and "SPARQL" main menu labels will render faster on window resize.

## Why?
The two labels would load slower than the rest during resize.

## How?
I changed the ng-if to ng-show and added a debounce function to the function called.


(cherry picked from commit 309bf22789698a40c0bb1ba2625d62e9f635925e)