### PR TITLE
(cherry-pick) GDB-10801 - Improve fast scrolling behavior in class relationships list

### DIFF
--- a/src/js/angular/graphexplore/controllers/dependencies-chord.controller.js
+++ b/src/js/angular/graphexplore/controllers/dependencies-chord.controller.js
@@ -168,7 +168,7 @@ function DependenciesChordCtrl($scope, $rootScope, $repositories, toastr, $timeo
     $rootScope.key = '';
 
     datasource.get = function (index, count, success) {
-        return UiScrollService.initLazyList(index, count, success, position, $scope.allClasses.items);
+        UiScrollService.initLazyList(index, count, success, position, $scope.allClasses.items);
     };
 
     $rootScope.$watch(function () {

--- a/src/pages/dependencies.html
+++ b/src/pages/dependencies.html
@@ -125,7 +125,7 @@
                     <div class="col-sm-6">{{'links.label' | translate}}</div>
                 </div>
                 <ul ui-scroll-viewport id="wb-dependencies-classInClasses" class="rdf-list row">
-                    <li ui-scroll="class in datasource" adapter="adapterContainer.adapter" class="item class-row col-sm-12 row"
+                    <li ui-scroll="class in datasource" buffer-size="70" padding="1" adapter="adapterContainer.adapter" class="item class-row col-sm-12 row"
                         padding="li">
                             <div class="col-sm-11 row deps-data" ng-class="{
                             'active': isClassByNameShown(class.name),

--- a/test-cypress/integration/explore/class.relationships.spec.js
+++ b/test-cypress/integration/explore/class.relationships.spec.js
@@ -52,15 +52,15 @@ describe('Class relations screen validation', () => {
     });
 
     it('Search for a class', function () {
-        // Expect 10 rows initially to be visible
-        verifyListLength(10);
+        // Expect 39 rows initially to be visible
+        verifyListLength(39);
         // Filter by partial name
         filterByClass(':Wine');
         // Expecting 6 rows to be present
         verifyListLength(6);
         // Clear the filter and expect all rows to be visible again
         getFilterField().clear();
-        verifyListLength(10);
+        verifyListLength(39);
     });
 
     it('Test class relationships for given graph', () => {


### PR DESCRIPTION
## What?
The Class list in Class relationships page will perform better when scrolled faster.

## Why?
When using a mouse with infinite scroll and scrolling very fast, the list would partially or entirely disappear. This is due to the capabilities of the library and the lazy loading of the list.

## How?
I added some additional properties to the directive in the HTML. This improves the usability without causing noticeably slower page loading.

**Know issue: Using infinite scroll and scrolling very fast will still cause the initial bug to appear. The directive used for handling this list removes items when they go out of view and adds items as they come close to being visible. The purpose is to improve loading performance. Scrolling fast breaks the internal logic, possibly due to the fast changes in the row indexes and the directive can't keep up with adding items.**