### PR TITLE
GDB-9968 revert the fix for the editor collapsing after paste

### DIFF
--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -444,6 +444,7 @@ function yasguiComponentDirective(
                     .then(SparqlRestService.addKnownPrefixes)
                     .then((response) => {
                         queryString = response.data;
+                        ontotextYasguiElement.setQuery(queryString);
                     })
                     .then(() => {
                         emitQueryChanged(JSON.stringify(queryString));


### PR DESCRIPTION
## What
Revert the fix for the editor collapsing after paste because it was fixed with another more generic approach with GDB-10399

## Why
The fix which was applied and which is now removed causes a regression in the editor where after query get's pasted, the needed prefixes are not automatically inserted.

## How
Reverted the fix applied with the related task so that the query to be re-applied in the editor after paste in order to trigger the prefixes insertion behavior.