### PR TITLE
GDB-11001: Filtering Repositories in TTYG Functionality

### DIFF
--- a/src/js/angular/core/services/repositories.service.js
+++ b/src/js/angular/core/services/repositories.service.js
@@ -271,6 +271,11 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
             });
         };
 
+        this.getReadableGraphdbRepositories = function () {
+            return this.getReadableRepositories()
+                .filter((repo) => repo.type === 'graphdb');
+        };
+
         this.getWritableRepositories = function () {
             const that = this;
             return _.filter(this.getRepositories(), function (repo) {

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -640,8 +640,7 @@ function TTYGViewCtrl(
     const buildAgentsFilterModel = () => {
         const currentRepository = $repositories.getActiveRepository();
         // TODO: this should be refreshed automatically when the repositories change
-        const repositoryObjects = $repositories.getReadableRepositories()
-            .filter((repo) => repo.type === 'graphdb')
+        const repositoryObjects = $repositories.getReadableGraphdbRepositories()
             .map((repo) => (
            new AgentListFilterModel(repo.id, repo.id, repo.id === currentRepository)
         ));
@@ -802,8 +801,7 @@ function TTYGViewCtrl(
     };
 
     const buildRepositoryList = () => {
-        $scope.activeRepositoryList = $repositories.getReadableRepositories()
-            .filter((repo) => repo.type === 'graphdb')
+        $scope.activeRepositoryList = $repositories.getReadableGraphdbRepositories()
             .map((repo) => (
                 new SelectMenuOptionsModel({
                     value: repo.id,

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -640,7 +640,9 @@ function TTYGViewCtrl(
     const buildAgentsFilterModel = () => {
         const currentRepository = $repositories.getActiveRepository();
         // TODO: this should be refreshed automatically when the repositories change
-        const repositoryObjects = $repositories.getReadableRepositories().map((repo) => (
+        const repositoryObjects = $repositories.getReadableRepositories()
+            .filter((repo) => repo.type === 'graphdb')
+            .map((repo) => (
            new AgentListFilterModel(repo.id, repo.id, repo.id === currentRepository)
         ));
         $scope.agentListFilterModel = [
@@ -801,6 +803,7 @@ function TTYGViewCtrl(
 
     const buildRepositoryList = () => {
         $scope.activeRepositoryList = $repositories.getReadableRepositories()
+            .filter((repo) => repo.type === 'graphdb')
             .map((repo) => (
                 new SelectMenuOptionsModel({
                     value: repo.id,

--- a/test-cypress/fixtures/repositories/get-ttyg-repositories.json
+++ b/test-cypress/fixtures/repositories/get-ttyg-repositories.json
@@ -41,6 +41,34 @@
             "writable": true,
             "unsupported": false,
             "state": "INACTIVE"
+        },
+        {
+            "id": "Fedx_repository",
+            "title": "",
+            "uri": "http://localhost:8080/graphdb/repositories/Fedx_repository",
+            "externalUrl": "http://boyantonchev:9000/repositories/Fedx_repository",
+            "local": true,
+            "type": "fedx",
+            "sesameType": "graphdb:FedXRepository",
+            "location": "",
+            "readable": true,
+            "writable": true,
+            "unsupported": false,
+            "state": "INACTIVE"
+        },
+        {
+            "id": "Ontop_repository",
+            "title": "",
+            "uri": "http://localhost:8080/graphdb/repositories/Fedx_repository",
+            "externalUrl": "http://boyantonchev:9000/repositories/Fedx_repository",
+            "local": true,
+            "type": "ontop",
+            "sesameType": "graphdb:FedXRepository",
+            "location": "",
+            "readable": true,
+            "writable": true,
+            "unsupported": false,
+            "state": "INACTIVE"
         }
     ]
 }

--- a/test-cypress/integration/ttyg/agent-list.spec.js
+++ b/test-cypress/integration/ttyg/agent-list.spec.js
@@ -63,6 +63,8 @@ describe('TTYG agent list', () => {
         TTYGViewSteps.getAgents().should('have.length', 2);
         // Then Agent list filter should be set to All
         TTYGViewSteps.getSelectedAgentFilter().should('contain', 'starwars');
+        TTYGViewSteps.verifyRepositoryOptionNotExist('Fedx_repository');
+        TTYGViewSteps.verifyRepositoryOptionNotExist('Ontop_repository');
         // When I filter the agents by repository 'biomarkers'
         TTYGViewSteps.filterAgentsByRepository('biomarkers');
         // Then I should see only 1 agent

--- a/test-cypress/integration/ttyg/create-agent.spec.js
+++ b/test-cypress/integration/ttyg/create-agent.spec.js
@@ -376,6 +376,9 @@ describe('TTYG create new agent', () => {
         TTYGViewSteps.createFirstAgent();
         // Then I expect the selected repository to be set as the repository ID in the form.
         TtygAgentSettingsModalSteps.verifyRepositorySelected('starwars');
+        // and all options are exclusively for GraphDB repositories.
+        TtygAgentSettingsModalSteps.verifyRepositoryOptionNotExist('Fedx_repository');
+        TtygAgentSettingsModalSteps.verifyRepositoryOptionNotExist('Ontop_repository');
 
         // When I open ChatGPT retrieval connector panel
         TtygAgentSettingsModalSteps.enableRetrievalMethodPanel();

--- a/test-cypress/steps/ttyg/ttyg-agent-settings-modal.steps.js
+++ b/test-cypress/steps/ttyg/ttyg-agent-settings-modal.steps.js
@@ -59,6 +59,12 @@ export class TtygAgentSettingsModalSteps extends ModalDialogSteps {
         this.getRepositorySelect().find('option:selected').should('have.text', repositoryId);
     }
 
+    static verifyRepositoryOptionNotExist(repositoryId) {
+        this.getRepositorySelect().each(($select) => {
+            cy.wrap($select).find('option').should('not.contain.text', repositoryId);
+        });
+    }
+
     // Extraction methods
 
     static getExtractionMethodError() {

--- a/test-cypress/steps/ttyg/ttyg-view-steps.js
+++ b/test-cypress/steps/ttyg/ttyg-view-steps.js
@@ -126,9 +126,19 @@ export class TTYGViewSteps {
         return this.getAgentFilter().find('.selected-filter');
     }
 
+    static getDropdownMenu() {
+        return this.getAgentFilter().find('.dropdown-menu');
+    }
+
+    static verifyRepositoryOptionNotExist(repositoryId) {
+        this.getDropdownMenu().each(($select) => {
+            cy.wrap($select).should('not.contain.text', repositoryId);
+        });
+    }
+
     static filterAgentsByRepository(repository) {
         this.getAgentFilter().click();
-        this.getAgentFilter().find('.dropdown-menu').find(`[data-value="${repository}"]`).click();
+        this.getDropdownMenu().find(`[data-value="${repository}"]`).click();
     }
 
     static selectAllAgentsFilter() {


### PR DESCRIPTION
## What
Added filtering of repositories for:
 - The dropdown in the "Create Agent" dialog;
 - The repository filter in the agent list panel.

## Why
TTYG functionality is designed to work only with GraphDB repositories.

## How
Implemented filtering by repository type when loading repositories for dropdowns.