### PR TITLE
GDB-10573 - Add hash to repositories list for "track by" in view

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1672,6 +1672,7 @@
     "search.plugins.placeholder": "Search plugins",
     "showing.label": "Showing",
     "results.label": "results",
+    "pagination.of.label": "of",
     "no.plugins.match.filter.warning": "No plugins match this filter.",
     "error.warning": "404 That’s an error!",
     "requested.url.not.found.msg": "The requested URL was not found on this server. That’s all I know.",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1683,6 +1683,7 @@
     "search.plugins.placeholder": "Rechercher des plugins",
     "showing.label": "Montrant",
     "results.label": "résultats",
+    "pagination.of.label": "sur",
     "no.plugins.match.filter.warning": "Aucun plug-ins correspond en ce filtre.",
     "error.warning": "404. C'est une erreur!",
     "requested.url.not.found.msg": "L'URL demandée n'a pas été trouvée sur ce serveur. C'est tout ce que je sais.",

--- a/src/js/angular/core/services/repositories.service.js
+++ b/src/js/angular/core/services/repositories.service.js
@@ -6,6 +6,7 @@ import 'ng-file-upload/dist/ng-file-upload.min';
 import 'ng-file-upload/dist/ng-file-upload-shim.min';
 import 'angular/core/services/event-emitter-service';
 import {QueryMode} from "../../models/ontotext-yasgui/query-mode";
+import {md5HashGenerator} from "../../utils/hash-utils";
 
 const modules = [
     'ngCookies',
@@ -131,6 +132,14 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
             }
         };
 
+        this.assignHashesToRepositories = function (repositoriesData) {
+            return repositoriesData.map((repo) => {
+                const hashGenerator = md5HashGenerator();
+                repo.hash = hashGenerator(JSON.stringify(repo));
+                return repo;
+            });
+        };
+
         this.init = function (successCallback, errorCallback, quick) {
             this.loading = true;
             if (!quick) {
@@ -145,8 +154,9 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
                                 .then(function(result) {
                                     that.location = location;
                                     Object.entries(result.data).forEach(([key, value]) => {
+                                        const reposWithHashes = that.assignHashesToRepositories(value);
                                         that.clearLocationErrorMsg(key);
-                                        that.repositories.set(key, value);
+                                        that.repositories.set(key, reposWithHashes);
                                     });
                                     that.resetActiveRepository();
                                     loadingDone();

--- a/src/pages/guides.html
+++ b/src/pages/guides.html
@@ -26,7 +26,7 @@
 </div>
 <div ng-show="displayedGuides.length > 0">
     <div paginations class="ot-guides-pagination pull-right ot-owlim-ctrl"></div>
-    <span class="showing-info-namespaces pull-right">{{'showing.label' | translate}} {{(pageSize * (page - 1)) + 1}} - {{pageSize * page >= displayedGuides.length ? displayedGuides.length + (pageSize * (page - 1)) : pageSize * page}} of {{guides.length}}</span>
+    <span class="showing-info-namespaces pull-right">{{'showing.label' | translate}} {{(pageSize * (page - 1)) + 1}} - {{pageSize * page >= displayedGuides.length ? displayedGuides.length + (pageSize * (page - 1)) : pageSize * page}} {{'pagination.of.label' | translate}} {{guides.length}}</span>
 </div>
 
 <table ng-show="displayedGuides.length > 0" id="guides-table" class="table table-striped table-hover" aria-describedby="Guides table">

--- a/src/pages/repositories.html
+++ b/src/pages/repositories.html
@@ -69,7 +69,7 @@
                                    class="table table-hover table-striped" aria-describedby="Repositories table">
                                 <tbody>
                                 <tr class="repository"
-                                    ng-repeat="repository in getRepositoriesFromLocation(location.uri) | orderBy: ['type === \'system\'', 'location', 'id']"
+                                    ng-repeat="repository in getRepositoriesFromLocation(location.uri) | orderBy: ['type === \'system\'', 'location', 'id'] track by repository.hash"
                                     ng-class="{'table-info text-secondary': isRepoActive(repository)}">
                                     <td width="25">
                                         <span role="button" class="icon-connection-off icon-lg text-secondary m-0"

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -1671,6 +1671,7 @@
     "search.plugins.placeholder": "Search plugins",
     "showing.label": "Showing",
     "results.label": "results",
+    "pagination.of.label": "of",
     "no.plugins.match.filter.warning": "No plugins match this filter.",
     "error.warning": "404 That’s an error!",
     "requested.url.not.found.msg": "The requested URL was not found on this server. That’s all I know.",

--- a/test-cypress/integration/import/import-view.spec.js
+++ b/test-cypress/integration/import/import-view.spec.js
@@ -98,6 +98,8 @@ describe('Import view', () => {
 
         // When I go to user tab and upload a file
         ImportSteps.openUserDataTab();
+        // And I wait for tab data to load
+        cy.wait(100);
         ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[0], bnodes));
         ImportSettingsDialogSteps.import();
         ImportUserDataSteps.getResources().should('have.length', 1);


### PR DESCRIPTION
## What?

- When hovering on a button in the repositories table, the popovers will remain visible until the mouse is moved away from the button or some of the data in the repository Map is changed.

- Added a missing French label in the Guides view.

## Why?
The popovers in the repositories table would hide each time the list was refreshed from a call to the API (every 5 seconds).

## How?
I add hashes to the repositories, before they are stored in the Locations Map. The template now will track the changes by each hash.