### PR TITLE
Cherry pick GDB-10527 Fix flaky pagination tests

### DIFF
--- a/src/js/angular/core/directives/paginations.js
+++ b/src/js/angular/core/directives/paginations.js
@@ -1,6 +1,6 @@
 // Due to a problem in the uib-pagination library, the template needs to be recompiled, in order to set the first and last text in a new language
 angular.module('graphdb.framework.core.directives.paginations', [])
-    .directive('paginations', function ($translate, $rootScope, $compile) {
+    .directive('paginations', ["$translate", "$rootScope", "$compile", function ($translate, $rootScope, $compile) {
         return {
             link: function ($scope, element) {
                 const template = '<uib-pagination class="nav navbar-right" ' +
@@ -25,4 +25,4 @@ angular.module('graphdb.framework.core.directives.paginations', [])
                $scope.$on('$destroy', languageChangedSubscription);
             }
         };
-    });
+    }]);

--- a/test-cypress/integration/explore/graphs.overview.spec.js
+++ b/test-cypress/integration/explore/graphs.overview.spec.js
@@ -51,7 +51,7 @@ describe('Graphs overview screen validation', () => {
      * @return a cypress chainer containing the selected page link.
      */
     function selectPage(page) {
-        return cy.get(`.top-pagination ul li a`).contains(page).click();
+        return GraphsOverviewSteps.getTopPaginationLinks().contains(page).click();
     }
 
     function selectItemFromMenu(number) {
@@ -66,9 +66,10 @@ describe('Graphs overview screen validation', () => {
 
     context('Test graphs overview pagination', () => {
         it('Should be visible', () => {
-            cy.get('div[paginations]')
+            GraphsOverviewSteps.getPaginations()
                 .should('be.visible')
                 .and('contain', '3');
+            GraphsOverviewSteps.getTopPaginationLinks().should('have.length', 5);
             verifyGraphExistence('The default graph');
         });
 

--- a/test-cypress/steps/explore/graphs-overview-steps.js
+++ b/test-cypress/steps/explore/graphs-overview-steps.js
@@ -53,4 +53,12 @@ export class GraphsOverviewSteps {
     static selectJSONLDMode(option) {
         cy.get('[id=wb-JSONLD-mode]').select(option);
     }
+
+    static getTopPaginationLinks() {
+        return cy.get('.top-pagination ul li a');
+    }
+
+    static getPaginations() {
+        return cy.get('[paginations]');
+    }
 }


### PR DESCRIPTION
## What?
The pagination directive tests will not fail due to errors in the directive's code.

## Why?
The tests were thought to be flaky due to a change in the directive. However, upon further examination of the Jenkins logs it could be seen that the root cause of the failure was the injector being incorrectly written to handle minification.

## How?
I used the inline array annotation for the directive. I also refactored some of the steps used in the tests for better readability.