### PR TITLE
Fixed NPE when trying to save agent ID for the first time

### DIFF
--- a/src/js/angular/ttyg/services/ttyg-storage.service.js
+++ b/src/js/angular/ttyg/services/ttyg-storage.service.js
@@ -24,6 +24,12 @@ function TTYGStorageService(localStorageAdapter, LSKeys) {
         if (!settings) {
             settings = defaultSettings;
         }
+        if (!settings.agent) {
+            settings.agent = {};
+        }
+        if (!settings.chat) {
+            settings.chat = {};
+        }
         return settings;
     };
 


### PR DESCRIPTION
What
A NullPointerException (NPE) occurs in the console when attempting to save the agent ID in the browser's local storage for the first time.

Why
The issue arises because, if the saved object in the local storage does not have an agent field, the code tries to save the ID to an undefined field.

How
A check was added to verify if the agent and chat fields of the TTYG persisted object exist. If they don't, they are initialized before saving the data.