### PR TITLE
GDB-10835 - Fix ACL table freezing after rule creation cancel

### DIFF
--- a/src/js/angular/aclmanagement/model.js
+++ b/src/js/angular/aclmanagement/model.js
@@ -124,7 +124,9 @@ export class ACListModel {
 
     setPrefixWarningFlag(scope, index) {
         const rule = this.getRule(scope, index);
-        rule.checkCustomOrNegatedPrefix();
+        if (rule) {
+            rule.checkCustomOrNegatedPrefix();
+        }
     }
 
     /**


### PR DESCRIPTION
## What?
When creating a new ACL rule and cancelling the process or when editing a rule and cancelling the edit, the table will not freeze and the `Create rule` button, tabs and other rule action buttons will be enabled.

## Why?
If the rule isn't created or found when checking it for the `CUSTOM_` prefix, the code execution would stop with an error and the controller thought that there were still unsaved changes. This prevented the tabs and `Create rule` button from being enabled.

## How?
I added a validation for the rule. If it doesn't exist in the `ACL list model`, it won't be checked for a prefix.