### PR TITLE
(Cherry pick) GDB-10785 - Rework and refactor existing solution for ACL role warnings

### DIFF
--- a/src/css/aclmanagement.css
+++ b/src/css/aclmanagement.css
@@ -104,9 +104,22 @@ html, body {
     margin: 4px 0 0 3px;
 }
 
-.acl-management-view .acl-rules .role-cell .data .icon-warning {
-    float: right;
-    vertical-align: middle;
+.acl-management-view .acl-rules .preview-rule-row .role-icon-container {
+    display: flex;
+    align-items: center;
+}
+
+.acl-management-view .acl-rules .preview-rule-row .role-icon-container .acl-tag-role {
+    overflow-wrap: anywhere;
+}
+
+.acl-management-view .acl-rules .input-container {
+    display: flex;
+    align-items: center;
+}
+
+.acl-management-view .acl-rules .role-cell .icon-warning {
+    margin-left: 3px;
 }
 
 .acl-management-view .acl-rules .operation-column {
@@ -252,6 +265,7 @@ input::placeholder {
 }
 
 .textarea-edit {
+    flex: 1;
     padding: 4px 8px;
     min-height: 29px;
 }

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -176,7 +176,7 @@
                 "role": "ROLE1",
                 "plugin": "Plugin"
             },
-            "prefix_warning": {
+            "custom_prefix_warning": {
                 "text": "Custom roles should be entered without the \"CUSTOM_\" prefix in Workbench"
             },
             "actions": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -176,7 +176,7 @@
                 "role": "ROLE1",
                 "plugin": "Brancher"
             },
-            "prefix_warning": {
+            "custom_prefix_warning": {
                 "text": "Les rôles personnalisés doivent être saisis sans le préfixe \"CUSTOM_\" dans workbench"
             },
             "actions": {

--- a/src/js/angular/aclmanagement/model.js
+++ b/src/js/angular/aclmanagement/model.js
@@ -124,7 +124,9 @@ export class ACListModel {
 
     setPrefixWarningFlag(scope, index) {
         const rule = this.getRule(scope, index);
-        rule.checkCustomOrNegatedPrefix();
+        if (rule) {
+            rule.checkCustomOrNegatedPrefix();
+        }
     }
 
     /**

--- a/src/js/angular/aclmanagement/model.js
+++ b/src/js/angular/aclmanagement/model.js
@@ -44,6 +44,7 @@ export class ACListModel {
         if (!this._aclRules.has(scope)) {
             this._aclRules.set(scope, []);
         }
+        rule.checkCustomOrNegatedPrefix();
         this._aclRules.get(scope).push(rule);
     }
 
@@ -119,6 +120,11 @@ export class ACListModel {
             }
             return false;
         });
+    }
+
+    setPrefixWarningFlag(scope, index) {
+        const rule = this.getRule(scope, index);
+        rule.checkCustomOrNegatedPrefix();
     }
 
     /**
@@ -221,6 +227,19 @@ export class ACRuleModel {
         this._policy = value;
     }
 
+    get warnForPrefix() {
+        return this._warnForPrefix;
+    }
+
+    checkCustomOrNegatedPrefix() {
+        // The BE requires CUSTOM_ to be prefixed to user created roles. Our custom-role-prefix directive handles this.
+        // However, if the user also types CUSTOM_ or !CUSTOM_ in the input before the role name, we need to detect the double prefix, and display the warnings before the rule is saved.
+        const doublePrefix = "CUSTOM_CUSTOM_";
+        const negatedDoublePrefix = "!CUSTOM_CUSTOM_";
+
+        this._warnForPrefix = this.role.startsWith(doublePrefix) || this.role.startsWith(negatedDoublePrefix);
+    }
+
     toJSON() {
         // abstract method
     }
@@ -300,7 +319,8 @@ export class StatementACRuleModel extends ACRuleModel {
             subject: this.subject,
             predicate: this.predicate,
             object: this.object,
-            context: this.context
+            context: this.context,
+            warnForPrefix: this.warnForPrefix
         };
     }
 
@@ -350,7 +370,8 @@ export class PluginACRuleModel extends ACRuleModel {
             policy: this.policy,
             role: this.role,
             operation: this.operation,
-            plugin: this.plugin
+            plugin: this.plugin,
+            warnForPrefix: this.warnForPrefix
         };
     }
 }
@@ -396,7 +417,8 @@ export class ClearGraphACRuleModel extends ACRuleModel {
             scope: this.scope,
             policy: this.policy,
             role: this.role,
-            context: this.context
+            context: this.context,
+            warnForPrefix: this.warnForPrefix
         };
     }
 }
@@ -424,7 +446,8 @@ export class SystemACRuleModel extends ACRuleModel {
             scope: this.scope,
             policy: this.policy,
             role: this.role,
-            operation: this.operation
+            operation: this.operation,
+            warnForPrefix: this.warnForPrefix
         };
     }
 }

--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -3,7 +3,7 @@ import 'angular/core/services/jwt-auth.service';
 import 'angular/core/services/openid-auth.service';
 import 'angular/rest/security.rest.service';
 import {UserUtils, UserRole, UserType} from 'angular/utils/user-utils';
-import {RoleNamePrefixUtils} from "../utils/role-name-prefix-utils";
+import 'angular/aclmanagement/directives/custom-role-prefix.directive';
 
 const SYSTEM_REPO = 'SYSTEM';
 const READ_REPO = 'READ_REPO';
@@ -18,6 +18,7 @@ const modules = [
     'graphdb.framework.core.services.openIDService',
     'graphdb.framework.rest.security.service',
     'toastr',
+    'graphdb.framework.aclmanagement.directives',
     'ngTagsInput'
 ];
 
@@ -511,7 +512,6 @@ securityCtrl.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 'toa
          * @return {boolean} true if valid, otherwise false
          */
         $scope.isCustomRoleValid = function (fieldValue) {
-            $scope.showCustomPrefixMessage = RoleNamePrefixUtils.isCustomPrefixUsed(fieldValue.text);
             $scope.isRoleValid = fieldValue.text.length >= minTagLength;
             return $scope.isRoleValid;
         };
@@ -521,12 +521,11 @@ securityCtrl.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 'toa
          *
          * @param {Object} event
          */
-        $scope.checkForBackspace = function(event) {
+        $scope.checkUserInput = function(event) {
             // If the key pressed is the backspace or delete key, the tag error message will be hidden
             if (event.keyCode === 8 || event.keyCode === 46) {
                 $scope.isRoleValid = true;
             }
-            $scope.showCustomPrefixMessage = RoleNamePrefixUtils.isCustomPrefixUsed(event.target.value);
         };
 
         /**

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -219,14 +219,15 @@
                                         paste-split-pattern="[\s+]"
                                         on-tag-adding="isCustomRoleValid($tag)"
                                         on-tag-added="addCustomRole($tag)"
-                                        ng-keydown="checkForBackspace($event)"
+                                        ng-keydown="checkUserInput($event)"
                                         ng-cut="removeErrorOnCut()"
-                                        placeholder="{{'security.user.add.custom_role.msg' | translate}}"></tags-input>
+                                        placeholder="{{'security.user.add.custom_role.msg' | translate}}"
+                                        custom-role-prefix></tags-input>
                             <div class="small" ng-hide="isRoleValid">
                                 <small>{{'security.user.role.too.short' | translate}}</small>
                             </div>
-                            <div class="small prefix-warning" ng-if="showCustomPrefixMessage">
-                                <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                            <div class="small prefix-warning" ng-if="form.customRoleTag.$warning">
+                                <small>{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}</small>
                             </div>
                         </div>
                     </div>

--- a/src/pages/aclmanagement.html
+++ b/src/pages/aclmanagement.html
@@ -107,12 +107,16 @@
                                             {{rule.policy}}
                                         </span>
                                     </td>
-                                    <td class="role-cell data">
+                                    <td class="role-cell data role-icon-container">
                                         <span class="acl-tag"
                                               ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
-                                            <em ng-if="rule.role.startsWith(doublePrefix)" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                         </span>
+                                        <em ng-if="rule.warnForPrefix"
+                                            class="icon-warning"
+                                            gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                            tooltip-placement="right">
+                                        </em>
                                     </td>
                                     <td class="operation-cell data">
                                          <span class="acl-tag" ng-class="{'wildcard-cell': rule.operation === '*', 'acl-tag-read': rule.operation === 'read','acl-tag-write': rule.operation === 'write'}">
@@ -152,25 +156,31 @@
                                         </select>
                                     </td>
                                     <td class="data role-cell">
-                                        <textarea type="text" name="role" minlength="2" required
-                                                  ng-model="rule.role"
-                                                  ng-change="setDirty(activeTabScope)"
-                                                  ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
-                                                  ng-blur="showWarning()"
-                                                  uppercased uppercase-placeholder="false"
-                                                  custom-role-prefix auto-grow
-                                                  autocomplete="off"
-                                                  class="form-control form-control-sm textarea-edit"
-                                               placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
-                                        </textarea>
-                                        <div class="small" ng-if="ruleData.role.$touched && !ruleData.role.$valid">
+                                        <div class="input-container">
+                                            <textarea type="text" name="role" minlength="2" required
+                                                      ng-model="rule.role"
+                                                      ng-change="setDirty(activeTabScope)"
+                                                      ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
+                                                      ng-blur="showPrefixWarningIcon(true)"
+                                                      uppercased uppercase-placeholder="false"
+                                                      custom-role-prefix auto-grow
+                                                      autocomplete="off"
+                                                      class="form-control form-control-sm textarea-edit"
+                                                      placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
+                                            </textarea>
+                                            <em ng-if="ruleData.role.$warning && hasCustomPrefix || rule.warnForPrefix"
+                                                class="icon-warning"
+                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                tooltip-placement="right"></em>
+                                        </div>
+                                        <div class="small" ng-if="ruleData.role.$touched && ruleData.role.$error.minlength">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
-                                        <div class="small float-lg-left prefix-warning-text" ng-if="rule.role.startsWith(doublePrefix) && !showPrefixWarningIcon">
-                                            <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                                        <div ng-if="ruleData.role.$warning && !hasCustomPrefix">
+                                            <small class="small float-lg-left prefix-warning-text">
+                                                {{'acl_management.rulestable.custom_prefix_warning.text' | translate}}
+                                            </small>
                                         </div>
-                                        <em></em>
-                                        <em ng-if="rule.role.startsWith(doublePrefix) && showPrefixWarningIcon" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                     </td>
                                     <td class="data operation-cell">
                                         <select ng-model="rule.operation" ng-change="setDirty(activeTabScope)" class="form-control form-control-sm select-rule">
@@ -314,11 +324,15 @@
                                             {{rule.policy}}
                                         </span>
                                     </td>
-                                    <td class="role-cell data">
+                                    <td class="role-cell data role-icon-container">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
-                                            <em ng-if="rule.role.startsWith(doublePrefix)" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                         </span>
+                                        <em ng-if="rule.warnForPrefix"
+                                            class="icon-warning"
+                                            gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                            tooltip-placement="right">
+                                        </em>
                                     </td>
                                     <td class="context-cell data" ng-class="{'wildcard-cell': rule.context === '*', 'context-cell-special': !rule.context.startsWith('<') && rule.context !== '*'}">
                                         {{rule.context}}
@@ -352,29 +366,33 @@
                                         </select>
                                     </td>
                                     <td class="data role-cell">
-                                        <textarea type="text" name="role" minlength="2" required
-                                                  ng-model="rule.role"
-                                                  ng-change="setDirty(activeTabScope)"
-                                                  ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
-                                                  ng-blur="showWarning()"
-                                                  uppercased uppercase-placeholder="false"
-                                                  custom-role-prefix auto-grow
-                                                  autocomplete="off" class="form-control form-control-sm textarea-edit"
-                                                  rows="1"
-                                                  placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
-                                        </textarea>
-                                        <div class="small" ng-if="ruleData.role.$touched && !ruleData.role.$valid">
+                                        <div class="input-container">
+                                            <textarea type="text" name="role" minlength="2" required
+                                                      ng-model="rule.role"
+                                                      ng-change="setDirty(activeTabScope)"
+                                                      ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
+                                                      ng-blur="showPrefixWarningIcon(true)"
+                                                      uppercased uppercase-placeholder="false"
+                                                      custom-role-prefix auto-grow
+                                                      autocomplete="off" class="form-control form-control-sm textarea-edit"
+                                                      rows="1"
+                                                      placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
+                                            </textarea>
+                                            <em ng-if="ruleData.role.$warning && hasCustomPrefix || rule.warnForPrefix"
+                                                class="icon-warning"
+                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                tooltip-placement="right">
+                                            </em>
+                                        </div>
+                                        <div class="small" ng-if="ruleData.role.$touched && ruleData.role.$error.minlength">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
-                                        <div class="small float-lg-left prefix-warning-text" ng-if="rule.role.startsWith(doublePrefix) && !showPrefixWarningIcon">
-                                            <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                                        <div ng-if="ruleData.role.$warning && !hasCustomPrefix">
+                                            <small class="small float-lg-left prefix-warning-text">
+                                                {{'acl_management.rulestable.custom_prefix_warning.text' | translate}}
+                                            </small>
                                         </div>
                                         <em></em>
-                                        <em ng-if="rule.role.startsWith(doublePrefix) && showPrefixWarningIcon"
-                                            class="icon-warning"
-                                            gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}"
-                                            tooltip-placement="right">
-                                        </em>
                                     </td>
                                     <td class="data context-cell">
                                         <autocomplete ng-model="rule.context" on-model-change="setDirty(activeTabScope)" name="context"
@@ -467,11 +485,15 @@
                                             {{rule.policy}}
                                         </span>
                                     </td>
-                                    <td class="role-cell data">
+                                    <td class="role-cell data role-icon-container">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
-                                            <em ng-if="rule.role.startsWith(doublePrefix)" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                         </span>
+                                        <em ng-if="rule.warnForPrefix"
+                                                   class="icon-warning"
+                                                   gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                   tooltip-placement="right">
+                                        </em>
                                     </td>
                                     <td class="operation-cell data">
                                          <span class="acl-tag" ng-class="{'wildcard-cell': rule.operation === '*', 'acl-tag-read': rule.operation === 'read','acl-tag-write': rule.operation === 'write'}">
@@ -511,25 +533,33 @@
                                         </select>
                                     </td>
                                     <td class="data role-cell">
-                                        <textarea type="text" name="role" minlength="2" required
-                                                  ng-model="rule.role"
-                                                  ng-change="setDirty(activeTabScope)"
-                                                  ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
-                                                  ng-blur="showWarning()"
-                                                  uppercased uppercase-placeholder="false"
-                                                  custom-role-prefix auto-grow
-                                                  autocomplete="off"
-                                                  class="form-control form-control-sm textarea-edit"
-                                                  placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
-                                        </textarea>
-                                        <div class="small" ng-if="ruleData.role.$touched && !ruleData.role.$valid">
+                                        <div class="input-container">
+                                            <textarea type="text" name="role" minlength="2" required
+                                                      ng-model="rule.role"
+                                                      ng-change="setDirty(activeTabScope)"
+                                                      ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
+                                                      ng-blur="showPrefixWarningIcon(true)"
+                                                      uppercased uppercase-placeholder="false"
+                                                      custom-role-prefix auto-grow
+                                                      autocomplete="off"
+                                                      class="form-control form-control-sm textarea-edit"
+                                                      placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
+                                            </textarea>
+                                            <em ng-if="ruleData.role.$warning && hasCustomPrefix || rule.warnForPrefix"
+                                                class="icon-warning"
+                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                tooltip-placement="right">
+                                            </em>
+                                        </div>
+                                        <div class="small" ng-if="ruleData.role.$touched && ruleData.role.$error.minlength">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
-                                        <div class="small float-lg-left prefix-warning-text" ng-if="rule.role.startsWith(doublePrefix) && !showPrefixWarningIcon">
-                                            <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                                        <div ng-if="ruleData.role.$warning && !hasCustomPrefix">
+                                            <small class="small float-lg-left prefix-warning-text">
+                                                {{'acl_management.rulestable.custom_prefix_warning.text' | translate}}
+                                            </small>
                                         </div>
                                         <em></em>
-                                        <em ng-if="rule.role.startsWith(doublePrefix) && showPrefixWarningIcon" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                     </td>
                                     <td class="data operation-cell">
                                         <select ng-model="rule.operation" ng-change="setDirty(activeTabScope)" class="form-control form-control-sm select-rule">
@@ -623,11 +653,15 @@
                                             {{rule.policy}}
                                         </span>
                                     </td>
-                                    <td class="role-cell data">
+                                    <td class="role-cell data role-icon-container">
                                         <span class="acl-tag" ng-class="{'acl-tag-role-negated': rule.roleWithoutCustomPrefix[0] === '!', 'acl-tag-role': rule.roleWithoutCustomPrefix[0] !== '!', 'wildcard-cell': rule.role === '*'}">
                                             {{rule.roleWithoutCustomPrefix}}
-                                            <em ng-if="rule.role.startsWith(doublePrefix)" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                         </span>
+                                        <em ng-if="rule.warnForPrefix"
+                                            class="icon-warning"
+                                            gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                            tooltip-placement="right">
+                                        </em>
                                     </td>
                                     <td class="operation-cell data">
                                          <span class="acl-tag" ng-class="{'wildcard-cell': rule.operation === '*', 'acl-tag-read': rule.operation === 'read','acl-tag-write': rule.operation === 'write'}">
@@ -664,25 +698,33 @@
                                         </select>
                                     </td>
                                     <td class="data role-cell">
-                                        <textarea type="text" name="role" minlength="2" required
-                                                  ng-model="rule.role"
-                                                  ng-change="setDirty(activeTabScope)"
-                                                  ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
-                                                  ng-blur="showWarning()"
-                                                  uppercased uppercase-placeholder="false"
-                                                  custom-role-prefix auto-grow
-                                                  autocomplete="off"
-                                                  class="form-control form-control-sm textarea-edit"
-                                                  placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
-                                        </textarea>
-                                        <div class="small" ng-if="ruleData.role.$touched && !ruleData.role.$valid">
+                                        <div class="input-container">
+                                            <textarea type="text" name="role" minlength="2" required
+                                                      ng-model="rule.role"
+                                                      ng-change="setDirty(activeTabScope)"
+                                                      ng-keypress="performSearchActionOnEnter($event, activeTabScope, ruleData)"
+                                                      ng-blur="showPrefixWarningIcon(true)"
+                                                      uppercased uppercase-placeholder="false"
+                                                      custom-role-prefix auto-grow
+                                                      autocomplete="off"
+                                                      class="form-control form-control-sm textarea-edit"
+                                                      placeholder="{{'acl_management.rulestable.field_placeholders.role' | translate}}">
+                                            </textarea>
+                                            <em ng-if="ruleData.role.$warning && hasCustomPrefix || rule.warnForPrefix"
+                                                class="icon-warning"
+                                                gdb-tooltip="{{'acl_management.rulestable.custom_prefix_warning.text' | translate}}"
+                                                tooltip-placement="right">
+                                            </em>
+                                        </div>
+                                        <div class="small" ng-if="ruleData.role.$touched && ruleData.role.$error.minlength">
                                             <small>{{'acl_management.errors.role_length_too_short' | translate}}</small>
                                         </div>
-                                        <div class="small float-lg-left prefix-warning-text" ng-if="rule.role.startsWith(doublePrefix) && !showPrefixWarningIcon">
-                                            <small>{{'acl_management.rulestable.prefix_warning.text' | translate}}</small>
+                                        <div ng-if="ruleData.role.$warning && !hasCustomPrefix">
+                                            <small class="small float-lg-left prefix-warning-text">
+                                                {{'acl_management.rulestable.custom_prefix_warning.text' | translate}}
+                                            </small>
                                         </div>
                                         <em></em>
-                                        <em ng-if="rule.role.startsWith(doublePrefix) && showPrefixWarningIcon" class="icon-warning" gdb-tooltip="{{'acl_management.rulestable.prefix_warning.text' | translate}}" tooltip-placement="right"></em>
                                     </td>
                                     <td class="data operation-cell">
                                         <select ng-model="rule.operation" ng-change="setDirty(activeTabScope)" class="form-control form-control-sm select-rule">

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -176,7 +176,7 @@
                 "role": "ROLE1",
                 "plugin": "Plugin"
             },
-            "prefix_warning": {
+            "custom_prefix_warning": {
                 "text": "Custom roles should be entered without the \"CUSTOM_\" prefix in Workbench"
             },
             "actions": {

--- a/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/create-rule.spec.js
@@ -108,7 +108,8 @@ describe('ACL Management: create rule', () => {
                     "subject": "<urn:Mary>",
                     "predicate": "*",
                     "object": "*",
-                    "context": "*"
+                    "context": "*",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "statement",
@@ -118,7 +119,8 @@ describe('ACL Management: create rule', () => {
                     "subject": "*",
                     "predicate": "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
                     "object": "*",
-                    "context": "*"
+                    "context": "*",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "statement",
@@ -128,7 +130,8 @@ describe('ACL Management: create rule', () => {
                     "subject": "<urn:John>",
                     "predicate": "*",
                     "object": "*",
-                    "context": "*"
+                    "context": "*",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "statement",
@@ -138,7 +141,8 @@ describe('ACL Management: create rule', () => {
                     "subject": "<<<http://example.com/test> <http://www.w3.org/2000/01/rdf-schema#label> \"test aber auf Deutsch\"@de>>",
                     "predicate": "*",
                     "object": "\"test aber auf Deutsch\"@en",
-                    "context": "<http://example.com/graph1>"
+                    "context": "<http://example.com/graph1>",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "statement",
@@ -148,7 +152,8 @@ describe('ACL Management: create rule', () => {
                     "subject": "*",
                     "predicate": "*",
                     "object": "\"15\"^^<http://www.w3.org/2001/XMLSchema#int>",
-                    "context": "*"
+                    "context": "*",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "statement",
@@ -158,7 +163,8 @@ describe('ACL Management: create rule', () => {
                     "subject": "<urn:Cat>",
                     "predicate": "*",
                     "object": "<<<http://example.com/test> <http://www.w3.org/2000/01/rdf-schema#label> \"test aber auf Deutsch\"@de>>",
-                    "context": "*"
+                    "context": "*",
+                    "warnForPrefix": false
                 }
             ];
             expect(interception.request.body).to.deep.eq(expected);
@@ -222,17 +228,16 @@ describe('ACL Management: create rule', () => {
         AclManagementSteps.fillRole(0, 'CUSTOM_ROLE_FOO');
 
         // Then I expect the prefix warning to appear
-        AclManagementSteps.getPrefixWarning().should('be.visible');
-        AclManagementSteps.getPrefixWarning().should('contain.text', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
+        AclManagementSteps.getPrefixWarning(0).should('be.visible');
+        AclManagementSteps.getPrefixWarning(0).should('contain.text', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
         // When I save the rule
         AclManagementSteps.saveRule(0);
         // Then the text should be how the user typed it
         AclManagementSteps.getSavedRoleField(0).should('contain', 'CUSTOM_ROLE_FOO');
         // And I expect a warning icon to appear
-        AclManagementSteps.getWarningIcon().should('be.visible');
-        AclManagementSteps.mouseoverWarningIcon();
+        AclManagementSteps.getWarningIcon(0).should('be.visible');
         // And the icon should have the same tooltip text as the warning
-        AclManagementSteps.getWarningIconTooltipText().should('be.visible').and('contain.text', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
+        AclManagementSteps.getWarningIconTooltipText(0).should('be.visible').and('contain.text', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
     });
 });
 

--- a/test-cypress/integration/setup/aclmanagement/scopes.spec.js
+++ b/test-cypress/integration/setup/aclmanagement/scopes.spec.js
@@ -138,20 +138,23 @@ describe('ACL Management: rule scopes', () => {
                     "scope": "clear_graph",
                     "policy": "deny",
                     "role": "CUSTOM_ROLE1",
-                    "context": "all"
+                    "context": "all",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "plugin",
                     "policy": "deny",
                     "role": "CUSTOM_ROLE2",
                     "operation": "write",
-                    "plugin": "*"
+                    "plugin": "*",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "system",
                     "policy": "allow",
                     "role": "CUSTOM_ROLE3",
-                    "operation": "write"
+                    "operation": "write",
+                    "warnForPrefix": false
                 },
                 {
                     "scope": "statement",
@@ -161,7 +164,8 @@ describe('ACL Management: rule scopes', () => {
                     "subject": "*",
                     "predicate": "*",
                     "object": "*",
-                    "context": "*"
+                    "context": "*",
+                    "warnForPrefix": false
                 }
             ];
             expect(interception.request.body).to.deep.eq(expectedPayload);

--- a/test-cypress/integration/setup/user-and-access.spec.js
+++ b/test-cypress/integration/setup/user-and-access.spec.js
@@ -109,9 +109,9 @@ describe('User and Access', () => {
         // When I create a user
         UserAndAccessSteps.clickCreateNewUserButton();
         // And I add a custom role tag with prefix CUSTOM_
-        UserAndAccessSteps.addTextToCustomRoleField('CUSTOM_USER');
+        UserAndAccessSteps.addTextToCustomRoleField('CUSTOM_USER{Enter}');
         // There should be a warning text
-        UserAndAccessSteps.getPrefixWarning().should('contain', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
+        UserAndAccessSteps.getPrefixWarning(0).should('contain', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
     });
 
     it('Warn users when setting no password when creating new user admin', () => {

--- a/test-cypress/steps/setup/acl-management-steps.js
+++ b/test-cypress/steps/setup/acl-management-steps.js
@@ -169,20 +169,17 @@ export class AclManagementSteps {
         return cy.get('div.small');
     }
 
-    static getPrefixWarning() {
-        return cy.get('.prefix-warning-text');
+    static getPrefixWarning(index) {
+        return this.getSavedRoleField(index).find('.prefix-warning-text');
     }
 
-    static getWarningIcon() {
-        return cy.get('.icon-warning');
+    static getWarningIcon(index) {
+        return this.getSavedRoleField(index).get('.icon-warning');
     }
 
-    static getWarningIconTooltipText() {
+    static getWarningIconTooltipText(index) {
+        this.getWarningIcon(index).trigger('mouseover');
         return cy.get('.angular-tooltip');
-    }
-
-    static mouseoverWarningIcon() {
-        cy.get('.icon-warning').first().trigger('mouseover');
     }
 
     static getPluginField(index) {


### PR DESCRIPTION
## What?
The functionality of the ACL role warnings will remain unchanged.

## Why?
The code needed to be reworked to reflect the review notes in MR https://github.com/Ontotext-AD/graphdb-workbench/pull/1511.

## How?
After discussing with team members, the changes proposed are in the existing custom-role-prefix.directive, which add a property to ngModel when the user types "CUSTOM_". When the field is no longer present, I use the model to signal if a warning icon should be visible or not.
I made minor changes to function names and tests.
JSdoc for the directive updated.

* GDB-10785 - rework and refactor existing solution for ACL role warnings on CUSTOM_ prefix use. Changes according to review notes.

* GDB-10785 - reused directive logic to show error message in user create/edit view. Add negation prefix check in model.

* GDB-10785 - add comment for scope variable

* GDB-10785 - implement solution in a more optimal way. Edit tests to include new model property

* GDB-10785 - improve css selectors and fix failing test

(cherry picked from commit 9689070a9e85ff172e03b5692d034020b02befb2)