### PR TITLE
GDB-10611 - Reword a sentence in import help

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1077,7 +1077,7 @@
                 "execution": "Import execution",
                 "work_in_background": "Imports are executed in the background while you continue working on other things.",
                 "to_reimport_again": "To reimport a file, URL or text snippet click the Import button again.",
-                "interrupt_support": "Interrupt is supported only when the location is local.",
+                "interrupt_support": "Interrupt is supported only when the repository is local.",
                 "parser_config": "Parser config options are not available for remote locations."
             },
             "on_server_import": {
@@ -1089,7 +1089,7 @@
                 "execution": "Import execution",
                 "work_in_background": "Imports are executed in the background while you continue working on other things.",
                 "to_reimport_again": "To reimport a file, URL or text snippet click the Import button again.",
-                "interrupt_support": "Interrupt is supported only when the location is local."
+                "interrupt_support": "Interrupt is supported only when the repository is local."
             },
             "on_file_size_limit": {
                 "file_import_options_info_1": "Explore other file import options - ",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1086,7 +1086,7 @@
                 "execution": "Exécution d'importation",
                 "work_in_background": "Les importations sont exécutées en arrière-plan pendant que vous continuez à travailler sur d'autres choses.",
                 "to_reimport_again": "Pour réimporter un fichier, une URL ou un extrait de texte, cliquez à nouveau sur le bouton Importer.",
-                "interrupt_support": "L'interruption n'est prise en charge que lorsque l'emplacement est local.",
+                "interrupt_support": "L'interruption est prise en charge uniquement lorsque le référentiel est local.",
                 "parser_config": "Les options de configuration de l'analyseur ne sont pas disponibles pour les sites distants."
             },
             "on_server_import": {
@@ -1097,7 +1097,7 @@
                 "execution": "Exécution d'importation",
                 "work_in_background": "Les importations sont exécutées en arrière-plan pendant que vous continuez à travailler sur d'autres choses.",
                 "to_reimport_again": "Pour réimporter un fichier, une URL ou un extrait de texte, cliquez à nouveau sur le bouton Importer.",
-                "interrupt_support": "L'interruption n'est prise en charge que lorsque l'emplacement est local.",
+                "interrupt_support": "L'interruption est prise en charge uniquement lorsque le référentiel est local.",
                 "the_property": "propriété"
             },
             "on_file_size_limit": {

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -1004,7 +1004,7 @@
                 "execution": "Import execution",
                 "work_in_background": "Imports are executed in the background while you continue working on other things.",
                 "to_reimport_again": "To reimport a file, URL or text snippet click the Import button again.",
-                "interrupt_support": "Interrupt is supported only when the location is local.",
+                "interrupt_support": "Interrupt is supported only when the repository is local.",
                 "parser_config": "Parser config options are not available for remote locations."
             },
             "on_server_import": {
@@ -1016,7 +1016,7 @@
                 "execution": "Import execution",
                 "work_in_background": "Imports are executed in the background while you continue working on other things.",
                 "to_reimport_again": "To reimport a file, URL or text snippet click the Import button again.",
-                "interrupt_support": "Interrupt is supported only when the location is local."
+                "interrupt_support": "Interrupt is supported only when the repository is local."
             },
             "on_file_size_limit": {
                 "file_import_options_info_1": "Explore other file import options - ",


### PR DESCRIPTION
## What?
The change improves a sentence in the Server and User upload help boxes.

## Why?
The change makes it easier for the user to understand that the repository is the object in question.

## How?
Edited locale files.

## Screenshots?
Last bullet point changed. Previously was **"Interrupt is supported only when the location is local."**
![Screenshot from 2024-08-20 13-05-48](https://github.com/user-attachments/assets/ce2eb655-a477-4b1a-b004-ff2154481894)
