### PR TITLE
fix(GDB-10854) Remove unused locations

### DIFF
--- a/src/css/cluster-list.css
+++ b/src/css/cluster-list.css
@@ -21,10 +21,8 @@
     padding: 0 12px 12px 12px;
 }
 
-.labels-row {
-    th {
-        border-top: none;
-    }
+.labels-row th {
+    border-top: none;
 }
 
 @media (min-width: 1440px) {
@@ -47,17 +45,16 @@
     width: 36px;
     padding-left: 12px;
     border-left: 1px solid #eceeef;
-
 }
 
 .location-cell {
     width: 50%;
     border-left: 1px solid #eceeef;
+}
 
-    .autocomplete-container>.textarea-edit {
-        font-size: 1rem;
-        min-height: 32px;
-    }
+.location-cell .autocomplete-container>.textarea-edit {
+    font-size: 1rem;
+    min-height: 32px;
 }
 
 .location-cell.adding {
@@ -74,24 +71,28 @@
 
 .status-cell {
     border-left: 1px solid #eceeef;
-    .adding {
-        color: var(--color-success-dark);
-    }
-    .deleting {
-        color: var(--color-warning-dark);
-    }
-    .status-icon {
-        padding: 0 4px;
-    }
+}
+
+.status-cell .adding {
+    color: var(--color-success-dark);
+}
+
+.status-cell .deleting {
+    color: var(--color-warning-dark);
+}
+
+.status-cell .status-icon {
+    padding: 0 4px;
 }
 
 .actions-cell {
     width: 80px;
     border-left: 1px solid #eceeef;
     border-right: 1px solid #eceeef;
-    .btn-link, .btn-link a {
-        padding: 0.4em .4em;
-    }
+}
+
+.actions-cell .btn-link, .actions-cell .btn-link a {
+    padding: 0.4em .4em;
 }
 
 .delete-node-tooltip {

--- a/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
+++ b/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
@@ -86,7 +86,9 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
     };
 
     $scope.showUpdateClusterGroupDialog = () => {
+        $scope.setLoader(true);
         getLocationsWithRpcAddresses().then(() => {
+            $scope.setLoader(false);
             return $uibModal.open({
                 templateUrl: 'js/angular/clustermanagement/templates/modal/update-cluster-group-dialog.html',
                 controller: 'UpdateClusterGroupDialogCtrl',

--- a/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
+++ b/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
@@ -108,6 +108,9 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
                 const nodes = cluster.getUpdateActions();
                 editCluster(nodes);
             }
+        }).catch((error) => {
+            $scope.setLoader(false);
+            console.error(error); // eslint-disable-line no-console
         }).finally(() => {
             getLocationsWithRpcAddresses();
         });

--- a/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
+++ b/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
@@ -203,7 +203,7 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
             })
             .finally(() => {
                 $scope.setLoader(false);
-                updateCluster(true);
+                updateCluster(true, true);
             });
     };
 
@@ -340,15 +340,6 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
             });
     };
 
-    // Delete location
-    const deleteLocation = (location) => {
-        return ModalService.openSimpleModal({
-            title: $translate.instant('location.confirm.detach'),
-            message: $translate.instant('location.confirm.detach.warning', {uri: location.endpoint}),
-            warning: true
-        }).result.then(() => $repositories.deleteLocation(location.endpoint));
-    };
-
     const onAddRemoveSuccess = (message) => {
         toastr.success(message);
         $scope.getClusterConfiguration();
@@ -389,13 +380,6 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
         if ($scope.selectedNode && nodeTooltipElement !== targetEl && !nodeTooltipElement.contains(targetEl)) {
             selectNode(null);
         }
-    };
-
-
-    const shouldSkipNodesUpdate = (nodes) => {
-        return (!nodes ||
-            (Array.isArray(nodes) && nodes.length === 0) ||
-            (nodes.oldNodes && nodes.newNodes && nodes.oldNodes.length === 0 && nodes.newNodes.length === 0));
     };
 
     // =========================

