### PR TITLE
Gdb 10610 file upload and progress improvements (#1509)

### DIFF
--- a/src/css/import-resource-tree.css
+++ b/src/css/import-resource-tree.css
@@ -2,6 +2,20 @@
     width: 100%;
 }
 
+.import-resource-table .progress {
+    font-size: .8rem;
+    height: 1rem;
+    line-height: 18px;
+    margin-bottom: 0;
+    text-align: center;
+    position: relative;
+}
+
+.import-resource-table .progress .progress-bar {
+    position: absolute;
+    top: 0;
+}
+
 .import-resource-table .row.even-row-start:hover,
 .import-resource-table .row.even-row-start:hover + .row,
 .import-resource-table .row.odd-row-start:hover,
@@ -140,7 +154,8 @@
     flex-wrap: wrap;
 }
 .import-resource-tree .import-resource-table .cell .import-resource-message .success-messages .success-message .import-counters .import-counter,
-.import-resource-tree .import-resource-table .cell .import-resource-message .success-messages .success-message .text-success {
+.import-resource-tree .import-resource-table .cell .import-resource-message .success-messages .success-message .text-success,
+.import-resource-tree .import-resource-table .cell .import-resource-message .error-message .message {
     padding-left: 10px;
 }
 

--- a/src/css/import.css
+++ b/src/css/import.css
@@ -1,7 +1,3 @@
-#wb-import .tab-content .progress {
-    font-size: 1rem;
-}
-
 .upload-buttons {
     align-items: stretch;
     display: flex;

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -936,6 +936,7 @@
         "could.not.send.data": "Could not send data for import; {{data}}",
         "could.not.send.url": "Could not send url for import; {{data}}",
         "could.not.upload.file": "Could not upload file; {{data}}",
+        "upload.file.failure": "File upload failed.",
         "could.not.update.text": "Could not update text import; {{data}}",
         "text.snippet.not.imported": "Text snippet was edited but has not been imported again.",
         "graph.already.in.list": "This graph is already in the list.",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -944,6 +944,7 @@
         "could.not.send.data": "Impossible d'envoyer des données pour l'importation; {{data}}",
         "could.not.send.url": "Impossible d'envoyer l'url pour l'importation; {{data}}",
         "could.not.upload.file": "Impossible de télécharger un fichier; {{data}}",
+        "upload.file.failure": "Échec du téléchargement du fichier.",
         "could.not.update.text": "Impossible de mettre à jour le texte importé; {{data}}",
         "text.snippet.not.imported": "L'extrait de texte a été modifié mais n'a pas été réimporté.",
         "graph.already.in.list": "Ce graphe est déjà dans la liste.",

--- a/src/js/angular/core/services/event-emitter-service.js
+++ b/src/js/angular/core/services/event-emitter-service.js
@@ -9,12 +9,21 @@ angular
  */
 function EventEmitterService() {
     const subscribers = {};
+    const syncSubscribers = {};
 
     /**
-     * Registers the <code>subscriber</code> for event with name <code>eventName</code>. When event occurred the subscribers will be called.
-     * @param eventName - the name of the event that will trigger a subscriber call.
-     * @param {Promise<any>} subscriber - promise that will call when event with <code>eventName</code> occurred.
-     * @return {(function(): void)|*} - unsubscribe function.
+     * Registers the <code>subscriber</code> for an event with the name <code>eventName</code>.
+     * When the event occurs, all subscribers registered to that event will be called sequentially,
+     * in the order they were added. Each subscriber is expected to return a promise, and the value
+     * resolved by this promise will be passed as input to the next subscriber in the sequence.
+     *
+     * @param {String} eventName - The name of the event that will trigger the subscriber call.
+     * @param {Function} subscriber - A function that returns a promise. This function will be called
+     *                                when the event with <code>eventName</code> occurs. The resolved
+     *                                value from one subscriber will be passed to the next one.
+     *
+     * @return {Function} - An unsubscribe function that can be called to remove the subscriber
+     *                       from the list of subscribers for this event.
      */
     const subscribe = (eventName, subscriber) => {
         if (!subscribers[eventName]) {
@@ -32,18 +41,25 @@ function EventEmitterService() {
     };
 
     /**
-     * Call all subscribers that are registered for event with <code>eventName</code>.
-     * @param eventName - name of event.
-     * @param eventData - event data that passed between subscribers.
-     * @param callback - function that will be called (if exist), after all subscribers are called. The modified event data form subscribers
-     * will be pass as argument of callback functions.
+     * Emits an event by sequentially calling all subscribers associated with the event name.
+     * Each subscriber is expected to return a promise. The resolved value of the promise is passed
+     * as the event data to the next subscriber in the sequence. This allows subscribers to modify
+     * the event data before it is passed to the next one.
+     *
+     * Once all subscribers have been executed, an optional callback function is invoked with the
+     * final event data.
+     *
+     * @param {String} eventName - The name of the event to emit.
+     * @param {Object} eventData - The initial data to pass to the first subscriber. The data may
+     *                             be modified by each subscriber and passed on to the next one.
+     * @param {Function} [callback] - Optional callback function to be executed after all subscribers
+     *                                have been called, receiving the final event data.
      */
     const emit = (eventName, eventData, callback) => {
         const eventSubscribers = subscribers[eventName] || [];
         const eventSubscribersChain = eventSubscribers.reduce((prev, next) => {
-            return prev.then((value) => next(value))
+            return prev.then((value) => next(value));
         }, Promise.resolve(eventData));
-
         eventSubscribersChain.then(() => {
             if (angular.isFunction(callback)) {
                 callback(eventData);
@@ -51,8 +67,61 @@ function EventEmitterService() {
         });
     };
 
+    /**
+     * Subscribes a callback function to a specified event, allowing it to be called whenever the event is emitted.
+     * This function manages the all execution of event subscribers, storing the callback in an array
+     * corresponding to the event name. It also provides an unsubscribe function to remove the callback when
+     * it's no longer needed.
+     *
+     * @param {String} eventName - The name of the event to subscribe to.
+     * @param {Function} callback - The function to be called when the event is emitted.
+     *                              The callback will receive the event data as its argument.
+     *
+     * @return {Function} - An unsubscribe function that can be called to remove the callback
+     *                       from the list of subscribers for this event.
+     */
+    const subscribeSync = (eventName, callback) => {
+        // Initialize the subscriber array for the event if it doesn't exist
+        if (!syncSubscribers[eventName]) {
+            syncSubscribers[eventName] = [];
+        }
+
+        // Add the callback function to the list of subscribers for the event
+        syncSubscribers[eventName].push(callback);
+
+        // Return an unsubscribe function
+        return function () {
+            const index = syncSubscribers[eventName].indexOf(callback);
+            if (index !== -1) {
+                syncSubscribers[eventName].splice(index, 1);
+            }
+        };
+    };
+
+    /**
+     * Emits an event by calling all subscribers associated with the event name in sequence.
+     * Each subscriber is expected to process the eventData and then invoke its own callback
+     * function (if provided) with the eventData independently.
+     *
+     * @param {String} eventName - The name of the event to emit.
+     * @param {Object} eventData - The data to pass to each subscriber.
+     */
+    const emitSync = (eventName, eventData) => {
+        const eventSubscribers = syncSubscribers[eventName] || [];
+        // Execute all subscribers in parallel
+        eventSubscribers.forEach((callback) => {
+            if (angular.isFunction(callback)) {
+                callback(eventData);
+            } else {
+                console.error(`Callback of "${eventName}" is not function:`, callback);
+            }
+        });
+    };
+
     return {
         subscribe,
-        emit
+        emit,
+        subscribeSync,
+        emitSync
     };
 }

--- a/src/js/angular/import/controllers/tab.controller.js
+++ b/src/js/angular/import/controllers/tab.controller.js
@@ -27,12 +27,12 @@ function TabController($scope, $location, ImportContextService) {
 
     const updateHelpVisibility = () => {
         if (helpVisibility.isPristine($scope.activeTabId)) {
-            let resources = ImportContextService.getResources();
+            const resources = ImportContextService.getResources();
             $scope.isHelpVisible = !resources || resources.length === 0;
         } else {
             $scope.isHelpVisible = helpVisibility.isHelpVisible($scope.activeTabId);
         }
-    }
+    };
 
     $scope.openTab = (tab) => {
         ImportContextService.updateActiveTabId(tab);

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -234,20 +234,20 @@ function importResourceTreeDirective($timeout, ImportContextService) {
             };
 
             const compareBySize = (acs) => (r1, r2) => {
-                const r1Size = r1.importResource.size | 0;
-                const r2Size = r2.importResource.size | 0;
+                const r1Size = r1.importResource.size || 0;
+                const r2Size = r2.importResource.size || 0;
                 return acs ? r1Size - r2Size : r2Size - r1Size;
             };
 
             const compareByModified = (acs) => (r1, r2) => {
-                const r1ModifiedOn = r1.importResource.modifiedOn | 0;
-                const r2ModifiedOn = r2.importResource.modifiedOn | 0;
+                const r1ModifiedOn = r1.importResource.modifiedOn || Number.MAX_VALUE;
+                const r2ModifiedOn = r2.importResource.modifiedOn || Number.MAX_VALUE;
                 return acs ? r1ModifiedOn - r2ModifiedOn : r2ModifiedOn - r1ModifiedOn;
             };
 
             const compareByImportedOn = (acs) => (r1, r2) => {
-                const r1ImportedOn = r1.importResource.importedOn | 0;
-                const r2ImportedOn = r2.importResource.importedOn | 0;
+                const r1ImportedOn = r1.importResource.importedOn || Number.MAX_VALUE;
+                const r2ImportedOn = r2.importResource.importedOn || Number.MAX_VALUE;
                 return acs ? r1ImportedOn - r2ImportedOn : r2ImportedOn - r1ImportedOn;
             };
 

--- a/src/js/angular/import/services/import-resource-tree.service.js
+++ b/src/js/angular/import/services/import-resource-tree.service.js
@@ -171,7 +171,7 @@ export class ImportResourceTreeService {
      */
     static setupShortenedMessage(importResourceElement) {
         const message = importResourceElement.importResource ? importResourceElement.importResource.message : '' || '';
-        if (message.length > MAX_MESSAGE_LENGTH) {
+        if (message && message.length > MAX_MESSAGE_LENGTH) {
             importResourceElement.shortenedMessage = message.substring(0, MAX_MESSAGE_LENGTH) + '...';
         }
     }
@@ -210,7 +210,7 @@ export class ImportResourceTreeService {
     }
 
     static isImportable(importResource) {
-        return importResource.status !== ImportResourceStatus.IMPORTING && importResource.status !== ImportResourceStatus.UPLOADING && importResource.status !== ImportResourceStatus.PENDING && importResource.status !== ImportResourceStatus.INTERRUPTING;
+        return importResource.status !== ImportResourceStatus.IMPORTING && importResource.status !== ImportResourceStatus.UPLOADING && importResource.status !== ImportResourceStatus.PENDING && importResource.status !== ImportResourceStatus.INTERRUPTING && importResource.status !== ImportResourceStatus.UPLOADING && importResource.status !== ImportResourceStatus.UPLOADED && importResource.status !== ImportResourceStatus.UPLOAD_ERROR;
     }
 
     static hasOngoingImport(importResource) {

--- a/src/js/angular/import/templates/import-resource-message.html
+++ b/src/js/angular/import/templates/import-resource-message.html
@@ -31,18 +31,23 @@
             </span>
         </div>
     </div>
-    <span ng-if="resource.importResource.status === ImportResourceStatus.ERROR" class="text-danger error-message">
+    <span ng-if="resource.importResource.status === ImportResourceStatus.ERROR || resource.importResource.status === ImportResourceStatus.UPLOAD_ERROR" class="text-danger error-message">
         <em class="icon-warning"></em>
         <button ng-if="resource.shortenedMessage"
                 class="btn btn-link"
                 ng-click="showMessage(resource)">
             <small>{{resource.shortenedMessage}}</small>
         </button>
-        <small ng-if="!resource.shortenedMessage">{{resource.importResource.message || ''}}</small>
+        <small class="message" ng-if="!resource.shortenedMessage">{{resource.importResource.message || ''}}</small>
     </span>
     <span class="text-secondary import-status-loader"
-          ng-if="resource.importResource.status === ImportResourceStatus.IMPORTING || resource.importResource.status === ImportResourceStatus.UPLOADING || resource.importResource.status === ImportResourceStatus.PENDING || resource.importResource.status === ImportResourceStatus.INTERRUPTING">
+          ng-if="resource.importResource.status === ImportResourceStatus.IMPORTING || resource.importResource.status === ImportResourceStatus.PENDING || resource.importResource.status === ImportResourceStatus.INTERRUPTING">
         <em class="icon-reload loader"></em>
         <small>{{toTitleCase(resource.importResource.status)}}...</small>
+    </span>
+    <span class="text-secondary import-status-loader"
+          ng-if="resource.importResource.status === ImportResourceStatus.UPLOADING || resource.importResource.status === ImportResourceStatus.UPLOADED">
+        <em class="icon-reload loader"></em>
+        <small>{{resource.importResource.message ? resource.importResource.message : (toTitleCase(resource.importResource.status) + '...')}}</small>
     </span>
 </div>

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -197,7 +197,7 @@
                             gdb-tooltip="{{'import.reset.status' | translate}}">
                         <span class="icon-close"></span>
                     </button>
-                    <button ng-if="canRemoveResource"
+                    <button ng-if="canRemoveResource && resource.importResource.status !== ImportResourceStatus.UPLOADING && resource.importResource.status !== ImportResourceStatus.UPLOADED && resource.importResource.status !== ImportResourceStatus.UPLOAD_ERROR"
                             class="btn btn-link btn-sm secondary import-resource-action-remove-btn"
                             ng-disabled="hasSelection"
                             ng-click="removeResource(resource)"

--- a/src/js/angular/models/import/import-resource-status.js
+++ b/src/js/angular/models/import/import-resource-status.js
@@ -9,6 +9,11 @@ export const ImportResourceStatus = {
      */
     'NONE': 'NONE',
     'UPLOADING': 'UPLOADING',
+    'UPLOAD_ERROR': 'UPLOAD_ERROR',
+    /**
+     * Marks resource as uploaded.
+     */
+    'UPLOADED': 'UPLOADED',
     /**
      * The import of rdf resources in this state was not started because GraphDB was stopped.
      */

--- a/src/js/angular/rest/mappers/import-mapper.js
+++ b/src/js/angular/rest/mappers/import-mapper.js
@@ -5,3 +5,34 @@ export const toImportResource = (importResourcesServerData) => {
     const hashGenerator = md5HashGenerator();
     return importResourcesServerData.map((importResourceServerData) => new ImportResource(importResourceServerData, hashGenerator));
 };
+
+export const fileToImportResource = (file) => {
+    const hashGenerator = md5HashGenerator();
+    return new ImportResource({
+        name: file.name,
+        size: file.size,
+        type: 'file',
+        modifiedOn: file.lastModified,
+        file: file
+    }, hashGenerator);
+};
+
+/**
+ * Converts a list of files to a list of import resources.
+ * @param {File[]} files
+ * @return {ImportResource[]}
+ */
+export const filesToImportResource = (files, initialStatus) => {
+    const hashGenerator = md5HashGenerator();
+    const resources = files.map((file) => {
+        return new ImportResource({
+            name: file.name,
+            size: file.size,
+            type: 'file',
+            modifiedOn: undefined,
+            file: file,
+            status: initialStatus
+        }, hashGenerator);
+    });
+    return resources;
+};

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -935,6 +935,7 @@
         "could.not.send.data": "Could not send data for import; {{data}}",
         "could.not.send.url": "Could not send url for import; {{data}}",
         "could.not.upload.file": "Could not upload file; {{data}}",
+        "upload.file.failure": "File upload failed.",
         "could.not.update.text": "Could not update text import; {{data}}",
         "text.snippet.not.imported": "Text snippet was edited but has not been imported again.",
         "graph.already.in.list": "This graph is already in the list.",

--- a/test-cypress/steps/import/import-steps.js
+++ b/test-cypress/steps/import/import-steps.js
@@ -205,7 +205,7 @@ class ImportSteps {
     }
 
     static checkImportedStatusIsEmpty(resourceName) {
-        this.getResourceStatus(resourceName).find('.import-resource-message').children().should('have.length', 0);
+        this.getResourceStatus(resourceName).find('.import-resource-message .success-messages').should('have.length', 0);
     }
 
     static checkUserDataUploadedResource(index, resourceName) {


### PR DESCRIPTION
# Extends EventEmitterService

## What
- Introduced `emitSynch` function to handle events in parallel, invoking each subscriber and their callbacks independently.
- Added `subscribeSynch` function to register subscribers for parallel event handling with an option to unsubscribe.
- Update javadoc for old functions.

## Why
- To support scenarios where event subscribers need to be executed in parallel.
- To provide a mechanism for parallel event subscription and easy removal of subscribers when they are no longer needed.

## How
- Implemented `emitSynch` to call all registered subscribers for an event in parallel and handle their individual callbacks.
- Created `subscribeSynch` to add subscribers for parallel event handling and return an unsubscribe function to manage subscription lifecycle.
- Revised Javadoc documentation to accurately describe the behavior of event data handling and subscriber execution patterns.

# Update ImportContextService with parallel event handling and pure functions

## What
- Refactored `ImportContextService` to use new `subscribeSynch` and `emitSynch` methods for event handling.
- Updated all methods in `ImportContextService` to be pure functions, ensuring no side effects.

## Why
- Previously, each subscriber was called with a function that returned interested data. Now, data is collected once and passed to all subscribers.
- To prevent side effects by ensuring functions do not modify external state.

## How
- Replaced existing event handling logic with `subscribeSynch` for concurrent subscriber registration and `emitSynch` for parallel event dispatch.
- Refactored the service’s methods to be pure functions, cloning passed parameters instead of modifying them directly or relying on external state.

# Refactoring ImportContextService

## What
Renamed the _resources field to _importedResources and related functions as well.

## Why
We have two independent types of resources: those being uploaded and those already uploaded. The second type is returned from the backend (BE), while the first type is selected by the user for uploading. The name _resources will be used to refer to both types of resources.

## How
Renamed the _resources field and all related functions.

(cherry picked from commit a774fed18d7d9bc7666da5c31a9f2c4026bf3043)