### PR TITLE
GDB-10582 fix api url used for abort operation of server files

### DIFF
--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -226,12 +226,13 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
         };
 
         /**
-         * Triggers a stop operation in the backend for selected resources.
+         * Triggers abort operation in the backend for selected resources.
          * @param {ImportResourceTreeElement} resource - The resource for which the import should be stopped.
          */
         $scope.onStopImport = (resource) => {
             const file = resource.importResource;
-            ImportRestService.stopImport($repositories.getActiveRepository(), {name: file.name, type: file.type})
+            const importAborter = $scope.activeTabId === TABS.USER ? ImportRestService.stopUserDataImport : ImportRestService.stopServerImport;
+            importAborter($repositories.getActiveRepository(), {name: file.name, type: file.type})
                 .success(function () {
                     $scope.updateList();
                 }).error(function (data) {

--- a/src/js/angular/rest/import.rest.service.js
+++ b/src/js/angular/rest/import.rest.service.js
@@ -16,7 +16,8 @@ function ImportRestService($http) {
         updateTextSnippet,
         importFromUrl,
         updateFromUrl,
-        stopImport,
+        stopServerImport,
+        stopUserDataImport,
         resetServerFileStatus,
         resetUserDataStatus
     };
@@ -90,13 +91,23 @@ function ImportRestService($http) {
     }
 
     /**
-     * Stops the import process.
+     * Stops the user data import process.
      * @param {string} repositoryId - The repository id
      * @param {{name: string, type: string}} params - The parameters to be sent to the server
      * @return {*}
      */
-    function stopImport(repositoryId, params) {
+    function stopUserDataImport(repositoryId, params) {
         return $http.delete(`${BASE_ENDPOINT}/${repositoryId}/import/upload`, {params});
+    }
+
+    /**
+     * Stops the server file import process.
+     * @param {string} repositoryId - The repository id
+     * @param {{name: string, type: string}} params - The parameters to be sent to the server
+     * @return {*}
+     */
+    function stopServerImport(repositoryId, params) {
+        return $http.delete(`${BASE_ENDPOINT}/${repositoryId}/import/server`, {params});
     }
 
     /**


### PR DESCRIPTION
## What
Fix api url used for abort operation of server files.

## Why
As most operations on the import view, there two distinct API's for aborting the import on the server files and user data tabs. The issue was that the API for aborting user data import was used on the server file import which resulted in anability to stop the import.

## How
Exposed a REST service for aborting server file import and updated the import controller to switch between REST services depending on the currently selected tab in the view.