### PR TITLE
GDB-11001: The Explain Example button does not work

### DIFF
--- a/src/js/angular/models/ttyg/chats.js
+++ b/src/js/angular/models/ttyg/chats.js
@@ -165,6 +165,17 @@ export class ChatsListModel {
         this.updateChatsByDay();
     }
 
+    replaceChat(newChat, oldChat) {
+        this._chats = this._chats.map((chat) => {
+            if (chat.id === oldChat.id) {
+                return newChat;
+            }
+            return chat;
+        });
+        this.sortByTime();
+        this.updateChatsByDay();
+    }
+
     /**
      * Checks if the chat list is empty.
      * @return {boolean}

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -10,13 +10,14 @@ import 'angular/ttyg/services/ttyg-storage.service';
 import {TTYGEventName} from '../services/ttyg-context.service';
 import {AGENT_OPERATION, AGENTS_FILTER_ALL_KEY} from '../services/constants';
 import {AgentListFilterModel, AgentModel} from '../../models/ttyg/agents';
-import {ChatsListModel} from '../../models/ttyg/chats';
+import {ChatModel, ChatsListModel} from '../../models/ttyg/chats';
 import {agentFormModelMapper} from '../services/agents.mapper';
 import {SelectMenuOptionsModel} from '../../models/form-fields';
 import {repositoryInfoMapper} from '../../rest/mappers/repositories-mapper';
 import {saveAs} from 'lib/FileSaver-patch';
 import {AgentSettingsModal} from "../model/agent-settings-modal";
 import {decodeHTML} from "../../../../app";
+import {md5HashGenerator} from "../../utils/hash-utils";
 
 const modules = [
     'toastr',
@@ -166,7 +167,12 @@ function TTYGViewCtrl(
      * Creates a new chat and selects it.
      */
     $scope.startNewChat = () => {
-        TTYGContextService.emit(TTYGEventName.NEW_CHAT);
+        let nonPersistedChat = TTYGContextService.getChats().getNonPersistedChat();
+        if (!nonPersistedChat) {
+            nonPersistedChat = getEmptyChat();
+            TTYGContextService.addChat(nonPersistedChat);
+        }
+        TTYGContextService.selectChat(nonPersistedChat);
     };
 
     $scope.onopen = $scope.onclose = () => angular.noop();
@@ -462,17 +468,33 @@ function TTYGViewCtrl(
         }
     };
 
