### PR TITLE
GDB-10785 - Rework and refactor existing solution for ACL role warnings on CUSTOM_ prefix use

### DIFF
--- a/src/css/aclmanagement.css
+++ b/src/css/aclmanagement.css
@@ -104,6 +104,12 @@ html, body {
     margin: 4px 0 0 3px;
 }
 
+#graphRoleCell, #pluginRoleCell, #systemRoleCell, #statementRoleCell {
+    overflow-wrap: anywhere;
+    display: flex;
+    align-items: center;
+}
+
 .acl-management-view .acl-rules .input-container {
     display: flex;
     align-items: center;

--- a/src/css/aclmanagement.css
+++ b/src/css/aclmanagement.css
@@ -104,10 +104,13 @@ html, body {
     margin: 4px 0 0 3px;
 }
 
-#graphRoleCell, #pluginRoleCell, #systemRoleCell, #statementRoleCell {
-    overflow-wrap: anywhere;
+.acl-management-view .acl-rules .preview-rule-row .role-icon-container {
     display: flex;
     align-items: center;
+}
+
+.acl-management-view .acl-rules .preview-rule-row .role-icon-container .acl-tag-role {
+    overflow-wrap: anywhere;
 }
 
 .acl-management-view .acl-rules .input-container {

--- a/src/css/aclmanagement.css
+++ b/src/css/aclmanagement.css
@@ -104,9 +104,13 @@ html, body {
     margin: 4px 0 0 3px;
 }
 
-.acl-management-view .acl-rules .role-cell .data .icon-warning {
-    float: right;
-    vertical-align: middle;
+.acl-management-view .acl-rules .input-container {
+    display: flex;
+    align-items: center;
+}
+
+.acl-management-view .acl-rules .role-cell .icon-warning {
+    margin-left: 3px;
 }
 
 .acl-management-view .acl-rules .operation-column {
@@ -252,6 +256,7 @@ input::placeholder {
 }
 
 .textarea-edit {
+    flex: 1;
     padding: 4px 8px;
     min-height: 29px;
 }

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -176,7 +176,7 @@
                 "role": "ROLE1",
                 "plugin": "Plugin"
             },
-            "prefix_warning": {
+            "custom_prefix_warning": {
                 "text": "Custom roles should be entered without the \"CUSTOM_\" prefix in Workbench"
             },
             "actions": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -176,7 +176,7 @@
                 "role": "ROLE1",
                 "plugin": "Brancher"
             },
-            "prefix_warning": {
+            "custom_prefix_warning": {
                 "text": "Les rôles personnalisés doivent être saisis sans le préfixe \"CUSTOM_\" dans workbench"
             },
             "actions": {

--- a/src/js/angular/aclmanagement/controllers.js
+++ b/src/js/angular/aclmanagement/controllers.js
@@ -4,7 +4,6 @@ import {mapAclRulesResponse} from "../rest/mappers/aclmanagement-mapper";
 import {isEqual} from 'lodash';
 import {mapNamespacesResponse} from "../rest/mappers/namespaces-mapper";
 import {ACL_SCOPE, DEFAULT_CONTEXT_VALUES, DEFAULT_URI_VALUES, DEFAULT_CLEAR_GRAPH_CONTEXT_VALUES} from "./model";
-import {RoleNamePrefixUtils} from "../utils/role-name-prefix-utils";
 
 const modules = [
     'graphdb.framework.rest.plugins.service',
@@ -138,7 +137,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
 
     $scope.rowHeights = {};
 
-    $scope.doublePrefix = "CUSTOM_CUSTOM_";
+    $scope.hasCustomPrefix = false;
 
     //
     // Public functions
@@ -155,6 +154,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
      */
     $scope.addRule = (scope, index) => {
         $scope.rulesModel.addRule(scope, index);
+        $scope.showPrefixWarningIcon(false);
         $scope.editedRuleIndex = index;
         $scope.editedRuleScope = scope;
         $scope.isNewRule = true;
@@ -311,8 +311,8 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
         setModelDirty(scope);
     };
 
-    $scope.showWarning = function () {
-        $scope.showPrefixWarningIcon = true;
+    $scope.showPrefixWarningIcon = function (showWarning) {
+        $scope.hasCustomPrefix = showWarning;
     };
 
     /**
@@ -328,14 +328,11 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
      * @param {FormController} form - The form object.
      */
     $scope.performSearchActionOnEnter = function (event, scope, form) {
-        if (!RoleNamePrefixUtils.isCustomPrefixUsed(event.target.value)) {
-            $scope.showPrefixWarningIcon = false;
-        }
         if (event.keyCode === 13) {
             event.stopPropagation();
             event.preventDefault();
             $scope.triggerValidation(form);
-            if (form.$valid) {
+            if (!form.$error.required || !form.$error.minLength) {
                 $scope.saveRule(scope);
             }
         }

--- a/src/js/angular/aclmanagement/controllers.js
+++ b/src/js/angular/aclmanagement/controllers.js
@@ -172,6 +172,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
         $scope.editedRuleScope = scope;
         $scope.isNewRule = false;
         $scope.editedRuleCopy = $scope.rulesModel.getRuleCopy(scope, index);
+        $scope.rulesModel.setPrefixWarningFlag(scope, index);
         $scope.getRowHeight = 'height: ' + $scope.rowHeights[$scope.editedRuleIndex];
         setModelDirty(scope);
     };
@@ -196,10 +197,12 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
      * @param {string} scope
      */
     $scope.saveRule = (scope) => {
+        $scope.rulesModel.setPrefixWarningFlag($scope.editedRuleScope, $scope.editedRuleIndex);
         if ($scope.rulesModel.isRuleDuplicated($scope.editedRuleScope, $scope.editedRuleIndex)) {
             notifyDuplication();
             return;
         }
+
         $scope.editedRuleIndex = undefined;
         $scope.editedRuleScope = undefined;
         $scope.isNewRule = false;
@@ -219,6 +222,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
             $scope.rulesModel.replaceRule(scope, index, $scope.editedRuleCopy);
             $scope.editedRuleCopy = undefined;
         }
+        $scope.rulesModel.setPrefixWarningFlag(scope, index);
         $scope.editedRuleIndex = undefined;
         $scope.editedRuleScope = undefined;
         setModelDirty(scope);
@@ -333,7 +337,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
             event.stopPropagation();
             event.preventDefault();
             $scope.triggerValidation(form);
-            if (!form.$error.required || !form.$error.minLength) {
+            if (form.$valid) {
                 $scope.saveRule(scope);
             }
         }

--- a/src/js/angular/aclmanagement/controllers.js
+++ b/src/js/angular/aclmanagement/controllers.js
@@ -137,6 +137,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
 
     $scope.rowHeights = {};
 
+    // When the user clicks outside the input, this flag is used to signal that the CUSTOM_ prefix warning icon should appear and the warning text should disappear
     $scope.hasCustomPrefix = false;
 
     //

--- a/src/js/angular/aclmanagement/directives/custom-role-prefix.directive.js
+++ b/src/js/angular/aclmanagement/directives/custom-role-prefix.directive.js
@@ -45,7 +45,7 @@ function customRolePrefixDirective() {
         restrict: 'A',
         link: function(scope, element, attrs) {
             const customPrefix = "CUSTOM_";
-            const negatedPrefix = "!CUSTOM_";
+            const negatedCustomPrefix = "!CUSTOM_";
             const subscriptions = [];
 
             // Function to add or remove the custom prefix
@@ -54,7 +54,7 @@ function customRolePrefixDirective() {
                     return value;
                 }
                 const negated = value.startsWith('!');
-                const prefix = negated ? negatedPrefix : customPrefix;
+                const prefix = negated ? negatedCustomPrefix : customPrefix;
                 if (addPrefix) {
                     return prefix + value.replace(/^!/, '');
                 }
@@ -62,7 +62,7 @@ function customRolePrefixDirective() {
             }
 
             function hasCustomOrNegatedPrefix(tag) {
-                return tag.startsWith(customPrefix) || tag.startsWith(negatedPrefix);
+                return tag.startsWith(customPrefix) || tag.startsWith(negatedCustomPrefix);
             }
 
             // Check if the element is an input, textarea, or tags-input and has ngModel associated with it

--- a/src/js/angular/aclmanagement/directives/custom-role-prefix.directive.js
+++ b/src/js/angular/aclmanagement/directives/custom-role-prefix.directive.js
@@ -12,6 +12,9 @@ angular
  * from the model value bound to an input field. It ensures that the prefix is present in the model
  * for consistency but is removed when displaying the value in the edit view for better user experience.
  *
+ * The directive also includes validation to check if the view value starts with 'CUSTOM_' or '!CUSTOM_'.
+ * If the value starts with either of these prefixes, the model will be marked as invalid.
+ *
  * Special cases:
  * - If the role starts with '!', '!CUSTOM_' is used instead.
  * - If the role is '*', it is considered a special value and is not prefixed.
@@ -57,6 +60,14 @@ function customRolePrefixDirective() {
             // Check if the element is an input or textarea and has ngModel associated with it
             if ((element[0].tagName === 'INPUT' || element[0].tagName === 'TEXTAREA') && attrs.ngModel) {
                 const ngModelCtrl = element.controller('ngModel');
+                ngModelCtrl.$parsers.push(function(viewValue) {
+                    if (viewValue && (viewValue.startsWith('CUSTOM_') || viewValue.startsWith('!CUSTOM_'))) {
+                        ngModelCtrl.$setValidity('customPrefix', false);
+                    } else {
+                        ngModelCtrl.$setValidity('customPrefix', true);
+                    }
+                    return viewValue;
+                });
 
                 // Set up ngModel formatters and parsers for input element
                 ngModelCtrl.$formatters.push(function(modelValue) {

--- a/src/js/angular/aclmanagement/model.js
+++ b/src/js/angular/aclmanagement/model.js
@@ -189,6 +189,9 @@ export class ACRuleModel {
         this._scope = scope;
         this._role = role;
         this._policy = policy;
+        // The BE requires CUSTOM_ to be prefixed to user created roles. Our custom-role-prefix directive handles this.
+        // However, if the user also types CUSTOM_ in the input before the role name, we need to detect the double prefix, and display the warnings before the rule is saved.
+        this.doublePrefix = "CUSTOM_CUSTOM_";
     }
 
     get scope() {
@@ -219,6 +222,10 @@ export class ACRuleModel {
 
     set policy(value) {
         this._policy = value;
+    }
+
+    get hasDoublePrefix() {
+        return this._role && this._role.startsWith(this.doublePrefix);
     }
 
     toJSON() {

--- a/src/js/angular/aclmanagement/model.js
+++ b/src/js/angular/aclmanagement/model.js
@@ -190,8 +190,9 @@ export class ACRuleModel {
         this._role = role;
         this._policy = policy;
         // The BE requires CUSTOM_ to be prefixed to user created roles. Our custom-role-prefix directive handles this.
-        // However, if the user also types CUSTOM_ in the input before the role name, we need to detect the double prefix, and display the warnings before the rule is saved.
+        // However, if the user also types CUSTOM_ or !CUSTOM_ in the input before the role name, we need to detect the double prefix, and display the warnings before the rule is saved.
         this.doublePrefix = "CUSTOM_CUSTOM_";
+        this.negatedDoublePrefix = "!CUSTOM_CUSTOM_";
     }
 
     get scope() {
@@ -225,7 +226,7 @@ export class ACRuleModel {
     }
 
     get hasDoublePrefix() {
-        return this._role && this._role.startsWith(this.doublePrefix);
+        return this._role && (this._role.startsWith(this.doublePrefix) || this._role.startsWith(this.negatedDoublePrefix));
     }
 
     toJSON() {

--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -511,17 +511,17 @@ securityCtrl.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 'toa
          * @return {boolean} true if valid, otherwise false
          */
         $scope.isCustomRoleValid = function (fieldValue) {
-            $scope.showCustomPrefixMessage = RoleNamePrefixUtils.isCustomPrefixUsed(fieldValue.text);
             $scope.isRoleValid = fieldValue.text.length >= minTagLength;
             return $scope.isRoleValid;
         };
 
         /**
          * Checks if the user pressed the 'Backspace' or 'Delete' key and sets the role validity flag accordingly.
+         * Checks for the CUSTOM_ prefix and displays warning, if present.
          *
          * @param {Object} event
          */
-        $scope.checkForBackspace = function(event) {
+        $scope.checkUserInput = function(event) {
             // If the key pressed is the backspace or delete key, the tag error message will be hidden
             if (event.keyCode === 8 || event.keyCode === 46) {
                 $scope.isRoleValid = true;

--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -3,7 +3,7 @@ import 'angular/core/services/jwt-auth.service';
 import 'angular/core/services/openid-auth.service';
 import 'angular/rest/security.rest.service';
 import {UserUtils, UserRole, UserType} from 'angular/utils/user-utils';
-import {RoleNamePrefixUtils} from "../utils/role-name-prefix-utils";
+import 'angular/aclmanagement/directives/custom-role-prefix.directive';
 
 const SYSTEM_REPO = 'SYSTEM';
 const READ_REPO = 'READ_REPO';
@@ -18,6 +18,7 @@ const modules = [
     'graphdb.framework.core.services.openIDService',
     'graphdb.framework.rest.security.service',
     'toastr',
+    'graphdb.framework.aclmanagement.directives',
     'ngTagsInput'
 ];
 
@@ -517,7 +518,6 @@ securityCtrl.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 'toa
 
         /**
          * Checks if the user pressed the 'Backspace' or 'Delete' key and sets the role validity flag accordingly.
-         * Checks for the CUSTOM_ prefix and displays warning, if present.
          *
          * @param {Object} event
          */
@@ -526,7 +526,6 @@ securityCtrl.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 'toa
             if (event.keyCode === 8 || event.keyCode === 46) {
                 $scope.isRoleValid = true;
             }
-            $scope.showCustomPrefixMessage = RoleNamePrefixUtils.isCustomPrefixUsed(event.target.value);
         };
 
         /**

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -219,14 +219,14 @@
                                         paste-split-pattern="[\s+]"
                                         on-tag-adding="isCustomRoleValid($tag)"
                                         on-tag-added="addCustomRole($tag)"
-                                        ng-keydown="checkForBackspace($event)"
+                                        ng-keydown="checkUserInput($event)"
                                         ng-cut="removeErrorOnCut()"
                                         placeholder="{{'security.user.add.custom_role.msg' | translate}}"></tags-input>
                             <div class="small" ng-hide="isRoleValid">
                                 <small>{{'security.user.role.too.short' | translate}}</small>
                             </div>
                             <div class="small prefix-warning" ng-if="showCustomPrefixMessage">
-                                <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                                <small>{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}</small>
                             </div>
                         </div>
                     </div>

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -221,11 +221,12 @@
                                         on-tag-added="addCustomRole($tag)"
                                         ng-keydown="checkUserInput($event)"
                                         ng-cut="removeErrorOnCut()"
-                                        placeholder="{{'security.user.add.custom_role.msg' | translate}}"></tags-input>
+                                        placeholder="{{'security.user.add.custom_role.msg' | translate}}"
+                                        custom-role-prefix></tags-input>
                             <div class="small" ng-hide="isRoleValid">
                                 <small>{{'security.user.role.too.short' | translate}}</small>
                             </div>
-                            <div class="small prefix-warning" ng-if="showCustomPrefixMessage">
+                            <div class="small prefix-warning" ng-if="form.customRoleTag.$error.customPrefix">
                                 <small>{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}</small>
                             </div>
                         </div>

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -226,7 +226,7 @@
                             <div class="small" ng-hide="isRoleValid">
                                 <small>{{'security.user.role.too.short' | translate}}</small>
                             </div>
-                            <div class="small prefix-warning" ng-if="form.customRoleTag.$error.customPrefix">
+                            <div class="small prefix-warning" ng-if="form.customRoleTag.$warning">
                                 <small>{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}</small>
                             </div>
                         </div>

--- a/src/pages/aclmanagement.html
+++ b/src/pages/aclmanagement.html
@@ -107,7 +107,7 @@
                                             {{rule.policy}}
                                         </span>
                                     </td>
-                                    <td id="statementRoleCell" class="role-cell data">
+                                    <td class="role-cell data role-icon-container">
                                         <span class="acl-tag"
                                               ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
@@ -324,7 +324,7 @@
                                             {{rule.policy}}
                                         </span>
                                     </td>
-                                    <td id="graphRoleCell" class="role-cell data">
+                                    <td class="role-cell data role-icon-container">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
                                         </span>
@@ -485,7 +485,7 @@
                                             {{rule.policy}}
                                         </span>
                                     </td>
-                                    <td id="pluginRoleCell" class="role-cell data">
+                                    <td class="role-cell data role-icon-container">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
                                         </span>
@@ -653,7 +653,7 @@
                                             {{rule.policy}}
                                         </span>
                                     </td>
-                                    <td id="systemRoleCell" class="role-cell data">
+                                    <td class="role-cell data role-icon-container">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
                                         </span>

--- a/src/pages/aclmanagement.html
+++ b/src/pages/aclmanagement.html
@@ -111,7 +111,10 @@
                                         <span class="acl-tag"
                                               ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
-                                            <em ng-if="rule.role.startsWith(doublePrefix)" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
+                                            <em ng-if="rule.hasDoublePrefix"
+                                                class="icon-warning"
+                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                tooltip-placement="right"></em>
                                         </span>
                                     </td>
                                     <td class="operation-cell data">
@@ -152,25 +155,31 @@
                                         </select>
                                     </td>
                                     <td class="data role-cell">
-                                        <textarea type="text" name="role" minlength="2" required
-                                                  ng-model="rule.role"
-                                                  ng-change="setDirty(activeTabScope)"
-                                                  ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
-                                                  ng-blur="showWarning()"
-                                                  uppercased uppercase-placeholder="false"
-                                                  custom-role-prefix auto-grow
-                                                  autocomplete="off"
-                                                  class="form-control form-control-sm textarea-edit"
-                                               placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
-                                        </textarea>
-                                        <div class="small" ng-if="ruleData.role.$touched && !ruleData.role.$valid">
+                                        <div class="input-container">
+                                            <textarea type="text" name="role" minlength="2" required
+                                                      ng-model="rule.role"
+                                                      ng-change="setDirty(activeTabScope)"
+                                                      ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
+                                                      ng-blur="showPrefixWarningIcon(true)"
+                                                      uppercased uppercase-placeholder="false"
+                                                      custom-role-prefix auto-grow
+                                                      autocomplete="off"
+                                                      class="form-control form-control-sm textarea-edit"
+                                                      placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
+                                            </textarea>
+                                            <em ng-if="ruleData.role.$error.customPrefix && hasCustomPrefix"
+                                                class="icon-warning"
+                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                tooltip-placement="right"></em>
+                                        </div>
+                                        <div class="small" ng-if="ruleData.role.$touched && ruleData.role.$error.minlength">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
-                                        <div class="small float-lg-left prefix-warning-text" ng-if="rule.role.startsWith(doublePrefix) && !showPrefixWarningIcon">
-                                            <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                                        <div ng-if="ruleData.role.$error.customPrefix && !hasCustomPrefix">
+                                            <small class="small float-lg-left prefix-warning-text">
+                                                {{'acl_management.rulestable.custom_prefix_warning.text' | translate}}
+                                            </small>
                                         </div>
-                                        <em></em>
-                                        <em ng-if="rule.role.startsWith(doublePrefix) && showPrefixWarningIcon" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                     </td>
                                     <td class="data operation-cell">
                                         <select ng-model="rule.operation" ng-change="setDirty(activeTabScope)" class="form-control form-control-sm select-rule">
@@ -251,7 +260,7 @@
                                             </button>
                                             <button ng-click="saveRule(activeTabScope)"
                                                     class="btn btn-link save-rule-btn"
-                                                    ng-disabled="!ruleData.$valid"
+                                                    ng-disabled="ruleData.role.$error.required || ruleData.role.$error.minlength"
                                                     gdb-tooltip="{{ruleData.$valid ? 'acl_management.rulestable.actions.apply_rule' : 'acl_management.rulestable.messages.invalid_form' | translate}}">
                                                 <em class="icon-check"></em>
                                             </button>
@@ -317,7 +326,10 @@
                                     <td class="role-cell data">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
-                                            <em ng-if="rule.role.startsWith(doublePrefix)" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
+                                            <em ng-if="rule.hasDoublePrefix"
+                                                class="icon-warning"
+                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                tooltip-placement="right"></em>
                                         </span>
                                     </td>
                                     <td class="context-cell data" ng-class="{'wildcard-cell': rule.context === '*', 'context-cell-special': !rule.context.startsWith('<') && rule.context !== '*'}">
@@ -352,29 +364,33 @@
                                         </select>
                                     </td>
                                     <td class="data role-cell">
-                                        <textarea type="text" name="role" minlength="2" required
-                                                  ng-model="rule.role"
-                                                  ng-change="setDirty(activeTabScope)"
-                                                  ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
-                                                  ng-blur="showWarning()"
-                                                  uppercased uppercase-placeholder="false"
-                                                  custom-role-prefix auto-grow
-                                                  autocomplete="off" class="form-control form-control-sm textarea-edit"
-                                                  rows="1"
-                                                  placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
-                                        </textarea>
-                                        <div class="small" ng-if="ruleData.role.$touched && !ruleData.role.$valid">
+                                        <div class="input-container">
+                                            <textarea type="text" name="role" minlength="2" required
+                                                      ng-model="rule.role"
+                                                      ng-change="setDirty(activeTabScope)"
+                                                      ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
+                                                      ng-blur="showPrefixWarningIcon(true)"
+                                                      uppercased uppercase-placeholder="false"
+                                                      custom-role-prefix auto-grow
+                                                      autocomplete="off" class="form-control form-control-sm textarea-edit"
+                                                      rows="1"
+                                                      placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
+                                            </textarea>
+                                            <em ng-if="ruleData.role.$error.customPrefix && hasCustomPrefix"
+                                                class="icon-warning"
+                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                tooltip-placement="right">
+                                            </em>
+                                        </div>
+                                        <div class="small" ng-if="ruleData.role.$touched && ruleData.role.$error.minlength">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
-                                        <div class="small float-lg-left prefix-warning-text" ng-if="rule.role.startsWith(doublePrefix) && !showPrefixWarningIcon">
-                                            <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                                        <div ng-if="ruleData.role.$error.customPrefix && !hasCustomPrefix">
+                                            <small class="small float-lg-left prefix-warning-text">
+                                                {{'acl_management.rulestable.custom_prefix_warning.text' | translate}}
+                                            </small>
                                         </div>
                                         <em></em>
-                                        <em ng-if="rule.role.startsWith(doublePrefix) && showPrefixWarningIcon"
-                                            class="icon-warning"
-                                            gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}"
-                                            tooltip-placement="right">
-                                        </em>
                                     </td>
                                     <td class="data context-cell">
                                         <autocomplete ng-model="rule.context" on-model-change="setDirty(activeTabScope)" name="context"
@@ -401,7 +417,7 @@
                                             </button>
                                             <button ng-click="saveRule(activeTabScope)"
                                                     class="btn btn-link save-rule-btn"
-                                                    ng-disabled="!ruleData.$valid"
+                                                    ng-disabled="ruleData.role.$error.required || ruleData.role.$error.minlength"
                                                     gdb-tooltip="{{ruleData.$valid ? 'acl_management.rulestable.actions.apply_rule' : 'acl_management.rulestable.messages.invalid_form' | translate}}">
                                                 <em class="icon-check"></em>
                                             </button>
@@ -470,7 +486,11 @@
                                     <td class="role-cell data">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
-                                            <em ng-if="rule.role.startsWith(doublePrefix)" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
+                                            <em ng-if="rule.hasDoublePrefix"
+                                                class="icon-warning"
+                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                tooltip-placement="right">
+                                            </em>
                                         </span>
                                     </td>
                                     <td class="operation-cell data">
@@ -511,25 +531,33 @@
                                         </select>
                                     </td>
                                     <td class="data role-cell">
-                                        <textarea type="text" name="role" minlength="2" required
-                                                  ng-model="rule.role"
-                                                  ng-change="setDirty(activeTabScope)"
-                                                  ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
-                                                  ng-blur="showWarning()"
-                                                  uppercased uppercase-placeholder="false"
-                                                  custom-role-prefix auto-grow
-                                                  autocomplete="off"
-                                                  class="form-control form-control-sm textarea-edit"
-                                                  placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
-                                        </textarea>
-                                        <div class="small" ng-if="ruleData.role.$touched && !ruleData.role.$valid">
+                                        <div class="input-container">
+                                            <textarea type="text" name="role" minlength="2" required
+                                                      ng-model="rule.role"
+                                                      ng-change="setDirty(activeTabScope)"
+                                                      ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
+                                                      ng-blur="showPrefixWarningIcon(true)"
+                                                      uppercased uppercase-placeholder="false"
+                                                      custom-role-prefix auto-grow
+                                                      autocomplete="off"
+                                                      class="form-control form-control-sm textarea-edit"
+                                                      placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
+                                            </textarea>
+                                            <em ng-if="ruleData.role.$error.customPrefix && hasCustomPrefix"
+                                                class="icon-warning"
+                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                tooltip-placement="right">
+                                            </em>
+                                        </div>
+                                        <div class="small" ng-if="ruleData.role.$touched && ruleData.role.$error.minlength">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
-                                        <div class="small float-lg-left prefix-warning-text" ng-if="rule.role.startsWith(doublePrefix) && !showPrefixWarningIcon">
-                                            <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                                        <div ng-if="ruleData.role.$error.customPrefix && !hasCustomPrefix">
+                                            <small class="small float-lg-left prefix-warning-text">
+                                                {{'acl_management.rulestable.custom_prefix_warning.text' | translate}}
+                                            </small>
                                         </div>
                                         <em></em>
-                                        <em ng-if="rule.role.startsWith(doublePrefix) && showPrefixWarningIcon" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                     </td>
                                     <td class="data operation-cell">
                                         <select ng-model="rule.operation" ng-change="setDirty(activeTabScope)" class="form-control form-control-sm select-rule">
@@ -560,7 +588,7 @@
                                             </button>
                                             <button ng-click="saveRule(activeTabScope)"
                                                     class="btn btn-link save-rule-btn"
-                                                    ng-disabled="!ruleData.$valid"
+                                                    ng-disabled="ruleData.role.$error.required || ruleData.role.$error.minlength"
                                                     gdb-tooltip="{{ruleData.$valid ? 'acl_management.rulestable.actions.apply_rule' : 'acl_management.rulestable.messages.invalid_form' | translate}}">
                                                 <em class="icon-check"></em>
                                             </button>
@@ -626,7 +654,11 @@
                                     <td class="role-cell data">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
-                                            <em ng-if="rule.role.startsWith(doublePrefix)" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
+                                            <em ng-if="rule.hasDoublePrefix"
+                                                class="icon-warning"
+                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                tooltip-placement="right">
+                                            </em>
                                         </span>
                                     </td>
                                     <td class="operation-cell data">
@@ -664,25 +696,33 @@
                                         </select>
                                     </td>
                                     <td class="data role-cell">
-                                        <textarea type="text" name="role" minlength="2" required
-                                                  ng-model="rule.role"
-                                                  ng-change="setDirty(activeTabScope)"
-                                                  ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
-                                                  ng-blur="showWarning()"
-                                                  uppercased uppercase-placeholder="false"
-                                                  custom-role-prefix auto-grow
-                                                  autocomplete="off"
-                                                  class="form-control form-control-sm textarea-edit"
-                                                  placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
-                                        </textarea>
-                                        <div class="small" ng-if="ruleData.role.$touched && !ruleData.role.$valid">
+                                        <div class="input-container">
+                                            <textarea type="text" name="role" minlength="2" required
+                                                      ng-model="rule.role"
+                                                      ng-change="setDirty(activeTabScope)"
+                                                      ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
+                                                      ng-blur="showPrefixWarningIcon(true)"
+                                                      uppercased uppercase-placeholder="false"
+                                                      custom-role-prefix auto-grow
+                                                      autocomplete="off"
+                                                      class="form-control form-control-sm textarea-edit"
+                                                      placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
+                                            </textarea>
+                                            <em ng-if="ruleData.role.$error.customPrefix && hasCustomPrefix"
+                                                class="icon-warning"
+                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                tooltip-placement="right">
+                                            </em>
+                                        </div>
+                                        <div class="small" ng-if="ruleData.role.$touched && ruleData.role.$error.minlength">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
-                                        <div class="small float-lg-left prefix-warning-text" ng-if="rule.role.startsWith(doublePrefix) && !showPrefixWarningIcon">
-                                            <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                                        <div ng-if="ruleData.role.$error.customPrefix && !hasCustomPrefix">
+                                            <small class="small float-lg-left prefix-warning-text">
+                                                {{'acl_management.rulestable.custom_prefix_warning.text' | translate}}
+                                            </small>
                                         </div>
                                         <em></em>
-                                        <em ng-if="rule.role.startsWith(doublePrefix) && showPrefixWarningIcon" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                     </td>
                                     <td class="data operation-cell">
                                         <select ng-model="rule.operation" ng-change="setDirty(activeTabScope)" class="form-control form-control-sm select-rule">
@@ -701,7 +741,7 @@
                                             </button>
                                             <button ng-click="saveRule(activeTabScope)"
                                                     class="btn btn-link save-rule-btn"
-                                                    ng-disabled="!ruleData.$valid"
+                                                    ng-disabled="ruleData.role.$error.required || ruleData.role.$error.minlength"
                                                     gdb-tooltip="{{ruleData.$valid ? 'acl_management.rulestable.actions.apply_rule' : 'acl_management.rulestable.messages.invalid_form' | translate}}">
                                                 <em class="icon-check"></em>
                                             </button>

--- a/src/pages/aclmanagement.html
+++ b/src/pages/aclmanagement.html
@@ -107,15 +107,16 @@
                                             {{rule.policy}}
                                         </span>
                                     </td>
-                                    <td class="role-cell data">
+                                    <td id="statementRoleCell" class="role-cell data">
                                         <span class="acl-tag"
                                               ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
-                                            <em ng-if="rule.hasDoublePrefix"
-                                                class="icon-warning"
-                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
-                                                tooltip-placement="right"></em>
                                         </span>
+                                        <em ng-if="rule.warnForPrefix"
+                                            class="icon-warning"
+                                            gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                            tooltip-placement="right">
+                                        </em>
                                     </td>
                                     <td class="operation-cell data">
                                          <span class="acl-tag" ng-class="{'wildcard-cell': rule.operation === '*', 'acl-tag-read': rule.operation === 'read','acl-tag-write': rule.operation === 'write'}">
@@ -167,7 +168,7 @@
                                                       class="form-control form-control-sm textarea-edit"
                                                       placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
                                             </textarea>
-                                            <em ng-if="ruleData.role.$error.customPrefix && hasCustomPrefix"
+                                            <em ng-if="ruleData.role.$warning && hasCustomPrefix || rule.warnForPrefix"
                                                 class="icon-warning"
                                                 gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
                                                 tooltip-placement="right"></em>
@@ -175,7 +176,7 @@
                                         <div class="small" ng-if="ruleData.role.$touched && ruleData.role.$error.minlength">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
-                                        <div ng-if="ruleData.role.$error.customPrefix && !hasCustomPrefix">
+                                        <div ng-if="ruleData.role.$warning && !hasCustomPrefix">
                                             <small class="small float-lg-left prefix-warning-text">
                                                 {{'acl_management.rulestable.custom_prefix_warning.text' | translate}}
                                             </small>
@@ -260,7 +261,7 @@
                                             </button>
                                             <button ng-click="saveRule(activeTabScope)"
                                                     class="btn btn-link save-rule-btn"
-                                                    ng-disabled="ruleData.role.$error.required || ruleData.role.$error.minlength"
+                                                    ng-disabled="!ruleData.$valid"
                                                     gdb-tooltip="{{ruleData.$valid ? 'acl_management.rulestable.actions.apply_rule' : 'acl_management.rulestable.messages.invalid_form' | translate}}">
                                                 <em class="icon-check"></em>
                                             </button>
@@ -323,14 +324,15 @@
                                             {{rule.policy}}
                                         </span>
                                     </td>
-                                    <td class="role-cell data">
+                                    <td id="graphRoleCell" class="role-cell data">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
-                                            <em ng-if="rule.hasDoublePrefix"
-                                                class="icon-warning"
-                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
-                                                tooltip-placement="right"></em>
                                         </span>
+                                        <em ng-if="rule.warnForPrefix"
+                                            class="icon-warning"
+                                            gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                            tooltip-placement="right">
+                                        </em>
                                     </td>
                                     <td class="context-cell data" ng-class="{'wildcard-cell': rule.context === '*', 'context-cell-special': !rule.context.startsWith('<') && rule.context !== '*'}">
                                         {{rule.context}}
@@ -376,7 +378,7 @@
                                                       rows="1"
                                                       placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
                                             </textarea>
-                                            <em ng-if="ruleData.role.$error.customPrefix && hasCustomPrefix"
+                                            <em ng-if="ruleData.role.$warning && hasCustomPrefix || rule.warnForPrefix"
                                                 class="icon-warning"
                                                 gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
                                                 tooltip-placement="right">
@@ -385,7 +387,7 @@
                                         <div class="small" ng-if="ruleData.role.$touched && ruleData.role.$error.minlength">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
-                                        <div ng-if="ruleData.role.$error.customPrefix && !hasCustomPrefix">
+                                        <div ng-if="ruleData.role.$warning && !hasCustomPrefix">
                                             <small class="small float-lg-left prefix-warning-text">
                                                 {{'acl_management.rulestable.custom_prefix_warning.text' | translate}}
                                             </small>
@@ -417,7 +419,7 @@
                                             </button>
                                             <button ng-click="saveRule(activeTabScope)"
                                                     class="btn btn-link save-rule-btn"
-                                                    ng-disabled="ruleData.role.$error.required || ruleData.role.$error.minlength"
+                                                    ng-disabled="!ruleData.$valid"
                                                     gdb-tooltip="{{ruleData.$valid ? 'acl_management.rulestable.actions.apply_rule' : 'acl_management.rulestable.messages.invalid_form' | translate}}">
                                                 <em class="icon-check"></em>
                                             </button>
@@ -483,15 +485,15 @@
                                             {{rule.policy}}
                                         </span>
                                     </td>
-                                    <td class="role-cell data">
+                                    <td id="pluginRoleCell" class="role-cell data">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
-                                            <em ng-if="rule.hasDoublePrefix"
-                                                class="icon-warning"
-                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
-                                                tooltip-placement="right">
-                                            </em>
                                         </span>
+                                        <em ng-if="rule.warnForPrefix"
+                                                   class="icon-warning"
+                                                   gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                   tooltip-placement="right">
+                                        </em>
                                     </td>
                                     <td class="operation-cell data">
                                          <span class="acl-tag" ng-class="{'wildcard-cell': rule.operation === '*', 'acl-tag-read': rule.operation === 'read','acl-tag-write': rule.operation === 'write'}">
@@ -543,7 +545,7 @@
                                                       class="form-control form-control-sm textarea-edit"
                                                       placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
                                             </textarea>
-                                            <em ng-if="ruleData.role.$error.customPrefix && hasCustomPrefix"
+                                            <em ng-if="ruleData.role.$warning && hasCustomPrefix || rule.warnForPrefix"
                                                 class="icon-warning"
                                                 gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
                                                 tooltip-placement="right">
@@ -552,7 +554,7 @@
                                         <div class="small" ng-if="ruleData.role.$touched && ruleData.role.$error.minlength">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
-                                        <div ng-if="ruleData.role.$error.customPrefix && !hasCustomPrefix">
+                                        <div ng-if="ruleData.role.$warning && !hasCustomPrefix">
                                             <small class="small float-lg-left prefix-warning-text">
                                                 {{'acl_management.rulestable.custom_prefix_warning.text' | translate}}
                                             </small>
@@ -588,7 +590,7 @@
                                             </button>
                                             <button ng-click="saveRule(activeTabScope)"
                                                     class="btn btn-link save-rule-btn"
-                                                    ng-disabled="ruleData.role.$error.required || ruleData.role.$error.minlength"
+                                                    ng-disabled="!ruleData.$valid"
                                                     gdb-tooltip="{{ruleData.$valid ? 'acl_management.rulestable.actions.apply_rule' : 'acl_management.rulestable.messages.invalid_form' | translate}}">
                                                 <em class="icon-check"></em>
                                             </button>
@@ -651,15 +653,15 @@
                                             {{rule.policy}}
                                         </span>
                                     </td>
-                                    <td class="role-cell data">
+                                    <td id="systemRoleCell" class="role-cell data">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
-                                            <em ng-if="rule.hasDoublePrefix"
-                                                class="icon-warning"
-                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
-                                                tooltip-placement="right">
-                                            </em>
                                         </span>
+                                        <em ng-if="rule.warnForPrefix"
+                                            class="icon-warning"
+                                            gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                            tooltip-placement="right">
+                                        </em>
                                     </td>
                                     <td class="operation-cell data">
                                          <span class="acl-tag" ng-class="{'wildcard-cell': rule.operation === '*', 'acl-tag-read': rule.operation === 'read','acl-tag-write': rule.operation === 'write'}">
@@ -708,7 +710,7 @@
                                                       class="form-control form-control-sm textarea-edit"
                                                       placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
                                             </textarea>
-                                            <em ng-if="ruleData.role.$error.customPrefix && hasCustomPrefix"
+                                            <em ng-if="ruleData.role.$warning && hasCustomPrefix || rule.warnForPrefix"
                                                 class="icon-warning"
                                                 gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
                                                 tooltip-placement="right">
@@ -717,7 +719,7 @@
                                         <div class="small" ng-if="ruleData.role.$touched && ruleData.role.$error.minlength">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
-                                        <div ng-if="ruleData.role.$error.customPrefix && !hasCustomPrefix">
+                                        <div ng-if="ruleData.role.$warning && !hasCustomPrefix">
                                             <small class="small float-lg-left prefix-warning-text">
                                                 {{'acl_management.rulestable.custom_prefix_warning.text' | translate}}
                                             </small>
@@ -741,7 +743,7 @@
                                             </button>
                                             <button ng-click="saveRule(activeTabScope)"
                                                     class="btn btn-link save-rule-btn"
-                                                    ng-disabled="ruleData.role.$error.required || ruleData.role.$error.minlength"
+                                                    ng-disabled="!ruleData.$valid"
                                                     gdb-tooltip="{{ruleData.$valid ? 'acl_management.rulestable.actions.apply_rule' : 'acl_management.rulestable.messages.invalid_form' | translate}}">
                                                 <em class="icon-check"></em>
                                             </button>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -176,7 +176,7 @@
                 "role": "ROLE1",
                 "plugin": "Plugin"
             },
-            "prefix_warning": {
+            "custom_prefix_warning": {
                 "text": "Custom roles should be entered without the \"CUSTOM_\" prefix in Workbench"
             },
             "actions": {

--- a/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
@@ -222,17 +222,16 @@ describe('ACL Management: create rule', () => {
         AclManagementSteps.fillRole(0, 'CUSTOM_ROLE_FOO');
 
         // Then I expect the prefix warning to appear
-        AclManagementSteps.getPrefixWarning().should('be.visible');
-        AclManagementSteps.getPrefixWarning().should('contain.text', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
+        AclManagementSteps.getPrefixWarning(0).should('be.visible');
+        AclManagementSteps.getPrefixWarning(0).should('contain.text', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
         // When I save the rule
         AclManagementSteps.saveRule(0);
         // Then the text should be how the user typed it
         AclManagementSteps.getSavedRoleField(0).should('contain', 'CUSTOM_ROLE_FOO');
         // And I expect a warning icon to appear
-        AclManagementSteps.getWarningIcon().should('be.visible');
-        AclManagementSteps.mouseoverWarningIcon();
+        AclManagementSteps.getWarningIcon(0).should('be.visible');
         // And the icon should have the same tooltip text as the warning
-        AclManagementSteps.getWarningIconTooltipText().should('be.visible').and('contain.text', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
+        AclManagementSteps.getWarningIconTooltipText(0).should('be.visible').and('contain.text', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
     });
 });
 

--- a/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
@@ -108,7 +108,8 @@ describe('ACL Management: create rule', () => {
                     "subject": "<urn:Mary>",
                     "predicate": "*",
                     "object": "*",
-                    "context": "*"
+                    "context": "*",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "statement",
@@ -118,7 +119,8 @@ describe('ACL Management: create rule', () => {
                     "subject": "*",
                     "predicate": "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
                     "object": "*",
-                    "context": "*"
+                    "context": "*",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "statement",
@@ -128,7 +130,8 @@ describe('ACL Management: create rule', () => {
                     "subject": "<urn:John>",
                     "predicate": "*",
                     "object": "*",
-                    "context": "*"
+                    "context": "*",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "statement",
@@ -138,7 +141,8 @@ describe('ACL Management: create rule', () => {
                     "subject": "<<<http://example.com/test> <http://www.w3.org/2000/01/rdf-schema#label> \"test aber auf Deutsch\"@de>>",
                     "predicate": "*",
                     "object": "\"test aber auf Deutsch\"@en",
-                    "context": "<http://example.com/graph1>"
+                    "context": "<http://example.com/graph1>",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "statement",
@@ -148,7 +152,8 @@ describe('ACL Management: create rule', () => {
                     "subject": "*",
                     "predicate": "*",
                     "object": "\"15\"^^<http://www.w3.org/2001/XMLSchema#int>",
-                    "context": "*"
+                    "context": "*",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "statement",
@@ -158,7 +163,8 @@ describe('ACL Management: create rule', () => {
                     "subject": "<urn:Cat>",
                     "predicate": "*",
                     "object": "<<<http://example.com/test> <http://www.w3.org/2000/01/rdf-schema#label> \"test aber auf Deutsch\"@de>>",
-                    "context": "*"
+                    "context": "*",
+                    "warnForPrefix": false
                 }
             ];
             expect(interception.request.body).to.deep.eq(expected);

--- a/test-cypress/integration/setup/aclmanagement/scopes.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/scopes.spec.js
@@ -138,20 +138,23 @@ describe('ACL Management: rule scopes', () => {
                     "scope": "clear_graph",
                     "policy": "deny",
                     "role": "CUSTOM_ROLE1",
-                    "context": "all"
+                    "context": "all",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "plugin",
                     "policy": "deny",
                     "role": "CUSTOM_ROLE2",
                     "operation": "write",
-                    "plugin": "*"
+                    "plugin": "*",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "system",
                     "policy": "allow",
                     "role": "CUSTOM_ROLE3",
-                    "operation": "write"
+                    "operation": "write",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "statement",
@@ -161,7 +164,8 @@ describe('ACL Management: rule scopes', () => {
                     "subject": "*",
                     "predicate": "*",
                     "object": "*",
-                    "context": "*"
+                    "context": "*",
+                    "warnForPrefix": false
                 }
             ];
             expect(interception.request.body).to.deep.eq(expectedPayload);

--- a/test-cypress/integration/setup/user-and-access.spec.js
+++ b/test-cypress/integration/setup/user-and-access.spec.js
@@ -111,7 +111,7 @@ describe('User and Access', () => {
         // And I add a custom role tag with prefix CUSTOM_
         UserAndAccessSteps.addTextToCustomRoleField('CUSTOM_USER');
         // There should be a warning text
-        UserAndAccessSteps.getPrefixWarning().should('contain', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
+        UserAndAccessSteps.getPrefixWarning(0).should('contain', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
     });
 
     it('Warn users when setting no password when creating new user admin', () => {

--- a/test-cypress/integration/setup/user-and-access.spec.js
+++ b/test-cypress/integration/setup/user-and-access.spec.js
@@ -109,7 +109,7 @@ describe('User and Access', () => {
         // When I create a user
         UserAndAccessSteps.clickCreateNewUserButton();
         // And I add a custom role tag with prefix CUSTOM_
-        UserAndAccessSteps.addTextToCustomRoleField('CUSTOM_USER');
+        UserAndAccessSteps.addTextToCustomRoleField('CUSTOM_USER{Enter}');
         // There should be a warning text
         UserAndAccessSteps.getPrefixWarning(0).should('contain', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
     });

--- a/test-cypress/steps/setup/acl-management-steps.js
+++ b/test-cypress/steps/setup/acl-management-steps.js
@@ -169,20 +169,17 @@ export class AclManagementSteps {
         return cy.get('div.small');
     }
 
-    static getPrefixWarning() {
-        return cy.get('.prefix-warning-text');
+    static getPrefixWarning(index) {
+        return this.getSavedRoleField(index).find('.prefix-warning-text');
     }
 
-    static getWarningIcon() {
-        return cy.get('.icon-warning');
+    static getWarningIcon(index) {
+        return this.getSavedRoleField(index).get('.icon-warning');
     }
 
-    static getWarningIconTooltipText() {
+    static getWarningIconTooltipText(index) {
+        this.getWarningIcon(index).trigger('mouseover');
         return cy.get('.angular-tooltip');
-    }
-
-    static mouseoverWarningIcon() {
-        cy.get('.icon-warning').first().trigger('mouseover');
     }
 
     static getPluginField(index) {


### PR DESCRIPTION
## What?
The functionality of the ACL role warnings will remain mostly unchanged. Only the input field border will be highlighted when CUSTOM_ prefix detected.

## Why?
The code needed to be reworked to reflect the review notes in MR https://github.com/Ontotext-AD/graphdb-workbench/pull/1511.

## How?
After discussing with team members, the changes proposed are in the existing custom-role-prefix.directive, which I extended to act as a validator in the cases when the user types "CUSTOM_". When the field is no longer present, I use the model to signal if a warning icon should be visible or not.
I made minor changes to function names and tests.
JSdoc for the directive updated.