### PR TITLE
GDB-10563: Fix workbench version replacements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "ignore-loader": "^0.1.2",
                 "less-loader": "^12.2.0",
                 "mini-css-extract-plugin": "^2.9.0",
+                "string-replace-loader": "^3.1.0",
                 "style-loader": "^4.0.0",
                 "webpack": "^5.93.0",
                 "webpack-cli": "^5.1.4",
@@ -6634,6 +6635,94 @@
             "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.2.0"
+            }
+        },
+        "node_modules/string-replace-loader": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/string-replace-loader/-/string-replace-loader-3.1.0.tgz",
+            "integrity": "sha512-5AOMUZeX5HE/ylKDnEa/KKBqvlnFmRZudSOjVJHxhoJg9QYTwl1rECx7SLR8BBH7tfxb4Rp7EM2XVfQFxIhsbQ==",
+            "dev": true,
+            "dependencies": {
+                "loader-utils": "^2.0.0",
+                "schema-utils": "^3.0.0"
+            },
+            "peerDependencies": {
+                "webpack": "^5"
+            }
+        },
+        "node_modules/string-replace-loader/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/string-replace-loader/node_modules/ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "dev": true,
+            "peerDependencies": {
+                "ajv": "^6.9.1"
+            }
+        },
+        "node_modules/string-replace-loader/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "node_modules/string-replace-loader/node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/string-replace-loader/node_modules/loader-utils": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+            "dev": true,
+            "dependencies": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
+            }
+        },
+        "node_modules/string-replace-loader/node_modules/schema-utils": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+            "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+            "dev": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "ignore-loader": "^0.1.2",
         "less-loader": "^12.2.0",
         "mini-css-extract-plugin": "^2.9.0",
+        "string-replace-loader": "^3.1.0",
         "style-loader": "^4.0.0",
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -7,14 +7,9 @@ const singleSpaDefaults = require("webpack-config-single-spa");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const path = require("path");
 
-// Pass this function as a transform argument to CopyPlugin elements to replace [AIV]{version}[/AIV]
-// with the current workbench version number. This is not related to the WebpackAutoInject plugin
-// (it will replace only in bundled files, not in CopyPlugin) but we use the same tag for consistency.
-function replaceVersion(content) {
-    return content
-        .toString()
-        .replace(/\[AIV]{version}\[\/AIV]/g, PACKAGE.version);
-}
+// The "string-replace-loader" replaces the version in all HTML and JS files except those copied by CopyPlugin.
+// This function must be used as the transform parameter of the plugin to replace the version.
+const replaceVersion = (content) => content.toString().replace(/\[AIV]{version}\[\/AIV]/g, PACKAGE.version);
 
 const host = 'localhost';
 const portHere = 9000;
@@ -230,6 +225,14 @@ module.exports = (webpackConfigEnv, argv) => {
         ],
         module: {
             rules: [
+                {
+                    test: /\.(js|html)$/,
+                    loader: 'string-replace-loader',
+                    options: {
+                        search: /\[AIV\]{version}\[\/AIV\]/g,
+                        replace: PACKAGE.version
+                    }
+                },
                 {
                     test: /\.(md|gzip|map)$/,
                     use: 'ignore-loader'


### PR DESCRIPTION
## What
Extended the webpack build process with functionality that replaces specific strings inside JS and HTML files with the actual version of the workbench.

## Why
There was such functionality before, which prevented browsers from using cached resources if the workbench version changed.

## How
The old plugin that performed this task is not supported in Webpack version 5. It was replaced with the "string-replace-loader" that performs the same function.