### PR TITLE
Cherry pick GDB-10527 Fix usability issues (buttons and styling)

### DIFF
--- a/src/css/sparql-templates.css
+++ b/src/css/sparql-templates.css
@@ -5,3 +5,8 @@ yasgui-component .CodeMirror {
 .keyboard-shortcuts-dialog-wrapper {
     margin-top: -21px;
 }
+
+.no-wrap-popover {
+    max-width: none;
+    white-space: nowrap;
+}

--- a/src/js/angular/clustermanagement/templates/cluster-configuration.html
+++ b/src/js/angular/clustermanagement/templates/cluster-configuration.html
@@ -4,13 +4,13 @@
         {{'cluster_management.cluster_configuration.label' | translate}}
     </h3>
     <div class="mb-2" ng-if="isAdmin">
-        <button type="button" class="btn btn-secondary delete-cluster-btn mr-1"
+        <button type="button" class="btn btn-secondary delete-cluster-btn mr-1 mt-1"
                 ng-click="showDeleteDialog()"
                 gdb-tooltip="{{'cluster_management.buttons.delete_cluster_tooltip' | translate}}"
                 tooltip-placement="bottom">
             <span class="icon-trash"></span> {{'cluster_management.buttons.delete_cluster' | translate}}
         </button>
-        <button type="button" class="btn btn-primary edit-cluster-configuration"
+        <button type="button" class="btn btn-primary edit-cluster-configuration mt-1"
                 ng-click="showEditConfigurationDialog()"
                 gdb-tooltip="{{'cluster_management.buttons.edit_cluster_tooltip' | translate}}"
                 tooltip-placement="bottom">

--- a/src/pages/sparql-template-create.html
+++ b/src/pages/sparql-template-create.html
@@ -69,6 +69,7 @@
                 uib-popover="{{'save.sparql.template.tooltip' | translate}}"
                 popover-placement="top"
                 popover-trigger="mouseenter"
+                popover-class="no-wrap-popover"
                 ng-if="canEditActiveRepo" ng-disabled="!isDirty && !sparqlTemplateInfo.isNewTemplate">
             {{'common.save.btn' | translate}}
         </button>

--- a/test-cypress/integration/setup/namespaces.spec.js
+++ b/test-cypress/integration/setup/namespaces.spec.js
@@ -37,7 +37,7 @@ describe('Namespaces', () => {
         getAddNamespaceForm().should('be.visible');
     }
 
-    it.skip('verify initial state', () => {
+    it('verify initial state', () => {
         getNoNamespacesAlert().should('not.be.visible');
 
         // Should be able to insert new prefix

--- a/test-cypress/integration/setup/namespaces.spec.js
+++ b/test-cypress/integration/setup/namespaces.spec.js
@@ -37,7 +37,7 @@ describe('Namespaces', () => {
         getAddNamespaceForm().should('be.visible');
     }
 
-    it('verify initial state', () => {
+    it.skip('verify initial state', () => {
         getNoNamespacesAlert().should('not.be.visible');
 
         // Should be able to insert new prefix


### PR DESCRIPTION
## What?
When in French, the buttons in the Cluster configuration panel will have space between them and the popover in the SPARQL Templates create view will not cover part of the button.

## Why?
The issues with these elements created an inconsistent style when switching languages.

## How?
I edited the styling.

## Screenshots?
The popover covering part of the button when in French (before and after fix):
![Screenshot from 2024-07-17 12-45-47](https://github.com/user-attachments/assets/4241c993-1ad1-4f07-bf7e-75995792e9ea)

![Screenshot from 2024-07-17 12-45-33](https://github.com/user-attachments/assets/0888f4d7-9f68-4b82-a18f-b5816f5e2196)