### PR TITLE
GDB-10717: Fix sorting by size (#1515)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,7 @@ import 'angular/core/directives/operations-statuses-monitor/operations-statuses-
 import 'angular/core/directives/autocomplete/autocomplete.directive';
 import 'angular/core/directives/prop-indeterminate/prop-indeterminate.directive';
 import {defineCustomElements} from 'ontotext-yasgui-web-component/loader';
+import {convertToHumanReadable} from "./js/angular/utils/size-util";
 
 // $translate.instant converts <b> from strings to &lt;b&gt
 // and $sce.trustAsHtml could not recognise that this is valid html
@@ -221,6 +222,7 @@ const moduleDefinition = function (productInfo) {
     });
 
     workbench.filter('prettyJSON', () => (json) => angular.toJson(json, true));
+    workbench.filter('humanReadableSize', () => (size) => convertToHumanReadable(size));
 
     angular.bootstrap(document, ['graphdb.workbench']);
 };

--- a/src/js/angular/import/directives/import-resource-tree.directive.js
+++ b/src/js/angular/import/directives/import-resource-tree.directive.js
@@ -5,6 +5,7 @@ import {SortingType} from "../../models/import/sorting-type";
 import {ImportResourceTreeElement} from "../../models/import/import-resource-tree-element";
 import {TABS} from "../services/import-context.service";
 import {ImportResourceTreeService} from "../services/import-resource-tree.service";
