### PR TITLE
(cherry-pick) Upgrade ontotext-yasgui-web-component version to 1.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.3.17",
+                "ontotext-yasgui-web-component": "1.3.18",
                 "shepherd.js": "^11.2.0"
             },
             "devDependencies": {
@@ -9137,9 +9137,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.17",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.17.tgz",
-            "integrity": "sha512-5/WzugiaBVtJC36ooiXOL3A7fDdn8Dk6aStoSM7PVfMF2iWOnWV3HXCrOQT0mGDzWmXWf/zLe8s4oqIpFBrnjQ==",
+            "version": "1.3.18",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.18.tgz",
+            "integrity": "sha512-Ll24Pzkp24jYy0KFYHDg0jj2xcugIMtOXDtchmt7CHxfTQlZ49drLA4eobWrcZCA/t4UC2VRo/qO/FG7J8gIbQ==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"
@@ -22530,9 +22530,9 @@
             }
         },
         "ontotext-yasgui-web-component": {
-            "version": "1.3.17",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.17.tgz",
-            "integrity": "sha512-5/WzugiaBVtJC36ooiXOL3A7fDdn8Dk6aStoSM7PVfMF2iWOnWV3HXCrOQT0mGDzWmXWf/zLe8s4oqIpFBrnjQ==",
+            "version": "1.3.18",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.18.tgz",
+            "integrity": "sha512-Ll24Pzkp24jYy0KFYHDg0jj2xcugIMtOXDtchmt7CHxfTQlZ49drLA4eobWrcZCA/t4UC2VRo/qO/FG7J8gIbQ==",
             "requires": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.3.17",
+        "ontotext-yasgui-web-component": "1.3.18",
         "shepherd.js": "^11.2.0"
     },
     "resolutions": {


### PR DESCRIPTION
## What?
Increase the version of the ontotext-yasgui-web-component.
New in this version:

- GDB-10876 - Add escape HTML entity "&"

## Why?
The new version of the component includes a functionality fix to reduce XSS attacks.

## How?
Version increased.

(cherry picked from commit 7687740ec3df526539103421d4a1ccd208d3355c)