### PR TITLE
Cherry pick - Increase yasgui version and add prefix test (related GDB-9968) (#1488)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.3.16",
+                "ontotext-yasgui-web-component": "1.3.17",
                 "shepherd.js": "^11.2.0"
             },
             "devDependencies": {
@@ -9137,9 +9137,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.16",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.16.tgz",
-            "integrity": "sha512-8pa5VEIQGGIxm1wfpzxcfjs2qIVWxQ/aCe7Hl90t9ASurMTJdbt51Ymmqt63cCamHyheXqHlmMk1i18hoE6y/w==",
+            "version": "1.3.17",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.17.tgz",
+            "integrity": "sha512-5/WzugiaBVtJC36ooiXOL3A7fDdn8Dk6aStoSM7PVfMF2iWOnWV3HXCrOQT0mGDzWmXWf/zLe8s4oqIpFBrnjQ==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -22530,9 +22530,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.3.16",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.16.tgz",
-            "integrity": "sha512-8pa5VEIQGGIxm1wfpzxcfjs2qIVWxQ/aCe7Hl90t9ASurMTJdbt51Ymmqt63cCamHyheXqHlmMk1i18hoE6y/w==",
+            "version": "1.3.17",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.17.tgz",
+            "integrity": "sha512-5/WzugiaBVtJC36ooiXOL3A7fDdn8Dk6aStoSM7PVfMF2iWOnWV3HXCrOQT0mGDzWmXWf/zLe8s4oqIpFBrnjQ==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.3.16",
+        "ontotext-yasgui-web-component": "1.3.17",
         "shepherd.js": "^11.2.0"
     },
     "resolutions": {

--- a/test-cypress/integration/sparql-editor/sparql-editor.spec.js
+++ b/test-cypress/integration/sparql-editor/sparql-editor.spec.js
@@ -52,4 +52,30 @@ describe('Sparql editor', () => {
         // And yasr tabs should not be visible
         YasrSteps.getResultHeader().should('not.be.visible');
     });
+
+    it('Should paste and add prefixes', () => {
+        // Given I have opened the workbench
+        // When I visit the sparql editor page
+        SparqlEditorSteps.visitSparqlEditorPage();
+        YasqeSteps.clearEditor();
+        const prefix = 'PREFIX afn: <http://jena.apache.org/ARQ/function#>\n';
+        const query = 'select distinct ?x ?Person  where {\n' +
+            '?x a afn:Person .\n' +
+            '?x afn:preferredLabel ?Person .\n' +
+            '?doc afn:containsMention / pub-old:hasInstance ?x .\n' +
+            '}';
+        // I paste a query into the editor
+        cy.pasteIntoCodeMirror('.CodeMirror', query);
+        // Then I expect the prefixes to be added automatically
+        cy.get('.CodeMirror').then((codeMirrorElement) => {
+            const codeMirror = codeMirrorElement[0].CodeMirror;
+            // Wait, so that Yasqe can have time to replace the existing query with the new one
+            cy.waitUntil(() => {
+                return codeMirror.getValue() === prefix + query;
+            }).then(() => {
+                const value = codeMirror.getValue();
+                expect(value).to.equal(prefix + query);
+            });
+        });
+    });
 });

--- a/test-cypress/support/sparql-commands.js
+++ b/test-cypress/support/sparql-commands.js
@@ -37,6 +37,22 @@ Cypress.Commands.add('waitUntilQueryIsVisible', () => {
 Cypress.Commands.add('verifyQueryAreaContains', (query) => {
     verifyQueryAreaContains(query);
 });
+
+Cypress.Commands.add('pasteIntoCodeMirror', (selector, text) => {
+    cy.get(selector).then((codeMirrorElement) => {
+        const codeMirror = codeMirrorElement[0].CodeMirror;
+        const event = new ClipboardEvent('paste', {
+            bubbles: true,
+            cancelable: true,
+            clipboardData: new DataTransfer()
+        });
+        event.clipboardData.setData('text/plain', text);
+
+        const inputField = codeMirror.getInputField();
+        inputField.dispatchEvent(event);
+    });
+});
+
 // Helper functions
 
 function clearQuery() {


### PR DESCRIPTION
## What?
Increase the version of the ontotext-yasgui-web-component and add a test for the paste functionality.
New in this version:

- GDB-9968 - Prevent CodeMirror auto-scroll on paste

## Why?
The new version of the component includes a bug fix. The paste functionality should add prefixes, if the query has any. There was no test for this.

## How?
Version increased and test introduced.


* Increase yasgui version and add prefix test

* Refactor test and command. Now using waitUntil

* Refactor test for better readability

(cherry picked from commit bbb27ebff27694a4dfb97d1fb27f476b827994a7)