+    const getEmptyChat = () => {
+        const data = {
+            name: "\u00B7 \u00B7 \u00B7",
+            timestamp: Math.floor(Date.now() / 1000)
+        };
+        return new ChatModel(data, md5HashGenerator());
+    };
+
     /**
      * @param {ChatItemModel} chatItem
      */
     const onCreateNewChat = (chatItem) => {
+        $scope.startNewChat();
+
         TTYGService.createConversation(chatItem)
             .then((newChatId) => {
                 TTYGContextService.emit(TTYGEventName.CREATE_CHAT_SUCCESSFUL);
                 return TTYGService.getConversation(newChatId);
             })
             .then((chat) => {
-                TTYGContextService.selectChat(chat);
+                const selectedChat = TTYGContextService.getSelectedChat();
+                // If the selected chat is not changed during the creation process.
+                if (selectedChat && !selectedChat.id) {
+                    const nonPersistedChat = TTYGContextService.getChats().getNonPersistedChat();
+                    TTYGContextService.updateSelectedChat(chat);
+                    TTYGContextService.replaceChat(chat, nonPersistedChat);
+                }
                 TTYGContextService.emit(TTYGEventName.LOAD_CHATS);
             })
             .catch(() => {

--- a/src/js/angular/ttyg/directives/chat-list.directive.js
+++ b/src/js/angular/ttyg/directives/chat-list.directive.js
@@ -51,6 +51,10 @@ function ChatListComponent(TTYGContextService, ModalService, $translate, $filter
              */
             $scope.onSelectChat = (chat) => {
                 if (!$scope.selectedChat || $scope.selectedChat.id !== chat.id) {
+                    const nonPersistedChat = TTYGContextService.getChats().getNonPersistedChat();
+                    if (nonPersistedChat) {
+                        TTYGContextService.deleteChat(nonPersistedChat);
+                    }
                     TTYGContextService.selectChat(chat);
                     $scope.renamedChat = undefined;
                 }
@@ -132,23 +136,6 @@ function ChatListComponent(TTYGContextService, ModalService, $translate, $filter
                 $scope.chatList = chatList;
             };
 
-            const onNewChat = () => {
-                const newChat = $scope.chatList.getNonPersistedChat();
-                if (newChat) {
-                    if ($scope.selectedChat.id !== newChat.id) {
-                        TTYGContextService.selectChat(newChat);
-                    }
-                    return;
-                }
-                const data = {
-                    name: "\u00B7 \u00B7 \u00B7",
-                    timestamp: Math.floor(Date.now() / 1000)
-                };
-                const chatModel = new ChatModel(data, md5HashGenerator());
-                $scope.chatList.appendChat(chatModel);
-                TTYGContextService.selectChat(chatModel);
-            };
-
             /**
              * Handles the progress of deletion of a chat.
              * @param {{chatId: string, inProgress: boolean}} event
@@ -167,8 +154,8 @@ function ChatListComponent(TTYGContextService, ModalService, $translate, $filter
             };
 
             subscriptions.push(TTYGContextService.onSelectedChatChanged(onSelectedChatChanged));
+            subscriptions.push(TTYGContextService.onSelectedChatUpdated(onSelectedChatChanged));
             subscriptions.push(TTYGContextService.onChatsListChanged(onChatsListChanged));
-            subscriptions.push(TTYGContextService.subscribe(TTYGEventName.NEW_CHAT, onNewChat));
             subscriptions.push(TTYGContextService.subscribe(TTYGEventName.DELETING_CHAT, onDeletingChat));
 
             // Deregister the watcher when the scope/directive is destroyed

--- a/src/js/angular/ttyg/directives/chat-panel.directive.js
+++ b/src/js/angular/ttyg/directives/chat-panel.directive.js
@@ -124,7 +124,6 @@ function ChatPanelComponent(toastr, $translate, TTYGContextService) {
             // Private functions
             // =========================
             const createNewChat = () => {
-                TTYGContextService.emit(TTYGEventName.NEW_CHAT, $scope.chatItem);
                 TTYGContextService.emit(TTYGEventName.CREATE_CHAT, $scope.chatItem);
             };
 
@@ -133,11 +132,15 @@ function ChatPanelComponent(toastr, $translate, TTYGContextService) {
             };
 
             /**
-             * Handles the change of the selected chat.
+             * Handles the update of the selected chat.
              * @param {ChatModel} chat - the new selected chat.
              */
-            const onChatChanged = (chat) => {
+            const onSelectedChatUpdated = (chat) => {
                 $scope.chat = chat;
+                if (!chat.id && $scope.askingChatItem) {
+                    // Do nothing if the chat is new (dummy) and a question is currently being asked.
+                    return;
+                }
                 $scope.loadingChat = false;
                 $scope.chatItem = getEmptyChatItem();
                 $scope.askingChatItem = undefined;
@@ -223,7 +226,7 @@ function ChatPanelComponent(toastr, $translate, TTYGContextService) {
             };
 
             subscriptions.push($scope.$watchCollection('chat.chatHistory.items', scrollToBottom));
-            subscriptions.push(TTYGContextService.onSelectedChatUpdated(onChatChanged));
+            subscriptions.push(TTYGContextService.onSelectedChatUpdated(onSelectedChatUpdated));
             subscriptions.push(TTYGContextService.onSelectedAgentChanged(onSelectedAgentChanged));
             subscriptions.push(TTYGContextService.onSelectedChatChanged(onSelectedChatChanged));
             subscriptions.push(TTYGContextService.subscribe(TTYGEventName.ASK_QUESTION_FAILURE, onQuestionFailure));

--- a/src/js/angular/ttyg/services/ttyg-context.service.js
+++ b/src/js/angular/ttyg/services/ttyg-context.service.js
@@ -109,6 +109,11 @@ function TTYGContextService(EventEmitterService, TTYGService) {
         updateChats(_chats);
     };
 
+    const replaceChat = (newChat, oldChat) => {
+     _chats.replaceChat(newChat, oldChat);
+     updateChats(_chats);
+    };
+
     /** Subscribes to the 'chatListUpdated' event.
      * @param {function} callback - The callback to be called when the event is fired.
      *
@@ -165,7 +170,7 @@ function TTYGContextService(EventEmitterService, TTYGService) {
      * @param {ChatModel} chat - The chat object that is being updated.
      */
     const updateSelectedChat = (chat) => {
-        if (!_selectedChat || !chat || _selectedChat.id === chat.id) {
+        if (!_selectedChat || !_selectedChat.id || !chat || _selectedChat.id === chat.id) {
             _selectedChat = cloneDeep(chat);
             emit(TTYGEventName.SELECTED_CHAT_UPDATED, getSelectedChat());
         }
@@ -314,6 +319,7 @@ function TTYGContextService(EventEmitterService, TTYGService) {
         updateChats,
         deleteChat,
         addChat,
+        replaceChat,
         onChatsListChanged,
         getSelectedChat,
         selectChat,
@@ -338,11 +344,6 @@ function TTYGContextService(EventEmitterService, TTYGService) {
 }
 
 export const TTYGEventName = {
-    /**
-     * Emitting the "newChat" event notifies that a new chat is about to be created.
-     */
-    NEW_CHAT: 'newChat',
-
     /**
      * Emitting the "createChat" event triggers a backend request to create a new chat.
      */

--- a/src/js/angular/ttyg/templates/chat-panel.html
+++ b/src/js/angular/ttyg/templates/chat-panel.html
@@ -15,6 +15,7 @@
             show-actions="!askingChatItem && $last"
             on-regenerate-question="regenerateQuestion(chatItem)"
             on-copy-answer-to-clipboard="copyAnswerToClipboard(chatItem)"
+            on-ask-how-delivered-answer="onAskHowDeliveredAnswer(chatItem)"
             disabled="askingChatItem">
         </chat-item-detail>
         <chat-item-detail ng-if="askingChatItem" chat-item-detail="askingChatItem"


### PR DESCRIPTION
## What
- The "Explain Example" button is non-functional;
- A new chat field is not created when attempting to start a chat for the first time. ## Why
- The onAskHowDeliveredAnswer function binding is not passed to the chatItemDetail component;
- There was an issue where an action reset the question during the chat creation flow.

## How
- Added the missing binding for onAskHowDeliveredAnswer;
- Updated the chat creation flow. When the "Start a New Chat" button is clicked, or the "Ask" button is clicked when no chats exist, the ttygController now creates a dummy chat model instance and updates the context with it. Once the chat is created by the backend, the dummy chat is replaced with the newly created instance.