### PR TITLE
GDB-10682 properly manage import settings dialog buttons visibility

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -916,6 +916,7 @@
         "force.serial.pipeline": "Force serial pipeline",
         "restore.defaults.btn": "Restore defaults",
         "only.upload.btn": "Only upload",
+        "cancel.btn": "Cancel",
         "abort.btn": "Abort",
         "no.files.found": "No files found",
         "enable.for.auto.start": "Enable this option to start the import when you click the Import button. If it is disabled the import will be added to the list but not started automatically.",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -924,6 +924,7 @@
         "force.serial.pipeline": "Forcer le pipeline série",
         "restore.defaults.btn": "Restaurer les valeurs par défaut",
         "only.upload.btn": "Télécharger uniquement",
+        "cancel.btn": "Annuler",
         "abort.btn": "Abandonner",
         "no.files.found": "Aucun fichier trouvé",
         "enable.for.auto.start": "Activez cette option pour lancer l'importation lorsque vous cliquez sur le bouton Importer. Si elle est désactivée, l'importation sera ajoutée à la liste mais ne démarrera pas automatiquement.",

--- a/src/js/angular/import/controllers/settings-modal.controller.js
+++ b/src/js/angular/import/controllers/settings-modal.controller.js
@@ -1,23 +1,34 @@
 import {TABS} from "../services/import-context.service";
+import {Operation} from "./import-view.controller";
 angular
     .module('graphdb.framework.impex.import.controllers.settings-modal', [])
     .controller('SettingsModalController', SettingsModalController);
 
-SettingsModalController.$inject = ['$scope', '$uibModalInstance', 'toastr', 'UriUtils', 'settings', 'hasParserSettings', 'defaultSettings', 'isMultiple', 'activeTab', '$translate'];
 
