### PR TITLE
GDB-10626 improve cluster legend positioning in firefox and safari

### DIFF
--- a/src/css/clustermanagement.css
+++ b/src/css/clustermanagement.css
@@ -106,6 +106,11 @@
     visibility: hidden;
 }
 
+/* Using display: none on svg makes its parent to have no width and height under firefox and safari. */
+.hidden-legend {
+    visibility: hidden;
+}
+
 .hidden {
     display: none;
 }

--- a/src/js/angular/clustermanagement/directives/cluster-legend.directive.js
+++ b/src/js/angular/clustermanagement/directives/cluster-legend.directive.js
@@ -37,7 +37,7 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
 
             $scope.toggleLegend = () => {
                 $scope.hideLegend = !$scope.hideLegend;
-                legendGroup.classed('hidden', $scope.hideLegend);
+                legendGroup.classed('hidden-legend', $scope.hideLegend);
             };
 
             // =========================
@@ -178,7 +178,7 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
              */
             const createLegendGroup = (clusterViewD3Container) => {
                 legendGroup = clusterViewD3Container.append('g')
-                    .classed('hidden', $scope.hideLegend)
+                    .classed('hidden-legend', $scope.hideLegend)
                     .classed('cluster-legend-group', true);
             };
 
@@ -256,7 +256,7 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
 
             const closeDialog = () => {
                 $scope.hideLegend = true;
-                legendGroup.classed('hidden', $scope.hideLegend);
+                legendGroup.classed('hidden-legged', $scope.hideLegend);
             };
 
             const onKeyDown = (event) => {

--- a/src/js/angular/clustermanagement/directives/cluster-legend.directive.js
+++ b/src/js/angular/clustermanagement/directives/cluster-legend.directive.js
@@ -256,7 +256,7 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
 
             const closeDialog = () => {
                 $scope.hideLegend = true;
-                legendGroup.classed('hidden-legged', $scope.hideLegend);
+                legendGroup.classed('hidden-legend', $scope.hideLegend);
             };
 
             const onKeyDown = (event) => {

--- a/test-cypress/steps/cluster/cluster-page-steps.js
+++ b/test-cypress/steps/cluster/cluster-page-steps.js
@@ -48,7 +48,7 @@ export class ClusterPageSteps {
     }
 
     static openLegend() {
-        return cy.get('.toggle-legend-btn button');
+        return cy.get('.toggle-legend-btn button').click();
     }
 
     static getLegend() {


### PR DESCRIPTION
## What
Improve cluster legend positioning in firefox and safari.

## Why
In firefox and safari the legend is not properly positioned because of an issue with the width and height of the topmost svg when it had been hidden with `display: none`.

## How
Replaced the legend toggle using `display: none` with `visibility: hidden` to prevent misplacement of the legend items.