### PR TITLE
GDB-10937 - reset context and fix sparql method config

### DIFF
--- a/src/js/angular/models/ttyg/agent-form.js
+++ b/src/js/angular/models/ttyg/agent-form.js
@@ -327,7 +327,7 @@ export class ExtractionMethodFormModel {
         if (this._sparqlOption === 'ontologyGraph') {
             payload.ontologyGraph = this._ontologyGraph ? this._ontologyGraph : null;
         } else if (this._sparqlOption === 'sparqlQuery') {
-            payload.constructQuery = this._sparqlQuery ? this._sparqlQuery.value : null;
+            payload.sparqlQuery = this._sparqlQuery ? this._sparqlQuery.value : null;
         }
         // this is used for all but the SPARQL method
         if (this._maxNumberOfTriplesPerCall) {

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -119,6 +119,11 @@ function TTYGViewCtrl(
      */
     $scope.agents = undefined;
     /**
+     * The model of the selected agent.
+     * @type {AgentModel|undefined}
+     */
+    $scope.selectedAgent = undefined;
+    /**
      * Flag to control the visibility of the loader when loading agent list on initial page load.
      * @type {boolean}
      */
@@ -595,6 +600,9 @@ function TTYGViewCtrl(
             })
             .then(() => {
                 TTYGContextService.emit(TTYGEventName.AGENT_DELETED, agent);
+                if ($scope.selectedAgent && $scope.selectedAgent.id === agent.id) {
+                    $scope.selectedAgent = undefined;
+                }
             })
             .catch((error) => {
                 toastr.error(getError(error, 0, 100));
@@ -637,6 +645,7 @@ function TTYGViewCtrl(
      * @param {AgentModel} agent
      */
     const onAgentSelected = (agent) => {
+        $scope.selectedAgent = agent;
         TTYGStorageService.saveAgent(agent);
     };
 
@@ -786,8 +795,9 @@ function TTYGViewCtrl(
     // Subscriptions
     // =========================
 
-    function removeAllListeners() {
+    function cleanUp() {
         subscriptions.forEach((subscription) => subscription());
+        TTYGContextService.resetContext();
     }
 
     subscriptions.push($scope.$watch($scope.getActiveRepositoryObject, getActiveRepositoryObjectHandler));
@@ -810,7 +820,7 @@ function TTYGViewCtrl(
     subscriptions.push(TTYGContextService.subscribe(TTYGEventName.GO_TO_CONNECTORS_VIEW, onGoToConnectorsView));
     subscriptions.push(TTYGContextService.subscribe(TTYGEventName.GO_TO_SPARQL_EDITOR, onGoToSparqlEditorView));
     subscriptions.push($rootScope.$on('$translateChangeSuccess', updateLabels));
-    $scope.$on('$destroy', removeAllListeners);
+    $scope.$on('$destroy', cleanUp);
 
     // =========================
     // Initialization

--- a/src/js/angular/ttyg/services/ttyg-context.service.js
+++ b/src/js/angular/ttyg/services/ttyg-context.service.js
@@ -42,7 +42,7 @@ function TTYGContextService(EventEmitterService, TTYGService) {
      *
      * @type {{[key: string]: ExplainResponseModel}}
      */
-    const _explainCache = {};
+    let _explainCache = {};
 
     /**
      * The default agent values.
@@ -50,6 +50,15 @@ function TTYGContextService(EventEmitterService, TTYGService) {
      * @private
      */
     let _defaultAgent = undefined;
+
+    const resetContext = () => {
+        _agents = undefined;
+        _chats = undefined;
+        _selectedChat = undefined;
+        _selectedAgent = undefined;
+        _explainCache = {};
+        _defaultAgent = undefined;
+    };
 
     /**
      * @return {Promise<AgentModel>}
@@ -298,6 +307,7 @@ function TTYGContextService(EventEmitterService, TTYGService) {
     };
 
     return {
+        resetContext,
         emit,
         subscribe,
         getChats,

--- a/src/js/angular/ttyg/templates/ttyg.html
+++ b/src/js/angular/ttyg/templates/ttyg.html
@@ -67,7 +67,7 @@
                 <div class="toolbar mb-2">
                     <agent-select-menu class="mr-1"></agent-select-menu>
                     <button class="btn btn-link btn-sm edit-current-agent-btn mr-1"
-                            ng-if="true"
+                            ng-if="selectedAgent"
                             ng-click="onOpenAgentSettings()"
                             ng-disabled="false"
                             gdb-tooltip="{{'ttyg.agent.btn.edit_agent.tooltip' | translate}}">

--- a/test-cypress/integration/ttyg/ttyg-view.spec.js
+++ b/test-cypress/integration/ttyg/ttyg-view.spec.js
@@ -38,7 +38,8 @@ describe('TTYG view', () => {
         // Verify the chat panel
         TTYGViewSteps.getChat().should('be.visible');
         TTYGViewSteps.getChatPanelToolbar().should('be.visible');
-        TTYGViewSteps.getEditCurrentAgentButton().should('be.visible');
+        // the edit agent settings button should not be visible when there is not a selected agent
+        TTYGViewSteps.getEditCurrentAgentButton().should('not.exist');
     });
 
     it('Should render no agents view if no agent is created yet', () => {


### PR DESCRIPTION
## What
* Reset the ttyg context on destroy.
* Change the sparqlConstruct parameter for the sparql search method to sparqlQuery.
* Hide the edit agent settings action when there is no selected agent.

## Why
* The context needs to be cleared because it is implemented as a service and the services in angular are singletons and the properties in it remains when the page controller is destroyed which is unexpected.
* The edit agent settings button needs to be hid because when there is no selected agent, it doesn't behave properly.
* The sparqlQuery property was changed again due to changes in the backend.

## How
Applied the needed changes.