--- a/src/js/angular/clustermanagement/directives/cluster-list.directive.js
+++ b/src/js/angular/clustermanagement/directives/cluster-list.directive.js
@@ -103,6 +103,7 @@ function ClusterListComponent($translate, $timeout, $repositories, productInfo, 
                         })
                         .catch((error) => {
                             handleErrors(error.data, error.status);
+                            $repositories.deleteLocation(endpoint);
                             ClusterContextService.emitUpdateClusterView();
                         })
                         .finally(() => {

--- a/src/js/angular/clustermanagement/directives/cluster-list.directive.js
+++ b/src/js/angular/clustermanagement/directives/cluster-list.directive.js
@@ -4,9 +4,9 @@ const modules = [];
 angular.module('graphdb.framework.clustermanagement.directives.cluster-list', modules)
     .directive('clusterList', ClusterListComponent);
 
-ClusterListComponent.$inject = ['$translate', '$timeout', '$repositories', 'productInfo', 'toastr', 'RemoteLocationsService', 'ClusterContextService', 'ModalService'];
+ClusterListComponent.$inject = ['$translate', '$timeout', 'productInfo', 'toastr', 'RemoteLocationsService', 'ClusterContextService', 'ModalService'];
 
-function ClusterListComponent($translate, $timeout, $repositories, productInfo, toastr, RemoteLocationsService, ClusterContextService, ModalService) {
+function ClusterListComponent($translate, $timeout, productInfo, toastr, RemoteLocationsService, ClusterContextService, ModalService) {
     return {
         restrict: 'E',
         templateUrl: 'js/angular/clustermanagement/templates/cluster-list.html',
@@ -103,7 +103,7 @@ function ClusterListComponent($translate, $timeout, $repositories, productInfo, 
                         })
                         .catch((error) => {
                             handleErrors(error.data, error.status);
-                            $repositories.deleteLocation(endpoint);
+                            RemoteLocationsService.deleteLocation(endpoint);
                             ClusterContextService.emitUpdateClusterView();
                         })
                         .finally(() => {

--- a/src/js/angular/clustermanagement/directives/cluster-list.directive.js
+++ b/src/js/angular/clustermanagement/directives/cluster-list.directive.js
@@ -237,10 +237,6 @@ function ClusterListComponent($translate, $timeout, $repositories, productInfo, 
             const addNewLocation = (newLocation) => {
                 return RemoteLocationsService.addLocationHttp(newLocation)
                     .then((location) => {
-                        if (location.error) {
-                            handleErrors(location.error);
-                            return;
-                        }
                         if (location) {
                             return Location.fromJSON(location);
                         }

--- a/src/js/angular/clustermanagement/services/remote-locations.service.js
+++ b/src/js/angular/clustermanagement/services/remote-locations.service.js
@@ -8,10 +8,11 @@ RemoteLocationsService.$inject = ['$http', 'toastr', '$uibModal', 'LocationsRest
 
 function RemoteLocationsService($http, toastr, $uibModal, LocationsRestService, $translate) {
     return {
-        addLocationHttp: addLocationHttp,
-        getLocationsWithRpcAddresses: getLocationsWithRpcAddresses,
-        createNewLocation: createNewLocation,
-        isInCluster: isInCluster
+        addLocationHttp,
+        getLocationsWithRpcAddresses,
+        createNewLocation,
+        isInCluster,
+        deleteLocation
     };
 
     function getLocationsWithRpcAddresses() {
@@ -113,5 +114,9 @@ function RemoteLocationsService($http, toastr, $uibModal, LocationsRestService, 
 
     function isInCluster(clusterNodes, location) {
         return clusterNodes.some((node) => location.rpcAddress === node.address);
+    }
+
+    function deleteLocation(endpoint) {
+        return LocationsRestService.deleteLocation(endpoint);
     }
 }


### PR DESCRIPTION
### WHAT
 Remove unused locations after cluster update. Locations with errors during creation are also removed.

 ## WHY
 To sanitize unused locations as they are unnecessary and slow down cluster configuration processes.

 ## HOW
 - Modified the `cluster-list.directive.js` and `cluster-management.controller.js` to delete locations after an error during the cluster update process and after cluster update.
 - Removed the unused methods.
 - Refactored `cluster-list.css` by removing nested rules left