### PR TITLE
GDB-10937: Reloads similarity indexes and ChatGPT connectors when the repository is changed

### DIFF
--- a/src/css/ttyg/agent-settings-modal.css
+++ b/src/css/ttyg/agent-settings-modal.css
@@ -45,7 +45,7 @@
     padding: 1rem 1rem 1rem 3.6rem;
 }
 
-.agent-settings-form .additional-extraction-methods .additional-extraction-method {
+.agent-settings-modal .agent-settings-form .additional-extraction-methods .additional-extraction-method {
     padding: 0 10px;
 }
 
@@ -53,9 +53,7 @@
     width: 100%
 }
 
-.agent-settings-form #similarityIndexThresholdSlider,
-.agent-settings-form #temperatureSlider,
-.agent-settings-form #topPSlider {
+.agent-settings-modal .agent-settings-form [type="range"] {
     position: relative;
     /* move the slider up next to the related input field to match the mockup */
     top: -6px;

--- a/src/css/ttyg/agent-settings-modal.css
+++ b/src/css/ttyg/agent-settings-modal.css
@@ -32,19 +32,7 @@
     justify-content: space-between;
 }
 
-.agent-settings-modal .agent-settings-form .extraction-methods .extraction-method-heading .panel-toggle-link .toggle-icon {
-    transition: transform 0.3s ease;
-}
-
-.agent-settings-modal .agent-settings-form .extraction-methods .extraction-method-heading .panel-toggle-link.collapsed .toggle-icon {
-    transform: rotate(0deg);
-}
-
-.agent-settings-modal .agent-settings-form .extraction-methods .extraction-method-heading .panel-toggle-link .toggle-icon {
-    transform: rotate(180deg);
-}
-
-.agent-settings-modal .agent-settings-form .extraction-methods .extraction-method-heading.selected .panel-toggle-link {
+.agent-settings-form .extraction-methods .extraction-method-heading.selected .panel-toggle-link {
     font-weight: var(--field-label-weight);
 }
 
@@ -75,4 +63,12 @@
     /* move the slider up next to the related input field to match the mockup */
     top: -6px;
     accent-color: var(--secondary-color);
+}
+
+.agent-settings-form .panel-toggle-link .toggle-icon {
+    transition: transform 0.3s ease; /* Smooth transition */
+}
+
+.extraction-method .panel-toggle-link .toggle-icon.expanded {
+    transform: rotate(180deg);
 }

--- a/src/css/ttyg/agent-settings-modal.css
+++ b/src/css/ttyg/agent-settings-modal.css
@@ -53,7 +53,9 @@
     width: 100%
 }
 
-.agent-settings-modal .agent-settings-form [type="range"] {
+.agent-settings-form #similarityIndexThresholdSlider,
+.agent-settings-form #temperatureSlider,
+.agent-settings-form #topPSlider {
     position: relative;
     /* move the slider up next to the related input field to match the mockup */
     top: -6px;

--- a/src/css/ttyg/agent-settings-modal.css
+++ b/src/css/ttyg/agent-settings-modal.css
@@ -45,12 +45,7 @@
     padding: 1rem 1rem 1rem 3.6rem;
 }
 
-/* when the panel is expanded */
-.agent-settings-modal .agent-settings-form .extraction-methods .extraction-method:has(.extraction-method-content.in) {
-    background-color: var(--base-background-color);
-}
-
-.agent-settings-modal .agent-settings-form .additional-extraction-methods .additional-extraction-method {
+.agent-settings-form .additional-extraction-methods .additional-extraction-method {
     padding: 0 10px;
 }
 
@@ -71,4 +66,9 @@
 
 .extraction-method .panel-toggle-link .toggle-icon.expanded {
     transform: rotate(180deg);
+}
+
+/* when the panel is expanded */
+.agent-settings-form .extraction-methods .extraction-method:has(.expanded) {
+    background-color: var(--base-background-color);
 }

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -368,6 +368,11 @@
                             "message_1": "You must",
                             "message_2": "create a similarity index",
                             "message_3": "to use this method"
+                        },
+                        "btn": {
+                            "reload": {
+                                "tooltip": "Refresh the similarity indexes."
+                            }
                         }
                     },
                     "similarity_threshold": {
@@ -379,6 +384,11 @@
                             "message_1": "You must",
                             "message_2": "create ChatGPT retrieval connector",
                             "message_3": "to use this method"
+                        },
+                        "btn": {
+                            "reload": {
+                                "tooltip": "Refresh the ChatGPT retrieval connectors."
+                            }
                         }
                     },
                     "connector_id": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -368,6 +368,11 @@
                             "message_1": "Vous devez",
                             "message_2": "créer un index de similarité",
                             "message_3": "pour utiliser cette méthode"
