### PR TITLE
GDB-10937 - show agent name and other improvements

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -308,8 +308,8 @@
             "labels": {
                 "query_method": "Query method",
                 "raw_query": "Raw query",
-                "sparql_query": "SPARQL query"
-
+                "sparql_query": "SPARQL query",
+                "agent_name": "Agent: {{agentName}}"
             },
             "query_name": {
                 "sparql_query":"SPARQL",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -309,7 +309,8 @@
             "labels": {
                 "query_method": "Méthode de requête",
                 "raw_query": "Requête brute",
-                "sparql_query": "Requête SPARQL"
+                "sparql_query": "Requête SPARQL",
+                "agent_name": "Agent: {{agentName}}"
             },
             "query_name": {
                 "sparql_query":"SPARQL",

--- a/src/js/angular/models/ttyg/agents.js
+++ b/src/js/angular/models/ttyg/agents.js
@@ -1,5 +1,6 @@
 import {cloneDeep} from "lodash";
 import {AGENTS_FILTER_ALL_KEY} from "../../ttyg/services/constants";
+
 export class AgentModel {
     constructor(data, hashGenerator) {
         this.hashGenerator = hashGenerator;
@@ -346,6 +347,16 @@ export class AgentListModel {
          * @private
          */
         this._filterableAgents = cloneDeep(agents);
+
+        this._agentNameByIdMap = {};
+        this._initializeAgentNameByIdMap();
+    }
+
+    _initializeAgentNameByIdMap() {
+        this._agentNameByIdMap = this._agents.reduce((map, agent) => {
+            map[agent.id] = agent.name;
+            return map;
+        }, {});
     }
 
     isEmpty() {
@@ -387,6 +398,14 @@ export class AgentListModel {
 
     set filterableAgents(value) {
         this._filterableAgents = value;
+    }
+
+    get agentNameByIdMap() {
+        return cloneDeep(this._agentNameByIdMap);
+    }
+
+    set agentNameByIdMap(value) {
+        this._agentNameByIdMap = value;
     }
 }
 

--- a/src/js/angular/ttyg/directives/chat-item-detail.directive.js
+++ b/src/js/angular/ttyg/directives/chat-item-detail.directive.js
@@ -39,12 +39,25 @@ function ChatItemDetailComponent(toastr, $translate, TTYGContextService, Markdow
             // =========================
             // Public variables
             // =========================
+
             $scope.MarkdownService = MarkdownService;
+
+            /**
+             * Mapping of agent id to agent name which is used to display the agent name in the UI.
+             * @type {{[key: string]: string}}
+             */
+            $scope.agentNameByIdMap = {};
 
             /**
              * @type {{[key: string]: ExplainResponseModel}}
              */
             $scope.explainResponseModel = {};
+
+            /**
+             * Mapping of answer id to a boolean value indicating whether the explanation of how the answer was
+             * generated is being loaded.
+             * @type {{[key: string]: boolean}}
+             */
             $scope.loadingExplainResponse = {};
 
             // =========================
@@ -117,6 +130,10 @@ function ChatItemDetailComponent(toastr, $translate, TTYGContextService, Markdow
                 });
             };
 
+            const onAgentsListChanged = () => {
+                $scope.agentNameByIdMap = TTYGContextService.getAgents().agentNameByIdMap;
+            };
+
             // =========================
             // Subscriptions
             // =========================
@@ -127,6 +144,7 @@ function ChatItemDetailComponent(toastr, $translate, TTYGContextService, Markdow
             };
 
             subscriptions.push(TTYGContextService.onExplainResponseCacheUpdated(onExplainResponseCacheUpdated));
+            subscriptions.push(TTYGContextService.onAgentsListChanged(onAgentsListChanged));
 
             // Deregister the watcher when the scope/directive is destroyed
             $scope.$on('$destroy', removeAllSubscribers);

--- a/src/js/angular/ttyg/directives/chat-panel.directive.js
+++ b/src/js/angular/ttyg/directives/chat-panel.directive.js
@@ -121,6 +121,11 @@ function ChatPanelComponent(toastr, $translate, TTYGContextService) {
                 scrollToBottom();
             };
 
+            /**
+             * Finds out if agent with such id exists and returns its name or a default message for deleted agent.
+             * @param {string} agentId
+             * @return {string}
+             */
             $scope.getAgentName = (agentId) => {
               const agent = TTYGContextService.getAgent(agentId);
               return agent ? agent.name : decodeHTML($translate.instant('ttyg.chat_panel.deleted_agent'));
@@ -129,6 +134,7 @@ function ChatPanelComponent(toastr, $translate, TTYGContextService) {
             // =========================
             // Private functions
             // =========================
+
             const createNewChat = () => {
                 TTYGContextService.emit(TTYGEventName.CREATE_CHAT, $scope.chatItem);
             };

--- a/src/js/angular/ttyg/services/ttyg-context.service.js
+++ b/src/js/angular/ttyg/services/ttyg-context.service.js
@@ -80,7 +80,7 @@ function TTYGContextService(EventEmitterService) {
 
     const getAgent = (agentId) => {
         if (_agents) {
-                return cloneDeep(_agents.getAgent(agentId));
+            return cloneDeep(_agents.getAgent(agentId));
         }
     };
 
@@ -114,8 +114,8 @@ function TTYGContextService(EventEmitterService) {
     };
 
     const replaceChat = (newChat, oldChat) => {
-     _chats.replaceChat(newChat, oldChat);
-     updateChats(_chats);
+        _chats.replaceChat(newChat, oldChat);
+        updateChats(_chats);
     };
 
     /** Subscribes to the 'chatListUpdated' event.

--- a/src/js/angular/ttyg/templates/chat-item-detail.html
+++ b/src/js/angular/ttyg/templates/chat-item-detail.html
@@ -8,7 +8,8 @@
     </div>
     <div class="answers" ng-repeat="answer in chatItemDetail.answers">
         <div class="assistant">
-            <div class="assistant-icon alert-help">
+            <div class="assistant-icon alert-help"
+                 gdb-tooltip="{{'ttyg.chat_panel.labels.agent_name' | translate : {agentName:  agentNameByIdMap[chatItemDetail.agentId]} }}">
                 <i class="fa-regular fa-message-bot"></i>
             </div>
             <div class="assistant-message">

--- a/src/js/angular/ttyg/templates/chat-panel.html
+++ b/src/js/angular/ttyg/templates/chat-panel.html
@@ -12,12 +12,13 @@
         <div ng-repeat="chatItemDetail in chat.chatHistory.items">
 
             <!-- Before the first chat item is displayed, show the agent change info if the agent of the first response is different from the selected agent. -->
-<!--            <div class="alert alert-info agent-changed-info" ng-if="$first && selectedAgent && chatItemDetail.agentId !== selectedAgent.id"-->
-<!--                 ng-bind-html="'ttyg.chat_panel.messages.agent_changed_info' | htmlTranslate: {agentName: getAgentName(chatItemDetail.agentId)}">-->
-<!--            </div>-->
+            <!--            <div class="alert alert-info agent-changed-info" ng-if="$first && selectedAgent && chatItemDetail.agentId !== selectedAgent.id"-->
+            <!--                 ng-bind-html="'ttyg.chat_panel.messages.agent_changed_info' | htmlTranslate: {agentName: getAgentName(chatItemDetail.agentId)}">-->
+            <!--            </div>-->
 
             <!-- Before each chat item, except the first one, is displayed, show the agent change info if the currently used agent is different from the previous one. -->
-            <div class="alert alert-info agent-changed-info" ng-if="!$first && chatItemDetail.agentId !== chat.chatHistory.items[$index - 1].agentId"
+            <div class="alert alert-info agent-changed-info"
+                 ng-if="!$first && chatItemDetail.agentId !== chat.chatHistory.items[$index - 1].agentId"
                  ng-bind-html="'ttyg.chat_panel.messages.agent_changed_info' | htmlTranslate: {agentName: getAgentName(chatItemDetail.agentId)}">
             </div>
 
@@ -32,15 +33,17 @@
         </div>
 
         <!-- After all chat items are displayed, show the agent change info if the selected agent is different from the one used in the last chat item. -->
-        <div class="alert alert-info agent-changed-info" ng-if="askingChatItem && selectedAgent && chat.chatHistory.items.length && chat.chatHistory.items[chat.chatHistory.items.length -1].agentId !== selectedAgent.id"
-                         ng-bind-html="'ttyg.chat_panel.messages.agent_changed_info' | htmlTranslate: {agentName: getAgentName(selectedAgent.id)}">
-                    </div>
+        <div class="alert alert-info agent-changed-info"
+             ng-if="askingChatItem && selectedAgent && chat.chatHistory.items.length && chat.chatHistory.items[chat.chatHistory.items.length -1].agentId !== selectedAgent.id"
+             ng-bind-html="'ttyg.chat_panel.messages.agent_changed_info' | htmlTranslate: {agentName: getAgentName(selectedAgent.id)}">
+        </div>
         <chat-item-detail ng-if="askingChatItem" chat-item-detail="askingChatItem"
                           asking="!!askingChatItem"></chat-item-detail>
     </div>
     <div class="new-question mb-2 mt-2 d-flex">
         <input class="form-control question-input" ng-model="chatItem.question.message" type="text"
-               ng-disabled="askingChatItem || loadingChat" ng-keypress="onKeypressOnInput($event)">
+               ng-disabled="askingChatItem || loadingChat || !selectedAgent || selectedAgent.isDeleted"
+               ng-keypress="onKeypressOnInput($event)">
         <button class="btn btn-primary ask-button"
                 ng-disabled="!chatItem.question.message || !selectedAgent || selectedAgent.isDeleted || askingChatItem || loadingChat"
                 ng-click="ask()">

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -241,13 +241,13 @@
             "deleting_chat": "Deleting chats...",
             "btn": {
                 "open_sidebar": {
-                    "tooltip": "Open sidebar"
+                    "tooltip": "Show chat list"
                 },
                 "close_sidebar": {
-                    "tooltip": "Close sidebar"
+                    "tooltip": "Hide chat list"
                 },
                 "create_chat": {
-                    "tooltip": "Create a new chat"
+                    "tooltip": "Start a new chat"
                 },
                 "export_chat": {
                     "label": "Export",
@@ -285,8 +285,14 @@
                 "regenerate": {
                     "tooltip": "Regenerate"
                 },
-                "copy": {
-                    "tooltip": "Copy"
+                "copy_answer": {
+                    "tooltip": "Copy answer"
+                },
+                "copy_raw_query": {
+                    "tooltip": "Copy raw query"
+                },
+                "copy_sparql": {
+                    "tooltip": "Copy SPARQL query"
                 },
                 "explain_response": {
                     "tooltip": "Explain response"
@@ -294,13 +300,16 @@
                 "derive_answer": {
                     "label": "How did you derive this answer?",
                     "hint": "Hint: you can also ask the model, for example"
+                },
+                "open_in_sparql_editor": {
+                    "tooltip": "Open in SPARQL editor"
                 }
             },
             "labels": {
                 "query_method": "Query method",
                 "raw_query": "Raw query",
-                "sparql_query": "SPARQL query"
-
+                "sparql_query": "SPARQL query",
+                "agent_name": "Agent: {{agentName}}"
             },
             "query_name": {
                 "sparql_query":"SPARQL",
@@ -336,20 +345,25 @@
                 "form": {
                     "agent_name": {
                         "label": "Agent name",
-                        "placeholder": "Enter user friendly name"
+                        "placeholder": "Enter user friendly name",
+                        "tooltip": "A descriptive name that helps you identify this agent."
                     },
                     "repository": {
-                        "label": "Repository ID"
+                        "label": "Repository ID",
+                        "tooltip": "The ID of the repository that will be used to retrieve information from GraphDB. Ontop and FedX repositories are not supported."
                     },
                     "model": {
                         "label": "Model",
+                        "tooltip": "The model to use for this agent. More powerful models will provide better results.",
                         "hint": "Check out the available OpenAI models <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">here</a>."
                     },
                     "temperature": {
-                        "label": "Temperature"
+                        "label": "Temperature",
+                        "tooltip": "The sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic."
                     },
                     "top_p": {
-                        "label": "Top_P"
+                        "label": "Top_P",
+                        "tooltip": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with Top P probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. OpenAI recommends altering this or temperature but not both."
                     },
                     "seed": {
                         "label": "Seed",
@@ -357,28 +371,44 @@
                     },
                     "extraction_method": {
                         "label": "Query methods",
-                        "required": "At least one query method must be selected"
+                        "required": "At least one query method must be selected",
+                        "tooltip": "Query methods to be used by the model to retrieve information from GraphDB and answer questions."
                     },
                     "fts_search": {
                         "label": "Full-text search",
+                        "tooltip": "Answers questions by using full-text search in literals and IRIs. Performs well on open-ended questions but not so well on providing aggregations.",
                         "fts_disabled_message": "You must <a href=\"{{repositoryEditPage}}\" target=\"_blank\">enable the full-text search (FTS) index</a> to use this method.",
                         "missing_repository_id": "Repository ID must be selected"
                     },
+                    "fts_search_max_number_of_triples_per_call": {
+                        "label": "Max number of results (triples) per call",
+                        "tooltip": "Limit the maximum number of triples returned by Full-text search. The default value is automatic and determined at runtime. If not sure, leave the default value.",
+                        "placeholder": "Automatic value"
+                    },
                     "sparql_search": {
                         "label": "SPARQL",
+                        "tooltip": "Answers questions by performing a SPARQL query. This works well for datasets with good ontologies and performs well on closed-ended questions, including aggregations.",
                         "required_option": "Select how an ontology should be fetched"
                     },
                     "ontology_graph": {
-                        "label": "Fetch ontology from a named graph"
+                        "label": "Fetch ontology from a named graph",
+                        "tooltip": "The named graph that contains the entire ontology or a subset sufficient to generate useful SPARQL queries."
                     },
                     "construct_query": {
-                        "label": "Provide a SPARQL CONSTRUCT query that fetches the ontology"
+                        "label": "Provide a SPARQL CONSTRUCT query that fetches the ontology",
+                        "tooltip": "A SPARQL CONSTRUCT query that returns the entire ontology or a subset sufficient to generate useful SPARQL queries."
                     },
                     "similarity_search": {
-                        "label": "Similarity search"
+                        "label": "Similarity search",
+                        "tooltip": "Answers questions by using Similarity search. Performs well on open-ended questions but not so well on providing aggregations."
+                    },
+                    "similarity_search_max_number_of_triples_per_call": {
+                        "label": "Max number of results (triples) per call",
+                        "tooltip": "Limit the maximum number of triples returned by Similarity search. The default value is automatic and determined at runtime. If not sure, leave the default value."
                     },
                     "similarity_index": {
                         "label": "Similarity index name",
+                        "tooltip": "The text similarity index to use for similarity search queries.",
                         "loading_indexes": "Loading similarity indexes...",
                         "no_similarity_index": {
                             "message_1": "You must",
@@ -392,10 +422,12 @@
                         }
                     },
                     "similarity_threshold": {
-                        "label": "Similarity threshold"
+                        "label": "Similarity score threshold",
+                        "tooltip": "Use only similarity results whose score is at least the threshold value, between 0 and 1. The default value is 0.6."
                     },
                     "retrieval_search": {
                         "label": "ChatGPT retrieval connector",
+                        "tooltip": "Answers questions by using vector search in text chunks created from RDF. Performs well on open-ended questions but not so well on providing aggregations.",
                         "no_retrieval_connectors": {
                             "message_1": "You must",
                             "message_2": "create ChatGPT retrieval connector",
@@ -408,27 +440,52 @@
                         }
                     },
                     "connector_id": {
-                        "label": "ChatGPT retrieval connector"
+                        "label": "ChatGPT retrieval connector",
+                        "tooltip": "The ChatGPT Retrieval Connector instance to use for CtatGPT retrieval queries."
                     },
                     "query_template": {
-                        "label": "Query template"
+                        "label": "Query template",
+                        "tooltip": "This template may use a filter with the available metadata fields in your ChatGPT Retrieval Connector instance. The default value contains only the query part and uses no metadata fields. Please consult the documentation for more information."
                     },
-                    "max_number_of_triples_per_call": {
-                        "label": "Max number of results (triples) per call",
+                    "retrieval_search_max_number_of_triples_per_call": {
+                        "label": "Max number of results (chunks) per call",
+                        "tooltip": "Limit the maximum number of text chunks returned by the ChatGPT Retrieval Connector. The default value is automatic and determined at runtime. If not sure, leave the default value.",
                         "placeholder": "Automatic value"
                     },
                     "system_instruction": {
                         "label": "System instructions",
-                        "placeholder": "Enter system instructions"
+                        "placeholder": "Enter system instructions",
+                        "tooltip": "Base instructions for the agent. The default value provides good results in most setups so there is no need to change it.",
+                        "btn": {
+                            "copy_instruction": {
+                                "tooltip": "Copy system instructions"
+                            },
+                            "restore_default": {
+                                "tooltip": "Reset to default"
+                            }
+                        }
                     },
                     "user_instruction": {
                         "label": "User instructions",
-                        "placeholder": "Enter user instructions"
+                        "placeholder": "Enter user instructions",
+                        "tooltip": "Additional instructions can be used to provide ground truths or proper instructions.",
+                        "btn": {
+                            "copy_instruction": {
+                                "tooltip": "Copy user instructions"
+                            },
+                            "restore_default": {
+                                "tooltip": "Reset to default"
+                            }
+                        }
                     },
                     "additional_query_methods": {
                         "label": "Additional query methods",
+                        "tooltip": "Additional query methods supplement the main query methods but cannot be used on their own to answer general questions.",
                         "method": {
-                            "iri_discovery_search": "Full-text search in labels for IRI discovery"
+                            "iri_discovery_search": {
+                                "label": "Full-text search in labels for IRI discovery",
+                                "tooltip": "Helps the model discover the IRIs for a particular incomplete query, for example the name Michael in “What’s Michael’s phone number?”"
+                            }
                         }
                     }
                 },
@@ -475,8 +532,8 @@
                     "all": "All"
                 },
                 "edit_agent": {
-                    "label": "Settings",
-                    "tooltip": "Edit Agent"
+                    "label": "Agent settings",
+                    "tooltip": "Edit agent settings"
                 },
                 "clone_agent": {
                     "label": "Clone",
@@ -488,10 +545,10 @@
                 },
                 "create_agent": {
                     "label": "Create Agent",
-                    "tooltip": "Create Agent"
+                    "tooltip": "Create a new agent"
                 },
                 "open_sidebar": {
-                    "tooltip": "Open sidebar"
+                    "tooltip": "Manage agents"
                 },
                 "close_sidebar": {
                     "tooltip": "Close sidebar"
@@ -501,6 +558,7 @@
                 "no_agents": "No agents found for the selected filter.",
                 "help_1": "Talk to your data in natural language. All you need to do is create and instruct your own AI Agent to assist you.",
                 "help_2": "The Agent is an AI-powered conversational agent designed to help with a wide range of tasks, from answering questions and providing information to assisting with creative and technical projects. It leverages advanced natural language processing to understand and respond to user inputs in a human-like manner, making interactions intuitive and efficient.",
+                "warn1": "To use this feature, the config property graphdb.gpt.token should be set to your GPT token in conf graphdb.properties file.",
                 "error_retrieval_connectors_loading": "Error loading retrieval connectors",
                 "error_similarity_indexes_loading": "Error loading similarity indexes",
                 "error_repository_config_loading": "Error loading repository configurations",


### PR DESCRIPTION
## What
* Show the agent name when the agent icon in the chat panel is hovered.
* Prevent typing in the question input field if there isn't a selected agent.

## Why
For better usability the agent name needs to be visible in each agent answer because we allow the agent to be changed in the same chat. There are cases where when the currently selected is missing the question input field is not disabled and the user can type a question and send it by clicking on the [enter] key which is unwanted.

## How
Extended the agent list model with a mapping of agent id to agent name map which is then used in the chat details component to show the agent tooltip. Extended the condition for disabling the question input with a check if there is a selected agent.