### PR TITLE
(cherry-pick) GDB-10772 - Show error message on resource edit when user not admin

### DIFF
--- a/src/js/angular/explore/controllers.js
+++ b/src/js/angular/explore/controllers.js
@@ -517,9 +517,9 @@ function FindResourceCtrl($scope, $http, $location, $repositories, $q, $timeout,
     }
 }
 
-EditResourceCtrl.$inject = ['$scope', '$http', '$location', 'toastr', '$repositories', '$uibModal', '$timeout', 'ClassInstanceDetailsService', 'StatementsService', 'RDF4JRepositoriesRestService', '$translate'];
+EditResourceCtrl.$inject = ['$scope', '$http', '$location', 'toastr', '$repositories', '$uibModal', '$timeout', 'ClassInstanceDetailsService', 'StatementsService', 'RDF4JRepositoriesRestService', '$translate', '$jwtAuth'];
 
-function EditResourceCtrl($scope, $http, $location, toastr, $repositories, $uibModal, $timeout, ClassInstanceDetailsService, StatementsService, RDF4JRepositoriesRestService, $translate) {
+function EditResourceCtrl($scope, $http, $location, toastr, $repositories, $uibModal, $timeout, ClassInstanceDetailsService, StatementsService, RDF4JRepositoriesRestService, $translate, $jwtAuth) {
     $scope.uriParam = $location.search().uri;
     $scope.newRow = {
         subject: $scope.uriParam,
@@ -583,6 +583,10 @@ function EditResourceCtrl($scope, $http, $location, toastr, $repositories, $uibM
             $scope.getClassInstancesDetails();
         }
     });
+
+    $scope.hasAdminRole = () => {
+        return $jwtAuth.isAuthenticated() && $jwtAuth.hasAdminRole();
+    };
 
     $scope.validateUri = function (val) {
         let check = true;

--- a/src/pages/edit.html
+++ b/src/pages/edit.html
@@ -1,7 +1,7 @@
 <link href="css/lib/angular-xeditable/xeditable.min.css?v=[AIV]{version}[/AIV]" rel="stylesheet">
 
-<div core-errors></div>
-<div class="page" ng-show="getActiveRepository()">
+<div core-errors write></div>
+<div class="page" ng-show="getActiveRepository() && hasAdminRole()">
     <div class="resource-info">
         <div class="thumb" ng-show="{{details.img}}">
             <a href="{{details.img}}"><img ng-src="{{details.img}}" alt="details image"/></a>


### PR DESCRIPTION
## What?
When editing a resource as an Admin and switching to a read only user, the page will show a message, instead of allowing the user to continue editing.

## Why?
Editing a resource as a non-admin user was allowed when the URL was accessed manually. The behavior should be that only admin users are allowed to edit resources.

## How?
I show an error message if the user does not have an admin role.

## Screeenshots?
![image](https://github.com/user-attachments/assets/a5067c7d-e571-4da3-a04c-c4770de6fc44)

(cherry picked from commit ba4cc4900ec7be8f585cafcd5cdf3dd1a26ef04a)