### PR TITLE
Gdb 10937 fixes links to create similarity and chatgpt pages

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -350,10 +350,10 @@
                     "similarity_index": {
                         "label": "Similarity index name",
                         "loading_indexes": "Loading similarity indexes...",
-                        "no_similarity_index_message": {
-                            "message_prefix": "You must",
-                            "link_label": "create a similarity index",
-                            "message_suffix": "to use this method"
+                        "no_similarity_index": {
+                            "message_1": "You must",
+                            "message_2": "create a similarity index",
+                            "message_3": "to use this method"
                         }
                     },
                     "similarity_threshold": {
@@ -361,10 +361,10 @@
                     },
                     "retrieval_search": {
                         "label": "ChatGPT retrieval connector",
-                        "no_retrieval_connectors_message": {
-                            "message_prefix": "You must",
-                            "link_label": "create ChatGPT retrieval connector",
-                            "message_suffix": "to use this method"
+                        "no_retrieval_connectors": {
+                            "message_1": "You must",
+                            "message_2": "create ChatGPT retrieval connector",
+                            "message_3": "to use this method"
                         }
                     },
                     "connector_id": {

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -284,6 +284,9 @@
             "dialog": {
                 "confirm_repository_change_before_open_similarity": {
                     "body": "If you proceed with creating the similarity index, GraphDB will open in a new tab and switch to the <b>{{repositoryId}}</b> repository."
+                },
+                "confirm_repository_change_before_open_connectors": {
+                    "body": "If you proceed with creating the ChatGPT retrieval connector, GraphDB will open in a new tab and switch to the <b>{{repositoryId}}</b> repository."
                 }
             }
         },
@@ -358,7 +361,11 @@
                     },
                     "retrieval_search": {
                         "label": "ChatGPT retrieval connector",
-                        "no_retrieval_connectors_message": "No connector instances.<br/>Create ChatGPT retrieval connector <a href=\"{{retrievalConnectorPage}}\" target=\"_blank\">here</a>."
+                        "no_retrieval_connectors_message": {
+                            "message_prefix": "You must",
+                            "link_label": "create ChatGPT retrieval connector",
+                            "message_suffix": "to use this method"
+                        }
                     },
                     "connector_id": {
                         "label": "ChatGPT retrieval connector"

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -280,6 +280,11 @@
             "messages": {
                 "answer_copy_successful": "The answer was successfully copied to the clipboard.",
                 "answer_copy_failed": "Failed to copy the answer to the clipboard."
+            },
+            "dialog": {
+                "confirm_repository_change_before_open_similarity": {
+                    "body": "If you proceed with creating the similarity index, GraphDB will open in a new tab and switch to the <b>{{repositoryId}}</b> repository."
+                }
             }
         },
         "agent": {
@@ -342,7 +347,11 @@
                     "similarity_index": {
                         "label": "Similarity index name",
                         "loading_indexes": "Loading similarity indexes...",
-                        "no_similarity_index_message": "To use this method, you must have a similarity index created.<br/>Create similarity text index <a href=\"{{similarityIndexPage}}\" target=\"_blank\">here</a>."
+                        "no_similarity_index_message": {
+                            "message_prefix": "You must",
+                            "link_label": "create a similarity index",
+                            "message_suffix": "to use this method"
+                        }
                     },
                     "similarity_threshold": {
                         "label": "Similarity threshold"

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -331,7 +331,7 @@
                     },
                     "fts_search": {
                         "label": "Full-text search",
-                        "fts_disabled_message": "To use this method, you must enable the full-text search (FTS) index on chosen repository and then restart it.<br/>Enable the index: <a href=\"{{repositoryEditPage}}\" target=\"_blank\">here</a>",
+                        "fts_disabled_message": "You must <a href=\"{{repositoryEditPage}}\" target=\"_blank\">enable the full-text search (FTS) index</a> to use this method.",
                         "missing_repository_id": "Repository ID must be selected"
                     },
                     "sparql_search": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -351,10 +351,10 @@
                     "similarity_index": {
                         "label": "Nom de l'index de similarité",
                         "loading_indexes": "Chargement des indices de similarité...",
-                        "no_similarity_index_message": {
-                            "message_prefix": "Vous devez",
-                            "link_label": "créer un index de similarité",
-                            "message_suffix": "pour utiliser cette méthode"
+                        "no_similarity_index": {
+                            "message_1": "Vous devez",
+                            "message_2": "créer un index de similarité",
+                            "message_3": "pour utiliser cette méthode"
                         }
                     },
                     "similarity_threshold": {
@@ -362,10 +362,10 @@
                     },
                     "retrieval_search": {
                         "label": "Connecteur de récupération ChatGPT",
-                        "no_retrieval_connectors_message": {
-                            "message_prefix": "Vous devez",
-                            "link_label": "créer un connecteur de récupération ChatGPT",
-                            "message_suffix": "pour utiliser cette méthode"
+                        "no_retrieval_connectors": {
+                            "message_1": "Vous devez",
+                            "message_2": "créer un connecteur de récupération ChatGPT",
+                            "message_3": "pour utiliser cette méthode"
                         }
                     },
                     "connector_id": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -285,6 +285,9 @@
             "dialog": {
                 "confirm_repository_change_before_open_similarity": {
                     "body": "Si vous continuez à créer l'index de similarité, GraphDB s'ouvrira dans un nouvel onglet et passera au dépôt <b>{{repositoryId}}</b>."
+                },
+                "confirm_repository_change_before_open_connectors": {
+                    "body": "Si vous continuez à créer le connecteur de récupération ChatGPT, GraphDB s'ouvrira dans un nouvel onglet et passera au dépôt <b>{{repositoryId}}</b>."
                 }
             }
         },
@@ -359,7 +362,11 @@
                     },
                     "retrieval_search": {
                         "label": "Connecteur de récupération ChatGPT",
-                        "no_retrieval_connectors_message": "Aucune instance de connecteur.<br/>Créez un connecteur de récupération ChatGPT <a href=\"{{retrievalConnectorPage}}\" target=\"_blank\">ici</a>."
+                        "no_retrieval_connectors_message": {
+                            "message_prefix": "Vous devez",
+                            "link_label": "créer un connecteur de récupération ChatGPT",
+                            "message_suffix": "pour utiliser cette méthode"
+                        }
                     },
                     "connector_id": {
                         "label": "Connecteur de récupération ChatGPT"

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -332,7 +332,7 @@
                     },
                     "fts_search": {
                         "label": "Recherche en texte intégral",
-                        "fts_disabled_message": "Pour utiliser cette méthode, vous devez activer l'index de recherche en texte intégral (FTS) sur le référentiel choisi, puis le redémarrer.<br/> Activez l'index <a href=\"{{repositoryEditPage}}\" target=\"_blank\">ici</a>.",
+                        "fts_disabled_message": "Vous devez <a href=\"{{repositoryEditPage}}\" target=\"_blank\">activer l'index de recherche en texte intégral (FTS)</a> pour utiliser cette méthode.",
                         "missing_repository_id": "L'ID du référentiel doit être sélectionné"
                     },
                     "sparql_search": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -281,6 +281,11 @@
             "messages": {
                 "answer_copy_successful": "La réponse a été copiée avec succès dans le presse-papiers.",
                 "answer_copy_failed": "Échec de la copie de la réponse dans le presse-papiers."
+            },
+            "dialog": {
+                "confirm_repository_change_before_open_similarity": {
+                    "body": "Si vous continuez à créer l'index de similarité, GraphDB s'ouvrira dans un nouvel onglet et passera au dépôt <b>{{repositoryId}}</b>."
+                }
             }
         },
         "agent": {
@@ -343,7 +348,11 @@
                     "similarity_index": {
                         "label": "Nom de l'index de similarité",
                         "loading_indexes": "Chargement des indices de similarité...",
-                        "no_similarity_index_message": "Pour utiliser cette méthode, vous devez avoir créé un index de similarité.<br/>Créez un index de texte de similarité <a href=\"{{similarityIndexPage}}\" target=\"_blank\">ici</a>."
+                        "no_similarity_index_message": {
+                            "message_prefix": "Vous devez",
+                            "link_label": "créer un index de similarité",
+                            "message_suffix": "pour utiliser cette méthode"
+                        }
                     },
                     "similarity_threshold": {
                         "label": "Seuil de similarité"

--- a/src/js/angular/core/services/repositories.service.js
+++ b/src/js/angular/core/services/repositories.service.js
@@ -255,6 +255,16 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
             return repos;
         };
 
+        /**
+         * Gets repository by id.
+         *
+         * @param {string} repositoryId
+         * @return {*}
+         */
+        this.getRepository = function (repositoryId) {
+            return this.getRepositories().find((repository) => repository.id === repositoryId);
+        };
+
         this.getReadableRepositories = function () {
             return _.filter(this.getRepositories(), function (repo) {
                 return $jwtAuth.canReadRepo(repo);

--- a/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -132,7 +132,7 @@ function AgentSettingsModalController($scope, $uibModalInstance, SimilarityServi
         const message = decodeHTML(
             $translate.instant(
                 'ttyg.agent.create_agent_modal.form.fts_search.fts_disabled_message',
-                {repositoryEditPage: '#/repository/edit/' + $scope.activeRepositoryInfo.id}
+                {repositoryEditPage: '#/repository/edit/' + $scope.agentFormModel.repositoryId}
             )
         );
         return $sce.trustAsHtml(message);

--- a/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -169,19 +169,10 @@ function AgentSettingsModalController(
     };
 
     /**
-     * Resolves the hint for the missing retrieval connector message. This is needed because the hint contains a html
-     * link that should be properly rendered.
-     * @return {*}
+     * Opens the 'Connectors' view in a new tab.
      */
-    $scope.getNoRetrievalConnectorHelpMessage = () => {
-        // The hint contains a html link which should be properly rendered.
-        const message = decodeHTML(
-            $translate.instant(
-                'ttyg.agent.create_agent_modal.form.retrieval_search.no_retrieval_connectors_message',
-                {retrievalConnectorPage: '#/connectors'}
-            )
-        );
-        return $sce.trustAsHtml(message);
+    $scope.goToConnectorsView = () => {
+        TTYGContextService.emit(TTYGEventName.GO_TO_CONNECTORS_VIEW, {repositoryId: $scope.agentFormModel.repositoryId});
     };
 
     /**

--- a/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -4,6 +4,7 @@ import 'angular/core/services/similarity.service';
 import 'angular/core/services/connectors.service';
 import 'angular/rest/repositories.rest.service';
 import {REPOSITORY_PARAMS} from "../../models/repository/repository";
+import {TTYGEventName} from "../services/ttyg-context.service";
 
 angular
     .module('graphdb.framework.ttyg.controllers.agent-settings-modal', [
@@ -13,9 +14,31 @@ angular
     ])
     .controller('AgentSettingsModalController', AgentSettingsModalController);
 
-AgentSettingsModalController.$inject = ['$scope', '$uibModalInstance', 'SimilarityService', 'ConnectorsService', 'RepositoriesRestService', '$sce', 'toastr', 'UriUtils', '$translate', 'dialogModel'];
+AgentSettingsModalController.$inject = [
+    '$scope',
+    '$uibModalInstance',
+    'SimilarityService',
+    'ConnectorsService',
+    'RepositoriesRestService',
+    '$sce',
+    'toastr',
+    'UriUtils',
+    '$translate',
+    'dialogModel',
+    'TTYGContextService'];
 
-function AgentSettingsModalController($scope, $uibModalInstance, SimilarityService, ConnectorsService, RepositoriesRestService, $sce, toastr, UriUtils, $translate, dialogModel) {
+function AgentSettingsModalController(
+    $scope,
+    $uibModalInstance,
+    SimilarityService,
+    ConnectorsService,
+    RepositoriesRestService,
+    $sce,
+    toastr,
+    UriUtils,
+    $translate,
+    dialogModel,
+    TTYGContextService) {
 
     // =========================
     // Private variables
@@ -139,19 +162,10 @@ function AgentSettingsModalController($scope, $uibModalInstance, SimilarityServi
     };
 
     /**
-     * Resolves the hint for the missing similarity index message. This is needed because the hint contains a html link
-     * that should be properly rendered.
-     * @return {*}
+     * Opens the 'Create Similarity' view in a new tab.
      */
-    $scope.getNoSimilarityIndexHelpMessage = () => {
-        // The hint contains a html link which should be properly rendered.
-        const message = decodeHTML(
-            $translate.instant(
-                'ttyg.agent.create_agent_modal.form.similarity_index.no_similarity_index_message',
-                {similarityIndexPage: '#/similarity'}
-            )
-        );
-        return $sce.trustAsHtml(message);
+    $scope.goToCreateSimilarityView = () => {
+        TTYGContextService.emit(TTYGEventName.GO_TO_CREATE_SIMILARITY_VIEW, {repositoryId: $scope.agentFormModel.repositoryId});
     };
 
     /**

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -15,6 +15,7 @@ import {agentFormModelMapper, newAgentFormModelProvider} from "../services/agent
 import {SelectMenuOptionsModel} from "../../models/form-fields";
 import {repositoryInfoMapper} from "../../rest/mappers/repositories-mapper";
 import {saveAs} from 'lib/FileSaver-patch';
+import {decodeHTML} from "../../../../app";
 
 const modules = [
     'toastr',
@@ -34,9 +35,37 @@ angular
     .module('graphdb.framework.ttyg.controllers.ttyg-view', modules)
     .controller('TTYGViewCtrl', TTYGViewCtrl);
 
-TTYGViewCtrl.$inject = ['$rootScope', '$scope', '$http', '$timeout', '$translate', '$uibModal', '$repositories', 'toastr', 'ModalService', 'LocalStorageAdapter', 'TTYGService', 'TTYGContextService', 'TTYGStorageService'];
+TTYGViewCtrl.$inject = [
+    '$window',
+    '$rootScope',
+    '$scope',
+    '$http',
+    '$timeout',
+    '$translate',
+    '$uibModal',
+    '$repositories',
+    'toastr',
+    'ModalService',
+    'LocalStorageAdapter',
+    'TTYGService',
+    'TTYGContextService',
+    'TTYGStorageService'];
 
-function TTYGViewCtrl($rootScope, $scope, $http, $timeout, $translate, $uibModal, $repositories, toastr, ModalService, LocalStorageAdapter, TTYGService, TTYGContextService, TTYGStorageService) {
+function TTYGViewCtrl(
+    $window,
+    $rootScope,
+    $scope,
+    $http,
+    $timeout,
+    $translate,
+    $uibModal,
+    $repositories,
+    toastr,
+    ModalService,
+    LocalStorageAdapter,
+    TTYGService,
+    TTYGContextService,
+    TTYGStorageService) {
 
     // =========================
     // Private variables
@@ -599,6 +628,35 @@ function TTYGViewCtrl($rootScope, $scope, $http, $timeout, $translate, $uibModal
     };
 
     /**
+     * Opens the create similarity view. It checks if the passed repository ID matches the one selected by the workbench.
+     * If they do not match, a confirmation dialog is shown to inform the user that the selected repository
+     * will be automatically changed upon confirmation.
+     *
+     * @param {{repositoryId: string}} payload - The payload containing the repository ID.
+     */
+    const onGoToCreateSimilarityView = (payload) => {
+        if (payload.repositoryId !== $repositories.getActiveRepository()) {
+            const repository = $repositories.getRepository(payload.repositoryId);
+            if (repository) {
+                ModalService.openConfirmation(
+                    $translate.instant('common.confirm'),
+                    decodeHTML($translate.instant('ttyg.chat_panel.dialog.confirm_repository_change_before_open_similarity.body', {repositoryId: repository.id})),
+                    () => {
+                        $repositories.setRepository(repository);
+                        openCreateSimilarityView();
+                    });
+            }
+
+        } else {
+            openCreateSimilarityView();
+        }
+    };
+
+    const openCreateSimilarityView = () => {
+        $window.open('/similarity/index/create', '_blank');
+    };
+
+    /**
      * Loads a chat using the chat ID stored in the local storage and selects it.
      */
     const setCurrentChat = () => {
@@ -651,6 +709,7 @@ function TTYGViewCtrl($rootScope, $scope, $http, $timeout, $translate, $uibModal
     subscriptions.push(TTYGContextService.subscribe(TTYGEventName.AGENT_SELECTED, onAgentSelected));
     subscriptions.push(TTYGContextService.subscribe(TTYGEventName.SELECT_CHAT, onChatSelected));
     subscriptions.push(TTYGContextService.subscribe(TTYGEventName.COPY_ANSWER_TO_CLIPBOARD, onCopiedAnswerToClipboard));
+    subscriptions.push(TTYGContextService.subscribe(TTYGEventName.GO_TO_CREATE_SIMILARITY_VIEW, onGoToCreateSimilarityView));
     subscriptions.push($rootScope.$on('$translateChangeSuccess', updateLabels));
     $scope.$on('$destroy', removeAllListeners);
 

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -657,6 +657,35 @@ function TTYGViewCtrl(
     };
 
     /**
+     * Opens the connectors view. It checks if the passed repository ID matches the one selected by the workbench.
+     * If they do not match, a confirmation dialog is shown to inform the user that the selected repository
+     * will be automatically changed upon confirmation.
+     *
+     * @param {{repositoryId: string}} payload - The payload containing the repository ID.
+     */
+    const onGoToConnectorsView = (payload) => {
+        if (payload.repositoryId !== $repositories.getActiveRepository()) {
+            const repository = $repositories.getRepository(payload.repositoryId);
+            if (repository) {
+                ModalService.openConfirmation(
+                    $translate.instant('common.confirm'),
+                    decodeHTML($translate.instant('ttyg.chat_panel.dialog.confirm_repository_change_before_open_connectors.body', {repositoryId: repository.id})),
+                    () => {
+                        $repositories.setRepository(repository);
+                        openConnectorsView();
+                    });
+            }
+
+        } else {
+            openConnectorsView();
+        }
+    };
+
+    const openConnectorsView = () => {
+        $window.open('/connectors', '_blank');
+    };
+
+    /**
      * Loads a chat using the chat ID stored in the local storage and selects it.
      */
     const setCurrentChat = () => {
@@ -710,6 +739,7 @@ function TTYGViewCtrl(
     subscriptions.push(TTYGContextService.subscribe(TTYGEventName.SELECT_CHAT, onChatSelected));
     subscriptions.push(TTYGContextService.subscribe(TTYGEventName.COPY_ANSWER_TO_CLIPBOARD, onCopiedAnswerToClipboard));
     subscriptions.push(TTYGContextService.subscribe(TTYGEventName.GO_TO_CREATE_SIMILARITY_VIEW, onGoToCreateSimilarityView));
+    subscriptions.push(TTYGContextService.subscribe(TTYGEventName.GO_TO_CONNECTORS_VIEW, onGoToConnectorsView));
     subscriptions.push($rootScope.$on('$translateChangeSuccess', updateLabels));
     $scope.$on('$destroy', removeAllListeners);
 

--- a/src/js/angular/ttyg/services/ttyg-context.service.js
+++ b/src/js/angular/ttyg/services/ttyg-context.service.js
@@ -329,5 +329,10 @@ export const TTYGEventName = {
     /**
      * This event will be emitted when copying an answer to the clipboard fails.
      */
-    COPY_ANSWER_TO_CLIPBOARD_FAILURE: 'copyAnswerToClipboardFailure'
+    COPY_ANSWER_TO_CLIPBOARD_FAILURE: 'copyAnswerToClipboardFailure',
+
+    /**
+     * This event will trigger the opening of the similarity view.
+     */
+    GO_TO_CREATE_SIMILARITY_VIEW: "goToCreateSimilarityView"
 };

--- a/src/js/angular/ttyg/services/ttyg-context.service.js
+++ b/src/js/angular/ttyg/services/ttyg-context.service.js
@@ -334,5 +334,10 @@ export const TTYGEventName = {
     /**
      * This event will trigger the opening of the similarity view.
      */
-    GO_TO_CREATE_SIMILARITY_VIEW: "goToCreateSimilarityView"
+    GO_TO_CREATE_SIMILARITY_VIEW: "goToCreateSimilarityView",
+
+    /**
+     * This event will trigger the opening of the connectors view.
+     */
+    GO_TO_CONNECTORS_VIEW: "goToConnectorsView"
 };

--- a/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -188,8 +188,12 @@
 
                         <div ng-if="extractionMethod.method === extractionMethods.RETRIEVAL"
                              class="extraction-method-options">
-                            <div ng-if="!retrievalConnectors.length" class="no-retrieval-connector-message"
-                                 ng-bind-html="getNoRetrievalConnectorHelpMessage()">
+                            <div ng-if="!retrievalConnectors.length" class="no-retrieval-connector-message">
+                                {{'ttyg.agent.create_agent_modal.form.retrieval_search.no_retrieval_connectors_message.message_prefix' | translate}}
+                                <a href="#" ng-click="goToConnectorsView()">
+                                    {{'ttyg.agent.create_agent_modal.form.retrieval_search.no_retrieval_connectors_message.link_label' | translate}}
+                                </a>
+                                {{'ttyg.agent.create_agent_modal.form.retrieval_search.no_retrieval_connectors_message.message_suffix' | translate}}.
                             </div>
                             <div ng-show="retrievalConnectors.length">
                                 <div class="form-group retrieval-connector">

--- a/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -134,8 +134,12 @@
 
                         <div ng-if="extractionMethod.method === extractionMethods.SIMILARITY"
                              class="extraction-method-options">
-                            <div ng-if="!similarityIndexes.length" class="no-similarity-index-message"
-                                 ng-bind-html="getNoSimilarityIndexHelpMessage()">
+                            <div ng-if="!similarityIndexes.length" class="no-similarity-index-message">
+                                {{'ttyg.agent.create_agent_modal.form.similarity_index.no_similarity_index_message.message_prefix' | translate}}
+                                <a href="#" ng-click="goToCreateSimilarityView()">
+                                    {{'ttyg.agent.create_agent_modal.form.similarity_index.no_similarity_index_message.link_label' | translate}}
+                                </a>
+                                {{'ttyg.agent.create_agent_modal.form.similarity_index.no_similarity_index_message.message_suffix' | translate}}.
                             </div>
                             <div ng-show="similarityIndexes.length">
                                 <div class="form-group similarity-index">

--- a/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -135,11 +135,11 @@
                         <div ng-if="extractionMethod.method === extractionMethods.SIMILARITY"
                              class="extraction-method-options">
                             <div ng-if="!similarityIndexes.length" class="no-similarity-index-message">
-                                {{'ttyg.agent.create_agent_modal.form.similarity_index.no_similarity_index_message.message_prefix' | translate}}
+                                {{'ttyg.agent.create_agent_modal.form.similarity_index.no_similarity_index.message_1' | translate}}
                                 <a href="#" ng-click="goToCreateSimilarityView()">
-                                    {{'ttyg.agent.create_agent_modal.form.similarity_index.no_similarity_index_message.link_label' | translate}}
+                                    {{'ttyg.agent.create_agent_modal.form.similarity_index.no_similarity_index.message_2' | translate}}
                                 </a>
-                                {{'ttyg.agent.create_agent_modal.form.similarity_index.no_similarity_index_message.message_suffix' | translate}}.
+                                {{'ttyg.agent.create_agent_modal.form.similarity_index.no_similarity_index.message_3' | translate}}.
                             </div>
                             <div ng-show="similarityIndexes.length">
                                 <div class="form-group similarity-index">
@@ -189,11 +189,11 @@
                         <div ng-if="extractionMethod.method === extractionMethods.RETRIEVAL"
                              class="extraction-method-options">
                             <div ng-if="!retrievalConnectors.length" class="no-retrieval-connector-message">
-                                {{'ttyg.agent.create_agent_modal.form.retrieval_search.no_retrieval_connectors_message.message_prefix' | translate}}
+                                {{'ttyg.agent.create_agent_modal.form.retrieval_search.no_retrieval_connectors.message_1' | translate}}
                                 <a href="#" ng-click="goToConnectorsView()">
-                                    {{'ttyg.agent.create_agent_modal.form.retrieval_search.no_retrieval_connectors_message.link_label' | translate}}
+                                    {{'ttyg.agent.create_agent_modal.form.retrieval_search.no_retrieval_connectors.message_2' | translate}}
                                 </a>
-                                {{'ttyg.agent.create_agent_modal.form.retrieval_search.no_retrieval_connectors_message.message_suffix' | translate}}.
+                                {{'ttyg.agent.create_agent_modal.form.retrieval_search.no_retrieval_connectors.message_3' | translate}}.
                             </div>
                             <div ng-show="retrievalConnectors.length">
                                 <div class="form-group retrieval-connector">

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -350,10 +350,10 @@
                     "similarity_index": {
                         "label": "Similarity index name",
                         "loading_indexes": "Loading similarity indexes...",
-                        "no_similarity_index_message": {
-                            "message_prefix": "You must",
-                            "link_label": "create a similarity index",
-                            "message_suffix": "to use this method"
+                        "no_similarity_index": {
+                            "message_1": "You must",
+                            "message_2": "create a similarity index",
+                            "message_3": "to use this method"
                         }
                     },
                     "similarity_threshold": {
@@ -361,10 +361,10 @@
                     },
                     "retrieval_search": {
                         "label": "ChatGPT retrieval connector",
-                        "no_retrieval_connectors_message": {
-                            "message_prefix": "You must",
-                            "link_label": "create ChatGPT retrieval connector",
-                            "message_suffix": "to use this method"
+                        "no_retrieval_connectors": {
+                            "message_1": "You must",
+                            "message_2": "create ChatGPT retrieval connector",
+                            "message_3": "to use this method"
                         }
                     },
                     "connector_id": {

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -284,6 +284,9 @@
             "dialog": {
                 "confirm_repository_change_before_open_similarity": {
                     "body": "If you proceed with creating the similarity index, GraphDB will open in a new tab and switch to the <b>{{repositoryId}}</b> repository."
+                },
+                "confirm_repository_change_before_open_connectors": {
+                    "body": "If you proceed with creating the ChatGPT retrieval connector, GraphDB will open in a new tab and switch to the <b>{{repositoryId}}</b> repository."
                 }
             }
         },
@@ -358,7 +361,11 @@
                     },
                     "retrieval_search": {
                         "label": "ChatGPT retrieval connector",
-                        "no_retrieval_connectors_message": "No connector instances.<br/>Create ChatGPT retrieval connector <a href=\"{{retrievalConnectorPage}}\" target=\"_blank\">here</a>."
+                        "no_retrieval_connectors_message": {
+                            "message_prefix": "You must",
+                            "link_label": "create ChatGPT retrieval connector",
+                            "message_suffix": "to use this method"
+                        }
                     },
                     "connector_id": {
                         "label": "ChatGPT retrieval connector"

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -280,6 +280,11 @@
             "messages": {
                 "answer_copy_successful": "The answer was successfully copied to the clipboard.",
                 "answer_copy_failed": "Failed to copy the answer to the clipboard."
+            },
+            "dialog": {
+                "confirm_repository_change_before_open_similarity": {
+                    "body": "If you proceed with creating the similarity index, GraphDB will open in a new tab and switch to the <b>{{repositoryId}}</b> repository."
+                }
             }
         },
         "agent": {
@@ -342,7 +347,11 @@
                     "similarity_index": {
                         "label": "Similarity index name",
                         "loading_indexes": "Loading similarity indexes...",
-                        "no_similarity_index_message": "To use this method, you must have a similarity index created.<br/>Create similarity text index <a href=\"{{similarityIndexPage}}\" target=\"_blank\">here</a>."
+                        "no_similarity_index_message": {
+                            "message_prefix": "You must",
+                            "link_label": "create a similarity index",
+                            "message_suffix": "to use this method"
+                        }
                     },
                     "similarity_threshold": {
                         "label": "Similarity threshold"

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -331,7 +331,7 @@
                     },
                     "fts_search": {
                         "label": "Full-text search",
-                        "fts_disabled_message": "To use this method, you must enable the full-text search (FTS) index on chosen repository and then restart it.<br/>Enable the index: <a href=\"{{repositoryEditPage}}\" target=\"_blank\">here</a>",
+                        "fts_disabled_message": "You must <a href=\"{{repositoryEditPage}}\" target=\"_blank\">enable the full-text search (FTS) index</a> to use this method.",
                         "missing_repository_id": "Repository ID must be selected"
                     },
                     "sparql_search": {

--- a/test-cypress/integration/ttyg/chat-list.spec.js
+++ b/test-cypress/integration/ttyg/chat-list.spec.js
@@ -5,7 +5,6 @@ import {RepositoriesStubs} from "../../stubs/repositories/repositories-stubs";
 import {ApplicationSteps} from "../../steps/application-steps";
 import HomeSteps from "../../steps/home-steps";
 
-// TODO: This test is skipped because it fails on CI. For some reason the chat list panel is not visible.
 describe('TTYG chat list', () => {
 
     beforeEach(() => {

--- a/test-cypress/integration/ttyg/ttyg-view.spec.js
+++ b/test-cypress/integration/ttyg/ttyg-view.spec.js
@@ -14,13 +14,13 @@ describe('TTYG view', () => {
         NamespaceStubs.stubNameSpaceResponse(repositoryId, '/namespaces/get-repository-starwars-namespaces.json');
     });
 
-    // TODO: This test is skipped because it fails on CI. For some reason the chat list panel is not visible.
-    it.skip('Should load ttyg page and render main components', () => {
+    it('Should load ttyg page and render main components', () => {
         TTYGStubs.stubChatsListGet();
         TTYGStubs.stubAgentListGet();
         TTYGStubs.stubChatGet();
         // Given I have opened the ttyg page
         TTYGViewSteps.visit();
+        cy.wait('@get-chat');
         // When the ttyg page is loaded
         // Then I should see the ttyg view
         TTYGViewSteps.getTtygView().should('exist');
@@ -28,8 +28,8 @@ describe('TTYG view', () => {
         // Verify the chats sidebar
         TTYGViewSteps.getChatsPanel().should('be.visible');
         TTYGViewSteps.getToggleChatsSidebarButton().should('be.visible');
-        // The create chat button is hidden by default when there are no chats
-        TTYGViewSteps.getCreateChatButton().should('not.exist');
+        // The create chat button is visible when there are chats
+        TTYGViewSteps.getCreateChatButton().should('exist');
         // Verify the agents sidebar
         TTYGViewSteps.getAgentsPanel().should('be.visible');
         TTYGViewSteps.getHelpButton().should('be.visible');


### PR DESCRIPTION
## What
Added confirmation dialog for repository change when the user clicks on a link redirecting to the create similarity page or create ChatGPT retrieval connector.

## Why
The both pages depends on the selected repository. To allow the user to create an index or connector in the repository chosen in the create agent dialog, the repository must be changed before navigating to the create similarity or create ChatGPT page if the repository selected in the workbench differs from the one in the dialog.

## How
Added a check to control when the confirmation dialog is displayed and when the user is redirected without prompting.