+import {convertToBytes} from "../../utils/size-util";
 
 const TYPE_FILTER_OPTIONS = {
     'FILE': 'FILE',
@@ -234,8 +235,10 @@ function importResourceTreeDirective($timeout, ImportContextService) {
             };
 
             const compareBySize = (acs) => (r1, r2) => {
-                const r1Size = r1.importResource.size || 0;
-                const r2Size = r2.importResource.size || 0;
+                // The format of size returned by the backend has changed, but we need to keep the old format for backward compatibility.
+                // Therefore, we convert the size to always be in bytes.
+                const r1Size = convertToBytes(r1.importResource.size);
+                const r2Size = convertToBytes(r2.importResource.size);
                 return acs ? r1Size - r2Size : r2Size - r1Size;
             };
 

--- a/src/js/angular/import/templates/import-resource-tree.html
+++ b/src/js/angular/import/templates/import-resource-tree.html
@@ -167,7 +167,7 @@
                 </span>
             </td>
             <td class="cell cell-size">
-                {{ resource.importResource.size || ''}}
+                {{ resource.importResource.size | humanReadableSize}}
             </td>
             <td class="cell cell-modified"
                 ng-class="{'font-weight-bold': resource.isModifiedBiggerThanImported}">

--- a/src/js/angular/utils/size-util.js
+++ b/src/js/angular/utils/size-util.js
@@ -1,0 +1,110 @@
+/**
+ * A mapping of human-readable size units to their corresponding byte values.
+ * @constant {Object}
+ */
+const HUMAN_READABLE_SIZE_UNITS = {
+    BYTES: 1,
+    KB: 1024,
+    MB: 1024 ** 2,
+    GB: 1024 ** 3,
+    TB: 1024 ** 4,
+    PB: 1024 ** 5
+};
+
+/**
+ * A regular expression to match human-readable size strings.
+ * Example matches: "123 bytes", "1.5 KB", "1 GB", etc.
+ * @constant {RegExp}
+ */
+const IS_HUMAN_READABLE_SIZE_REGEX = /^(\d+(?:\.\d+)?)\s*(bytes|KB|MB|GB|TB|PB)$/i;
+
+/**
+ * A regular expression to match strings containing only digits.
+ * Example matches: "123", "4567", etc.
+ * @constant {RegExp}
+ */
+const IS_DIGIT_ONLY_REGEX = /^\d+$/;
+
+/**
+ * Converts the given <code>size</code> to bytes as a number.
+ *
+ * The <code>size</code> parameter can be passed in the following forms:
+ * <ul>
+ *   <li>As a number, e.g., 123, 432, etc.</li>
+ *   <li>As a string representing a number, e.g., "123", "432", etc.</li>
+ *   <li>As a human-readable string with units, e.g., "123 bytes", "432 KB", etc.</li>
+ * </ul>
+ *
+ * @param {number|string|undefined|null} size - The size to convert.
+ * @return {number} The size in bytes. Returns 0 if the input is invalid.
+ */
+export const convertToBytes = (size) => {
+
+    if (size === undefined || size === null) {
+        return 0;
+    }
+
+    if (typeof size === 'number') {
+        // If size is a number, return it as-is.
+        return size;
+    }
+
+    size = size.trim();
+
+    if (IS_DIGIT_ONLY_REGEX.test(size)) {
+        // If the string contains only digits, parse and return it as an integer.
+        return parseInt(size, 10);
+    }
+
+    const match = size.match(IS_HUMAN_READABLE_SIZE_REGEX);
+    if (!match) {
+        return 0;
+    }
+
+    // If the size is in human-readable format, calculate the equivalent bytes.
+    const value = parseFloat(match[1]);
+    const unit = match[2];
+
+    return value * HUMAN_READABLE_SIZE_UNITS[unit.toUpperCase()];
+};
+
+/**
+ * Converts the given <code>size</code> in bytes to a human-readable string.
+ *
+ * If the size is already a human-readable string, it will be returned as-is.
+ *
+ * @param {number|string} size - The size in bytes to convert. Can be a number or a string.
+ * @return {string} A human-readable size string, e.g., "1.50 KB", "100 MB". Returns "0 bytes" if the input is invalid or less than or equal to 0.
+ */
+export const convertToHumanReadable = (size) => {
+
+    if (!angular.isDefined(size)) {
+        return '0 bytes';
+    }
+
+    if (IS_HUMAN_READABLE_SIZE_REGEX.test(size)) {
+        return size;
+    }
+
+    if (typeof size === 'string') {
+        size = parseFloat(size);
+    }
+
+    if (isNaN(size) || size <= 0) {
+        return '0 bytes';
+    }
+
+    const units = Object.keys(HUMAN_READABLE_SIZE_UNITS).reverse();
+
+    for (const unit of units) {
+        const unitValue = HUMAN_READABLE_SIZE_UNITS[unit];
+        if (size >= unitValue) {
+            const readableSize = size / unitValue;
+            // If readableSize is an integer, don't include decimal places.
+            const formattedSize = Number.isInteger(readableSize) ? readableSize : readableSize.toFixed(2);
+            return `${formattedSize} ${unit.toLowerCase()}`;
+        }
+    }
+
+    return '0 bytes';
+};

--- a/test-cypress/integration/import/import-server-files.spec.js
+++ b/test-cypress/integration/import/import-server-files.spec.js
@@ -144,4 +144,44 @@ describe('Import server files', () => {
         // Then I expect the dialog closed
         ImportResourceMessageDialog.getDialog().should('not.exist');
     });
+
+    it('Should order by size', () => {
+        // When I sort the listed files by their size.
+        ImportServerFilesSteps.orderBySize();
+
+        // Then I expect the directories to be sorted in ascending order,
+        ImportServerFilesSteps.getResource(0).should('contain', "more-files");
+        ImportServerFilesSteps.getResource(3).should('contain', "more-files-with-error");
+
+        // and inner files to be sorted ascending as well.
+        // checks first folder files
+        ImportServerFilesSteps.getResource(1).should('contain', "jsonld-file.jsonld");
+        ImportServerFilesSteps.getResource(2).should('contain', "rdfxml.rdf");
+        // checks second folder files
+        ImportServerFilesSteps.getResource(4).should('contain', "import-resource-with-correct-data.jsonld");
+        ImportServerFilesSteps.getResource(5).should('contain', "import-resource-with-incorrect-data.rdf");
+        ImportServerFilesSteps.getResource(6).should('contain', "import-resource-with-long-error.rdf");
+        // checks files in root
+        ImportServerFilesSteps.getResource(7).should('contain', "bnodes.ttl");
+        ImportServerFilesSteps.getResource(8).should('contain', "test_turtlestar.ttls");
+        ImportServerFilesSteps.getResource(9).should('contain', "0007-import-file.jsonld");
+
+        // When I change the order by size.
+        ImportServerFilesSteps.orderBySize();
+
+        // Then I expect the directories to be sorted in descending order,
+        ImportServerFilesSteps.getResource(0).should('contain', "more-files-with-error");
+        ImportServerFilesSteps.getResource(4).should('contain', "more-files");
+        // checks first folder files
+        ImportServerFilesSteps.getResource(1).should('contain', "import-resource-with-long-error.rdf");
+        ImportServerFilesSteps.getResource(2).should('contain', "import-resource-with-incorrect-data.rdf");
+        ImportServerFilesSteps.getResource(3).should('contain', "import-resource-with-correct-data.jsonld");
+        // checks second folder files
+        ImportServerFilesSteps.getResource(5).should('contain', "rdfxml.rdf");
+        ImportServerFilesSteps.getResource(6).should('contain', "jsonld-file.jsonld");
+        // checks files in root
+        ImportServerFilesSteps.getResource(15).should('contain', "0007-import-file.jsonld");
+        ImportServerFilesSteps.getResource(16).should('contain', "test_turtlestar.ttls");
+        ImportServerFilesSteps.getResource(17).should('contain', "bnodes.ttl");
+    });
 });

--- a/test-cypress/steps/import/import-steps.js
+++ b/test-cypress/steps/import/import-steps.js
@@ -458,6 +458,14 @@ class ImportSteps {
             .and('not.have.class', 'ng-animate')
             .and('have.class', 'in');
     }
+
+    static getSizeCell() {
+        return cy.get('th.cell-size');
+    }
+
+    static orderBySize() {
+        ImportSteps.getSizeCell().click();
+    }
 }
 
 export default ImportSteps;


### PR DESCRIPTION
## What
The sorting by size in the import view was not functioning.

## Why
The size field of imported resources was returned in a human-readable format, while the sorting algorithm expected the size in bytes.

## How
The backend has been updated to return sizes in bytes. However, existing files' data, which is persisted as human-readable strings, needed to be handled. The sorting algorithm was kept the same, sorting by bytes. Before sorting, the value is now converted to bytes, regardless of whether it is in a human-readable format or not.

(cherry picked from commit 0a3c7ed3adf8e3226e2b5e280c526c2804f03390)