### PR TITLE
(cherry pick) GDB-10450 - Add warnings when user uses CUSTOM_ prefix (#1511)

### DIFF
--- a/src/css/aclmanagement.css
+++ b/src/css/aclmanagement.css
@@ -104,6 +104,11 @@ html, body {
     margin: 4px 0 0 3px;
 }
 
+.acl-management-view .acl-rules .role-cell .data .icon-warning {
+    float: right;
+    vertical-align: middle;
+}
+
 .acl-management-view .acl-rules .operation-column {
     width: 10%;
 }
@@ -129,11 +134,11 @@ html, body {
 }
 
 .acl-management-view .acl-rules .policy-column {
-    width: 10%;
+    width: 7%;
 }
 
 .acl-management-view .acl-rules .role-column {
-    width: 10%;
+    width: 13%;
 }
 .acl-management-view .acl-rules .actions-column {
     width: 8%;

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -176,6 +176,9 @@
                 "role": "ROLE1",
                 "plugin": "Plugin"
             },
+            "prefix_warning": {
+                "text": "Custom roles should be entered without the \"CUSTOM_\" prefix in Workbench"
+            },
             "actions": {
                 "move_up": "Move the rule up",
                 "move_down": "Move the rule down",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -176,6 +176,9 @@
                 "role": "ROLE1",
                 "plugin": "Brancher"
             },
+            "prefix_warning": {
+                "text": "Les rôles personnalisés doivent être saisis sans le préfixe \"CUSTOM_\" dans workbench"
+            },
             "actions": {
                 "move_up": "Déplacer la règle vers le haut",
                 "move_down": "Déplacer la règle vers le bas",

--- a/src/js/angular/aclmanagement/controllers.js
+++ b/src/js/angular/aclmanagement/controllers.js
@@ -4,6 +4,7 @@ import {mapAclRulesResponse} from "../rest/mappers/aclmanagement-mapper";
 import {isEqual} from 'lodash';
 import {mapNamespacesResponse} from "../rest/mappers/namespaces-mapper";
 import {ACL_SCOPE, DEFAULT_CONTEXT_VALUES, DEFAULT_URI_VALUES, DEFAULT_CLEAR_GRAPH_CONTEXT_VALUES} from "./model";
+import {RoleNamePrefixUtils} from "../utils/role-name-prefix-utils";
 
 const modules = [
     'graphdb.framework.rest.plugins.service',
@@ -137,6 +138,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
 
     $scope.rowHeights = {};
 
+    $scope.doublePrefix = "CUSTOM_CUSTOM_";
 
     //
     // Public functions
@@ -309,6 +311,10 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
         setModelDirty(scope);
     };
 
+    $scope.showWarning = function () {
+        $scope.showPrefixWarningIcon = true;
+    };
+
     /**
      * Handles event when the "Enter" key is pressed.
      *
@@ -322,6 +328,9 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
      * @param {FormController} form - The form object.
      */
     $scope.performSearchActionOnEnter = function (event, scope, form) {
+        if (!RoleNamePrefixUtils.isCustomPrefixUsed(event.target.value)) {
+            $scope.showPrefixWarningIcon = false;
+        }
         if (event.keyCode === 13) {
             event.stopPropagation();
             event.preventDefault();

--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -3,6 +3,7 @@ import 'angular/core/services/jwt-auth.service';
 import 'angular/core/services/openid-auth.service';
 import 'angular/rest/security.rest.service';
 import {UserUtils, UserRole, UserType} from 'angular/utils/user-utils';
+import {RoleNamePrefixUtils} from "../utils/role-name-prefix-utils";
 
 const SYSTEM_REPO = 'SYSTEM';
 const READ_REPO = 'READ_REPO';
@@ -510,6 +511,7 @@ securityCtrl.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 'toa
          * @return {boolean} true if valid, otherwise false
          */
         $scope.isCustomRoleValid = function (fieldValue) {
+            $scope.showCustomPrefixMessage = RoleNamePrefixUtils.isCustomPrefixUsed(fieldValue.text);
             $scope.isRoleValid = fieldValue.text.length >= minTagLength;
             return $scope.isRoleValid;
         };
@@ -524,6 +526,7 @@ securityCtrl.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 'toa
             if (event.keyCode === 8 || event.keyCode === 46) {
                 $scope.isRoleValid = true;
             }
+            $scope.showCustomPrefixMessage = RoleNamePrefixUtils.isCustomPrefixUsed(event.target.value);
         };
 
         /**

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -225,6 +225,9 @@
                             <div class="small" ng-hide="isRoleValid">
                                 <small>{{'security.user.role.too.short' | translate}}</small>
                             </div>
+                            <div class="small prefix-warning" ng-if="showCustomPrefixMessage">
+                                <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/js/angular/utils/role-name-prefix-utils.js
+++ b/src/js/angular/utils/role-name-prefix-utils.js
@@ -1,0 +1,10 @@
+export class RoleNamePrefixUtils {
+    /**
+     * Checks if the given string starts with "CUSTOM_".
+     * @param {string} name the string to verify
+     * @return {boolean} true, if starts with "CUSTOM_", otherwise false.
+     */
+    static isCustomPrefixUsed(name) {
+        return name.toUpperCase().startsWith("CUSTOM_");
+    }
+}

--- a/src/pages/aclmanagement.html
+++ b/src/pages/aclmanagement.html
@@ -111,6 +111,7 @@
                                         <span class="acl-tag"
                                               ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
+                                            <em ng-if="rule.role.startsWith(doublePrefix)" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                         </span>
                                     </td>
                                     <td class="operation-cell data">
@@ -155,6 +156,7 @@
                                                   ng-model="rule.role"
                                                   ng-change="setDirty(activeTabScope)"
                                                   ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
+                                                  ng-blur="showWarning()"
                                                   uppercased uppercase-placeholder="false"
                                                   custom-role-prefix auto-grow
                                                   autocomplete="off"
@@ -164,7 +166,11 @@
                                         <div class="small" ng-if="ruleData.role.$touched && !ruleData.role.$valid">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
+                                        <div class="small float-lg-left prefix-warning-text" ng-if="rule.role.startsWith(doublePrefix) && !showPrefixWarningIcon">
+                                            <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                                        </div>
                                         <em></em>
+                                        <em ng-if="rule.role.startsWith(doublePrefix) && showPrefixWarningIcon" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                     </td>
                                     <td class="data operation-cell">
                                         <select ng-model="rule.operation" ng-change="setDirty(activeTabScope)" class="form-control form-control-sm select-rule">
@@ -311,6 +317,7 @@
                                     <td class="role-cell data">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
+                                            <em ng-if="rule.role.startsWith(doublePrefix)" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                         </span>
                                     </td>
                                     <td class="context-cell data" ng-class="{'wildcard-cell': rule.context === '*', 'context-cell-special': !rule.context.startsWith('<') && rule.context !== '*'}">
@@ -349,6 +356,7 @@
                                                   ng-model="rule.role"
                                                   ng-change="setDirty(activeTabScope)"
                                                   ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
+                                                  ng-blur="showWarning()"
                                                   uppercased uppercase-placeholder="false"
                                                   custom-role-prefix auto-grow
                                                   autocomplete="off" class="form-control form-control-sm textarea-edit"
@@ -358,7 +366,15 @@
                                         <div class="small" ng-if="ruleData.role.$touched && !ruleData.role.$valid">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
+                                        <div class="small float-lg-left prefix-warning-text" ng-if="rule.role.startsWith(doublePrefix) && !showPrefixWarningIcon">
+                                            <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                                        </div>
                                         <em></em>
+                                        <em ng-if="rule.role.startsWith(doublePrefix) && showPrefixWarningIcon"
+                                            class="icon-warning"
+                                            gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}"
+                                            tooltip-placement="right">
+                                        </em>
                                     </td>
                                     <td class="data context-cell">
                                         <autocomplete ng-model="rule.context" on-model-change="setDirty(activeTabScope)" name="context"
@@ -454,6 +470,7 @@
                                     <td class="role-cell data">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
+                                            <em ng-if="rule.role.startsWith(doublePrefix)" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                         </span>
                                     </td>
                                     <td class="operation-cell data">
@@ -498,6 +515,7 @@
                                                   ng-model="rule.role"
                                                   ng-change="setDirty(activeTabScope)"
                                                   ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
+                                                  ng-blur="showWarning()"
                                                   uppercased uppercase-placeholder="false"
                                                   custom-role-prefix auto-grow
                                                   autocomplete="off"
@@ -507,7 +525,11 @@
                                         <div class="small" ng-if="ruleData.role.$touched && !ruleData.role.$valid">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
+                                        <div class="small float-lg-left prefix-warning-text" ng-if="rule.role.startsWith(doublePrefix) && !showPrefixWarningIcon">
+                                            <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                                        </div>
                                         <em></em>
+                                        <em ng-if="rule.role.startsWith(doublePrefix) && showPrefixWarningIcon" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                     </td>
                                     <td class="data operation-cell">
                                         <select ng-model="rule.operation" ng-change="setDirty(activeTabScope)" class="form-control form-control-sm select-rule">
@@ -604,6 +626,7 @@
                                     <td class="role-cell data">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
+                                            <em ng-if="rule.role.startsWith(doublePrefix)" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                         </span>
                                     </td>
                                     <td class="operation-cell data">
@@ -645,6 +668,7 @@
                                                   ng-model="rule.role"
                                                   ng-change="setDirty(activeTabScope)"
                                                   ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
+                                                  ng-blur="showWarning()"
                                                   uppercased uppercase-placeholder="false"
                                                   custom-role-prefix auto-grow
                                                   autocomplete="off"
@@ -654,7 +678,11 @@
                                         <div class="small" ng-if="ruleData.role.$touched && !ruleData.role.$valid">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
+                                        <div class="small float-lg-left prefix-warning-text" ng-if="rule.role.startsWith(doublePrefix) && !showPrefixWarningIcon">
+                                            <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                                        </div>
                                         <em></em>
+                                        <em ng-if="rule.role.startsWith(doublePrefix) && showPrefixWarningIcon" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                     </td>
                                     <td class="data operation-cell">
                                         <select ng-model="rule.operation" ng-change="setDirty(activeTabScope)" class="form-control form-control-sm select-rule">

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -176,6 +176,9 @@
                 "role": "ROLE1",
                 "plugin": "Plugin"
             },
