### PR TITLE
GDB-9177: Workbench fails to authenticate when Authorization header is provided externally

### DIFF
--- a/src/js/angular/core/interceptors/authentication.interceptor.js
+++ b/src/js/angular/core/interceptors/authentication.interceptor.js
@@ -19,7 +19,16 @@ angular.module('graphdb.framework.core.interceptors.authentication', [
                     // Angular doesn't send this header by default, and we need it to detect XHR requests
                     // so that we don't advertise Basic auth with them.
                     headers['X-Requested-With'] = 'XMLHttpRequest';
-                    headers.Authorization = AuthTokenService.getAuthToken();
+                    const token = AuthTokenService.getAuthToken();
+                    if (token) {
+                        // If a token is present, add it to the headers under the 'Authorization' key.
+                        // However, adding this 'Authorization' header can break Kerberos authentication.
+                        // Kerberos does not use tokens for authentication; it relies on ticket-based
+                        // authentication via SPNEGO (Simple and Protected GSSAPI Negotiation Mechanism).
+                        // If 'Authorization' is set with a token, the server may prioritize it over
+                        // Kerberos, causing the Kerberos authentication to fail.
+                        headers.Authorization = AuthTokenService.getAuthToken();
+                    }
 
                     const repositoryId = LocalStorageAdapter.get(LSKeys.REPOSITORY_ID);
                     const repositoryLocation = LocalStorageAdapter.get(LSKeys.REPOSITORY_LOCATION);


### PR DESCRIPTION
## What
Kerberos authentication is not working as expected. When GraphDB is configured to use Kerberos authentication, and a user with the correct browser configuration tries to access any page in the Workbench (WB), the WB redirects the user to the login page.

## Why
After the login/logout functionality was refactored, an "Authorization" header was added to requests regardless of its value or the configured authentication method. When Kerberos is configured, the "Authorization" header is set with a null value because no token is present. This null header breaks the Kerberos authentication process.

## How
When Kerberos is configured the authentication token is null, that's why the code was changed to add Authentication header only if there is token.