### PR TITLE
GDB-10422 prevent requests without repository id in import view

### DIFF
--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -375,6 +375,9 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
          * @param {boolean} force - Force the files list to be replaced with the new data
          */
         $scope.updateListHttp = (force) => {
+            if (!$repositories.getActiveRepository()) {
+                return Promise.resolve();
+            }
             const filesLoader = $scope.activeTabId === TABS.USER ? ImportRestService.getUploadedFiles : ImportRestService.getServerFiles;
             const executedInTabId = $scope.activeTabId;
             return filesLoader($repositories.getActiveRepository())


### PR DESCRIPTION
## What
Prevent requests without repository id in import view.

## Why
When the import view is loaded, a request for uploaded/imported files is made, but in case where a repository is not selected the request fails to be registered by the authentication interceptor and in result the server responds with 401 which causes the browser to open the native login form. That's why we need to ensure that each request will have the mandatory repository id parameter.

## How
Implemented a check if there is a repository selected before issuing the GET request for the imported files.