### PR TITLE
GDB-10931 - Remove "+" in href for file download

### DIFF
--- a/src/js/angular/utils/yasgui-utils.js
+++ b/src/js/angular/utils/yasgui-utils.js
@@ -39,7 +39,7 @@ export const toYasguiOutputModel = ($event) => {
 
 export const downloadAsFile = (filename, contentType, content) => {
     const element = document.createElement('a');
-    element.setAttribute('href', `data:${contentType};charset=utf-8, + ${encodeURIComponent(content)}`);
+    element.setAttribute('href', `data:${contentType};charset=utf-8,${encodeURIComponent(content)}`);
     element.setAttribute('download', filename);
     element.style.display = 'none';
     document.body.appendChild(element);


### PR DESCRIPTION
## What?
When downloading SPARQL results, the downloaded files won't include a "+" in the beginning.

## Why?
The extra character made the json files invalid.

## How?
I removed the extra characters before the encoded content.