### PR TITLE
GDB-10709 introduce a no agents view with create agent button and help message

### DIFF
--- a/src/css/ttyg/agent-list.css
+++ b/src/css/ttyg/agent-list.css
@@ -1,5 +1,7 @@
 .agent-list-component .agent-list {
     margin-top: 1rem;
+    max-height: 75vh;
+    overflow-y: auto;
 }
 
 .agent-list-component .agents-filter-dropdown {
@@ -25,7 +27,7 @@
 }
 
 .agent-list-component .agent-item {
-    padding: 4px 8px;
+    padding: 6px 8px;
     display: flex;
     justify-content: space-between;
 }

--- a/src/css/ttyg/agent-list.css
+++ b/src/css/ttyg/agent-list.css
@@ -1,5 +1,12 @@
+.agent-list-component {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
 .agent-list-component .agent-list {
     margin-top: 1rem;
+    height: 75vh;
     max-height: 75vh;
     overflow-y: auto;
 }

--- a/src/css/ttyg/chat-list.css
+++ b/src/css/ttyg/chat-list.css
@@ -12,7 +12,7 @@
 }
 
 .chat-list-component .chat-item {
-    padding: 4px;
+    padding: 6px 4px;
     display: flex;
     justify-content: space-between;
     width: 100%;

--- a/src/css/ttyg/no-agents-view.css
+++ b/src/css/ttyg/no-agents-view.css
@@ -1,0 +1,19 @@
+.no-agents-view-component {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    padding: 0 1rem 0 2rem;
+}
+
+.no-agents-view-component .content {
+    width: 1024px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.no-agents-view-component .actions {
+    display: flex;
+    justify-content: center;
+}

--- a/src/css/ttyg/ttyg.css
+++ b/src/css/ttyg/ttyg.css
@@ -48,7 +48,7 @@ common sidebar and slidepanel styles
 }
 
 .ttyg-view .sidebar .sidebar-content {
-    /*padding: 1rem 0;*/
+    height: 100%;
     padding: 0;
 }
 

--- a/src/css/ttyg/ttyg.css
+++ b/src/css/ttyg/ttyg.css
@@ -94,10 +94,6 @@ right sidebar
     justify-content: end;
 }
 