-function SettingsModalController($scope, $uibModalInstance, toastr, UriUtils, settings, hasParserSettings, defaultSettings, isMultiple, activeTab, $translate) {
+export const SettingsModalActions = {
+    UPLOAD_ONLY: 'upload_only',
+    UPLOAD_AND_IMPORT: 'upload_and_import',
+    CANCEL: 'cancel',
+    CANCEL_IMPORT: 'cancel_import'
+};
+
+// TODO: combine all model parameters into one object!!!
+SettingsModalController.$inject = ['$scope', '$uibModalInstance', 'toastr', 'UriUtils', '$translate', 'dialogModel'];
+
+function SettingsModalController($scope, $uibModalInstance, toastr, UriUtils, $translate, dialogModel) {
 
     // =========================
     // Public variables
     // =========================
 
-    $scope.settings = settings;
-    $scope.hasParserSettings = hasParserSettings;
-    $scope.isMultiple = isMultiple;
+    $scope.settings = dialogModel.settings;
+    $scope.hasParserSettings = dialogModel.hasParserSettings;
+    $scope.isMultiple = dialogModel.isMultiple;
     $scope.enableReplace = !!($scope.settings.replaceGraphs && $scope.settings.replaceGraphs.length);
     $scope.showAdvancedSettings = false;
-    $scope.activeTab = activeTab;
+    $scope.activeTab = dialogModel.activeTab;
     $scope.userTabId = TABS.USER;
+    $scope.isUploadOperation = dialogModel.operation === Operation.UPLOAD;
 
     // =========================
     // Public functions
@@ -35,17 +46,32 @@ function SettingsModalController($scope, $uibModalInstance, toastr, UriUtils, se
 
         if ($scope.settingsForm.$valid) {
             fixSettings();
-            $uibModalInstance.close($scope.settings);
+            $uibModalInstance.close(getDismissModel(SettingsModalActions.UPLOAD_AND_IMPORT));
         }
     };
 
     $scope.cancel = function () {
         fixSettings();
-        $uibModalInstance.dismiss($scope.settings);
+        $uibModalInstance.dismiss(getDismissModel(SettingsModalActions.CANCEL));
+    };
+
+    $scope.onlyUpload = function () {
+        fixSettings();
+        $uibModalInstance.dismiss(getDismissModel(SettingsModalActions.UPLOAD_ONLY));
+    };
+
+    $scope.cancelImport = function () {
+        fixSettings();
+        $uibModalInstance.dismiss(getDismissModel(SettingsModalActions.CANCEL_IMPORT));
+    };
+
+    $scope.close = function () {
+        fixSettings();
+        $uibModalInstance.dismiss(getDismissModel(SettingsModalActions.CANCEL));
     };
 
     $scope.reset = function () {
-        $scope.settings = _.cloneDeep(defaultSettings);
+        $scope.settings = _.cloneDeep(dialogModel.defaultSettings);
         $scope.target = 'data';
     };
 
@@ -82,6 +108,18 @@ function SettingsModalController($scope, $uibModalInstance, toastr, UriUtils, se
     // =========================
     // Private functions
     // =========================
+
+    /**
+     * Returns the model for the dismiss action.
+     * @param {string} action The action to be performed.
+     * @return {{settings: *, action}}
+     */
+    const getDismissModel = function (action) {
+        return {
+            settings: $scope.settings,
+            action
+        };
+    };
 
     const fixSettings = function () {
         if ($scope.target === 'default') {

--- a/src/js/angular/import/services/import-context.service.js
+++ b/src/js/angular/import/services/import-context.service.js
@@ -19,7 +19,7 @@ function ImportContextService(EventEmitterService) {
 
     let _activeTabId = TABS.USER;
     /**
-     * @type {ImportResourceTreeElement}
+     * @type {ImportResource[]}
      * @private
      */
     let _resources = undefined;
@@ -164,7 +164,7 @@ function ImportContextService(EventEmitterService) {
      * Updates the resources.
      * Emits the 'resourcesUpdated' event when the resources are updated.
      * The 'filesUpdated' event contains the new resources.
-     * @param {ImportResourceTreeElement} resources
+     * @param {ImportResource[]} resources
      */
     function updateResources(resources) {
         _resources = resources;
@@ -173,7 +173,7 @@ function ImportContextService(EventEmitterService) {
 
     /**
      * Gets the resources.
-     * @return {ImportResourceTreeElement} - The resources.
+     * @return {ImportResource[]} - The resources.
      */
     function getResources() {
         return cloneDeep(_resources);

--- a/src/js/angular/import/templates/settingsModal.html
+++ b/src/js/angular/import/templates/settingsModal.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-    <button type="button" class="close" ng-click="cancel()"></button>
+    <button type="button" class="close" ng-click="close()"></button>
     <h4 class="modal-title">{{'import.settings' | translate}}</h4>
 </div>
 <div class="modal-body">
@@ -309,8 +309,17 @@
     <button type="button" class="btn btn-link pull-left" ng-click="reset()">
         {{'import.restore.defaults.btn' | translate}}
     </button>
-    <button type="button" class="btn btn-secondary cancel-import-button" ng-click="cancel()" guide-selector="import-settings-cancel-button">
-        {{activeTab === userTabId ? 'import.only.upload.btn' : 'common.cancel.btn' | translate}}
+    <button type="button" ng-if="activeTab === userTabId" ng-click="cancel()"
+            class="btn btn-secondary cancel-btn cancel-upload-button">
+        {{'import.cancel.btn' | translate}}
+    </button>
+    <button type="button" ng-if="activeTab === userTabId && isUploadOperation" ng-click="onlyUpload()"
+            class="btn btn-secondary upload-only-button" guide-selector="import-settings-cancel-button">
+        {{'import.only.upload.btn' | translate}}
+    </button>
+    <button type="button" ng-if="activeTab !== userTabId" ng-click="cancelImport()"
+            class="btn btn-secondary cancel-import-button" guide-selector="import-settings-cancel-button">
+        {{'common.cancel.btn' | translate}}
     </button>
     <button type="submit" form="settingsForm" ng-click="ok()" ng-disabled="settingsForm.$invalid"
             class="btn btn-primary import-settings-import-button"

--- a/test-cypress/integration/import/import-server-files.spec.js
+++ b/test-cypress/integration/import/import-server-files.spec.js
@@ -124,13 +124,13 @@ describe('Import server files', () => {
         ImportServerFilesSteps.openErrorDialog(importResourceName);
 
         // Then I expect to see dialog,
-        ImportSettingsDialogSteps.getDialog().should('be.visible');
+        ImportResourceMessageDialog.getDialog().should('be.visible');
 
         // with full error message
         ImportResourceMessageDialog.getMessage().should('have.value', 'RDF Parse Error: The element type "ex:looooooooooooooooooooooooooooooooongTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaame" must be terminated by the matching end-tag "</ex:looooooooooooooooooooooooooooooooongTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaame>". [line 9, column 6]');
 
         // When I click on corner close button.
-        ImportResourceMessageDialog.clickOnCornerCloseButton();
+        ImportResourceMessageDialog.close();
 
         // // Then I expect the dialog closed
         ImportResourceMessageDialog.getDialog().should('not.exist');

--- a/test-cypress/integration/import/import-user-data-file-upload.spec.js
+++ b/test-cypress/integration/import/import-user-data-file-upload.spec.js
@@ -47,6 +47,40 @@ describe('Import user data: File upload', () => {
         // Then I should see the uploaded file
         ImportUserDataSteps.getResources().should('have.length', 1);
         ImportUserDataSteps.checkImportedResource(0, 'bnodes.ttl');
+        // When I try to import the same file again
+        ImportUserDataSteps.importFile(0);
+        // Then I should not see the upload only option
+        ImportSettingsDialogSteps.getDialog().should('be.visible');
+        ImportSettingsDialogSteps.getUploadOnlyButton().should('not.exist');
+        ImportSettingsDialogSteps.getCancelUploadButton().should('be.visible');
+        ImportSettingsDialogSteps.import();
+        ImportSettingsDialogSteps.getDialog().should('not.exist');
+        ImportUserDataSteps.getResources().should('have.length', 1);
+        ImportUserDataSteps.checkImportedResource(0, 'bnodes.ttl');
+    });
+
+    it('Should be able to cancel the file upload', () => {
+        // Given there are no files uploaded yet
+        ImportUserDataSteps.getResourcesTable().should('be.hidden');
+        // And I have selected to upload a file
+        ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[0], bnodes));
+        ImportSettingsDialogSteps.getDialog().should('be.visible');
+        // When I cancel the file upload via the cancel button
+        ImportSettingsDialogSteps.cancelUpload();
+        // Then the file upload dialog should close
+        ImportSettingsDialogSteps.getDialog().should('not.exist');
+        // And there should be no files uploaded
+        ImportUserDataSteps.getResourcesTable().should('be.hidden');
+        // When I select to upload a file again
+        ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[0], bnodes));
+        // Then the import settings dialog should open
+        ImportSettingsDialogSteps.getDialog().should('be.visible');
+        // And I close the file upload dialog via the close button
+        ImportSettingsDialogSteps.close();
+        // Then the file upload dialog should close
+        ImportSettingsDialogSteps.getDialog().should('not.exist');
+        // And there should be no files uploaded
+        ImportUserDataSteps.getResourcesTable().should('be.hidden');
     });
 
     it('Should allow replacing graph when uploading and importing single file', () => {
@@ -97,7 +131,7 @@ describe('Import user data: File upload', () => {
         // When I start to upload a file
         ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[0], bnodes));
         // Then the import settings dialog should open automatically
-        ImportSettingsDialogSteps.cancelImport();
+        ImportSettingsDialogSteps.uploadOnly();
         // Then I should see the uploaded file
         ImportUserDataSteps.getResources().should('have.length', 1);
         ImportUserDataSteps.checkUserDataUploadedResource(0, 'bnodes.ttl');

--- a/test-cypress/steps/import/import-resource-message-dialog.js
+++ b/test-cypress/steps/import/import-resource-message-dialog.js
@@ -1,27 +1,8 @@
-export class ImportResourceMessageDialog {
+import {ModalDialogSteps} from "../modal-dialog-steps";
 
+export class ImportResourceMessageDialog extends ModalDialogSteps {
     static getDialog() {
-        return cy.get('.import-resource-message-dialog');
-    }
-
-    static getDialogHeader() {
-        return ImportResourceMessageDialog.getDialog().find('.modal-header');
-    }
-
-    static getCornerCloseButton() {
-        return ImportResourceMessageDialog.getDialogHeader().find('.close');
-    }
-
-    static clickOnCornerCloseButton() {
-        ImportResourceMessageDialog.getCornerCloseButton().click();
-    }
-
-    static getDialogBody() {
-        return ImportResourceMessageDialog.getDialog().find('.modal-body');
-    }
-
-    static getDialogFooter() {
-        return ImportResourceMessageDialog.getDialog().find('.modal-footer');
+        return super.getDialog('.import-resource-message-dialog');
     }
 
     static getCloseButton() {
@@ -37,7 +18,7 @@ export class ImportResourceMessageDialog {
     }
 
     static getCopyToClipboard() {
-        return ImportResourceMessageDialog.getDialogFooter().find('.copy-to-clipboard-btn')
+        return ImportResourceMessageDialog.getDialogFooter().find('.copy-to-clipboard-btn');
     }
 
     static copyToClipboard() {

--- a/test-cypress/steps/import/import-settings-dialog-steps.js
+++ b/test-cypress/steps/import/import-settings-dialog-steps.js
@@ -1,6 +1,10 @@
 import {ModalDialogSteps} from "../modal-dialog-steps";
 
 export class ImportSettingsDialogSteps extends ModalDialogSteps {
+    static getDialog() {
+        return super.getDialog('.import-settings-modal');
+    }
+
     static getImportButton() {
         return this.getDialog().find('.import-settings-import-button');
     }
@@ -15,6 +19,22 @@ export class ImportSettingsDialogSteps extends ModalDialogSteps {
 
     static cancelImport() {
         this.getCancelImportButton().click();
+    }
+
+    static getUploadOnlyButton() {
+        return this.getDialog().find('.upload-only-button');
+    }
+
+    static uploadOnly() {
+        this.getUploadOnlyButton().click();
+    }
+
+    static getCancelUploadButton() {
+        return this.getDialog().find('.cancel-btn');
+    }
+
+    static cancelUpload() {
+        this.getCancelUploadButton().click();
     }
 
     static getSettingsForm() {

--- a/test-cypress/steps/modal-dialog-steps.js
+++ b/test-cypress/steps/modal-dialog-steps.js
@@ -1,6 +1,6 @@
 export class ModalDialogSteps {
-    static getDialog() {
-        return cy.get('.modal-dialog');
+    static getDialog(cssClass = '.modal-dialog') {
+        return cy.get(cssClass);
     }
 
     static getDialogHeader() {
@@ -13,6 +13,10 @@ export class ModalDialogSteps {
 
     static clickOnCloseButton() {
         ModalDialogSteps.getCloseButton().click();
+    }
+
+    static close() {
+        this.clickOnCloseButton();
     }
 
     static getDialogBody() {


### PR DESCRIPTION
## What
Properly manage import settings dialog buttons visibility.

## Why
The import settings dialog is used in user data and server files tabs for all (upload) and import operations. Technically it contains information only for the import, but as far as we now have a composite operation upload+import, it is now opened also after the user selects some files for upload. Due to above reasons, this dialog renders multiple action buttons: import, cancel import, only upload and cancel upload, plus the close dialog [x] button. It appeared that some buttons appear in scenarios where they shouldn't.

## How
* Passed additional options to the settings dialog so that it is able to decide properly which buttons should be rendered.
* Added a button `cancel` upload which was missing for some reason, but is allows the dialog to be closed without actually uploading the selected files.
* Implemented additional tests.