### PR TITLE
(cherry-pick) GDB-10888 - add missing label key and remove button right margin (#1543)

### DIFF
--- a/src/css/import.css
+++ b/src/css/import.css
@@ -4,6 +4,10 @@
     flex-flow: row wrap;
 }
 
+.modal-footer .btn-group .import-format-dropdown-btn {
+    margin-right: 0;
+}
+
 .upload-buttons .btn {
     display: flex;
     height: 100%;

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -925,6 +925,7 @@
         "enable.for.auto.start": "Enable this option to start the import when you click the Import button. If it is disabled the import will be added to the list but not started automatically.",
         "auto.start": "Start import automatically",
         "data.from.url": "Import RDF data from URL",
+        "format": "Format",
         "supported.url.with.rdf": "URL with RDF data. Supported formats are",
         "invalid.url": "Not valid url!",
         "gz.zip": ", as well as their .gz versions and .zip archives",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -933,6 +933,7 @@
         "enable.for.auto.start": "Activez cette option pour lancer l'importation lorsque vous cliquez sur le bouton Importer. Si elle est désactivée, l'importation sera ajoutée à la liste mais ne démarrera pas automatiquement.",
         "auto.start": "Démarrer l'importation automatiquement",
         "data.from.url": "Importer des données RDF depuis une URL",
+        "format": "Format",
         "supported.url.with.rdf": "URL avec des données RDF. Les formats supportés sont",
         "invalid.url": "URL non valide!",
         "gz.zip": "ainsi que leurs versions .gz et leurs archives .zip.",

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -924,6 +924,7 @@
         "enable.for.auto.start": "Enable this option to start the import when you click the Import button. If it is disabled the import will be added to the list but not started automatically.",
         "auto.start": "Start import automatically",
         "data.from.url": "Import RDF data from URL",
+        "format": "Format",
         "supported.url.with.rdf": "URL with RDF data. Supported formats are",
         "invalid.url": "Not valid url!",
         "gz.zip": ", as well as their .gz versions and .zip archives",


### PR DESCRIPTION
## What?
The "Import RDF data from URL" dialog format button will have an aligned drop-down menu and the label will not appear as a JSON key.

## Why?
The label was missing and the drop-down was misaligned.

## How?
I removed the margin for the dialog buttons and added the missing key.

## Screenshots?
Before
![image](https://github.com/user-attachments/assets/0576542c-c7fd-4f07-9e89-c9f4290e3f53)

After
![image](https://github.com/user-attachments/assets/90f7f08b-579c-42ea-b3ae-a31b2a6031ec)

(cherry picked from commit ef6c3ffd740092b7374ab681dd089114259172e8)