+                        },
+                        "btn": {
+                            "reload": {
+                                "tooltip": "Rafraîchir les index de similarité."
+                            }
                         }
                     },
                     "similarity_threshold": {
@@ -379,6 +384,11 @@
                             "message_1": "Vous devez",
                             "message_2": "créer un connecteur de récupération ChatGPT",
                             "message_3": "pour utiliser cette méthode"
+                        },
+                        "btn": {
+                            "reload": {
+                                "tooltip": "Rafraîchir les connecteurs de récupération ChatGPT."
+                            }
                         }
                     },
                     "connector_id": {

--- a/src/js/angular/core/interceptors/authentication.interceptor.js
+++ b/src/js/angular/core/interceptors/authentication.interceptor.js
@@ -30,11 +30,13 @@ angular.module('graphdb.framework.core.interceptors.authentication', [
                         headers.Authorization = AuthTokenService.getAuthToken();
                     }
 
-                    const repositoryId = LocalStorageAdapter.get(LSKeys.REPOSITORY_ID);
-                    const repositoryLocation = LocalStorageAdapter.get(LSKeys.REPOSITORY_LOCATION);
+                    if (!headers['X-GraphDB-Repository']) {
+                        const repositoryId = LocalStorageAdapter.get(LSKeys.REPOSITORY_ID);
+                        const repositoryLocation = LocalStorageAdapter.get(LSKeys.REPOSITORY_LOCATION);
 
-                    headers['X-GraphDB-Repository'] = repositoryId ? repositoryId : undefined;
-                    headers['X-GraphDB-Repository-Location'] = repositoryLocation ? repositoryLocation : undefined;
+                        headers['X-GraphDB-Repository'] = repositoryId ? repositoryId : undefined;
+                        headers['X-GraphDB-Repository-Location'] = repositoryLocation ? repositoryLocation : undefined;
+                    }
 
                     config.headers = headers;
                     return config;

--- a/src/js/angular/core/services/connectors.service.js
+++ b/src/js/angular/core/services/connectors.service.js
@@ -14,7 +14,7 @@ function ConnectorsService(ConnectorsRestService) {
 
     /**
      * Fetches all connector types from the server for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
-     * If the repository ID and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     * If the repository ID and repository location are not provided, the currently selected repository will be used.
      *
      * @param {string} repositoryId - (optional) The repository id.
      * @param {string} repositoryLocation - (optional) The repository location.
@@ -27,7 +27,7 @@ function ConnectorsService(ConnectorsRestService) {
 
     /**
      * Fetches the connector prefix by its name for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
-     * If the repository ID and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     * If the repository ID and repository location are not provided, the currently selected repository will be used.
      *
      * @param {string} name
      * @param {string} repositoryId - (optional) The repository id.
@@ -44,8 +44,7 @@ function ConnectorsService(ConnectorsRestService) {
 
     /**
      * Fetches all connectors of a specific type defined by the prefix for the repository with id <code>repositoryId</code>
-     * and location <code>repositoryLocation</code>. If the repository ID and repository location are not provided,
-     * the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     * and location <code>repositoryLocation</code>. If the repository ID and repository location are not provided, the currently selected repository will be used.
      * @param {string} prefix
      * @param {string} repositoryId - (optional) The repository id.
      * @param {string} repositoryLocation - (optional) The repository location.
@@ -60,8 +59,8 @@ function ConnectorsService(ConnectorsRestService) {
 
     /**
      * Fetches all connectors of a specific type defined by the prefix and returns them as SelectMenuOptionsModel
-     * for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>. If the repository ID
-     * and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     * for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
+     * If the repository ID and repository location are not provided, the currently selected repository will be used.
      * @param {string} prefix
      * @param {string} repositoryId - (optional) The repository id.
      * @param {string} repositoryLocation - (optional) The repository location.

--- a/src/js/angular/core/services/connectors.service.js
+++ b/src/js/angular/core/services/connectors.service.js
@@ -13,21 +13,29 @@ ConnectorsService.$inject = ['ConnectorsRestService'];
 function ConnectorsService(ConnectorsRestService) {
 
     /**
-     * Fetches all connector types from the server.
+     * Fetches all connector types from the server for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
+     * If the repository ID and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     *
+     * @param {string} repositoryId - (optional) The repository id.
+     * @param {string} repositoryLocation - (optional) The repository location.
      * @return {Promise<ConnectorTypesListModel>}
      */
-    const getConnectorTypes = () => {
-        return ConnectorsRestService.getConnectors()
+    const getConnectorTypes = (repositoryId, repositoryLocation) => {
+        return ConnectorsRestService.getConnectors(repositoryId, repositoryLocation)
             .then((response) => connectorTypesListMapper(response.data));
     };
 
     /**
-     * Fetches the connector prefix by its name.
+     * Fetches the connector prefix by its name for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
+     * If the repository ID and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     *
      * @param {string} name
+     * @param {string} repositoryId - (optional) The repository id.
+     * @param {string} repositoryLocation - (optional) The repository location.
      * @return {Promise<string|null>}
      */
-    const getConnectorPrefixByName = (name) => {
-        return getConnectorTypes()
+    const getConnectorPrefixByName = (name, repositoryId, repositoryLocation) => {
+        return getConnectorTypes(repositoryId, repositoryLocation)
             .then((connectorTypesModel) => {
                 const connector = connectorTypesModel.getConnectorByName(name);
                 return connector ? connector.prefix : null;
@@ -35,22 +43,32 @@ function ConnectorsService(ConnectorsRestService) {
     };
 
     /**
-     * Fetches all connectors of a specific type defined by the prefix.
+     * Fetches all connectors of a specific type defined by the prefix for the repository with id <code>repositoryId</code>
+     * and location <code>repositoryLocation</code>. If the repository ID and repository location are not provided,
+     * the values persisted in local storage will be used {@see authentication.interceptor.js}.
      * @param {string} prefix
+     * @param {string} repositoryId - (optional) The repository id.
+     * @param {string} repositoryLocation - (optional) The repository location.
      * @return {Promise<ConnectorListModel>}
      */
-    const getConnectorsByType = (prefix) => {
-        return ConnectorsRestService.hasConnector(encodeURIComponent(prefix))
-            .then((response) => connectorsMapper(response.data));
+    const getConnectorsByType = (prefix, repositoryId, repositoryLocation) => {
+        return ConnectorsRestService.hasConnector(encodeURIComponent(prefix), repositoryId, repositoryLocation)
+            .then((response) => {
+                return connectorsMapper(response.data);
+            });
     };
 
     /**
-     * Fetches all connectors of a specific type defined by the prefix and returns them as SelectMenuOptionsModel.
+     * Fetches all connectors of a specific type defined by the prefix and returns them as SelectMenuOptionsModel
+     * for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>. If the repository ID
+     * and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
      * @param {string} prefix
+     * @param {string} repositoryId - (optional) The repository id.
+     * @param {string} repositoryLocation - (optional) The repository location.
      * @return {Promise<SelectMenuOptionsModel[]>}
      */
-    const getConnectorsByTypeAsSelectMenuOptions = (prefix) => {
-        return getConnectorsByType(prefix)
+    const getConnectorsByTypeAsSelectMenuOptions = (prefix, repositoryId, repositoryLocation) => {
+        return getConnectorsByType(prefix, repositoryId, repositoryLocation)
             .then((connectorsModel) => connectorsModel.connectors.map((connector) => {
                 return new SelectMenuOptionsModel({
                     value: connector.name,

--- a/src/js/angular/core/services/connectors.service.js
+++ b/src/js/angular/core/services/connectors.service.js
@@ -16,8 +16,8 @@ function ConnectorsService(ConnectorsRestService) {
      * Fetches all connector types from the server for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
      * If the repository ID and repository location are not provided, the currently selected repository will be used.
      *
-     * @param {string} repositoryId - (optional) The repository id.
-     * @param {string} repositoryLocation - (optional) The repository location.
+     * @param {string | undefined} repositoryId - The repository id.
+     * @param {string | undefined} repositoryLocation - The repository location.
      * @return {Promise<ConnectorTypesListModel>}
      */
     const getConnectorTypes = (repositoryId, repositoryLocation) => {
@@ -30,8 +30,8 @@ function ConnectorsService(ConnectorsRestService) {
      * If the repository ID and repository location are not provided, the currently selected repository will be used.
      *
      * @param {string} name
-     * @param {string} repositoryId - (optional) The repository id.
-     * @param {string} repositoryLocation - (optional) The repository location.
+     * @param {string | undefined} repositoryId - The repository id.
+     * @param {string | undefined} repositoryLocation - The repository location.
      * @return {Promise<string|null>}
      */
     const getConnectorPrefixByName = (name, repositoryId, repositoryLocation) => {
@@ -46,8 +46,8 @@ function ConnectorsService(ConnectorsRestService) {
      * Fetches all connectors of a specific type defined by the prefix for the repository with id <code>repositoryId</code>
      * and location <code>repositoryLocation</code>. If the repository ID and repository location are not provided, the currently selected repository will be used.
      * @param {string} prefix
-     * @param {string} repositoryId - (optional) The repository id.
-     * @param {string} repositoryLocation - (optional) The repository location.
+     * @param {string | undefined} repositoryId - The repository id.
+     * @param {string | undefined} repositoryLocation - The repository location.
      * @return {Promise<ConnectorListModel>}
      */
     const getConnectorsByType = (prefix, repositoryId, repositoryLocation) => {
@@ -62,8 +62,8 @@ function ConnectorsService(ConnectorsRestService) {
      * for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
      * If the repository ID and repository location are not provided, the currently selected repository will be used.
      * @param {string} prefix
-     * @param {string} repositoryId - (optional) The repository id.
-     * @param {string} repositoryLocation - (optional) The repository location.
+     * @param {string | undefined} repositoryId - The repository id.
+     * @param {string | undefined} repositoryLocation - The repository location.
      * @return {Promise<SelectMenuOptionsModel[]>}
      */
     const getConnectorsByTypeAsSelectMenuOptions = (prefix, repositoryId, repositoryLocation) => {

--- a/src/js/angular/core/services/similarity.service.js
+++ b/src/js/angular/core/services/similarity.service.js
@@ -16,8 +16,8 @@ function SimilarityService(SimilarityRestService) {
      * Returns the similarity indexes for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
      * If the repository ID and repository location are not provided, the currently selected repository will be used.
      *
-     * @param {string} repositoryId - (optional) The repository id.
-     * @param {string} repositoryLocation - (optional) The repository location.
+     * @param {string | undefined} repositoryId - The repository id.
+     * @param {string | undefined} repositoryLocation - The repository location.
      * @return {Promise<SimilarityIndex[]>}
      */
     const getIndexes = (repositoryId, repositoryLocation) => {
@@ -29,8 +29,8 @@ function SimilarityService(SimilarityRestService) {
      * Returns the similarity indexes for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code> as a menu model.
      * If the repository ID and repository location are not provided, the currently selected repository will be used.
      *
-     * @param {string} repositoryId - (optional) The repository id.
-     * @param {string} repositoryLocation - (optional) The repository location.
+     * @param {string | undefined} repositoryId - The repository id.
+     * @param {string | undefined} repositoryLocation - The repository location.
      * @return {Promise<SelectMenuOptionsModel[]>}
      */
     const getIndexesAsMenuModel = (repositoryId, repositoryLocation) => {

--- a/src/js/angular/core/services/similarity.service.js
+++ b/src/js/angular/core/services/similarity.service.js
@@ -13,20 +13,28 @@ SimilarityService.$inject = ['SimilarityRestService'];
 function SimilarityService(SimilarityRestService) {
 
     /**
-     * Returns the similarity indexes.
+     * Returns the similarity indexes for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
+     * If the repository ID and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     *
+     * @param {string} repositoryId - (optional) The repository id.
+     * @param {string} repositoryLocation - (optional) The repository location.
      * @return {Promise<SimilarityIndex[]>}
      */
-    const getIndexes = () => {
-        return SimilarityRestService.getIndexes()
+    const getIndexes = (repositoryId, repositoryLocation) => {
+        return SimilarityRestService.getIndexes(repositoryId, repositoryLocation)
             .then((response) => mapIndexesResponseToSimilarityIndex(response.data));
     };
 
     /**
-     * Returns the indexes as a menu model.
+     * Returns the similarity indexes for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code> as a menu model.
+     * If the repository ID and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     *
+     * @param {string} repositoryId - (optional) The repository id.
+     * @param {string} repositoryLocation - (optional) The repository location.
      * @return {Promise<SelectMenuOptionsModel[]>}
      */
-    const getIndexesAsMenuModel = () => {
-        return getIndexes()
+    const getIndexesAsMenuModel = (repositoryId, repositoryLocation) => {
+        return getIndexes(repositoryId, repositoryLocation)
             .then((indexesModel) => {
                 return indexesModel.map((index) => {
                     return new SelectMenuOptionsModel({label: index.name, value: index.name});

--- a/src/js/angular/core/services/similarity.service.js
+++ b/src/js/angular/core/services/similarity.service.js
@@ -14,7 +14,7 @@ function SimilarityService(SimilarityRestService) {
 
     /**
      * Returns the similarity indexes for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
-     * If the repository ID and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     * If the repository ID and repository location are not provided, the currently selected repository will be used.
      *
      * @param {string} repositoryId - (optional) The repository id.
      * @param {string} repositoryLocation - (optional) The repository location.
@@ -27,7 +27,7 @@ function SimilarityService(SimilarityRestService) {
 
     /**
      * Returns the similarity indexes for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code> as a menu model.
-     * If the repository ID and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     * If the repository ID and repository location are not provided, the currently selected repository will be used.
      *
      * @param {string} repositoryId - (optional) The repository id.
      * @param {string} repositoryLocation - (optional) The repository location.

--- a/src/js/angular/models/ttyg/agent-form.js
+++ b/src/js/angular/models/ttyg/agent-form.js
@@ -294,6 +294,12 @@ export class ExtractionMethodFormModel {
          * @private
          */
         this._retrievalConnectorInstance = data.retrievalConnectorInstance;
+
+        this._expanded = data.expanded !== undefined ? data.expanded : false;
+    }
+
+    toggleCollapse() {
+        this._expanded = !this._expanded;
     }
 
     toPayload() {
@@ -405,6 +411,14 @@ export class ExtractionMethodFormModel {
 
     set retrievalConnectorInstance(value) {
         this._retrievalConnectorInstance = value;
+    }
+
+    get expanded() {
+        return this._expanded;
+    }
+
+    set expanded(value) {
+        this._expanded = value;
     }
 }
 

--- a/src/js/angular/models/ttyg/agent-form.js
+++ b/src/js/angular/models/ttyg/agent-form.js
@@ -243,6 +243,23 @@ export class ExtractionMethodsFormModel {
     set extractionMethods(value) {
         this._extractionMethods = value;
     }
+
+    /**
+     * Gets the extraction method with <code>extractionMethodName</code> name.
+     * @param {'retrieval_search' | 'similarity_search' | 'sparql_search' | 'fts_search'} extractionMethodName
+     * @return {ExtractionMethodFormModel}
+     */
+    getExtractionMethod(extractionMethodName) {
+        return this._extractionMethods.find((extractionMethod) => extractionMethod.method === extractionMethodName);
+    }
+
+    getSimilarityExtractionMethod() {
+        return this.getExtractionMethod(ExtractionMethod.SIMILARITY);
+    }
+
+    getRetrievalExtractionMethod() {
+        return this.getExtractionMethod(ExtractionMethod.RETRIEVAL);
+    }
 }
 
 export class ExtractionMethodFormModel {

--- a/src/js/angular/rest/connectors.rest.service.js
+++ b/src/js/angular/rest/connectors.rest.service.js
@@ -15,7 +15,23 @@ function ConnectorsRestService($http) {
         checkConnector
     };
 
-    function getConnectors() {
+    /**
+     * Fetches all connectors for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
+     * If the repository ID and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     *
+     * @param {string} repositoryId - (optional) The repository id.
+     * @param {string} repositoryLocation - (optional) The repository location.
+     * @return {*} The similarity indexes for the specified repository.
+     */
+    function getConnectors(repositoryId, repositoryLocation) {
+        if (repositoryId) {
+            return $http.get(CONNECTORS_ENDPOINT, {
+                headers: {
+                    'X-GraphDB-Repository': repositoryId,
+                    'X-GraphDB-Repository-Location': repositoryLocation
+                }
+            });
+        }
         return $http.get(CONNECTORS_ENDPOINT);
     }
 
@@ -23,7 +39,24 @@ function ConnectorsRestService($http) {
         return $http.get(`${CONNECTORS_ENDPOINT}/options?prefix=${prefix}`);
     }
 
-    function hasConnector(prefix) {
+    /**
+     * Fetches all connectors of a specific type defined by the prefix for the repository with id <code>repositoryId</code>
+     * and location <code>repositoryLocation</code>. If the repository ID and repository location are not provided,
+     * the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     * @param {string} prefix
+     * @param {string} repositoryId - (optional) The repository id.
+     * @param {string} repositoryLocation - (optional) The repository location.
+     * @return {Promise<ConnectorListModel>}
+     */
+    function hasConnector(prefix, repositoryId, repositoryLocation) {
+        if (repositoryId) {
+            return $http.get(`${CONNECTORS_ENDPOINT}/existing?prefix=${prefix}`, {
+                headers: {
+                    'X-GraphDB-Repository': repositoryId,
+                    'X-GraphDB-Repository-Location': repositoryLocation
+                }
+            });
+        }
         return $http.get(`${CONNECTORS_ENDPOINT}/existing?prefix=${prefix}`);
     }
 

--- a/src/js/angular/rest/connectors.rest.service.js
+++ b/src/js/angular/rest/connectors.rest.service.js
@@ -41,8 +41,7 @@ function ConnectorsRestService($http) {
 
     /**
      * Fetches all connectors of a specific type defined by the prefix for the repository with id <code>repositoryId</code>
-     * and location <code>repositoryLocation</code>. If the repository ID and repository location are not provided,
-     * the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     * and location <code>repositoryLocation</code>. If the repository ID and repository location are not provided, the currently selected repository will be used.
      * @param {string} prefix
      * @param {string} repositoryId - (optional) The repository id.
      * @param {string} repositoryLocation - (optional) The repository location.

--- a/src/js/angular/rest/connectors.rest.service.js
+++ b/src/js/angular/rest/connectors.rest.service.js
@@ -19,8 +19,8 @@ function ConnectorsRestService($http) {
      * Fetches all connectors for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
      * If the repository ID and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
      *
-     * @param {string} repositoryId - (optional) The repository id.
-     * @param {string} repositoryLocation - (optional) The repository location.
+     * @param {string | undefined} repositoryId - The repository id.
+     * @param {string | undefined} repositoryLocation - The repository location.
      * @return {*} The similarity indexes for the specified repository.
      */
     function getConnectors(repositoryId, repositoryLocation) {
@@ -43,8 +43,8 @@ function ConnectorsRestService($http) {
      * Fetches all connectors of a specific type defined by the prefix for the repository with id <code>repositoryId</code>
      * and location <code>repositoryLocation</code>. If the repository ID and repository location are not provided, the currently selected repository will be used.
      * @param {string} prefix
-     * @param {string} repositoryId - (optional) The repository id.
-     * @param {string} repositoryLocation - (optional) The repository location.
+     * @param {string | undefined} repositoryId - The repository id.
+     * @param {string | undefined} repositoryLocation - The repository location.
      * @return {Promise<ConnectorListModel>}
      */
     function hasConnector(prefix, repositoryId, repositoryLocation) {

--- a/src/js/angular/rest/similarity.rest.service.js
+++ b/src/js/angular/rest/similarity.rest.service.js
@@ -19,7 +19,23 @@ function SimilarityRestService($http) {
         saveSearchQuery
     };
 
-    function getIndexes() {
+    /**
+     * Fetches the similarity indexes for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
+     * If the repository ID and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     *
+     * @param {string} repositoryId - (optional) The repository id.
+     * @param {string} repositoryLocation - (optional) The repository location.
+     * @return {*} The similarity indexes for the specified repository.
+     */
+    function getIndexes(repositoryId, repositoryLocation) {
+        if (repositoryId) {
+            return $http.get(SIMILARITY_ENDPOINT, {
+                headers: {
+                    'X-GraphDB-Repository': repositoryId,
+                    'X-GraphDB-Repository-Location': repositoryLocation
+                }
+            });
+        }
         return $http.get(SIMILARITY_ENDPOINT);
     }
 

--- a/src/js/angular/rest/similarity.rest.service.js
+++ b/src/js/angular/rest/similarity.rest.service.js
@@ -21,7 +21,7 @@ function SimilarityRestService($http) {
 
     /**
      * Fetches the similarity indexes for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
-     * If the repository ID and repository location are not provided, the values persisted in local storage will be used {@see authentication.interceptor.js}.
+     * If the repository ID and repository location are not provided, the currently selected repository will be used.
      *
      * @param {string} repositoryId - (optional) The repository id.
      * @param {string} repositoryLocation - (optional) The repository location.

--- a/src/js/angular/rest/similarity.rest.service.js
+++ b/src/js/angular/rest/similarity.rest.service.js
@@ -23,8 +23,8 @@ function SimilarityRestService($http) {
      * Fetches the similarity indexes for the repository with id <code>repositoryId</code> and location <code>repositoryLocation</code>.
      * If the repository ID and repository location are not provided, the currently selected repository will be used.
      *
-     * @param {string} repositoryId - (optional) The repository id.
-     * @param {string} repositoryLocation - (optional) The repository location.
+     * @param {string | undefined} repositoryId - The repository id.
+     * @param {string | undefined} repositoryLocation - The repository location.
      * @return {*} The similarity indexes for the specified repository.
      */
     function getIndexes(repositoryId, repositoryLocation) {

--- a/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -222,8 +222,7 @@ function AgentSettingsModalController(
      * @param {boolean} clearIndexSelection - If true, the selected index will be cleared.
      */
     $scope.updateSimilaritySearchPanel = (clearIndexSelection = false) => {
-        const similaritySearchExtractionMethod = $scope.agentFormModel.assistantExtractionMethods.extractionMethods
-            .find((extractionMethod) => extractionMethod.method === ExtractionMethod.SIMILARITY);
+        const similaritySearchExtractionMethod = $scope.agentFormModel.assistantExtractionMethods.getSimilarityExtractionMethod();
         if (clearIndexSelection) {
             similaritySearchExtractionMethod.similarityIndex = null;
         }
@@ -236,8 +235,7 @@ function AgentSettingsModalController(
      * @param {boolean} clearSelection - If true, the selected connector will be cleared.
      */
     $scope.updateRetrievalConnectorPanel = (clearSelection = false) => {
-        const retrievalExtractionExtractionMethod = $scope.agentFormModel.assistantExtractionMethods.extractionMethods
-            .find((extractionMethod) => extractionMethod.method === ExtractionMethod.RETRIEVAL);
+        const retrievalExtractionExtractionMethod = $scope.agentFormModel.assistantExtractionMethods.getRetrievalExtractionMethod();
         if (clearSelection) {
             retrievalExtractionExtractionMethod.retrievalConnectorInstance = null;
         }

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -759,7 +759,13 @@ function TTYGViewCtrl(
     const buildRepositoryList = () => {
         $scope.activeRepositoryList = $repositories.getReadableRepositories()
             .map((repo) => (
-                new SelectMenuOptionsModel({value: repo.id, label: repo.id}))
+                new SelectMenuOptionsModel({
+                    value: repo.id,
+                    label: repo.id,
+                    data: {
+                        repository: repo
+                    }
+                }))
             );
     };
 

--- a/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -113,9 +113,8 @@
 
                         <div ng-if="extractionMethod.expanded && extractionMethod.method === extractionMethods.FTS_SEARCH"
                              class="extraction-method-options">
-                            <button class="btn btn-link btn-sm regenerate-question-btn pull-right"
+                            <button class="btn btn-link btn-sm pull-right"
                                     ng-click="checkIfFTSEnabled()"
-                                    ng-disabled="disabled"
                                     gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.retrieval_search.btn.reload.tooltip' | translate}}">
                                 <i class="fa-regular fa-arrows-rotate"></i>
                             </button>
@@ -144,7 +143,7 @@
                         <div ng-if="extractionMethod.expanded && extractionMethod.method === extractionMethods.SIMILARITY"
                              ng-class="{'has-error': extractionMethod.selected && !extractionMethod.sparqlOption}"
                              class="extraction-method-options">
-                            <button class="btn btn-link btn-sm regenerate-question-btn pull-right"
+                            <button class="btn btn-link btn-sm pull-right"
                                     ng-click="updateSimilaritySearchPanel()"
                                     ng-disabled="disabled"
                                     gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.similarity_index.btn.reload.tooltip' | translate}}">
@@ -208,7 +207,7 @@
                         <div ng-if="extractionMethod.expanded && extractionMethod.method === extractionMethods.RETRIEVAL"
                              ng-class="{'has-error': agentSettingsForm.$error.missingConnector}"
                              class="extraction-method-options">
-                            <button class="btn btn-link btn-sm regenerate-question-btn pull-right"
+                            <button class="btn btn-link btn-sm pull-right"
                                     ng-click="updateRetrievalConnectorPanel()"
                                     ng-disabled="disabled"
                                     gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.retrieval_search.btn.reload.tooltip' | translate}}">

--- a/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -50,24 +50,24 @@
                                    ng-model="extractionMethod.selected"/>
                             <label for="{{extractionMethod.method + '_checkbox'}}"></label>
                         </div>
-                        <a class="btn btn-link panel-toggle-link collapsed"
-                           data-toggle="collapse"
-                           data-target="#{{extractionMethod.method + '_method_content'}}"
+                        <a class="btn btn-link panel-toggle-link"
                            aria-expanded="false" aria-controls="{{extractionMethod.method + '_method_content'}}"
                            ng-click="onExtractionMethodPanelToggle(extractionMethod)">
                             <span class="mr-1">{{'ttyg.agent.create_agent_modal.form.' + extractionMethod.method + '.label' | translate}}</span>
-                            <i class="fa-regular fa-chevron-down toggle-icon"></i>
+                            <i class="fa-regular fa-chevron-down toggle-icon"
+                               ng-class="{'expanded': extractionMethod.expanded}">
+                            </i>
                         </a>
                     </div>
 
                     <div id="{{extractionMethod.method + '_method_content'}}"
-                         class="collapse show extraction-method-content"
+                         class="show extraction-method-content"
                          aria-labelledby="{{extractionMethod.method + '_method_heading'}}"
                          data-parent="#extractionMethods">
 
                         <!-- SPARQL method settings -->
 
-                        <div ng-if="extractionMethod.method === extractionMethods.SPARQL"
+                        <div ng-if="extractionMethod.expanded && extractionMethod.method === extractionMethods.SPARQL"
                              class="extraction-method-options"
                              ng-class="{'has-error': extractionMethod.selected && !extractionMethod.sparqlOption}">
                             <div class="sparql-option ontology-graph-option">
@@ -111,8 +111,14 @@
 
                         <!-- FTS method settings -->
 
-                        <div ng-if="extractionMethod.method === extractionMethods.FTS_SEARCH"
+                        <div ng-if="extractionMethod.expanded && extractionMethod.method === extractionMethods.FTS_SEARCH"
                              class="extraction-method-options">
+                            <button class="btn btn-link btn-sm regenerate-question-btn pull-right"
+                                    ng-click="checkIfFTSEnabled()"
+                                    ng-disabled="disabled"
+                                    gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.retrieval_search.btn.reload.tooltip' | translate}}">
+                                <i class="fa-regular fa-arrows-rotate"></i>
+                            </button>
                             <div class="alert alert-danger missing-repositoryid-error mb-0"
                                  ng-if="!agentFormModel.repositoryId">
                                 {{'ttyg.agent.create_agent_modal.form.fts_search.missing_repository_id' | translate}}
@@ -135,9 +141,15 @@
 
                         <!-- Similarity method settings -->
 
-                        <div ng-if="extractionMethod.method === extractionMethods.SIMILARITY"
+                        <div ng-if="extractionMethod.expanded && extractionMethod.method === extractionMethods.SIMILARITY"
                              ng-class="{'has-error': extractionMethod.selected && !extractionMethod.sparqlOption}"
                              class="extraction-method-options">
+                            <button class="btn btn-link btn-sm regenerate-question-btn pull-right"
+                                    ng-click="updateSimilaritySearchPanel()"
+                                    ng-disabled="disabled"
+                                    gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.similarity_index.btn.reload.tooltip' | translate}}">
+                                <i class="fa-regular fa-arrows-rotate"></i>
+                            </button>
                             <div ng-if="!similarityIndexes.length" class="no-similarity-index-message">
                                 {{'ttyg.agent.create_agent_modal.form.similarity_index.no_similarity_index.message_1' |
                                 translate}}
@@ -193,9 +205,15 @@
 
                         <!-- Retrieval method settings -->
 
-                        <div ng-if="extractionMethod.method === extractionMethods.RETRIEVAL"
+                        <div ng-if="extractionMethod.expanded && extractionMethod.method === extractionMethods.RETRIEVAL"
                              ng-class="{'has-error': agentSettingsForm.$error.missingConnector}"
                              class="extraction-method-options">
+                            <button class="btn btn-link btn-sm regenerate-question-btn pull-right"
+                                    ng-click="updateRetrievalConnectorPanel()"
+                                    ng-disabled="disabled"
+                                    gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.retrieval_search.btn.reload.tooltip' | translate}}">
+                                <i class="fa-regular fa-arrows-rotate"></i>
+                            </button>
                             <div ng-if="!retrievalConnectors.length" class="no-retrieval-connector-message">
                                 {{'ttyg.agent.create_agent_modal.form.retrieval_search.no_retrieval_connectors.message_1'
                                 | translate}}

--- a/test-cypress/fixtures/connectors/get-ttyg-chatgpt-connectors.json
+++ b/test-cypress/fixtures/connectors/get-ttyg-chatgpt-connectors.json
@@ -1,0 +1,188 @@
+{
+    "starwars": [
+        {
+            "values": {
+                "retrievalBearerToken": "<replace-this-with-actual-value>",
+                "types": [
+                    "http://www.ontotext.com/example/wine#Wine"
+                ],
+                "retrievalUrl": "http://localhost:8000",
+                "fields": [
+                    {
+                        "propertyChain": [
+                            "localName()"
+                        ],
+                        "fieldName": "subject"
+                    },
+                    {
+                        "propertyChain": [
+                            "$self"
+                        ],
+                        "fieldName": "metadata",
+                        "objectFields": [
+                            {
+                                "propertyChain": [
+                                    "http://www.ontotext.com/example/wine#hasWinery"
+                                ],
+                                "fieldName": "author"
+                            }
+                        ]
+                    },
+                    {
+                        "valueFilter": "isExplicit($this)",
+                        "propertyChain": [
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                            "localName()"
+                        ],
+                        "fieldName": "type",
+                        "fieldTextPrefix": "is a"
+                    },
+                    {
+                        "propertyChain": [
+                            "http://www.ontotext.com/example/wine#madeFromGrape",
+                            "http://www.w3.org/2000/01/rdf-schema#label"
+                        ],
+                        "fieldName": "grape",
+                        "fieldTextPrefix": "made from {}"
+                    },
+                    {
+                        "propertyChain": [
+                            "http://www.ontotext.com/example/wine#hasSugar"
+                        ],
+                        "fieldName": "sugar"
+                    },
+                    {
+                        "propertyChain": [
+                            "http://www.ontotext.com/example/wine#hasYear"
+                        ],
+                        "fieldName": "year"
+                    }
+                ]
+            },
+            "name": "ChatGPT_starwars_one"
+        },
+        {
+            "values": {
+                "retrievalBearerToken": "<replace-this-with-actual-value>",
+                "types": [
+                    "http://www.ontotext.com/example/wine#Wine"
+                ],
+                "retrievalUrl": "http://localhost:8000",
+                "fields": [
+                    {
+                        "propertyChain": [
+                            "localName()"
+                        ],
+                        "fieldName": "subject"
+                    },
+                    {
+                        "propertyChain": [
+                            "$self"
+                        ],
+                        "fieldName": "metadata",
+                        "objectFields": [
+                            {
+                                "propertyChain": [
+                                    "http://www.ontotext.com/example/wine#hasWinery"
+                                ],
+                                "fieldName": "author"
+                            }
+                        ]
+                    },
+                    {
+                        "valueFilter": "isExplicit($this)",
+                        "propertyChain": [
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                            "localName()"
+                        ],
+                        "fieldName": "type",
+                        "fieldTextPrefix": "is a"
+                    },
+                    {
+                        "propertyChain": [
+                            "http://www.ontotext.com/example/wine#madeFromGrape",
+                            "http://www.w3.org/2000/01/rdf-schema#label"
+                        ],
+                        "fieldName": "grape",
+                        "fieldTextPrefix": "made from {}"
+                    },
+                    {
+                        "propertyChain": [
+                            "http://www.ontotext.com/example/wine#hasSugar"
+                        ],
+                        "fieldName": "sugar"
+                    },
+                    {
+                        "propertyChain": [
+                            "http://www.ontotext.com/example/wine#hasYear"
+                        ],
+                        "fieldName": "year"
+                    }
+                ]
+            },
+            "name": "ChatGPT_starwars_two"
+        }
+    ],
+    "biomarkers": [ {
+        "values": {
+            "retrievalBearerToken": "<replace-this-with-actual-value>",
+            "types": [
+                "http://www.ontotext.com/example/wine#Wine"
+            ],
+            "retrievalUrl": "http://localhost:8000",
+            "fields": [
+                {
+                    "propertyChain": [
+                        "localName()"
+                    ],
+                    "fieldName": "subject"
+                },
+                {
+                    "propertyChain": [
+                        "$self"
+                    ],
+                    "fieldName": "metadata",
+                    "objectFields": [
+                        {
+                            "propertyChain": [
+                                "http://www.ontotext.com/example/wine#hasWinery"
+                            ],
+                            "fieldName": "author"
+                        }
+                    ]
+                },
+                {
+                    "valueFilter": "isExplicit($this)",
+                    "propertyChain": [
+                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                        "localName()"
+                    ],
+                    "fieldName": "type",
+                    "fieldTextPrefix": "is a"
+                },
+                {
+                    "propertyChain": [
+                        "http://www.ontotext.com/example/wine#madeFromGrape",
+                        "http://www.w3.org/2000/01/rdf-schema#label"
+                    ],
+                    "fieldName": "grape",
+                    "fieldTextPrefix": "made from {}"
+                },
+                {
+                    "propertyChain": [
+                        "http://www.ontotext.com/example/wine#hasSugar"
+                    ],
+                    "fieldName": "sugar"
+                },
+                {
+                    "propertyChain": [
+                        "http://www.ontotext.com/example/wine#hasYear"
+                    ],
+                    "fieldName": "year"
+                }
+            ]
+        },
+        "name": "ChatGPT_biomarkers_one"
+    }],
+    "ttyg-repo-1725518186812": []
+}

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -368,6 +368,11 @@
                             "message_1": "You must",
                             "message_2": "create a similarity index",
                             "message_3": "to use this method"
+                        },
+                        "btn": {
+                            "reload": {
+                                "tooltip": "Refresh the similarity indexes."
+                            }
                         }
                     },
                     "similarity_threshold": {
@@ -379,6 +384,11 @@
                             "message_1": "You must",
                             "message_2": "create ChatGPT retrieval connector",
                             "message_3": "to use this method"
+                        },
+                        "btn": {
+                            "reload": {
+                                "tooltip": "Refresh the ChatGPT retrieval connectors."
+                            }
                         }
                     },
                     "connector_id": {

--- a/test-cypress/fixtures/similarity/get-ttyg-similarity-connectors.json
+++ b/test-cypress/fixtures/similarity/get-ttyg-similarity-connectors.json
@@ -1,0 +1,46 @@
+{
+    "starwars": [
+        {
+            "name": "similarity_index_starwars_one",
+            "options": "-termweight idf",
+            "selectQuery": "SELECT ?documentID ?documentText {\n\t?documentID ?p ?documentText .\n\tfilter(isLiteral(?documentText))\n}",
+            "searchQuery": "PREFIX :<http://www.ontotext.com/graphdb/similarity/>\nPREFIX similarity-index:<http://www.ontotext.com/graphdb/similarity/instance/>\nPREFIX pubo: <http://ontology.ontotext.com/publishing#>\n\nSELECT ?documentID ?score {\n    ?search a ?index ;\n        ?searchType ?query;\n        :searchParameters ?parameters;\n        ?resultType ?result .\n    ?result :value ?documentID ;\n            :score ?score.\n}",
+            "analogicalQuery": "",
+            "stopList": null,
+            "analyzer": "org.apache.lucene.analysis.en.EnglishAnalyzer",
+            "status": "BUILT",
+            "infer": true,
+            "sameAs": true,
+            "type": "text"
+        },
+        {
+            "name": "similarity_index_starwars_two",
+            "options": "-termweight idf",
+            "selectQuery": "SELECT ?documentID ?documentText {\n\t?documentID ?p ?documentText .\n\tfilter(isLiteral(?documentText))\n}",
+            "searchQuery": "PREFIX :<http://www.ontotext.com/graphdb/similarity/>\nPREFIX similarity-index:<http://www.ontotext.com/graphdb/similarity/instance/>\nPREFIX pubo: <http://ontology.ontotext.com/publishing#>\n\nSELECT ?documentID ?score {\n    ?search a ?index ;\n        ?searchType ?query;\n        :searchParameters ?parameters;\n        ?resultType ?result .\n    ?result :value ?documentID ;\n            :score ?score.\n}",
+            "analogicalQuery": "",
+            "stopList": null,
+            "analyzer": "org.apache.lucene.analysis.en.EnglishAnalyzer",
+            "status": "BUILT",
+            "infer": true,
+            "sameAs": true,
+            "type": "text"
+        }
+    ],
+    "biomarkers": [
+        {
+            "name": "similarity_index_biomarkers_one",
+            "options": "-termweight idf",
+            "selectQuery": "SELECT ?documentID ?documentText {\n\t?documentID ?p ?documentText .\n\tfilter(isLiteral(?documentText))\n}",
+            "searchQuery": "PREFIX :<http://www.ontotext.com/graphdb/similarity/>\nPREFIX similarity-index:<http://www.ontotext.com/graphdb/similarity/instance/>\nPREFIX pubo: <http://ontology.ontotext.com/publishing#>\n\nSELECT ?documentID ?score {\n    ?search a ?index ;\n        ?searchType ?query;\n        :searchParameters ?parameters;\n        ?resultType ?result .\n    ?result :value ?documentID ;\n            :score ?score.\n}",
+            "analogicalQuery": "",
+            "stopList": null,
+            "analyzer": "org.apache.lucene.analysis.en.EnglishAnalyzer",
+            "status": "BUILT",
+            "infer": true,
+            "sameAs": true,
+            "type": "text"
+        }
+    ],
+    "ttyg-repo-1725518186812": []
+}

--- a/test-cypress/integration/ttyg/chat-panel.spec.js
+++ b/test-cypress/integration/ttyg/chat-panel.spec.js
@@ -54,6 +54,7 @@ describe('Ttyg ChatPanel', () => {
         ChatPanelSteps.getAskButtonElement().should('be.enabled');
 
         // When I click on "Ask" button.
+        TTYGStubs.stubAnswerQuestion();
         ChatPanelSteps.getAskButtonElement().scrollIntoView().click();
 
         // Then I expect the question be in chat history,
@@ -65,6 +66,7 @@ describe('Ttyg ChatPanel', () => {
         ChatPanelSteps.getAskButtonElement().should('be.disabled');
 
         // When I click on regenerate button.
+        TTYGStubs.stubAnswerQuestion();
         ChatPanelSteps.regenerateQuestion(2);
 
         // Then I expect the question to be regenerated and appear in the chat history.

--- a/test-cypress/steps/ttyg/ttyg-agent-settings-modal.steps.js
+++ b/test-cypress/steps/ttyg/ttyg-agent-settings-modal.steps.js
@@ -55,6 +55,10 @@ export class TtygAgentSettingsModalSteps extends ModalDialogSteps {
         return this.getRepositoryIdFromGroup().find('.alert-danger');
     }
 
+    static verifyRepositorySelected(repositoryId) {
+        this.getRepositorySelect().find('option:selected').should('have.text', repositoryId);
+    }
+
     // Extraction methods
 
     static getExtractionMethodError() {
@@ -172,6 +176,10 @@ export class TtygAgentSettingsModalSteps extends ModalDialogSteps {
         return this.getExtractionMethodPanel('similarity_search').find('.no-similarity-index-message');
     }
 
+    static clickOnSimilaritySearchIndexMissingHelp() {
+        this.getSimilaritySearchIndexMissingHelp().find('a').click();
+    }
+
     static getSimilarityIndexFormGroup() {
         return this.getExtractionMethodPanel('similarity_search').find('.similarity-index');
     }
@@ -182,6 +190,10 @@ export class TtygAgentSettingsModalSteps extends ModalDialogSteps {
 
     static selectSimilarityIndex(index) {
         this.getSimilarityIndexField().select(index);
+    }
+
+    static verifySimilarityIndexSelected(similarityIndex) {
+        this.getSimilarityIndexField().find('option:selected').should('have.text', similarityIndex);
     }
 
     static getSimilarityIndexThresholdFormGroup() {
@@ -220,6 +232,10 @@ export class TtygAgentSettingsModalSteps extends ModalDialogSteps {
 
     static getMissingRetrievalConnectorHelp() {
         return this.getExtractionMethodPanel('retrieval_search').find('.no-retrieval-connector-message');
+    }
+
+    static clickOnMissingRetrievalConnectorHelp() {
+        this.getMissingRetrievalConnectorHelp().find('a').click();
     }
 
     static getRetrievalConnectorFormGroup() {
@@ -261,6 +277,10 @@ export class TtygAgentSettingsModalSteps extends ModalDialogSteps {
 
     static setRetrievalMaxTriples(value) {
         this.getRetrievalMaxTriplesField().invoke('val', value).trigger('input');
+    }
+
+    static verifyRetrievalConnectorSelected(connectorName) {
+        this.getRetrievalConnectorField().find('option:selected').should('have.text', connectorName);
     }
 
     // GPT model

--- a/test-cypress/stubs/connector-stubs.js
+++ b/test-cypress/stubs/connector-stubs.js
@@ -12,4 +12,28 @@ export class ConnectorStubs extends Stubs {
             'get-connector'
         );
     }
+
+    /**
+     * Stubs ChatGPT connectors for three repositories:
+     * <ol>
+     *     <li> "starwars" - it has two connectors "ChatGPT_starwars_one" and "ChatGPT_starwars_two"
+     *     <li> "biomarkers" - it has one connector "ChatGPT_biomarkers_one"
+     *     <li> "ttyg-repo-1725518186812" - it has no any connections.
+     * </ol>
+     * @param {number} delay
+     */
+    static stubTTYGChatGPTConnectors(delay = 0) {
+        cy.fixture('/connectors/get-ttyg-chatgpt-connectors.json').then((body) => {
+            cy.intercept('/rest/connectors/existing?prefix=http%3A%2F%2Fwww.ontotext.com%2Fconnectors%2Fretrieval%23', (req) => {
+                const repositoryId = req.headers['x-graphdb-repository'];
+                const connectors = body[repositoryId];
+                // Respond with the modified body
+                req.reply({
+                    statusCode: 200,
+                    body: JSON.stringify(connectors),
+                    delay: delay
+                });
+            }).as('get-ttyg-ChatGPT-connector');
+        });
+    }
 }

--- a/test-cypress/stubs/similarity-index-stubs.js
+++ b/test-cypress/stubs/similarity-index-stubs.js
@@ -4,4 +4,29 @@ export class SimilarityIndexStubs extends Stubs {
     static stubGetSimilarityIndexes(fixture = '/similarity/get-similarity-indexes.json', delay = 0) {
         this.stubQueryResponse('/rest/similarity', fixture, 'get-similarity-indexes', delay);
     }
+
+
+    /**
+     * Stubs Similarity indexes for three repositories:
+     * <ol>
+     *     <li> "starwars" - it has two similarity indexes "similarity_index_starwars_one" and "similarity_index_starwars_two"
+     *     <li> "biomarkers" - it has one similarity index "similarity_index_biomarkers_one"
+     *     <li> "ttyg-repo-1725518186812" - it has no any similarity indexes.
+     * </ol>
+     * @param {number} delay
+     */
+    static stubTTYGSimilarityIndexes(delay = 0) {
+        cy.fixture('/similarity/get-ttyg-similarity-connectors.json').then((body) => {
+            cy.intercept('/rest/similarity', (req) => {
+                const repositoryId = req.headers['x-graphdb-repository'];
+                const connectors = body[repositoryId];
+                // Respond with the modified body
+                req.reply({
+                    statusCode: 200,
+                    body: JSON.stringify(connectors),
+                    delay: delay
+                });
+            }).as('get-ttyg-similarity-indexes');
+        });
+    }
 }

--- a/test-cypress/stubs/ttyg/ttyg-stubs.js
+++ b/test-cypress/stubs/ttyg/ttyg-stubs.js
@@ -2,8 +2,7 @@ import {Stubs} from "../stubs";
 
 export class TTYGStubs extends Stubs {
     static stubChatsListGet(fixture = '/ttyg/chats/get-chat-list.json', delay = 0) {
-        cy.intercept('/rest/chat/conversations', {
-            method: 'GET',
+        cy.intercept('GET', '/rest/chat/conversations', {
             fixture: fixture,
             statusCode: 200,
             delay: delay
@@ -35,14 +34,17 @@ export class TTYGStubs extends Stubs {
     static stubChatGet(fixture = '/ttyg/chats/get-chat-1.json', delay = 0) {
         cy.fixture(fixture).then((body) => {
             const bodyString = JSON.stringify(body);
-            cy.intercept('/rest/chat/conversations/*', (req) => {
+            cy.intercept({
+                method: 'GET',
+                url: '/rest/chat/conversations/*'
+            }, (req) => {
                 const chatId = req.url.split('/').pop();
-                    // Respond with the modified body
-                    req.reply({
-                        statusCode: 200,
-                        body: bodyString.replace(/{chatId}/g, chatId),
-                        delay: delay
-                    });
+                // Respond with the modified body
+                req.reply({
+                    statusCode: 200,
+                    body: bodyString.replace(/{chatId}/g, chatId),
+                    delay: delay
+                });
             }).as('get-chat');
         });
     }
@@ -118,5 +120,28 @@ export class TTYGStubs extends Stubs {
             fixture: '/ttyg/agent/get-agent-defaults.json',
             statusCode: 200
         }).as('get-agent-defaults');
+    }
+
+    static stubAnswerQuestion() {
+        cy.intercept({
+            method: 'POST',
+            url: '/rest/chat/conversations'
+        }, (req) => {
+            const requestBody = req.body;
+
+            const answer = {
+                id: "msg_Bn07kVDCYT1qmgu1G7Zw0KNe_" + Date.now(),
+                conversationId: requestBody.conversationId,
+                agentId: requestBody.agentId,
+                message: `Reply to '${requestBody.question}'`,
+                role: 'assistant',
+                timestamp: Math.floor(Date.now() / 1000)
+            };
+
+            req.reply({
+                statusCode: 200,
+                body: answer
+            });
+        }).as('get-answer');
     }
 }


### PR DESCRIPTION
## What
 - When the repository in the create/edit agent form is changed, the options in "Full-text search" and "Similarity search" are incorrect.

## Why
 - The options are generated when the dialog is opened and are based on the selected repository in the workbench.

## How
 - Implemented logic in the create/edit agent to refresh the options and selected values for "Full-text search," "Similarity search," and "ChatGPT retrieval connector" when the repository is changed;
 - Changed the functionality for expanding and collapsing query methods;
 - Modified the behavior of the authentication interceptor that reads the saved repository ID and location from local storage. Implemented a check to determine if the request headers contain repository headers. If not, the interceptor retrieves them from local storage; otherwise, it uses the headers passed in the request;
 - Extended the similarity service to include two optional parameters: repository ID and repository location;
 - Updated the similarity options to refresh when the panel is opened or when the repository is changed;
 - Extended the connectors service to include two optional parameters: repository ID and repository location;
 - Updated the ChatGPT options to refresh when the panel is opened or when the repository is changed.