### PR TITLE
ref(GDB-10848) Refactor cluster management components for naming consistency

### DIFF
--- a/src/css/cluster-nodes-configuration.css
+++ b/src/css/cluster-nodes-configuration.css
@@ -9,7 +9,7 @@
     padding: 16px 12px 0 12px;
 }
 
-.cluster-list-modal {
+.cluster-nodes-configuration-modal {
     padding: 0;
 }
 

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1826,6 +1826,7 @@
     "manage.remote.location.dialog.graph_db.password.placeholder": "my password",
     "manage.remote.location.dialog.ontopic.password.placeholder": "my secret",
     "valid.remote.location.warning": "Note that the location should be a URL that points to a remote GraphDB installation, e.g.",
+    "duplicate.remote.location.warning": "The URL is already in the list",
     "auth.type.header": "Authentication type",
     "remote.location.no.auth.used.tooltip": "No authentication used with remote location",
     "auth.type.none": "None",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -102,7 +102,7 @@
                 "create_failed": "La création du cluster a échoué",
                 "update_success": "Cluster mis à jour avec succès",
                 "update_failed": "La mise à jour du cluster a échoué",
-                "form_invalid": "Les données du formulaire ne sont pas valides",
+                "form_invalid": "Les données du formulaire ne sont pas valides"
             }
         },
         "delete_cluster_dialog": {
@@ -1834,6 +1834,7 @@
     "remote.location.url": "URL de l'emplacement*",
     "remote.location.enter.url.msg": "Entrez l'URL d'une instance GraphDB distante",
     "valid.remote.location.warning": "Notez que l'emplacement doit être une URL qui pointe vers une installation GraphDB distante, par ex.",
+    "duplicate.remote.location.warning": "L'URL est déjà dans la liste",
     "auth.type.header": "Type d'authentification",
     "remote.location.no.auth.used.tooltip": "Aucune authentification utilisée avec l'emplacement distant",
     "auth.type.none": "Aucun",

--- a/src/js/angular/clustermanagement/app.js
+++ b/src/js/angular/clustermanagement/app.js
@@ -3,11 +3,12 @@ import 'angular/core/directives';
 import 'angular/clustermanagement/controllers/cluster-management.controller';
 import 'angular/clustermanagement/directives/cluster-graphical-view.directive';
 import 'angular/clustermanagement/directives/cluster-configuration.directive';
-import 'angular/clustermanagement/directives/cluster-list.directive';
+import 'angular/clustermanagement/directives/cluster-nodes-configuration.directive';
 import 'angular/core/services/repositories.service';
 import 'lib/d3.patch.js';
 import 'angular-pageslide-directive/dist/angular-pageslide-directive';
 import 'angular/core/directives/validate-url.directive';
+import 'angular/core/directives/validate-duplicate-url.directive';
 
 const modules = [
     'ngAnimate',
@@ -15,8 +16,9 @@ const modules = [
     'graphdb.framework.clustermanagement.controllers.cluster-management',
     'graphdb.framework.clustermanagement.directives.cluster-graphical-view',
     'graphdb.framework.clustermanagement.directives.cluster-configuration',
-    'graphdb.framework.clustermanagement.directives.cluster-list',
-    'graphdb.framework.core.directives.validate-url'
+    'graphdb.framework.clustermanagement.directives.cluster-nodes-configuration',
+    'graphdb.framework.core.directives.validate-url',
+    'graphdb.framework.core.directives.validate-duplicate-url'
 ];
 
 angular.module('graphdb.framework.clustermanagement', modules);

--- a/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
+++ b/src/js/angular/clustermanagement/controllers/cluster-management.controller.js
@@ -3,7 +3,7 @@ import 'angular/clustermanagement/services/remote-locations.service';
 import 'angular/clustermanagement/services/cluster-view-context.service';
 import 'angular/clustermanagement/controllers/edit-cluster.controller';
 import 'angular/clustermanagement/controllers/delete-cluster.controller';
-import 'angular/clustermanagement/controllers/update-cluster-group.controller';
+import 'angular/clustermanagement/controllers/edit-cluster-nodes-modal.controller';
 import {isString} from "lodash";
 import {LinkState, NodeState, RecoveryState} from "../../models/clustermanagement/states";
 import {CLICK_IN_VIEW, CREATE_CLUSTER, DELETE_CLUSTER, MODEL_UPDATED, NODE_SELECTED, UPDATE_CLUSTER} from "../events";
@@ -17,7 +17,7 @@ const modules = [
     'graphdb.framework.clustermanagement.services.remote-locations',
     'graphdb.framework.clustermanagement.controllers.edit-cluster',
     'graphdb.framework.clustermanagement.controllers.delete-cluster',
-    'graphdb.framework.clustermanagement.controllers.update-cluster-group',
+    'graphdb.framework.clustermanagement.controllers.edit-cluster-nodes-modal',
     'toastr',
     'pageslide-directive'
 ];
@@ -90,8 +90,8 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
         getLocationsWithRpcAddresses().then(() => {
             $scope.setLoader(false);
             return $uibModal.open({
-                templateUrl: 'js/angular/clustermanagement/templates/modal/update-cluster-group-dialog.html',
-                controller: 'UpdateClusterGroupDialogCtrl',
+                templateUrl: 'js/angular/clustermanagement/templates/modal/edit-cluster-nodes-modal.html',
+                controller: 'EditClusterNodesModalController',
                 size: 'lg',
                 backdrop: 'static',
                 keyboard: false,
@@ -110,6 +110,7 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
             }
         }).catch((error) => {
             $scope.setLoader(false);
+            updateCluster(true, true);
             console.error(error); // eslint-disable-line no-console
         }).finally(() => {
             getLocationsWithRpcAddresses();
@@ -291,7 +292,7 @@ function ClusterManagementCtrl($scope, $http, $q, toastr, $repositories, $uibMod
                 return node.endpoint === location.endpoint;
             });
             if (index === -1) {
-                $repositories.deleteLocation(location.endpoint);
+                RemoteLocationsService.deleteLocation(location.endpoint);
             }
         });
     };

--- a/src/js/angular/clustermanagement/controllers/edit-cluster-nodes-modal.controller.js
+++ b/src/js/angular/clustermanagement/controllers/edit-cluster-nodes-modal.controller.js
@@ -5,12 +5,12 @@ const modules = [
 ];
 
 angular
-    .module('graphdb.framework.clustermanagement.controllers.update-cluster-group', modules)
-    .controller('UpdateClusterGroupDialogCtrl', UpdateClusterGroupDialogCtrl);
+    .module('graphdb.framework.clustermanagement.controllers.edit-cluster-nodes-modal', modules)
+    .controller('EditClusterNodesModalController', EditClusterNodesModalController);
 
-UpdateClusterGroupDialogCtrl.$inject = ['$scope', '$uibModalInstance', '$translate', 'data', 'ClusterContextService', 'ModalService'];
+EditClusterNodesModalController.$inject = ['$scope', '$uibModalInstance', '$translate', 'data', 'ClusterContextService', 'ModalService'];
 
-function UpdateClusterGroupDialogCtrl($scope, $uibModalInstance, $translate, data, ClusterContextService, ModalService) {
+function EditClusterNodesModalController($scope, $uibModalInstance, $translate, data, ClusterContextService, ModalService) {
     // =========================
     // Private variables
     // =========================

--- a/src/js/angular/clustermanagement/templates/cluster-nodes-configuration.html
+++ b/src/js/angular/clustermanagement/templates/cluster-nodes-configuration.html
@@ -1,4 +1,4 @@
-<link href="css/cluster-list.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+<link href="css/cluster-nodes-configuration.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 
 <div onto-loader-new ng-if="loader" class="create-cluster-loader" message="getLoaderMessage" size="100  "></div>
 <div class="add-node-wrapper pull-right mb-1">
@@ -103,6 +103,7 @@
                                       ng-click="filterSuggestions(node)"
                                       auto-grow
                                       validate-url exclude="/repositories" exclude-protocol="ftp,ftps"
+                                      validate-duplicate-url excluded-urls="clusterNodesEndpoints"
                                       allow-empty="false"
                                       autocomplete="off"
                                       class="form-control form-control-sm textarea-edit"
@@ -116,13 +117,6 @@
                                 {{ suggestion }}
                             </li>
                         </ul>
-                        <div class="error-message"
-                             ng-show="form.location.$error.validUrl && !form.location.$pristine">
-                            * {{'valid.remote.location.warning' | translate}} http://server.example.com:7200/.
-                        </div>
-                        <div ng-repeat="error in errors" class="error-message">
-                            {{error}}
-                        </div>
                     </div>
                 </td>
                 <td class="info-cell data">
@@ -165,6 +159,7 @@
                                       ng-click="filterSuggestions(newLocation)"
                                       auto-grow
                                       validate-url exclude="/repositories" exclude-protocol="ftp,ftps"
+                                      validate-duplicate-url excluded-urls="clusterNodesEndpoints"
                                       allow-empty="false"
                                       autocomplete="off"
                                       class="form-control form-control-sm textarea-edit"
@@ -205,6 +200,10 @@
             <div class="error-message"
                  ng-show="form.location.$error.validUrl && !form.location.$pristine">
                 * {{'valid.remote.location.warning' | translate}} http://server.example.com:7200/.
+            </div>
+            <div class="error-message"
+                 ng-show="form.location.$error.duplicateUrl && !form.location.$pristine">
+                * {{'duplicate.remote.location.warning' | translate}}
             </div>
             <div ng-repeat="error in errors" class="error-message">
                 {{error}}

--- a/src/js/angular/clustermanagement/templates/modal/edit-cluster-nodes-modal.html
+++ b/src/js/angular/clustermanagement/templates/modal/edit-cluster-nodes-modal.html
@@ -2,15 +2,15 @@
     <h3 class="modal-title" ng-if="hasCluster">{{'cluster_management.update_cluster_group_dialog.title' | translate}}</h3>
     <h3 class="modal-title" ng-if="!hasCluster">{{'cluster_management.update_cluster_group_dialog.title_create' | translate}}</h3>
 </div>
-<div class="modal-body cluster-list-modal">
-        <cluster-list ng-if="!loading"></cluster-list>
+<div class="modal-body cluster-nodes-configuration-modal">
+        <cluster-nodes-configuration ng-if="!loading"></cluster-nodes-configuration>
     <div class="alert alert-warning alert-save" ng-if="isChanged">
         {{'cluster_management.update_cluster_group_dialog.messages.save_to_apply' | translate}}
     </div>
 </div>
 <div class="modal-footer mt-0">
     <button type="button" class="btn btn-secondary" ng-click="cancel()">{{'common.cancel.btn' | translate}}</button>
-    <button id="wb-update-cluster-group-submit" class="btn btn-primary"
+    <button id="wb-edit-cluster-nodes-modal-submit" class="btn btn-primary"
             ng-disabled="!isValid || !isChanged"
             ng-click="ok()" type="submit">{{'save.changes.label' | translate}}
     </button>

--- a/src/js/angular/core/directives/validate-duplicate-url.directive.js
+++ b/src/js/angular/core/directives/validate-duplicate-url.directive.js
@@ -1,0 +1,57 @@
+/**
+ * @ngdoc directive
+ * @name validateDuplicateUrl
+ * @module graphdb.framework.core.directives.validate-duplicate-url
+ * @restrict A
+ *
+ * @description
+ * This directive validates an input field for duplicate URLs. It checks whether the input URL
+ * exists within a provided list of excluded or duplicate URLs and marks the input as invalid if a match is found.
+ *
+ * The directive requires an array of URLs to be passed using the `excluded-urls` attribute.
+ * If the input URL is found within this array, a `duplicateUrl` error is added to the form control.
+ *
+ * This directive works in conjunction with other validators such as `validate-url` for format validation.
+ *
+ * @example
+ * <pre>
+ *   <form name="myForm">
+ *     <!-- Basic URL duplicate validation -->
+ *     <input type="text" name="urlField" ng-model="url" validate-duplicate-url excluded-urls="existingUrls"/>
+ *     <div ng-show="myForm.urlField.$error.duplicateUrl">
+ *       URL already exists.
+ *     </div>
+ *   </form>
+ * </pre>
+ *
+ * @usage
+ * This directive can be added as an attribute to any input field where duplicate URL validation is required.
+ * It will automatically validate the input value against the provided list of excluded URLs.
+ *
+ * @param {Array} excludedUrls - An array of URLs to check against for duplicates.
+ * @returns {boolean} Whether the URL is valid. It returns `true` if the URL is not in the `excludedUrls` array and `false` if it is.
+ */
+angular
+    .module('graphdb.framework.core.directives.validate-duplicate-url', [])
+    .directive('validateDuplicateUrl', validateDuplicateUrl);
+
+function validateDuplicateUrl() {
+    return {
+        restrict: 'A',
+        require: 'ngModel',
+        scope: {
+            excludedUrls: '='
+        },
+        link: function (scope, element, attr, ctrl) {
+            ctrl.$validators.duplicateUrl = function (modelValue, viewValue) {
+                if (scope.excludedUrls && scope.excludedUrls.includes(viewValue)) {
+                    ctrl.$setValidity('duplicateUrl', false);
+                    return false;
+                } else {
+                    ctrl.$setValidity('duplicateUrl', true);
+                }
+                return true;
+            };
+        }
+    };
+}

--- a/src/js/angular/models/clustermanagement/cluster.js
+++ b/src/js/angular/models/clustermanagement/cluster.js
@@ -581,6 +581,10 @@ export class ClusterItemViewModel {
         return this._item._address !== undefined;
     }
 
+    isLocation() {
+        return this._item._address === undefined;
+    }
+
     getNodeState() {
         if (this.isNode()) {
             return this._item._nodeState;

--- a/src/pages/cluster-management/clusterInfo.html
+++ b/src/pages/cluster-management/clusterInfo.html
@@ -24,7 +24,7 @@
 <div class="clearfix d-flex" ng-if="!loader && clusterConfiguration">
     <div class="action-buttons">
         <div ng-if="isAdmin()" class="buttons-wrapper">
-            <button type="button" class="btn btn-primary update-cluster-btn" ng-if="currentLeader"
+            <button type="button" class="btn btn-primary edit-cluster-nodes-modal-btn" ng-if="currentLeader"
                     ng-click="showUpdateClusterGroupDialog()"
                     gdb-tooltip="{{'cluster_management.buttons.update_nodes_group_btn_tooltip' | translate}}" tooltip-placement="bottom">
                 <i class="fa-regular fa-plus"></i> {{'cluster_management.buttons.update_nodes_group_btn' | translate}}

--- a/test-cypress/fixtures/cluster/2-nodes-cluster-group-status-deleted.json
+++ b/test-cypress/fixtures/cluster/2-nodes-cluster-group-status-deleted.json
@@ -1,0 +1,24 @@
+[
+    {
+        "address": "pc-desktop:7300",
+        "nodeState": "LEADER",
+        "term": 2,
+        "syncStatus": {
+            "pc-desktop:7302": "IN_SYNC"
+        },
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7200",
+        "recoveryStatus": {}
+    },
+    {
+        "address": "pc-desktop:7302",
+        "nodeState": "FOLLOWER",
+        "term": 2,
+        "syncStatus": {},
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7202",
+        "recoveryStatus": {}
+    }
+]

--- a/test-cypress/fixtures/cluster/2-nodes-cluster-group-status.json
+++ b/test-cypress/fixtures/cluster/2-nodes-cluster-group-status.json
@@ -1,0 +1,24 @@
+[
+    {
+        "address": "pc-desktop:7300",
+        "nodeState": "LEADER",
+        "term": 2,
+        "syncStatus": {
+            "pc-desktop:7303": "IN_SYNC"
+        },
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7200",
+        "recoveryStatus": {}
+    },
+    {
+        "address": "pc-desktop:7303",
+        "nodeState": "FOLLOWER",
+        "term": 2,
+        "syncStatus": {},
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7203",
+        "recoveryStatus": {}
+    }
+]

--- a/test-cypress/fixtures/cluster/3-nodes-cluster-group-status-after-replace.json
+++ b/test-cypress/fixtures/cluster/3-nodes-cluster-group-status-after-replace.json
@@ -1,0 +1,35 @@
+[
+    {
+        "address": "pc-desktop:7333",
+        "nodeState": "FOLLOWER",
+        "term": 2,
+        "syncStatus": {},
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7233",
+        "recoveryStatus": {}
+    },
+    {
+        "address": "pc-desktop:7302",
+        "nodeState": "LEADER",
+        "term": 2,
+        "syncStatus": {
+            "pc-desktop:7333": "IN_SYNC",
+            "pc-desktop:7303": "IN_SYNC"
+        },
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7202",
+        "recoveryStatus": {}
+    },
+    {
+        "address": "pc-desktop:7303",
+        "nodeState": "FOLLOWER",
+        "term": 2,
+        "syncStatus": {},
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7203",
+        "recoveryStatus": {}
+    }
+]

--- a/test-cypress/fixtures/cluster/4-nodes-cluster-group-status.json
+++ b/test-cypress/fixtures/cluster/4-nodes-cluster-group-status.json
@@ -1,0 +1,46 @@
+[
+    {
+        "address": "pc-desktop:7300",
+        "nodeState": "FOLLOWER",
+        "term": 2,
+        "syncStatus": {},
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7200",
+        "recoveryStatus": {}
+    },
+    {
+        "address": "pc-desktop:7301",
+        "nodeState": "LEADER",
+        "term": 2,
+        "syncStatus": {
+            "pc-desktop:7300": "IN_SYNC",
+            "pc-desktop:7302": "IN_SYNC",
+            "pc-desktop:7303": "IN_SYNC"
+        },
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7201",
+        "recoveryStatus": {}
+    },
+    {
+        "address": "pc-desktop:7302",
+        "nodeState": "FOLLOWER",
+        "term": 2,
+        "syncStatus": {},
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7202",
+        "recoveryStatus": {}
+    },
+    {
+        "address": "pc-desktop:7303",
+        "nodeState": "FOLLOWER",
+        "term": 2,
+        "syncStatus": {},
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7203",
+        "recoveryStatus": {}
+    }
+]

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -1826,6 +1826,7 @@
     "manage.remote.location.dialog.graph_db.password.placeholder": "my password",
     "manage.remote.location.dialog.ontopic.password.placeholder": "my secret",
     "valid.remote.location.warning": "Note that the location should be a URL that points to a remote GraphDB installation, e.g.",
+    "duplicate.remote.location.warning": "The URL is already in the list",
     "auth.type.header": "Authentication type",
     "remote.location.no.auth.used.tooltip": "No authentication used with remote location",
     "auth.type.none": "None",

--- a/test-cypress/integration/cluster/edit-cluster-nodes-modal.spec.js
+++ b/test-cypress/integration/cluster/edit-cluster-nodes-modal.spec.js
@@ -2,7 +2,7 @@ import {GlobalOperationsStatusesStub} from "../../stubs/global-operations-status
 import {ClusterPageSteps} from "../../steps/cluster/cluster-page-steps";
 import {ClusterStubs} from "../../stubs/cluster/cluster-stubs";
 import {RemoteLocationStubs} from "../../stubs/cluster/remote-location-stubs";
-import {ClusterListSteps} from "../../steps/cluster/custer-list-steps";
+import {ClusterNodesConfigurationSteps} from "../../steps/cluster/custer-nodes-configuration-steps";
 import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
 import {ApplicationSteps} from "../../steps/application-steps";
 
@@ -23,7 +23,6 @@ describe('Cluster management', () => {
         ClusterStubs.stubClusterConfigByList(clusterLocations);
         ClusterStubs.stubClusterGroupStatus();
         ClusterStubs.stubClusterNodeStatus();
-        RemoteLocationStubs.stubGetRemoteLocationsByList(urisToAdd);
         RemoteLocationStubs.stubRemoteLocationFilter();
         RemoteLocationStubs.stubRemoteLocationCheckByAddress([{uri: 'pc-desktop:7203', rpc: 'pc-desktop:7303'}]);
 
@@ -34,32 +33,34 @@ describe('Cluster management', () => {
 
         // When I click on update cluster
         ClusterPageSteps.updateCluster();
-        ClusterListSteps.getClusterUpdateModal().should('be.visible');
+        ClusterNodesConfigurationSteps.getClusterNodesConfigurationModal().should('be.visible');
 
         // Then I should see the 3 nodes in the cluster
         clusterLocations.forEach((node) => {
-            ClusterListSteps.getNodeByEndpoint(node).should('exist');
+            ClusterNodesConfigurationSteps.getNodeByEndpoint(node).should('exist');
         });
 
         // When I add node
-        ClusterListSteps.clickAddNodeButton();
+        ClusterNodesConfigurationSteps.clickAddNodeButton();
 
         // Then I should see the edit node row
-        ClusterListSteps.getEditNodeRow().should('be.visible');
+        ClusterNodesConfigurationSteps.getEditNodeRow().should('be.visible');
 
         // When I enter a new endpoint
-        ClusterListSteps.enterNodeEndpoint(urisToAdd[0]);
+        ClusterNodesConfigurationSteps.enterNodeEndpoint(urisToAdd[0]);
 
         // And I save the node
         RemoteLocationStubs.stubAddRemoteLocation();
-        ClusterListSteps.clickSaveNodeButton();
+        RemoteLocationStubs.stubGetRemoteLocationsByList(urisToAdd);
+        ClusterNodesConfigurationSteps.clickSaveNodeButton();
 
         // Then I should see the new node in the list
-        ClusterListSteps.getNodeByEndpoint(urisToAdd[0]).should('exist');
+        ClusterNodesConfigurationSteps.getNodeByEndpoint(urisToAdd[0]).should('exist');
 
         //And when I confirm changes
         ClusterStubs.stubAddNodesByList(nodesToAdd);
-        ClusterListSteps.clickOkButton();
+        ClusterStubs.stubClusterGroupStatusAfterAdd();
+        ClusterNodesConfigurationSteps.clickOkButton();
         cy.wait('@response-add-nodes').then((interception) => {
             expect(interception.request.body).to.deep.equal({
                 "addNodes": nodesToAdd,
@@ -84,18 +85,18 @@ describe('Cluster management', () => {
 
         // When I click on update cluster
         ClusterPageSteps.updateCluster();
-        ClusterListSteps.getClusterUpdateModal().should('be.visible');
+        ClusterNodesConfigurationSteps.getClusterNodesConfigurationModal().should('be.visible');
 
         // I see tree nodes in the list
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7200').should('have.text', '1');
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7201').should('have.text', '2');
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7202').should('have.text', '3');
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7200').should('eq', '');
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7201').should('eq', '');
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7202').should('eq', '');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7200').should('have.text', '1');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7201').should('have.text', '2');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7202').should('have.text', '3');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7200').should('eq', '');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7201').should('eq', '');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7202').should('eq', '');
 
         // When I delete the second node
-        ClusterListSteps.clickDeleteNodeButtonByEndpoint('http://pc-desktop:7201');
+        ClusterNodesConfigurationSteps.clickDeleteNodeButtonByEndpoint('http://pc-desktop:7201');
 
         // I expect to see deleting confirmation dialog.
         ModalDialogSteps.getDialogBody().should('contain', 'Are you sure you want to detach the location \'http://pc-desktop:7201\'?');
@@ -104,25 +105,26 @@ describe('Cluster management', () => {
         ModalDialogSteps.getConfirmButton().click();
 
         // Then the node should be decorated with deleting class
-        ClusterListSteps.getNodeLocationByEndpoint('http://pc-desktop:7201').should('have.class', 'deleting');
+        ClusterNodesConfigurationSteps.getNodeLocationByEndpoint('http://pc-desktop:7201').should('have.class', 'deleting');
 
         // And the node has no index number
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7200').should('have.text', '1');
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7201').should('have.text', '');
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7202').should('have.text', '2');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7200').should('have.text', '1');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7201').should('have.text', '');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7202').should('have.text', '2');
 
         // And deleted node should have new status
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7200').should('eq', '');
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7201').should('eq', 'Node will be removed');
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7202').should('eq', '');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7200').should('eq', '');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7201').should('eq', 'Node will be removed');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7202').should('eq', '');
 
         // And the delete button should be disabled if minimum nodes required
-        ClusterListSteps.isDeleteNodeButtonEnabledByEndpoint('http://pc-desktop:7202')
+        ClusterNodesConfigurationSteps.isDeleteNodeButtonEnabledByEndpoint('http://pc-desktop:7202')
             .should('be.false');
 
         //And when I confirm changes
         ClusterStubs.stubDeleteNodesByList(nodesToDelete);
-        ClusterListSteps.clickOkButton();
+        ClusterStubs.stubClusterGroupStatusAfterDelete();
+        ClusterNodesConfigurationSteps.clickOkButton();
         cy.wait('@response-delete-nodes').then((interception) => {
             expect(interception.request.body).to.deep.equal({
                 "addNodes": [],
@@ -149,10 +151,10 @@ describe('Cluster management', () => {
 
         // When I click on update cluster
         ClusterPageSteps.updateCluster();
-        ClusterListSteps.getClusterUpdateModal().should('be.visible');
+        ClusterNodesConfigurationSteps.getClusterNodesConfigurationModal().should('be.visible');
 
         // When I delete the second node
-        ClusterListSteps.clickDeleteNodeButtonByEndpoint('http://pc-desktop:7201');
+        ClusterNodesConfigurationSteps.clickDeleteNodeButtonByEndpoint('http://pc-desktop:7201');
 
         // I expect to see deleting confirmation dialog.
         ModalDialogSteps.getDialogBody().should('contain', 'Are you sure you want to detach the location \'http://pc-desktop:7201\'?');
@@ -161,23 +163,23 @@ describe('Cluster management', () => {
         ModalDialogSteps.getConfirmButton().click();
 
         // Then the node should be decorated with deleting class
-        ClusterListSteps.getNodeLocationByEndpoint('http://pc-desktop:7201').should('have.class', 'deleting');
+        ClusterNodesConfigurationSteps.getNodeLocationByEndpoint('http://pc-desktop:7201').should('have.class', 'deleting');
 
         // When I add node
-        ClusterListSteps.clickAddNodeButton();
+        ClusterNodesConfigurationSteps.clickAddNodeButton();
 
         // Then I should see the edit node row
-        ClusterListSteps.getEditNodeRow().should('be.visible');
+        ClusterNodesConfigurationSteps.getEditNodeRow().should('be.visible');
 
         // When I enter a new endpoint
-        ClusterListSteps.enterNodeEndpoint('http://pc-desktop:7203');
+        ClusterNodesConfigurationSteps.enterNodeEndpoint('http://pc-desktop:7203');
 
         // And I save the node
         RemoteLocationStubs.stubAddRemoteLocation();
-        ClusterListSteps.clickSaveNodeButton();
+        ClusterNodesConfigurationSteps.clickSaveNodeButton();
 
         // When I delete the second node
-        ClusterListSteps.clickDeleteNodeButtonByEndpoint('http://pc-desktop:7202');
+        ClusterNodesConfigurationSteps.clickDeleteNodeButtonByEndpoint('http://pc-desktop:7202');
 
         // I expect to see deleting confirmation dialog.
         ModalDialogSteps.getDialogBody().should('contain', 'Are you sure you want to detach the location \'http://pc-desktop:7202\'?');
@@ -186,29 +188,30 @@ describe('Cluster management', () => {
         ModalDialogSteps.getConfirmButton().click();
 
         // Then the node should be decorated with deleting class
-        ClusterListSteps.getNodeLocationByEndpoint('http://pc-desktop:7202').should('have.class', 'deleting');
+        ClusterNodesConfigurationSteps.getNodeLocationByEndpoint('http://pc-desktop:7202').should('have.class', 'deleting');
 
         // Then I should see the new node in the list
-        ClusterListSteps.getNodeByEndpoint('http://pc-desktop:7203').should('exist');
+        ClusterNodesConfigurationSteps.getNodeByEndpoint('http://pc-desktop:7203').should('exist');
 
         // And all changed nodes should have new status and index numbers
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7200').should('eq', '');
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7201').should('eq', 'Node will be removed');
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7202').should('eq', 'Node will be removed');
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7203').should('eq', 'Node will be added');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7200').should('eq', '');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7201').should('eq', 'Node will be removed');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7202').should('eq', 'Node will be removed');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7203').should('eq', 'Node will be added');
         // And the node has no index number
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7200').should('have.text', '1');
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7201').should('have.text', '');
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7202').should('have.text', '');
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7203').should('have.text', '2');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7200').should('have.text', '1');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7201').should('have.text', '');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7202').should('have.text', '');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7203').should('have.text', '2');
 
 
         //And when I confirm changes
         ClusterStubs.stubAddNodesByList(['pc-desktop:7203']);
         ClusterStubs.stubDeleteNodesByList(['pc-desktop:7201', 'pc-desktop:7202']);
         ClusterStubs.stubReplaceNodesByList(['pc-desktop:7203'], ['pc-desktop:7201']);
+        ClusterStubs.stubClusterGroupStatusAfterReplace();
 
-        ClusterListSteps.clickOkButton();
+        ClusterNodesConfigurationSteps.clickOkButton();
         cy.wait('@response-replace-nodes').then((interception) => {
             expect(interception.request.body).to.deep.equal({
                 "addNodes": [
@@ -246,16 +249,16 @@ describe('Cluster management', () => {
 
         // When I click on update cluster
         ClusterPageSteps.updateCluster();
-        ClusterListSteps.getClusterUpdateModal().should('be.visible');
+        ClusterNodesConfigurationSteps.getClusterNodesConfigurationModal().should('be.visible');
 
         // Then I should see the 3 nodes in the cluster
         const nodes = ['http://pc-desktop:7200', 'http://pc-desktop:7201', 'http://pc-desktop:7202'];
         nodes.forEach((node) => {
-            ClusterListSteps.getNodeByEndpoint(node).should('exist');
+            ClusterNodesConfigurationSteps.getNodeByEndpoint(node).should('exist');
         });
 
         // When I delete the second node
-        ClusterListSteps.clickDeleteNodeButtonByEndpoint('http://pc-desktop:7201');
+        ClusterNodesConfigurationSteps.clickDeleteNodeButtonByEndpoint('http://pc-desktop:7201');
 
         // I expect to see deleting confirmation dialog.
         ModalDialogSteps.getDialogBody().should('contain', 'Are you sure you want to detach the location \'http://pc-desktop:7201\'?');
@@ -264,39 +267,39 @@ describe('Cluster management', () => {
         ModalDialogSteps.getConfirmButton().click();
 
         // Then the node should be decorated with deleting class
-        ClusterListSteps.getNodeLocationByEndpoint('http://pc-desktop:7201').should('have.class', 'deleting');
+        ClusterNodesConfigurationSteps.getNodeLocationByEndpoint('http://pc-desktop:7201').should('have.class', 'deleting');
 
         // And deleted node should have new status
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7201').should('eq', 'Node will be removed');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7201').should('eq', 'Node will be removed');
 
         // And the delete button should be disabled if minimum nodes required
-        ClusterListSteps.isDeleteNodeButtonEnabledByEndpoint('http://pc-desktop:7202').should('be.false');
+        ClusterNodesConfigurationSteps.isDeleteNodeButtonEnabledByEndpoint('http://pc-desktop:7202').should('be.false');
 
         // When I add a new node
-        ClusterListSteps.clickAddNodeButton();
+        ClusterNodesConfigurationSteps.clickAddNodeButton();
 
         // Then I should see the edit node row
-        ClusterListSteps.getEditNodeRow().should('be.visible');
+        ClusterNodesConfigurationSteps.getEditNodeRow().should('be.visible');
 
         // When I enter a new endpoint
         const newNodeEndpoint = 'http://pc-desktop:7233';
-        ClusterListSteps.enterNodeEndpoint(newNodeEndpoint);
+        ClusterNodesConfigurationSteps.enterNodeEndpoint(newNodeEndpoint);
 
         // And I save the node
         RemoteLocationStubs.stubAddRemoteLocation();
-        ClusterListSteps.clickSaveNodeButton();
+        ClusterNodesConfigurationSteps.clickSaveNodeButton();
 
         // Then I should see the new node in the list
-        ClusterListSteps.getNodeByEndpoint(newNodeEndpoint).should('exist');
+        ClusterNodesConfigurationSteps.getNodeByEndpoint(newNodeEndpoint).should('exist');
 
         // With new status
-        ClusterListSteps.getNodeStatusByEndpoint(newNodeEndpoint).should('eq', 'Node will be added');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint(newNodeEndpoint).should('eq', 'Node will be added');
 
         // And the edit node row should not be visible
-        ClusterListSteps.getEditNodeRow().should('not.exist');
+        ClusterNodesConfigurationSteps.getEditNodeRow().should('not.exist');
 
         // When I replace the first node
-        ClusterListSteps.clickReplaceNodeButtonByEndpoint('http://pc-desktop:7200');
+        ClusterNodesConfigurationSteps.clickReplaceNodeButtonByEndpoint('http://pc-desktop:7200');
 
         // I expect to see replacing confirmation dialog.
         ModalDialogSteps.getDialogBody().should('contain', 'Are you sure you want to change the location?');
@@ -305,40 +308,41 @@ describe('Cluster management', () => {
         ModalDialogSteps.getConfirmButton().click();
 
         // Then I should see the edit node row
-        ClusterListSteps.getEditNodeRow().should('be.visible');
+        ClusterNodesConfigurationSteps.getEditNodeRow().should('be.visible');
 
         // When I enter a new endpoint for replacement
         const replacementNodeEndpoint = 'http://pc-desktop:7203';
-        ClusterListSteps.enterNodeEndpoint(replacementNodeEndpoint);
+        ClusterNodesConfigurationSteps.enterNodeEndpoint(replacementNodeEndpoint);
 
         // And I save the replacement
-        ClusterListSteps.clickSaveNodeButton();
+        ClusterNodesConfigurationSteps.clickSaveNodeButton();
 
         // Then I should see the replacement node in the list
-        ClusterListSteps.getNodeByEndpoint(replacementNodeEndpoint).should('exist');
-        ClusterListSteps.getNodeStatusByEndpoint(replacementNodeEndpoint).should('eq', 'Node will be added');
+        ClusterNodesConfigurationSteps.getNodeByEndpoint(replacementNodeEndpoint).should('exist');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint(replacementNodeEndpoint).should('eq', 'Node will be added');
 
         // And the old node should have new class and status
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7200').should('eq', 'Node will be removed');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7200').should('eq', 'Node will be removed');
 
         // And all changed nodes should have new status and index numbers
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7200').should('eq', 'Node will be removed');
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7201').should('eq', 'Node will be removed');
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7202').should('eq', '');
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7233').should('eq', 'Node will be added');
-        ClusterListSteps.getNodeStatusByEndpoint('http://pc-desktop:7203').should('eq', 'Node will be added');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7200').should('eq', 'Node will be removed');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7201').should('eq', 'Node will be removed');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7202').should('eq', '');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7233').should('eq', 'Node will be added');
+        ClusterNodesConfigurationSteps.getNodeStatusByEndpoint('http://pc-desktop:7203').should('eq', 'Node will be added');
         // And the node has no index number
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7200').should('have.text', '');
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7201').should('have.text', '');
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7202').should('have.text', '1');
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7233').should('have.text', '2');
-        ClusterListSteps.getNodeIndexByEndpoint('http://pc-desktop:7203').should('have.text', '3');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7200').should('have.text', '');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7201').should('have.text', '');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7202').should('have.text', '1');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7233').should('have.text', '2');
+        ClusterNodesConfigurationSteps.getNodeIndexByEndpoint('http://pc-desktop:7203').should('have.text', '3');
 
         //And when I confirm changes
         const nodesToAdd = ['pc-desktop:7233', 'pc-desktop:7203'];
         const nodesToRemove = ['pc-desktop:7301', 'pc-desktop:7300'];
         ClusterStubs.stubReplaceNodesByList(nodesToAdd, nodesToRemove);
-        ClusterListSteps.clickOkButton();
+        ClusterStubs.stubClusterGroupStatusAfterReplaceAndDelete();
+        ClusterNodesConfigurationSteps.clickOkButton();
         cy.wait('@response-replace-nodes').then((interception) => {
             expect(interception.request.body).to.deep.equal({
                 "addNodes": [
@@ -373,14 +377,14 @@ describe('Cluster management', () => {
         ClusterPageSteps.createCluster();
 
         // Then I should see create cluster modal
-        ClusterListSteps.getClusterUpdateModal().should('be.visible');
+        ClusterNodesConfigurationSteps.getClusterNodesConfigurationModal().should('be.visible');
         // I should see the local node
-        ClusterListSteps.getNodeByEndpoint('http://pc-desktop:7200').should('exist');
+        ClusterNodesConfigurationSteps.getNodeByEndpoint('http://pc-desktop:7200').should('exist');
         // I should see buttons, warnings and advanced options
-        ClusterListSteps.getAddNodeButton().should('be.visible').and('be.enabled');
-        ClusterListSteps.getOkButton().should('be.visible').and('be.disabled');
-        ClusterListSteps.getAdvancedOptions().should('be.visible').and('be.enabled');
-        ClusterListSteps.getSaveAlert().should('be.visible');
+        ClusterNodesConfigurationSteps.getAddNodeButton().should('be.visible').and('be.enabled');
+        ClusterNodesConfigurationSteps.getOkButton().should('be.visible').and('be.disabled');
+        ClusterNodesConfigurationSteps.getAdvancedOptions().should('be.visible').and('be.enabled');
+        ClusterNodesConfigurationSteps.getSaveAlert().should('be.visible');
 
 
         const urisToAdd = ['http://pc-desktop:7203'];
@@ -388,21 +392,21 @@ describe('Cluster management', () => {
         RemoteLocationStubs.stubRemoteLocationCheckByAddress([{uri: 'pc-desktop:7203', rpc: 'pc-desktop:7303'}]);
 
         // When I add node
-        ClusterListSteps.clickAddNodeButton();
+        ClusterNodesConfigurationSteps.clickAddNodeButton();
         // Then I should see the edit node row
-        ClusterListSteps.getEditNodeRow().should('be.visible');
+        ClusterNodesConfigurationSteps.getEditNodeRow().should('be.visible');
         // When I enter a new endpoint
-        ClusterListSteps.enterNodeEndpoint('http://pc-desktop:7203');
+        ClusterNodesConfigurationSteps.enterNodeEndpoint('http://pc-desktop:7203');
         // And I save the node
         RemoteLocationStubs.stubAddRemoteLocation();
-        ClusterListSteps.clickSaveNodeButton();
+        ClusterNodesConfigurationSteps.clickSaveNodeButton();
         // Then I should see the new node in the list
-        ClusterListSteps.getNodeByEndpoint('http://pc-desktop:7203').should('exist');
+        ClusterNodesConfigurationSteps.getNodeByEndpoint('http://pc-desktop:7203').should('exist');
 
 
         //And when I confirm changes
         ClusterStubs.stubCreateClusterByList(['http://pc-desktop:7200', 'http://pc-desktop:7203']);
-        ClusterListSteps.clickOkButton();
+        ClusterNodesConfigurationSteps.clickOkButton();
         cy.wait('@2-nodes-cluster-created').then((interception) => {
             console.log(interception.request.body);
             expect(interception.request.body).to.deep.equal({

--- a/test-cypress/steps/cluster/cluster-page-steps.js
+++ b/test-cypress/steps/cluster/cluster-page-steps.js
@@ -68,7 +68,7 @@ export class ClusterPageSteps {
     }
 
     static getUpdateClusterButton() {
-        return cy.get('.update-cluster-btn');
+        return cy.get('.edit-cluster-nodes-modal-btn');
     }
 
     static updateCluster() {

--- a/test-cypress/steps/cluster/custer-nodes-configuration-steps.js
+++ b/test-cypress/steps/cluster/custer-nodes-configuration-steps.js
@@ -1,7 +1,7 @@
-export class ClusterListSteps {
+export class ClusterNodesConfigurationSteps {
 
-    static getClusterUpdateModal() {
-        return cy.get('cluster-list');
+    static getClusterNodesConfigurationModal() {
+        return cy.get('cluster-nodes-configuration');
     }
 
     static clickAddNodeButton() {
@@ -9,11 +9,11 @@ export class ClusterListSteps {
     }
 
     static getAddNodeButton() {
-        return this.getClusterUpdateModal().find('.add-node-btn');
+        return this.getClusterNodesConfigurationModal().find('.add-node-btn');
     }
 
     static getAdvancedOptions() {
-        return this.getClusterUpdateModal().find('.advanced-options-btn');
+        return this.getClusterNodesConfigurationModal().find('.advanced-options-btn');
     }
 
     static getSaveAlert() {
@@ -25,33 +25,33 @@ export class ClusterListSteps {
     }
 
     static getNodeByIndex(index) {
-        return ClusterListSteps.getNodes().eq(index);
+        return ClusterNodesConfigurationSteps.getNodes().eq(index);
     }
 
     static getNodeByEndpoint(endpoint) {
-        return ClusterListSteps.getNodes().filter(`[data-endpoint="${endpoint}"]`);
+        return ClusterNodesConfigurationSteps.getNodes().filter(`[data-endpoint="${endpoint}"]`);
     }
 
     static getNodeLocationByEndpoint(endpoint) {
-        return ClusterListSteps.getNodeByEndpoint(endpoint).find('.location-cell');
+        return ClusterNodesConfigurationSteps.getNodeByEndpoint(endpoint).find('.location-cell');
     }
 
     static getNodeIndexByEndpoint(endpoint) {
-        return ClusterListSteps.getNodeByEndpoint(endpoint).find('.index-cell');
+        return ClusterNodesConfigurationSteps.getNodeByEndpoint(endpoint).find('.index-cell');
     }
 
     static getNodeStatusByEndpoint(endpoint) {
-        return ClusterListSteps.getNodeByEndpoint(endpoint).find('.status-cell').invoke('text').then((text) => text.trim());
+        return ClusterNodesConfigurationSteps.getNodeByEndpoint(endpoint).find('.status-cell').invoke('text').then((text) => text.trim());
     }
 
     static clickDeleteNodeButtonByEndpoint(endpoint) {
-        ClusterListSteps.getNodeByEndpoint(endpoint)
+        ClusterNodesConfigurationSteps.getNodeByEndpoint(endpoint)
             .find('.delete-node-btn')
-            .click();
+            .click({force:true});
     }
 
     static clickReplaceNodeButtonByEndpoint(endpoint) {
-        ClusterListSteps.getNodeByEndpoint(endpoint)
+        ClusterNodesConfigurationSteps.getNodeByEndpoint(endpoint)
             .find('.replace-node-btn')
             .click();
     }
@@ -79,7 +79,7 @@ export class ClusterListSteps {
     }
 
     static isDeleteNodeButtonEnabledByEndpoint(endpoint) {
-        return ClusterListSteps.getNodeByEndpoint(endpoint)
+        return ClusterNodesConfigurationSteps.getNodeByEndpoint(endpoint)
             .find('.delete-node-btn')
             .then((button) => !button.is(':disabled'));
     }
@@ -89,7 +89,7 @@ export class ClusterListSteps {
     }
 
     static getOkButton() {
-        return cy.get('#wb-update-cluster-group-submit');
+        return cy.get('#wb-edit-cluster-nodes-modal-submit');
     }
 
     static clickOkButton() {

--- a/test-cypress/stubs/cluster/cluster-stubs.js
+++ b/test-cypress/stubs/cluster/cluster-stubs.js
@@ -15,6 +15,42 @@ export class ClusterStubs extends Stubs {
         }).as('3-nodes-cluster-group-status');
     }
 
+    static stubClusterGroupStatusAfterAdd() {
+        cy.intercept('/rest/cluster/group/status', {
+            fixture: '/cluster/4-nodes-cluster-group-status.json',
+            statusCode: 200
+        }).as('4-nodes-cluster-group-status');
+    }
+
+    static stubClusterGroupStatusAfterDelete() {
+        cy.intercept('/rest/cluster/group/status', {
+            fixture: '/cluster/2-nodes-cluster-group-status-deleted.json',
+            statusCode: 200
+        }).as('2-nodes-cluster-group-status-deleted');
+    }
+
+    static stubClusterGroupStatusAfterReplaceAndDelete() {
+        cy.intercept('/rest/cluster/group/status', {
+            fixture: '/cluster/3-nodes-cluster-group-status-after-replace.json',
+            statusCode: 200
+        }).as('3-nodes-cluster-group-status-after-replace');
+    }
+
+    static stubClusterGroupStatusAfterReplace() {
+        cy.intercept('/rest/cluster/group/status', {
+            fixture: '/cluster/2-nodes-cluster-group-status.json',
+            statusCode: 200
+        }).as('2-nodes-cluster-group-status');
+    }
+
+    static stubDeleteUnusedLocation(uri) {
+        cy.intercept(`rest/locations?uri=${uri}`, {
+            body: `Successfully removed location '${uri}'`,
+            statusCode: 200,
+            method: 'DELETE'
+        }).as('delete-location');
+    }
+
     static stubClusterWithRecoveryStatusGroupStatus(recoveryStatus) {
         cy.intercept('/rest/cluster/group/status', {
             fixture: `/cluster/3-nodes-cluster-group-status-${recoveryStatus}`,

--- a/test-cypress/stubs/cluster/remote-location-stubs.js
+++ b/test-cypress/stubs/cluster/remote-location-stubs.js
@@ -61,10 +61,23 @@ export class RemoteLocationStubs extends Stubs {
     }
 
     static stubGetRemoteLocationsByList(uris) {
+        const local = [{
+            "uri": "",
+            "label": "Local",
+            "username": "",
+            "password": "",
+            "authType": "signature",
+            "active": false,
+            "local": true,
+            "system": false,
+            "errorMsg": null,
+            "defaultRepository": null,
+            "isInCluster": false
+        }];
         const locations = uris.map((uri) => {
             return {
-                "uri": uri || "",
-                "label": uri ? `Remote (${uri})` : "Local",
+                "uri": uri,
+                "label": `Remote (${uri})`,
                 "username": "",
                 "password": "",
                 "authType": "signature",
@@ -78,7 +91,7 @@ export class RemoteLocationStubs extends Stubs {
         });
 
         cy.intercept('GET', '/rest/locations', {
-            body: locations,
+            body: [...local, ...locations],
             statusCode: 200
         }).as('get-remote-locations-by-list');
     }


### PR DESCRIPTION
## WHAT:
- Renamed multiple components, templates, CSS classes, and Cypress tests from `cluster-list` to `cluster-nodes-configuration`
- Added a new directive `validate-duplicate-url` for checking duplicate URLs in the cluster configuration
- Updated Cypress tests and fixtures to reflect the changes
- Improved the logic in the `saveNode` method by refactoring duplicated code into helper functions

## WHY:
- This change was necessary to improve the naming consistency
- Adding the `validate-duplicate-url` directive is necessary for validation of added urls
- The refactored code in `saveNode` reduces duplication

## HOW:
- Renamed all instances of `cluster-list` to `cluster-nodes-configuration` across JS files, templates, CSS, and Cypress tests.
- Introduced a new AngularJS directive `validate-duplicate-url`, which takes an array of excluded URLs and validates against them.
- Updated the cluster management form to use the `validate-duplicate-url` directive alongside the existing `validate-url` directive.
- Updated test cases.