### PR TITLE
GDB-10572: Fix download query in 'SPARQL Query & Update' view

### DIFF
--- a/src/js/angular/queries/controllers.js
+++ b/src/js/angular/queries/controllers.js
@@ -127,7 +127,7 @@ queriesCtrl.controller('QueriesCtrl', ['$scope', '$uibModal', 'toastr', '$interv
 
         $scope.downloadQuery = function (queryId) {
             const filename = 'query_' + queryId + '.rq';
-            let link = '/rest/monitor/repository/' + $repositories.getActiveRepository()
+            let link = 'rest/monitor/repository/' + $repositories.getActiveRepository()
                 + '/query/download?query=' + encodeURIComponent(queryId)
                 + '&filename=' + encodeURIComponent(filename);
             if ($jwtAuth.isAuthenticated()) {


### PR DESCRIPTION
## What
Fixed the download query functionality in the 'SPARQL Query & Update' view.

## Why
When GDB WB is deployed behind a context path requests to all endpoints which the WB calls should start without `/` otherwise this might brake the request routing.

## How
Removed the leading `/` from the download query endpoint used by the 'SPARQL Query & Update' view download functionality.