### PR TITLE
(cherry-pick) GDB-10801 - set styling for dynamically fetched odd and even rows

### DIFF
--- a/src/css/dependencies.css
+++ b/src/css/dependencies.css
@@ -127,7 +127,6 @@ div.tooltip {
     background-color: hsla(var(--tertiary-color-hsl), 0.30) !important;
 }
 
-
 .rdf-list > li > div:first-child {
     border-bottom: 0.5pt solid #e8e3e3;
     border-left:1pt solid #e8e3e3;
@@ -135,15 +134,17 @@ div.tooltip {
     border-top:0.5pt solid #e8e3e3;
 }
 
-
-
 .rdf-list li {
     border-bottom: inherit !important;
     background-color: inherit !important;
 }
 
-.rdf-list li:nth-child(even) div.deps-data {
+#wb-dependencies-classInClasses li .even-row:not(.active)  {
     background-color: #f8f7f7;
+}
+
+#wb-dependencies-classInClasses li .odd-row:not(.active)  {
+    background-color: #ffffff;
 }
 
 .rdf-list li div {

--- a/src/pages/dependencies.html
+++ b/src/pages/dependencies.html
@@ -127,7 +127,11 @@
                 <ul ui-scroll-viewport id="wb-dependencies-classInClasses" class="rdf-list row">
                     <li ui-scroll="class in datasource" adapter="adapterContainer.adapter" class="item class-row col-sm-12 row"
                         padding="li">
-                        <div class="col-sm-11 row deps-data" ng-class="{'active': (isClassByNameShown(class.name))}">
+                            <div class="col-sm-11 row deps-data" ng-class="{
+                            'active': isClassByNameShown(class.name),
+                            'even-row': $index % 2 === 0,
+                            'odd-row': $index % 2 !== 0
+                            }">
                             <div class="col-sm-8 col-md-8 deps-class-name">
                                 {{class.name}}
                             </div>
@@ -138,11 +142,11 @@
                             <div class="related-arrow col-sm-1 col-md-1" gdb-tooltip="{{'related.classes.label' | translate}}"
                                  ng-click="showClass(class)">
                                 <em class="fa fa-exchange pointer related-classes"
-                                   ng-show="class.inConnectionsSum > 0 && class.outConnectionsSum > 0"></em>
+                                    ng-show="class.inConnectionsSum > 0 && class.outConnectionsSum > 0"></em>
                                 <em class="fa fa-long-arrow-left related-classes"
-                                   ng-show="class.inConnectionsSum > 0 && class.outConnectionsSum == 0"></em>
+                                    ng-show="class.inConnectionsSum > 0 && class.outConnectionsSum == 0"></em>
                                 <em class="fa fa-long-arrow-right related-classes"
-                                   ng-show="class.inConnectionsSum == 0 && class.outConnectionsSum > 0 "></em>
+                                    ng-show="class.inConnectionsSum == 0 && class.outConnectionsSum > 0 "></em>
                             </div>
                         </div>
                         <div class="plusminus col-sm-1 col-md-1">


### PR DESCRIPTION
## What?
When scrolling in Class relationships view, the even row background colors won't flicker.

## Why?
The background color for the even rows would flicker when the user scrolled the list. This was most likely due to the dynamic fetching of the list items. Angular would re-calculate the styling and re-render. However, this re-render made it difficult to track the list while scrolling, as it was distracting.

## How?
I changed the way the styling is set and added a background color to the odd rows as well.

## Screenshots?
![image](https://github.com/user-attachments/assets/47b9b116-f066-406f-aab5-0ee68c90677b)

(cherry picked from commit 70e7758447ba01a53abc0724ddfe23da0005b5d0)