### PR TITLE
GDB-10913 - On failed import, hide the invalid timestamp in the status info

### DIFF
--- a/src/js/angular/import/templates/import-resource-status-info.html
+++ b/src/js/angular/import/templates/import-resource-status-info.html
@@ -96,7 +96,7 @@
                 </td>
                 <td class="break-word">
                     <div class="value">
-                        {{importedOn | date:'yyyy-MM-dd, HH:mm' }}
+                        {{importedOn ? (importedOn | date:'yyyy-MM-dd, HH:mm') : '' }}
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
## What?
When a file import fails, an incorrect timestamp will not be displayed in the status info dialog. In this case, the timestamp will be hidden.

## Why?
The back-end returns "0" for `importedOn` in the case of a failed import. This incorrectly gets filtered into a date.

## How?
I added a condition to show the date only if it's defined.

## Screenshots?
![Screenshot from 2024-10-02 17-39-50](https://github.com/user-attachments/assets/1a53cb58-fd0a-4d04-aedd-96387def349b)
