### PR TITLE
feat(GDB-10852) Add local node handling and tooltip for delete restrctions

### DIFF
--- a/src/css/cluster-list.css
+++ b/src/css/cluster-list.css
@@ -92,3 +92,7 @@
         padding: 0.4em .4em;
     }
 }
+
+.delete-node-tooltip {
+    max-width: 250px;
+}

--- a/src/css/cluster-list.css
+++ b/src/css/cluster-list.css
@@ -38,7 +38,7 @@
     min-height: 36px;
 }
 
-.table td, .table th {
+.cluster-group-table td, .cluster-group-table th {
     padding: .4rem;
     border-bottom: 1px solid #eceeef;
 }
@@ -54,17 +54,18 @@
     width: 50%;
     border-left: 1px solid #eceeef;
 
-    &.adding {
-        color: var(--color-success-dark);
-    }
-    &.deleting {
-        text-decoration: line-through;
-    }
-
     .autocomplete-container>.textarea-edit {
         font-size: 1rem;
         min-height: 32px;
     }
+}
+
+.location-cell.adding {
+    color: var(--color-success-dark);
+}
+
+.location-cell.deleting {
+    text-decoration: line-through;
 }
 
 .info-cell {

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -153,7 +153,7 @@
         "update_cluster_group_dialog": {
             "title": "Edit cluster",
             "title_create": "Create cluster",
-            "current_node": "Current node ",
+            "current_node": "Current node",
             "new_node": "Node will be added",
             "deleted_node": "Node will be removed",
             "leader": "Leader",
@@ -173,6 +173,7 @@
             "actions": {
                 "replace_node": "Replace node",
                 "delete_node": "Delete node",
+                "cannot_delete_node": "You cannot remove more than half of the healthy nodes at the same time",
                 "add_node": "Add node",
                 "add_node_tooltip": "Add node to current cluster",
                 "cancel": "Cancel",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -153,7 +153,7 @@
         "update_cluster_group_dialog": {
             "title": "Modifier le cluster",
             "title_create": "Créer un cluster",
-            "current_node": "Nœud actuel ",
+            "current_node": "Nœud actuel",
             "new_node": "Le nœud sera ajouté",
             "deleted_node": "Le nœud sera supprimé",
             "leader": "Leader",
@@ -173,6 +173,7 @@
             "actions": {
                 "replace_node": "Remplacer le nœud",
                 "delete_node": "Supprimer le nœud",
+                "cannot_delete_node": "Vous ne pouvez pas supprimer plus de la moitié des nœuds sains en même temps",
                 "add_node": "Ajouter un nœud",
                 "add_node_tooltip": "Ajouter un nœud au cluster actuel",
                 "cancel": "Annuler",

--- a/src/js/angular/clustermanagement/templates/cluster-list.html
+++ b/src/js/angular/clustermanagement/templates/cluster-list.html
@@ -48,14 +48,14 @@
                     </div>
                 </td>
                 <td class="info-cell data">
-                    <div ng-if="node.item.isLocal">
-                        {{'cluster_management.update_cluster_group_dialog.current_node' | translate}}
-                    </div>
+                    <span ng-if="node.isLocal">
+                        {{'cluster_management.update_cluster_group_dialog.current_node' | translate}}<span ng-if="node.item.nodeState">, </span>
+                    </span>
 
-                    <div ng-if="node.item.nodeState">
+                    <span ng-if="node.item.nodeState">
                         {{ ('cluster_management.update_cluster_group_dialog.' + node.item.nodeState.toLowerCase()) |
                         translate }}
-                    </div>
+                    </span>
                 </td>
                 <td class="status-cell data">
                     <div ng-if="!node.item.address" class="adding">
@@ -72,7 +72,8 @@
                     <div ng-if="editedNodeIndex === undefined && !node.isDeleted" class="actions-group">
                         <button ng-click="deleteNode($index, node)" ng-disabled="!canDeleteNode"
                                 class="btn btn-link delete-node-btn secondary"
-                                gdb-tooltip="{{'cluster_management.update_cluster_group_dialog.actions.delete_node' | translate}}">
+                                gdb-tooltip="{{ canDeleteNode ? ('cluster_management.update_cluster_group_dialog.actions.delete_node' | translate) : ('cluster_management.update_cluster_group_dialog.actions.cannot_delete_node' | translate) }}"
+                                title-class="delete-node-tooltip">
                             <i class="fa-regular fa-xmark"></i>
                         </button>
                         <button ng-click="replaceNode($index, node)" class="btn btn-link replace-node-btn"
@@ -125,9 +126,14 @@
                     </div>
                 </td>
                 <td class="info-cell data">
-                    <div ng-if="node.item.isLocal">
-                        {{'cluster_management.update_cluster_group_dialog.current_node' | translate}}
-                    </div>
+                    <span ng-if="node.isLocal">
+                        {{'cluster_management.update_cluster_group_dialog.current_node' | translate}}<span ng-if="node.item.nodeState">, </span>
+                    </span>
+
+                    <span ng-if="node.item.nodeState">
+                        {{ ('cluster_management.update_cluster_group_dialog.' + node.item.nodeState.toLowerCase()) |
+                        translate }}
+                    </span>
                 </td>
                 <td class="status-cell"></td>
                 <td class="empty-cell"></td>

--- a/src/js/angular/clustermanagement/templates/cluster-list.html
+++ b/src/js/angular/clustermanagement/templates/cluster-list.html
@@ -11,7 +11,7 @@
 </div>
 <div class="table-responsive">
     <form name="form" id="updateClusterGroupForm">
-        <table class="cluster-group table table-striped table-hover" aria-describedby="cluster group table">
+        <table class="cluster-group table table-striped table-hover cluster-group-table" aria-describedby="cluster group table">
             <thead>
             <tr class="labels-row">
                 <th scope="col" class="index-column">

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -153,7 +153,7 @@
         "update_cluster_group_dialog": {
             "title": "Edit cluster",
             "title_create": "Create cluster",
-            "current_node": "Current node ",
+            "current_node": "Current node",
             "new_node": "Node will be added",
             "deleted_node": "Node will be removed",
             "leader": "Leader",
@@ -173,6 +173,7 @@
             "actions": {
                 "replace_node": "Replace node",
                 "delete_node": "Delete node",
+                "cannot_delete_node": "You cannot remove more than half of the healthy nodes at the same time",
                 "add_node": "Add node",
                 "add_node_tooltip": "Add node to current cluster",
                 "cancel": "Cancel",


### PR DESCRIPTION
## WHAT
- Implemented logic to identify the local node within the cluster.
- Enhanced the canDeleteNode function to restrict deletion if more than half of the healthy nodes are selected.
- Updated the UI to display a custom tooltip explaining why the delete button is disabled when applicable.
- Added translation keys and modified the cluster-list.html template to dynamically change tooltips.
- Updated CSS to style the tooltip when deletion is restricted.

## WHY
Ensuring that the system restricts users from deleting more than half of the healthy nodes to maintain quorum-based replication and prevent split-brain scenarios.

## HOW
- Modified the cluster model to set the local node's endpoint during initialization.
- Updated the canDeleteNode logic to enforce restrictions based on the total number of nodes in the cluster.
- Used dynamic tooltip messages in the HTML to show different messages depending on the button's enabled/disabled state.
- Added a CSS class to style the tooltip appropriately when deletion is restricted.
- Updated locale files