+            "prefix_warning": {
+                "text": "Custom roles should be entered without the \"CUSTOM_\" prefix in Workbench"
+            },
             "actions": {
                 "move_up": "Move the rule up",
                 "move_down": "Move the rule down",

--- a/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
@@ -214,5 +214,25 @@ describe('ACL Management: create rule', () => {
         // Then I expect an error notification to be displayed that tells me this ROLE length is not allowed
         AclManagementSteps.getFieldError().contains('Too short');
     });
+
+    it('should show message if role prefix is CUSTOM_', () => {
+        // When I am on "ACL Management" page and create a new rule with a CUSTOM_ prefix
+        AclManagementSteps.addRuleInBeginning();
+        AclManagementSteps.selectPolicy(0, 'allow');
+        AclManagementSteps.fillRole(0, 'CUSTOM_ROLE_FOO');
+
+        // Then I expect the prefix warning to appear
+        AclManagementSteps.getPrefixWarning().should('be.visible');
+        AclManagementSteps.getPrefixWarning().should('contain.text', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
+        // When I save the rule
+        AclManagementSteps.saveRule(0);
+        // Then the text should be how the user typed it
+        AclManagementSteps.getSavedRoleField(0).should('contain', 'CUSTOM_ROLE_FOO');
+        // And I expect a warning icon to appear
+        AclManagementSteps.getWarningIcon().should('be.visible');
+        AclManagementSteps.mouseoverWarningIcon();
+        // And the icon should have the same tooltip text as the warning
+        AclManagementSteps.getWarningIconTooltipText().should('be.visible').and('contain.text', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
+    });
 });
 

--- a/test-cypress/integration/setup/user-and-access.spec.js
+++ b/test-cypress/integration/setup/user-and-access.spec.js
@@ -105,6 +105,15 @@ describe('User and Access', () => {
         UserAndAccessSteps.getFieldError().should('not.be.visible');
     });
 
+    it('Adding a role with a CUSTOM_ prefix shows a warning message', () => {
+        // When I create a user
+        UserAndAccessSteps.clickCreateNewUserButton();
+        // And I add a custom role tag with prefix CUSTOM_
+        UserAndAccessSteps.addTextToCustomRoleField('CUSTOM_USER');
+        // There should be a warning text
+        UserAndAccessSteps.getPrefixWarning().should('contain', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
+    });
+
     it('Warn users when setting no password when creating new user admin', () => {
         UserAndAccessSteps.getUsersTable().should('be.visible');
         createUser("adminWithNoPassword", PASSWORD, ROLE_CUSTOM_ADMIN);

--- a/test-cypress/steps/setup/acl-management-steps.js
+++ b/test-cypress/steps/setup/acl-management-steps.js
@@ -157,12 +157,32 @@ export class AclManagementSteps {
         return this.getRule(index).find('.role-cell textarea');
     }
 
+    static getSavedRoleField(index) {
+        return this.getRule(index).find('.role-cell');
+    }
+
     static fillRole(index, value) {
         this.getRoleField(index).clear().type(value);
     }
 
     static getFieldError() {
         return cy.get('div.small');
+    }
+
+    static getPrefixWarning() {
+        return cy.get('.prefix-warning-text');
+    }
+
+    static getWarningIcon() {
+        return cy.get('.icon-warning');
+    }
+
+    static getWarningIconTooltipText() {
+        return cy.get('.angular-tooltip');
+    }
+
+    static mouseoverWarningIcon() {
+        cy.get('.icon-warning').first().trigger('mouseover');
     }
 
     static getPluginField(index) {

--- a/test-cypress/steps/setup/user-and-access-steps.js
+++ b/test-cypress/steps/setup/user-and-access-steps.js
@@ -148,6 +148,10 @@ export class UserAndAccessSteps {
         return cy.get('.modal-dialog');
     }
 
+    static getPrefixWarning() {
+        return cy.get('.prefix-warning');
+    }
+
     static getDialogText() {
         return this.getModal().find('.lead');
     }


### PR DESCRIPTION
## What?
The user will be warned when using "CUSTOM_" as a prefix for ACL rules and when adding roles to a User in Setup.

## Why?
The back-end adds the prefix and the user is not notified, which can lead to errors when adding roles.

## How?
I created new templates for the error messages and added a check during the rest of the rule validation steps.

## Testing?
Tests added.

## Screenshots?
The message in ACL view:
![image](https://github.com/user-attachments/assets/028874d2-cbd8-451d-bd64-fc9989a996a8)
![image](https://github.com/user-attachments/assets/0e38ff5a-d523-4a1e-800c-5fb77aa21cb8)

The message in User setup:
![image](https://github.com/user-attachments/assets/506172a7-0faa-4920-ae77-bc7cc2b9eea5)


* GDB-10450 - add warnings when user uses CUSTOM_ prefix on ACL rule creation and during user custom role addition. Tests added

* GDB-10450 - add new labels to cypress locale file

* GDB-10450 - remove prefix warning dialogs and replace with inline text. Alter tests and remove unused templates and controllers.

* GDB-10450 - resize columns in ACL table

* GDB-10450 - refactor and create util class

(cherry picked from commit 229d163af4d954d5c7f671d43110fb3166b09a32)