### PR TITLE
GDB-10610: Large Upload File Does not Appear in the Import List

### DIFF
--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -600,8 +600,13 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
         EventEmitterService.emit("filesForUploadSelected", eventData, (eventData) => {
             // Skip uploading of files if some subscriber canceled the uploading.
             if (!eventData.cancel) {
-                notifyForTooLargeFiles($invalidFiles);
-                const newFiles = $newFiles || [];
+                const invalidFiles = $invalidFiles || [];
+                notifyForTooLargeFiles(invalidFiles);
+                const invalidFileNames = invalidFiles.map((invalidFile) => invalidFile.name);
+
+                let newFiles = $newFiles || [];
+                newFiles = newFiles.filter((file) => !invalidFileNames.includes(file.name));
+
                 // RDF4J does not support decompressing .bz2 files, so we want to reject importing them
                 removeBZip2Files(newFiles);
 

--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -784,16 +784,19 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
                 $scope.uploadProgressMessage = '';
                 $scope.updateList();
             },
-            () => {},
+            (error) => {
+                toastr.error($translate.instant('import.could.not.upload.file', {data: getError(error.data)}));
+                file.status = ImportResourceStatus.ERROR;
+                file.message = getError(error.data);
+            },
             (evt) => {
                 $scope.progressPercentage = parseInt(100.0 * evt.loaded / evt.total);
                 $scope.uploadProgressMessage = $translate.instant('import.file.upload.progress', {progress: $scope.progressPercentage});
             }
-        ).catch((data) => {
-            toastr.error($translate.instant('import.could.not.upload.file', {data: getError(data)}));
-            file.status = ImportResourceStatus.ERROR;
-            file.message = getError(data);
-        }).finally(nextCallback || function () {});
+        ).finally(nextCallback || function () {
+            $scope.progressPercentage = null;
+            $scope.uploadProgressMessage = '';
+        });
     };
 
     const removeBZip2Files = (files) => {


### PR DESCRIPTION
## What:
Large upload files doesn't appear in the import list.

## Why:
Files in the list are fetched from the backend and displayed in the UI without modification. If a file is not appearing in the list, it indicates there was an error during the upload process. We discovered that error handling was not functioning correctly; specifically, an empty error handling function was added alongside a function to calculate the upload percentage. We expected that the error handling function would be executed, but it was not.

## How:
Moved the error handling logic from the catch function to a dedicated error handling function.
Added resetting of progressPercentage and uploadProgressMessage in the finally to ensure that the loader is hidden regardless of whether the upload fails or succeeds.

# Additional work
Files Are Imported Regardless of Size Limit

## What:
When attempting to import a file larger than the size configured in graphdb.workbench.maxUploadSize, an error notification is displayed. However, the import dialog still opens, and if the user clicks on "Import," the file is sent for upload despite being too large.

## Why:
The function that processes files for upload does not filter out files that exceed the size limit.

## How:
Added a filter to remove invalid files (i.e., files that exceed the size limit) from those eligible for upload.