### PR TITLE
GDB-10897 - Import page "copy" button fallback added for non-secure contexts

### DIFF
--- a/src/js/angular/core/directives/copy-to-clipboard/copy-to-clipboard.directive.js
+++ b/src/js/angular/core/directives/copy-to-clipboard/copy-to-clipboard.directive.js
@@ -45,6 +45,7 @@ function copyToClipboard($translate, toastr) {
         },
         link: function ($scope, element) {
             $scope.copyToClipboard = function() {
+                console.log('is secure context: ', window.isSecureContext);
                 const textToCopy = element.parent().find('.copyable').text();
                 navigator.clipboard.writeText(textToCopy).then(() => {
                     toastr.success($translate.instant('import.help.messages.copied_to_clipboard'));


### PR DESCRIPTION
## What?
When the Workbench is opened in a way, which doesn't have a secure context, or if `navigator.clipboard` is not supported, the text copying functionality will still work.

## Why?
Some copy buttons in the WB did not work  when the document was not in a secure context.

## How?
I added a fallback option using `document.execCommand('copy');`, as used in other views (e.g. repository URL copy button).