-.ttyg-view .right-sidebar .agent-list-panel {
-    overflow-y: auto;
-}
-
 /*
 chat area
 */

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -219,6 +219,7 @@
     "ttyg": {
         "helpInfo": "Talk to Your Graph is chat bot based on OpenAI's GPT-4 model that can answer questions about data stored in GraphDB, leveraging both your data and the general knowledge of the GPT-4 model. The bot works in connection with the ChatGPT Retrieval connector.",
         "hint": "Talk to your graph – simply ask a question!",
+        "loading": "Loading...",
         "help": {
             "btn": {
                 "show_help": {
@@ -267,6 +268,22 @@
         "agent": {
             "loading_agents": "Loading agents...",
             "deleted_repository": "Deleted repository",
+            "create_agent_modal": {
+                "title": "Create Agent",
+                "btn": {
+                    "create": {
+                        "label": "Create Agent"
+                    },
+                    "cancel": {
+                        "label": "Cancel"
+                    }
+                }
+            },
+            "fat_btn": {
+                "create_agent": {
+                    "label": "Create your first agent"
+                }
+            },
             "btn": {
                 "filter": {
                     "tooltip": "Filter by repository",
@@ -296,7 +313,9 @@
                 }
             },
             "messages": {
-                "no_agents": "No agents found for the selected filter."
+                "no_agents": "No agents found for the selected filter.",
+                "help_1": "Talk to your data in natural language. All you need to do is create and instruct your own AI Agent to assist you.",
+                "help_2": "The Agent is an AI-powered conversational agent designed to help with a wide range of tasks, from answering questions and providing information to assisting with creative and technical projects. It leverages advanced natural language processing to understand and respond to user inputs in a human-like manner, making interactions intuitive and efficient."
             }
         },
         "help.what.title": "What is this?",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -219,6 +219,7 @@
     "ttyg": {
         "helpInfo": "Parlez à votre graphe est un chatbot basé sur le modèle GPT-4 d'OpenAI qui peut répondre aux questions sur les données stockées dans GraphDB, en exploitant à la fois vos données et les connaissances générales du modèle GPT-4. Le bot fonctionne dans connexion avec le connecteur ChatGPT Retrieval.",
         "hint": "Parlez à votre graphe – posez simplement une question !\nPour le moment, cela fonctionne mieux si vous demandez en anglais, désolé !",
+        "loading": "Chargement...",
         "help": {
             "btn": {
                 "show_help": {
@@ -267,6 +268,23 @@
         },
         "agent": {
             "loading_agents": "Chargement des agents...",
+            "deleted_repository": "Dépôt supprimé",
+            "create_agent_modal": {
+                "title": "Créer un agent",
+                "btn": {
+                    "create": {
+                        "label": "Créer l'agent"
+                    },
+                    "cancel": {
+                        "label": "Annuler"
+                    }
+                }
+            },
+            "fat_btn": {
+                "create_agent": {
+                    "label": "Créez votre premier agent"
+                }
+            },
             "btn": {
                 "filter": {
                     "tooltip": "Filtrer par dépôt",
@@ -296,7 +314,9 @@
                 }
             },
             "messages": {
-                "no_agents": "Aucun agent n'est configuré pour le moment."
+                "no_agents": "Aucun agent n'est configuré pour le moment.",
+                "help_1": "Parlez à vos données en langage naturel. Il vous suffit de créer et d'instruire votre propre agent IA pour vous aider.",
+                "help_2": "The Agent est un agent conversationnel basé sur l'IA, conçu pour vous aider dans une large gamme de tâches, de la réponse aux questions et la fourniture d'informations à l'assistance dans le cadre de projets créatifs et techniques. Il exploite un traitement avancé du langage naturel pour comprendre et répondre aux entrées des utilisateurs de manière humaine, rendant les interactions intuitives et efficaces."
             }
         },
         "help.what.title": "Qu'est-ce que c'est ?",

--- a/src/js/angular/models/ttyg/agents.js
+++ b/src/js/angular/models/ttyg/agents.js
@@ -182,11 +182,11 @@ export class AgentListModel {
          */
         this._agents = agents;
         /**
-         * Used to store the original list of agents when filtering.
+         * Used to store the list of agents for filtering purposes.
          * @type {AgentModel[]}
          * @private
          */
-        this._agentsClone = cloneDeep(agents);
+        this._filterableAgents = cloneDeep(agents);
     }
 
     isEmpty() {
@@ -194,14 +194,14 @@ export class AgentListModel {
     }
 
     /**
-     * Filters the agents in place by the repository ID property. This uses the private _agentsClone property to do the
-     * filtering without losing the original list.
+     * Filters the agents in place by the repository ID property. This uses the private _filterableAgents property to do
+     * the filtering without losing the original list.
      * There is a special case when the repository ID is equal to AGENTS_FILTER_ALL_KEY which means that all agents
      * should be shown.
-     * @param {string} repositoryId
+     * @param {string} repositoryId - the repository ID to filter by
      */
     filterByRepository(repositoryId) {
-        this._agents = this._agentsClone.filter((agent) => {
+        this._filterableAgents = this._agents.filter((agent) => {
             if (repositoryId === AGENTS_FILTER_ALL_KEY) {
                 return true;
             } else if (agent.repositoryId === repositoryId) {
@@ -217,6 +217,14 @@ export class AgentListModel {
     set agents(value) {
         this._agents = value;
     }
+
+    get filterableAgents() {
+        return this._filterableAgents;
+    }
+
+    set filterableAgents(value) {
+        this._filterableAgents = value;
+    }
 }
 
 export const ExtractionMethod = {
@@ -230,7 +238,7 @@ export const ExtractionMethod = {
  * A model used for the filter dropdown in the agent list.
  */
 export class AgentListFilterModel {
-    constructor(key, label) {
+    constructor(key, label, selected = false) {
         /**
          * @type {string}
          * @private
@@ -241,6 +249,12 @@ export class AgentListFilterModel {
          * @private
          */
         this._label = label;
+        /**
+         * Whether the filter is selected or not.
+         * @type {boolean}
+         * @private
+         */
+        this._selected = selected;
     }
 
     get key() {
@@ -257,5 +271,13 @@ export class AgentListFilterModel {
 
     set label(value) {
         this._label = value;
+    }
+
+    get selected() {
+        return this._selected;
+    }
+
+    set selected(value) {
+        this._selected = value;
     }
 }

--- a/src/js/angular/rest/ttyg.rest.service.fake.backend.js
+++ b/src/js/angular/rest/ttyg.rest.service.fake.backend.js
@@ -64,6 +64,14 @@ export class TtygRestServiceFakeBackend {
     getAgents() {
         return Promise.resolve({data: [...agentsList]});
     }
+
+    // Simulate an HTTP error
+    simulateHttpError() {
+        return Promise.reject({
+            status: 500,
+            message: 'Internal Server Error'
+        });
+    }
 }
 
 const conversationList = [

--- a/src/js/angular/rest/ttyg.rest.service.js
+++ b/src/js/angular/rest/ttyg.rest.service.js
@@ -106,6 +106,9 @@ function TTYGRestService($http) {
     const getAgents = () => {
         if (DEVELOPMENT) {
             return _fakeBackend.getAgents();
+            // return new Promise((resolve) => {
+            //     setTimeout(() => resolve(_fakeBackend.getAgents()), 3000);
+            // });
         }
         return $http.get('rest/chat/agents');
     };

--- a/src/js/angular/rest/ttyg.rest.service.js
+++ b/src/js/angular/rest/ttyg.rest.service.js
@@ -105,6 +105,7 @@ function TTYGRestService($http) {
      */
     const getAgents = () => {
         if (DEVELOPMENT) {
+            // return _fakeBackend.simulateHttpError();
             return _fakeBackend.getAgents();
             // return new Promise((resolve) => {
             //     setTimeout(() => resolve(_fakeBackend.getAgents()), 3000);

--- a/src/js/angular/ttyg/app.js
+++ b/src/js/angular/ttyg/app.js
@@ -2,7 +2,7 @@ import 'angular/ttyg/controllers/ttyg-view.controller';
 
 const modules = [
     'ngRoute',
-    'graphdb.framework.ttyg.controllers'
+    'graphdb.framework.ttyg.controllers.ttyg-view'
 ];
 
 angular.module('graphdb.framework.ttyg', modules);

--- a/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -1,0 +1,42 @@
+angular
+    .module('graphdb.framework.ttyg.controllers.agent-settings-modal', [])
+    .controller('AgentSettingsModalController', AgentSettingsModalController);
+
+AgentSettingsModalController.$inject = ['$scope', '$uibModalInstance', 'toastr', 'UriUtils', '$translate', 'dialogModel'];
+
+function AgentSettingsModalController($scope, $uibModalInstance, toastr, UriUtils, $translate, dialogModel) {
+
+    // =========================
+    // Public variables
+    // =========================
+
+    // =========================
+    // Public functions
+    // =========================
+
+    $scope.ok = function () {
+
+    };
+
+    $scope.cancel = function () {
+        $uibModalInstance.dismiss({});
+    };
+
+    $scope.close = function () {
+        $uibModalInstance.dismiss({});
+    };
+
+    // =========================
+    // Private functions
+    // =========================
+
+
+    // =========================
+    // Initialization
+    // =========================
+
+    const init = function () {
+
+    };
+    init();
+}

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -356,7 +356,7 @@ function TTYGViewCtrl($rootScope, $scope, $http, $timeout, $translate, $uibModal
                 TTYGContextService.selectChat($scope.chats.getFirstChat());
             }
         }
-    }
+    };
 
     /**
      * Handles the deletion of a chat by calling the service and updating the chats list.

--- a/src/js/angular/ttyg/directives/agent-list.directive.js
+++ b/src/js/angular/ttyg/directives/agent-list.directive.js
@@ -86,7 +86,9 @@ function AgentListComponent(TTYGContextService, ModalService, $translate) {
             // =========================
 
             const updateSelectedAgentsFilter = () => {
-                $scope.selectedAgentsFilter = $scope.agentListFilterModel[0];
+                const selectedFilter = $scope.agentListFilterModel.find((filter) => filter.selected);
+                $scope.selectedAgentsFilter = selectedFilter || $scope.agentListFilterModel[0];
+                $scope.onAgentsFilterChange($scope.selectedAgentsFilter);
             };
 
             // =========================
@@ -99,7 +101,7 @@ function AgentListComponent(TTYGContextService, ModalService, $translate) {
                 subscriptions.forEach((subscription) => subscription());
             };
 
-            subscriptions.push($scope.$watch('repositoryList', updateSelectedAgentsFilter));
+            subscriptions.push($scope.$watch('agentListFilterModel', updateSelectedAgentsFilter));
 
             // Deregister the watcher when the scope/directive is destroyed
             $scope.$on('$destroy', removeAllSubscribers);

--- a/src/js/angular/ttyg/directives/no-agents-view.directive.js
+++ b/src/js/angular/ttyg/directives/no-agents-view.directive.js
@@ -1,0 +1,26 @@
+import {TTYGEventName} from "../services/ttyg-context.service";
+
+angular
+    .module('graphdb.framework.ttyg.directives.no-agents-view', [])
+    .directive('noAgentsView', NoAgentsView);
+
+NoAgentsView.$inject = ['TTYGContextService'];
+
+function NoAgentsView(TTYGContextService) {
+    return {
+        restrict: 'E',
+        templateUrl: 'js/angular/ttyg/templates/no-agents-view.html',
+        scope: {
+        },
+        link: ($scope, element, attrs) => {
+
+            // =========================
+            // Public functions
+            // =========================
+
+            $scope.onCreateAgent = () => {
+                TTYGContextService.emit(TTYGEventName.CREATE_AGENT);
+            };
+        }
+    };
+}

--- a/src/js/angular/ttyg/services/constants.js
+++ b/src/js/angular/ttyg/services/constants.js
@@ -1,5 +1,4 @@
-// export const AGENT_ID = 'asst_gy0XYDD8MupnFtErN860sKBn'; // repoId: starwars, method: fts_search
-export const AGENT_ID = 'asst_O1Hd0HhmZF3oo70yR9hmpxgC'; // repoId: starwars, method: sparql_search
+export const AGENT_ID = 'asst_uoKp5kgnPlyZHhRXY7P2r9D7'; // repoId: starwars, method: fts_search
 
 /**
  * The key to use when filtering agents indicating that all agents should be shown.

--- a/src/js/angular/ttyg/services/ttyg-context.service.js
+++ b/src/js/angular/ttyg/services/ttyg-context.service.js
@@ -146,5 +146,6 @@ export const TTYGEventName = {
     CHAT_EXPORT_SUCCESSFUL: 'chatExportSuccess',
     CHAT_EXPORT_FAILURE: 'chatExportFailure',
     CHAT_LIST_UPDATED: 'chatListUpdated',
-    AGENT_LIST_UPDATED: 'agentListUpdated'
+    AGENT_LIST_UPDATED: 'agentListUpdated',
+    CREATE_AGENT: 'createAgent'
 };

--- a/src/js/angular/ttyg/templates/agent-list.html
+++ b/src/js/angular/ttyg/templates/agent-list.html
@@ -21,7 +21,7 @@
             {{'ttyg.agent.messages.no_agents' | translate}}
         </div>
 
-        <div ng-repeat="agent in agentList.agents" class="agent-item">
+        <div ng-repeat="agent in agentList.filterableAgents" class="agent-item">
             <div class="agent-info" ng-if="agent.repositoryId">
                 <div class="agent-name">{{agent.name}}</div>
                 <div class="related-repository">

--- a/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -1,0 +1,20 @@
+<div class="modal-header">
+    <button type="button" class="close" ng-click="close()"></button>
+    <h4 class="modal-title">{{'ttyg.agent.create_agent_modal.title' | translate}}</h4>
+</div>
+<div class="modal-body">
+    <form name="agentSettingsForm" id="agentSettingsForm" class="agent-settings-form">
+        <div class="form-horizontal">
+            settings form here
+        </div>
+    </form>
+</div>
+<div class="modal-footer">
+    <button type="button" ng-click="cancel()" class="btn btn-link cancel-btn">
+        {{'ttyg.agent.create_agent_modal.btn.cancel.label' | translate}}
+    </button>
+    <button type="submit" form="agentSettingsForm" ng-click="ok()" ng-disabled="agentSettingsForm.$invalid"
+            class="btn btn-primary save-agent-settings-btn">
+        {{'ttyg.agent.create_agent_modal.btn.create.label' | translate}}
+    </button>
+</div>

--- a/src/js/angular/ttyg/templates/no-agents-view.html
+++ b/src/js/angular/ttyg/templates/no-agents-view.html
@@ -1,0 +1,15 @@
+<link href="css/ttyg/no-agents-view.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+
+<div class="no-agents-view-component">
+    <div class="content">
+        <div class="alert alert-help mb-3">{{ 'ttyg.agent.messages.help_1' | translate }}</div>
+        <div class="alert alert-help mb-3">{{ 'ttyg.agent.messages.help_2' | translate }}</div>
+
+        <div class="actions">
+            <button class="btn btn-outline-primary btn-lg text-xs-left create-agent-btn" ng-click="onCreateAgent()">
+                <i class="fa-regular fa-message-bot fa-xl"></i>
+                <span class="text ml-1">{{'ttyg.agent.fat_btn.create_agent.label' | translate}}</span>
+            </button>
+        </div>
+    </div>
+</div>

--- a/src/js/angular/ttyg/templates/ttyg.html
+++ b/src/js/angular/ttyg/templates/ttyg.html
@@ -12,7 +12,15 @@
 
     <div core-errors></div>
 
-    <div id="ttyg-container" class="ttyg-container" ng-show="getActiveRepository()">
+    <div onto-loader-new
+         ng-show="loadingAgents"
+         class="ttyg-page-loader"
+         size="100">
+    </div>
+
+    <no-agents-view ng-cloak ng-if="!loadingAgents && (!agents || agents.isEmpty())"></no-agents-view>
+
+    <div id="ttyg-container" class="ttyg-container" ng-show="getActiveRepository() && !loadingAgents && agents && !agents.isEmpty()">
 
         <div id="left-sidebar" class="left-sidebar sidebar" ng-class="showChats ? 'expanded' : 'collapsed'">
             <div class="toolbar">

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -219,6 +219,7 @@
     "ttyg": {
         "helpInfo": "Talk to Your Graph is chat bot based on OpenAI's GPT-4 model that can answer questions about data stored in GraphDB, leveraging both your data and the general knowledge of the GPT-4 model. The bot works in connection with the ChatGPT Retrieval connector.",
         "hint": "Talk to your graph – simply ask a question!",
+        "loading": "Loading...",
         "help": {
             "btn": {
                 "show_help": {
@@ -266,7 +267,28 @@
         },
         "agent": {
             "loading_agents": "Loading agents...",
+            "deleted_repository": "Deleted repository",
+            "create_agent_modal": {
+                "title": "Create Agent",
+                "btn": {
+                    "create": {
+                        "label": "Create Agent"
+                    },
+                    "cancel": {
+                        "label": "Cancel"
+                    }
+                }
+            },
+            "fat_btn": {
+                "create_agent": {
+                    "label": "Create your first agent"
+                }
+            },
             "btn": {
+                "filter": {
+                    "tooltip": "Filter by repository",
+                    "all": "All"
+                },
                 "edit_agent": {
                     "label": "Settings",
                     "tooltip": "Edit Agent"
@@ -291,6 +313,9 @@
                 }
             },
             "messages": {
+                "no_agents": "No agents found for the selected filter.",
+                "help_1": "Talk to your data in natural language. All you need to do is create and instruct your own AI Agent to assist you.",
+                "help_2": "The Agent is an AI-powered conversational agent designed to help with a wide range of tasks, from answering questions and providing information to assisting with creative and technical projects. It leverages advanced natural language processing to understand and respond to user inputs in a human-like manner, making interactions intuitive and efficient."
             }
         },
         "help.what.title": "What is this?",

--- a/test-cypress/fixtures/ttyg/chats/get-chat-1.json
+++ b/test-cypress/fixtures/ttyg/chats/get-chat-1.json
@@ -1,0 +1,34 @@
+{
+    "id": "thread_gy2K7D3efStfchq2v5VvpEvn",
+    "name": "Han Solo is a fictional character in the...",
+    "messages": [
+        {
+            "id": "msg_1niL7yYidTfiGZynCiryiMMd",
+            "conversationId": "thread_gy2K7D3efStfchq2v5VvpEvn",
+            "agentId": null,
+            "role": "user",
+            "message": "Who are the Han Solo's children?",
+            "timestamp": "1725875483",
+            "name": null
+        },
+        {
+            "id": "msg_YbtWCL64HPu9Kf7SbeRlrwCc",
+            "conversationId": "thread_gy2K7D3efStfchq2v5VvpEvn",
+            "agentId": "asst_uoKp5kgnPlyZHhRXY7P2r9D7",
+            "role": "assistant",
+            "message": "Han Solo is a fictional character in the Star Wars franchise. He is a Human male with fair skin and brown eyes. Han Solo is portrayed by Harrison Ford in the original Star Wars trilogy and in \"The Force Awakens.\" The character also appears in several other films and media within the Star Wars universe.\n\n**Key Details:**\n- **Gender:** Male\n- **Height:** 180 cm\n- **Mass:** 80 kg\n- **Birth Year:** 29BBY\n- **Eye Color:** Brown\n- **Hair Color:** Brown\n- **Homeworld:** Corellia (Planet 22)\n\n**Description:**\nHan Solo is a character in the Star Wars franchise. In the original film trilogy, Han and his co-pilot, Chewbacca, became involved in the Rebel Alliance's struggle against the Galactic Empire. During the course of the Star Wars narrative, he becomes a chief figure in the Alliance and succeeding galactic governments. Star Wars creator George Lucas described the character as \"a loner who realizes the importance of being part of a group and helping for the common good\". Harrison Ford portrayed the character in the original Star Wars trilogy as well as \"The Force Awakens\". Alden Ehrenreich portrays a young Han Solo in \"Solo: A Star Wars Story\".\n\n**Appearances in Films:**\n1. **Star Wars: Episode IV – A New Hope**\n2. **Star Wars: Episode V – The Empire Strikes Back**\n3. **Star Wars: Episode VI – Return of the Jedi**\n4. **Star Wars: Episode VII – The Force Awakens**\n\n**Starships:**\n- **Millennium Falcon (Starship 10)**\n- **Second Starship (Starship 22)**\n\n**Image:**\n![Han Solo and Chewbacca costumes](http://commons.wikimedia.org/wiki/Special:FilePath/Han%20Solo%20and%20Chewbacca%20costumes.jpg)\n\n**Wikidata Link:**\n[Han Solo on Wikidata](http://www.wikidata.org/entity/Q51802)\n\nHan Solo is a key figure in the Star Wars universe, known for his role as a smuggler turned hero, his partnership with Chewbacca, and his iconic starship, the Millennium Falcon.",
+            "timestamp": "1725875332",
+            "name": null
+        },
+        {
+            "id": "msg_A9UeOFT9SF3pKzJzar1HwM7d",
+            "conversationId": "thread_gy2K7D3efStfchq2v5VvpEvn",
+            "agentId": null,
+            "role": "user",
+            "message": "Who is Han Solo?",
+            "timestamp": "1725875323",
+            "name": null
+        }
+    ],
+    "timestamp": "1725875483"
+}

--- a/test-cypress/integration/ttyg/agent-list.spec.js
+++ b/test-cypress/integration/ttyg/agent-list.spec.js
@@ -3,16 +3,9 @@ import {TTYGStubs} from "../../stubs/ttyg/ttyg-stubs";
 import {RepositoriesStubs} from "../../stubs/repositories/repositories-stubs";
 
 describe('TTYG agent list', () => {
-    let repositoryId;
-
     beforeEach(() => {
-        repositoryId = 'ttyg-repo-' + Date.now();
-        cy.createRepository({id: repositoryId});
-        cy.presetRepository(repositoryId);
-    });
-
-    afterEach(() => {
-        cy.deleteRepository(repositoryId);
+        RepositoriesStubs.stubRepositories(0, '/repositories/get-ttyg-repositories.json');
+        cy.presetRepository('starwars');
     });
 
     it('Should render the agent list', () => {
@@ -31,26 +24,28 @@ describe('TTYG agent list', () => {
         ]);
     });
 
-    it('Should render agents panel closed when there are no agents', () => {
+    it('Should be able to toggle agents panel', () => {
         TTYGStubs.stubChatsListGet();
-        TTYGStubs.stubAgentListGet('/ttyg/agent/get-agent-list-0.json');
+        TTYGStubs.stubAgentListGet();
         // Given I have opened the ttyg page
         TTYGViewSteps.visit();
         // When the ttyg page is loaded
-        // And there are no agents, yet
+        // Then I should see the agent list
+        TTYGViewSteps.getAgents().should('have.length', 4);
+        // When I close the agent list panel
+        TTYGViewSteps.collapseAgentsSidebar();
         // Then I expect agent list panel to be closed
         TTYGViewSteps.getAgentsPanel().should('be.hidden');
         // When I open the agent list panel
         TTYGViewSteps.expandAgentsSidebar();
         // Then I should see no agents
-        TTYGViewSteps.getAgents().should('have.length', 0);
+        TTYGViewSteps.getAgentsPanel().should('be.visible');
+        TTYGViewSteps.getAgents().should('have.length', 4);
     });
 
     it('Should be able to filter the agent list by repository', () => {
         TTYGStubs.stubAgentListGet();
         TTYGStubs.stubChatsListGet();
-        RepositoriesStubs.stubRepositories(0, '/repositories/get-ttyg-repositories.json');
-        cy.presetRepository('starwars');
         // Given I have opened the ttyg page
         TTYGViewSteps.visit();
         // When the ttyg page is loaded

--- a/test-cypress/integration/ttyg/agent-list.spec.js
+++ b/test-cypress/integration/ttyg/agent-list.spec.js
@@ -14,13 +14,11 @@ describe('TTYG agent list', () => {
         // Given I have opened the ttyg page
         TTYGViewSteps.visit();
         // When the ttyg page is loaded
-        // Then I should see the agent list
+        // Then I should see the agent list with agents filtered by the current repository
         TTYGViewSteps.getAgentsPanel().should('be.visible');
         verifyAgentList([
             {name: 'agent-1', repositoryId: 'starwars'},
-            {name: 'agent-2', repositoryId: 'Deleted repository'},
-            {name: 'Databricks-general-unbiased', repositoryId: 'starwars'},
-            {name: 'Databricks-biomarkers', repositoryId: 'biomarkers'}
+            {name: 'Databricks-general-unbiased', repositoryId: 'starwars'}
         ]);
     });
 
@@ -31,7 +29,7 @@ describe('TTYG agent list', () => {
         TTYGViewSteps.visit();
         // When the ttyg page is loaded
         // Then I should see the agent list
-        TTYGViewSteps.getAgents().should('have.length', 4);
+        TTYGViewSteps.getAgents().should('have.length', 2);
         // When I close the agent list panel
         TTYGViewSteps.collapseAgentsSidebar();
         // Then I expect agent list panel to be closed
@@ -40,7 +38,7 @@ describe('TTYG agent list', () => {
         TTYGViewSteps.expandAgentsSidebar();
         // Then I should see no agents
         TTYGViewSteps.getAgentsPanel().should('be.visible');
-        TTYGViewSteps.getAgents().should('have.length', 4);
+        TTYGViewSteps.getAgents().should('have.length', 2);
     });
 
     it('Should be able to filter the agent list by repository', () => {
@@ -49,18 +47,9 @@ describe('TTYG agent list', () => {
         // Given I have opened the ttyg page
         TTYGViewSteps.visit();
         // When the ttyg page is loaded
-        TTYGViewSteps.getAgents().should('have.length', 4);
+        TTYGViewSteps.getAgents().should('have.length', 2);
         // Then Agent list filter should be set to All
-        TTYGViewSteps.getSelectedAgentFilter().should('contain', 'All');
-        // And I should see all agents (just check the count, the list is verified in another test)
-        TTYGViewSteps.getAgents().should('have.length', 4);
-        // When I filter the agents by repository 'starwars'
-        TTYGViewSteps.filterAgentsByRepository('starwars');
-        // Then I should see only 2 agents
-        verifyAgentList([
-            {name: 'agent-1', repositoryId: 'starwars'},
-            {name: 'Databricks-general-unbiased', repositoryId: 'starwars'}
-        ]);
+        TTYGViewSteps.getSelectedAgentFilter().should('contain', 'starwars');
         // When I filter the agents by repository 'biomarkers'
         TTYGViewSteps.filterAgentsByRepository('biomarkers');
         // Then I should see only 1 agent
@@ -70,7 +59,12 @@ describe('TTYG agent list', () => {
         // When I select the 'All' filter
         TTYGViewSteps.filterAgentsByRepository('All');
         // Then I should see all agents
-        TTYGViewSteps.getAgents().should('have.length', 4);
+        verifyAgentList([
+            {name: 'agent-1', repositoryId: 'starwars'},
+            {name: 'agent-2', repositoryId: 'Deleted repository'},
+            {name: 'Databricks-general-unbiased', repositoryId: 'starwars'},
+            {name: 'Databricks-biomarkers', repositoryId: 'biomarkers'}
+        ]);
     });
 });
 

--- a/test-cypress/integration/ttyg/chat-list.spec.js
+++ b/test-cypress/integration/ttyg/chat-list.spec.js
@@ -2,6 +2,7 @@ import {TTYGViewSteps} from "../../steps/ttyg/ttyg-view-steps";
 import {TTYGStubs} from "../../stubs/ttyg/ttyg-stubs";
 import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
 import {RepositoriesStubs} from "../../stubs/repositories/repositories-stubs";
+import {ApplicationSteps} from "../../steps/application-steps";
 
 // TODO: This test is skipped because it fails on CI. For some reason the chat list panel is not visible.
 describe.skip('TTYG chat list', () => {
@@ -126,6 +127,20 @@ describe.skip('TTYG chat list', () => {
         ModalDialogSteps.clickOnConfirmButton();
         // Then the chat should be deleted
         TTYGViewSteps.getChatByDayGroups().should('have.length', 1);
+    });
+
+    it('Should show error notification if chat list fails to load', () => {
+        TTYGStubs.stubChatListGetError();
+        TTYGStubs.stubAgentListGet();
+        // Given I have opened the ttyg page
+        TTYGViewSteps.visit();
+        // When the chat list fails to load
+        // Then I should see an error notification
+        TTYGViewSteps.getChatListLoadingIndicator().should('not.exist');
+        // And the error notification should be visible
+        ApplicationSteps.getErrorNotifications().should('be.visible');
+        // And the chat list should not be visible
+        TTYGViewSteps.getChatsPanel().should('be.hidden');
     });
 });
 

--- a/test-cypress/integration/ttyg/chat-list.spec.js
+++ b/test-cypress/integration/ttyg/chat-list.spec.js
@@ -1,23 +1,19 @@
 import {TTYGViewSteps} from "../../steps/ttyg/ttyg-view-steps";
 import {TTYGStubs} from "../../stubs/ttyg/ttyg-stubs";
 import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
+import {RepositoriesStubs} from "../../stubs/repositories/repositories-stubs";
 
 // TODO: This test is skipped because it fails on CI. For some reason the chat list panel is not visible.
 describe.skip('TTYG chat list', () => {
-    let repositoryId;
 
     beforeEach(() => {
-        repositoryId = 'ttyg-repo-' + Date.now();
-        cy.createRepository({id: repositoryId});
-        cy.presetRepository(repositoryId);
-    });
-
-    afterEach(() => {
-        cy.deleteRepository(repositoryId);
+        RepositoriesStubs.stubRepositories(0, '/repositories/get-ttyg-repositories.json');
+        cy.presetRepository('starwars');
     });
 
     it('Should render chat list', () => {
         TTYGStubs.stubChatsListGet();
+        TTYGStubs.stubAgentListGet();
         // Given I have opened the ttyg page
         TTYGViewSteps.visit();
         // When the ttyg page is loaded
@@ -40,6 +36,7 @@ describe.skip('TTYG chat list', () => {
 
     it('Should render no results when there are no chats', () => {
         TTYGStubs.stubChatsListGetNoResults();
+        TTYGStubs.stubAgentListGet();
         // Given I have opened the ttyg page
         TTYGViewSteps.visit();
         // When the ttyg page is loaded
@@ -54,6 +51,7 @@ describe.skip('TTYG chat list', () => {
 
     it('Should be able to edit an existing chat name by double click on the chat in the list', () => {
         TTYGStubs.stubChatsListGet();
+        TTYGStubs.stubAgentListGet();
         TTYGStubs.stubChatUpdate();
         // Given I have opened the ttyg page and there are chats loaded
         TTYGViewSteps.visit();
@@ -72,6 +70,7 @@ describe.skip('TTYG chat list', () => {
 
     it('Should be able to edit an existing chat name through the action menu', () => {
         TTYGStubs.stubChatsListGet();
+        TTYGStubs.stubAgentListGet();
         TTYGStubs.stubChatUpdate();
         // Given I have opened the ttyg page and there are chats loaded
         TTYGViewSteps.visit();
@@ -91,6 +90,7 @@ describe.skip('TTYG chat list', () => {
 
     it('Should be able to cancel a chat name editing', () => {
         TTYGStubs.stubChatsListGet();
+        TTYGStubs.stubAgentListGet();
         // Given I have opened the ttyg page and there are chats loaded
         TTYGViewSteps.visit();
         // And I double-click on the first chat
@@ -107,6 +107,7 @@ describe.skip('TTYG chat list', () => {
 
     it('Should be able to delete a chat', () => {
         TTYGStubs.stubChatsListGet();
+        TTYGStubs.stubAgentListGet();
         TTYGStubs.stubChatDelete();
         // Given I have opened the ttyg page and there are chats loaded
         TTYGViewSteps.visit();

--- a/test-cypress/integration/ttyg/ttyg-view.spec.js
+++ b/test-cypress/integration/ttyg/ttyg-view.spec.js
@@ -23,6 +23,7 @@ describe('TTYG view', () => {
     it('Should load ttyg page and render main components', () => {
         TTYGStubs.stubChatsListGet();
         TTYGStubs.stubAgentListGet();
+        TTYGStubs.stubChatGet();
         // Given I have opened the ttyg page
         TTYGViewSteps.visit();
         // When the ttyg page is loaded
@@ -63,6 +64,7 @@ describe('TTYG view', () => {
     it('Should show error notification if agents loading fails', () => {
         TTYGStubs.stubChatsListGet();
         TTYGStubs.stubAgentListGetError();
+        TTYGStubs.stubChatGet();
         // Given I have opened the ttyg page
         TTYGViewSteps.visit();
         // When the agents loading fails

--- a/test-cypress/integration/ttyg/ttyg-view.spec.js
+++ b/test-cypress/integration/ttyg/ttyg-view.spec.js
@@ -5,9 +5,19 @@ import {ApplicationSteps} from "../../steps/application-steps";
 
 describe('TTYG view', () => {
 
+    let repositoryId;
+
     beforeEach(() => {
+        // Create an actual repository to prevent stubbing all background requests that are not related to the ttyg view
+        repositoryId = 'starwars';
+        cy.createRepository({id: repositoryId});
+
         RepositoriesStubs.stubRepositories(0, '/repositories/get-ttyg-repositories.json');
         cy.presetRepository('starwars');
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
     });
 
     it('Should load ttyg page and render main components', () => {

--- a/test-cypress/integration/ttyg/ttyg-view.spec.js
+++ b/test-cypress/integration/ttyg/ttyg-view.spec.js
@@ -1,6 +1,7 @@
 import {TTYGViewSteps} from "../../steps/ttyg/ttyg-view-steps";
 import {TTYGStubs} from "../../stubs/ttyg/ttyg-stubs";
 import {RepositoriesStubs} from "../../stubs/repositories/repositories-stubs";
+import {ApplicationSteps} from "../../steps/application-steps";
 
 describe('TTYG view', () => {
 
@@ -47,6 +48,18 @@ describe('TTYG view', () => {
         TTYGViewSteps.getNoAgentsView().should('be.visible');
         // And the create agent button should be visible
         TTYGViewSteps.getCreateFirstAgentButton().should('be.visible');
+    });
+
+    it('Should show error notification if agents loading fails', () => {
+        TTYGStubs.stubChatsListGet();
+        TTYGStubs.stubAgentListGetError();
+        // Given I have opened the ttyg page
+        TTYGViewSteps.visit();
+        // When the agents loading fails
+        // Then I should see an error notification
+        ApplicationSteps.getErrorNotifications().should('be.visible');
+        // And the no agents view should be rendered
+        TTYGViewSteps.getNoAgentsView().should('be.visible');
     });
 });
 

--- a/test-cypress/integration/ttyg/ttyg-view.spec.js
+++ b/test-cypress/integration/ttyg/ttyg-view.spec.js
@@ -1,21 +1,17 @@
 import {TTYGViewSteps} from "../../steps/ttyg/ttyg-view-steps";
 import {TTYGStubs} from "../../stubs/ttyg/ttyg-stubs";
+import {RepositoriesStubs} from "../../stubs/repositories/repositories-stubs";
 
 describe('TTYG view', () => {
-    let repositoryId;
 
     beforeEach(() => {
-        repositoryId = 'ttyg-repo-' + Date.now();
-        cy.createRepository({id: repositoryId});
-        cy.presetRepository(repositoryId);
-    });
-
-    afterEach(() => {
-        cy.deleteRepository(repositoryId);
+        RepositoriesStubs.stubRepositories(0, '/repositories/get-ttyg-repositories.json');
+        cy.presetRepository('starwars');
     });
 
     it('Should load ttyg page and render main components', () => {
         TTYGStubs.stubChatsListGet();
+        TTYGStubs.stubAgentListGet();
         // Given I have opened the ttyg page
         TTYGViewSteps.visit();
         // When the ttyg page is loaded
@@ -37,6 +33,20 @@ describe('TTYG view', () => {
         TTYGViewSteps.getChatPanelToolbar().should('be.visible');
         TTYGViewSteps.getEditCurrentAgentButton().should('be.visible');
         TTYGViewSteps.getExportCurrentChatButton().should('be.visible');
+    });
+
+    it('Should render no agents view if no agent is created yet', () => {
+        TTYGStubs.stubChatsListGetNoResults();
+        TTYGStubs.stubAgentListGet('/ttyg/agent/get-agent-list-0.json');
+        // Given I have opened the ttyg page
+        TTYGViewSteps.visit();
+        // When the ttyg page is loaded
+        // Then I should see the ttyg view
+        TTYGViewSteps.getTtygView().should('exist');
+        // And the no agents view should be rendered
+        TTYGViewSteps.getNoAgentsView().should('be.visible');
+        // And the create agent button should be visible
+        TTYGViewSteps.getCreateFirstAgentButton().should('be.visible');
     });
 });
 

--- a/test-cypress/steps/ttyg/ttyg-view-steps.js
+++ b/test-cypress/steps/ttyg/ttyg-view-steps.js
@@ -11,6 +11,10 @@ export class TTYGViewSteps {
         return cy.get('#ttyg-view-title');
     }
 
+    static getNoAgentsView() {
+        return this.getTtygView().find('.no-agents-view-component');
+    }
+
     static getTtygViewContent() {
         return cy.get('.ttyg-view-content');
     }
@@ -132,6 +136,10 @@ export class TTYGViewSteps {
 
     static getHelpButton() {
         return this.getAgentsSidebar().find('.help-btn');
+    }
+
+    static getCreateFirstAgentButton() {
+        return this.getNoAgentsView().find('.create-agent-btn');
     }
 
     static getCreateAgentButton() {

--- a/test-cypress/stubs/ttyg/ttyg-stubs.js
+++ b/test-cypress/stubs/ttyg/ttyg-stubs.js
@@ -8,6 +8,16 @@ export class TTYGStubs {
         }).as('get-chat-list');
     }
 
+    static stubChatListGetError() {
+        cy.intercept('/rest/chat/conversations', {
+            method: 'GET',
+            statusCode: 500,
+            response: {
+                error: 'Internal Server Error'
+            }
+        }).as('get-chat-list');
+    }
+
     static stubChatsListGetNoResults() {
         cy.intercept('/rest/chat/conversations', {
             method: 'GET',
@@ -46,6 +56,16 @@ export class TTYGStubs {
             fixture: fixture,
             statusCode: 200,
             delay: delay
+        }).as('get-agent-list');
+    }
+
+    static stubAgentListGetError() {
+        cy.intercept('/rest/chat/agents', {
+            method: 'GET',
+            statusCode: 500,
+            response: {
+                error: 'Internal Server Error'
+            }
         }).as('get-agent-list');
     }
 }

--- a/test-cypress/stubs/ttyg/ttyg-stubs.js
+++ b/test-cypress/stubs/ttyg/ttyg-stubs.js
@@ -30,8 +30,13 @@ export class TTYGStubs {
 
     }
 
-    static stubChatGet() {
-
+    static stubChatGet(fixture = '/ttyg/chats/get-chat-1.json', delay = 0) {
+        cy.intercept('/rest/chat/conversations/**', {
+            method: 'GET',
+            fixture: fixture,
+            statusCode: 200,
+            delay: delay
+        }).as('get-chat');
     }
 
     static stubChatUpdate() {


### PR DESCRIPTION
## What
Introduce a no agents view with create agent button and help message.
Agent list is filtered by the current repository by default.

## Why
This no agent view is rendered when there are no agents created yet and displays help messages to the user and provides a create agent button.

## How
Implemented a new component for the view and integrated with the page.
Changed the way how the chats and agents are initially loaded because when there are no agents, then the no agents view must be rendered and chats request may not be executed.
Implemented tests.
Add more tests.
Improved styling by adding more padding to list items and made the agent list scrollable only so that the filter menu is always visible.