### PR TITLE
feat(GDB-11024) Add CookieService to manage installation ID tracking

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -42,7 +42,7 @@ const modules = [
     'graphdb.framework.core.directives.prop-indeterminate',
     'graphdb.framework.guides.services',
     'graphdb.framework.core.services.licenseService',
-    'graphdb.framework.core.services.cookieService',
+    'graphdb.framework.core.services.installationCookieService',
     'graphdb.framework.core.directives.operationsstatusesmonitor',
     'graphdb.framework.core.directives.autocomplete',
     'ngCustomElement'
@@ -195,8 +195,8 @@ const moduleDefinition = function (productInfo, translations) {
     workbench.constant('productInfo', productInfo);
 
     // we need to inject $jwtAuth here in order to init the service before everything else
-    workbench.run(['$rootScope', '$route', 'toastr', '$sce', '$translate', 'ThemeService', 'WorkbenchSettingsStorageService', 'LSKeys', 'GuidesService', '$licenseService', 'CookieService',
-        function ($rootScope, $route, toastr, $sce, $translate, ThemeService, WorkbenchSettingsStorageService, LSKeys, GuidesService, $licenseService, CookieService) {
+    workbench.run(['$rootScope', '$route', 'toastr', '$sce', '$translate', 'ThemeService', 'WorkbenchSettingsStorageService', 'LSKeys', 'GuidesService', '$licenseService', 'InstallationCookieService',
+        function ($rootScope, $route, toastr, $sce, $translate, ThemeService, WorkbenchSettingsStorageService, LSKeys, GuidesService, $licenseService, InstallationCookieService) {
             $rootScope.$on('$routeChangeSuccess', function () {
                 updateTitleAndHelpInfo();
 
@@ -227,11 +227,11 @@ const moduleDefinition = function (productInfo, translations) {
 
             // Checks license status and adds tracking code and cookies when free/evaluation license
             $licenseService.checkLicenseStatus().then(() => {
-                if ($licenseService.isTrackingAllowed) {
+                if ($licenseService.isTrackingAllowed()) {
                     const installationId = $licenseService.license().installationId || '';
-                    CookieService.setCookieIfAbsent(installationId);
+                    InstallationCookieService.setIfAbsent(installationId);
                 } else {
-                    $licenseService.deleteCookie();
+                    InstallationCookieService.remove();
                 }
             });
         }]);

--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -12,7 +12,7 @@ import 'ng-file-upload/dist/ng-file-upload-shim.min';
 import 'angular/core/services/jwt-auth.service';
 import 'angular/core/services/repositories.service';
 import 'angular/core/services/license.service';
-import 'angular/core/services/cookie.service';
+import 'angular/core/services/installation-cookie.service';
 import {UserRole} from 'angular/utils/user-utils';
 import 'angular/utils/local-storage-adapter';
 import 'angular/utils/workbench-settings-storage-service';
@@ -31,7 +31,7 @@ angular
         'graphdb.framework.core.services.jwtauth',
         'graphdb.framework.core.services.repositories',
         'graphdb.framework.core.services.licenseService',
-        'graphdb.framework.core.services.cookieService',
+        'graphdb.framework.core.services.installationCookieService',
         'graphdb.framework.core.services.theme-service',
         'ngCookies',
         'ngFileUpload',

--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -12,6 +12,7 @@ import 'ng-file-upload/dist/ng-file-upload-shim.min';
 import 'angular/core/services/jwt-auth.service';
 import 'angular/core/services/repositories.service';
 import 'angular/core/services/license.service';
+import 'angular/core/services/cookie.service';
 import {UserRole} from 'angular/utils/user-utils';
 import 'angular/utils/local-storage-adapter';
 import 'angular/utils/workbench-settings-storage-service';
@@ -30,6 +31,7 @@ angular
         'graphdb.framework.core.services.jwtauth',
         'graphdb.framework.core.services.repositories',
         'graphdb.framework.core.services.licenseService',
+        'graphdb.framework.core.services.cookieService',
         'graphdb.framework.core.services.theme-service',
         'ngCookies',
         'ngFileUpload',

--- a/src/js/angular/core/services/cookie.service.js
+++ b/src/js/angular/core/services/cookie.service.js
@@ -1,62 +1,211 @@
-const COOKIE_NAME = '_wb=';
-const COOKIE_VERSION = 'WB1';
-const EXPIRATION_DATE = new Date('2099-12-31T23:59:59Z');
-
 angular.module('graphdb.framework.core.services.cookieService', [])
-    .service('CookieService', ['$cookies', CookieService]);
+    .service('CookieService', ['$document', '$cookies', CookieService]);
 
 /**
- * Service to manage cookies for the application. It checks if a specific cookie exists,
- * sets it if necessary, retrieves it, or deletes it when required.
+ * Service to manage cookies for the application. It sets it, retrieves it, or deletes it when required.
  *
+ * @param {Object} $document - AngularJS service to manage document.
  * @param {Object} $cookies - AngularJS service to manage cookies.
- * @return {Object} - Returns an object with methods to get, set, and delete cookies.
+ * @return {Object} - Returns an object with methods to get, set, and remove cookies.
  */
-function CookieService($cookies) {
-
+function CookieService($document, $cookies) {
     /**
-     * Checks if the cookie exists and retrieves its value.
-     * @return {string|null} The cookie value if it exists, otherwise null.
-     */
-    const getCookie = () => {
-        return $cookies.get(COOKIE_NAME) || null;
-    };
-
-    /**
-     * Creates and sets a cookie with a specific installation ID and the current timestamp.
-     * The cookie is set to expire on December 31, 2099.
+     * Retrieves the value of a cookie by its key.
      *
-     * @param {string} installationId - The unique installation ID to be stored in the cookie.
+     * @param {string} key - The name of the cookie to retrieve.
+     * @return {string|undefined} - The value of the cookie, or `undefined` if the cookie doesn't exist.
      */
-    const setCookie = (installationId) => {
-        const timestamp = Date.now();
-        const cookieValue = `${COOKIE_VERSION}.${installationId}.${timestamp}`;
-        $cookies.put(COOKIE_NAME, cookieValue, {expires: EXPIRATION_DATE, path: '/'});
+    const get = (key) => {
+        return $cookies[key];
     };
 
     /**
-     * Checks if the cookie exists, and if it doesn't, creates a new cookie with the specified
-     * installation ID and sets it with the current timestamp.
+     * Sets a cookie with the given key, value, and options.
      *
-     * @param {string} installationId - The unique installation ID to be stored in the cookie.
+     * @param {string} key - The name of the cookie to set.
+     * @param {string} value - The value of the cookie to set.
+     * @param {Object} [options={}] - Optional parameters for cookie settings.
+     * @param {number} [options.expiration] - Number of days until the cookie expires.  Max supported by browsers
+     * is 400 days (or less depending on the browser). If omitted this is a session cookie.
+     * @param {string} [options.path='/'] - The URL path that must exist for the cookie to be sent.
+     * @param {string} [options.domain] - The domain the cookie is accessible from.
+     * @param {boolean} [options.secure] - If `true`, the cookie will only be sent over HTTPS.
+     * @param {boolean} [options.httpOnly] - If `true`, the cookie cannot be accessed via JavaScript.
+     * @param {string} [options.sameSite] - SameSite cookie attribute ('Strict', 'Lax', 'None').
      */
-    const setCookieIfAbsent = (installationId) => {
-        if (!getCookie()) {
-            setCookie(installationId);
-        }
+    const set = (key, value, options = {}) => {
+        $document[0].cookie = new CookieBuilder(key, value, options).build();
     };
 
     /**
-     * Deletes the cookie by removing it.
+     * Deletes a cookie by setting an expired date, effectively removing it from the browser.
+     *
+     * @param {string} key - The name of the cookie to delete.
      */
-    const deleteCookie = () => {
-        $cookies.remove(COOKIE_NAME, {path: '/'});
+    const remove = (key) => {
+        $document[0].cookie = new CookieBuilder(key, '', {expiration: -1}).build();
     };
 
     return {
-        getCookie,
-        setCookie,
-        setCookieIfAbsent,
-        deleteCookie
+        get,
+        set,
+        remove
     };
+}
+
+/**
+ * CookieBuilder class for constructing cookies with optional attributes (expiration, path, domain, etc.).
+ */
+class CookieBuilder {
+    /**
+     * Constructs a CookieBuilder instance with the given key, value, and options.
+     *
+     * @param {string} key - The name of the cookie to set.
+     * @param {string} value - The value of the cookie to set.
+     * @param {Object} [options={}] - Optional parameters for cookie settings (expiration, path, domain, etc.).
+     */
+    constructor(key, value, options = {}) {
+        this.key = encodeURIComponent(key);
+        this.value = encodeURIComponent(value);
+        this.setOptions(options);
+    }
+
+    /**
+     * Sets the options for the cookie.
+     *
+     * @param {Object} options - Object containing optional cookie settings.
+     * @param {number} [options.expiration] - Number of days until the cookie expires. If omitted this is a session cookie.
+     * @param {string} [options.path='/'] - The URL path for the cookie.
+     * @param {string} [options.domain] - The domain where the cookie is accessible.
+     * @param {boolean} [options.secure] - Whether the cookie is secure (HTTPS only).
+     * @param {boolean} [options.httpOnly] - Whether the cookie is inaccessible via JavaScript.
+     * @param {string} [options.sameSite] - SameSite attribute of the cookie ('Strict', 'Lax', 'None').
+     * @return {CookieBuilder} - Returns the current instance for method chaining.
+     */
+    setOptions(options) {
+        const {expiration, path, domain, secure, httpOnly, sameSite} = options;
+
+        if (expiration) {
+            this.setExpiration(expiration);
+        }
+
+        this.setPath(path);
+
+        if (domain) {
+            this.setDomain(domain);
+        }
+
+        if (secure) {
+            this.setSecure();
+        }
+
+        if (httpOnly) {
+            this.setHttpOnly();
+        }
+
+        if (sameSite) {
+            this.setSameSite(sameSite);
+        }
+
+        return this;
+    }
+
+    /**
+     * Sets the expiration date for the cookie in days.
+     *
+     * @param {number} expiration - Number of days until the cookie expires.
+     * @return {CookieBuilder} - Returns the current instance for method chaining.
+     */
+    setExpiration(expiration) {
+        const date = new Date();
+        date.setTime(date.getTime() + (expiration * 24 * 60 * 60 * 1000));
+        this.expires = date.toUTCString();
+        return this;
+    }
+
+    /**
+     * Sets the path where the cookie is available.
+     *
+     * @param {string} path - The URL path for the cookie.
+     * @return {CookieBuilder} - Returns the current instance for method chaining.
+     */
+    setPath(path) {
+        this.path = path || '/';
+        return this;
+    }
+
+    /**
+     * Sets the domain where the cookie is available.
+     *
+     * @param {string} domain - The domain for the cookie.
+     * @return {CookieBuilder} - Returns the current instance for method chaining.
+     */
+    setDomain(domain) {
+        this.domain = domain;
+        return this;
+    }
+
+    /**
+     * Marks the cookie as secure (sent over HTTPS only).
+     *
+     * @return {CookieBuilder} - Returns the current instance for method chaining.
+     */
+    setSecure() {
+        this.secure = true;
+        return this;
+    }
+
+    /**
+     * Marks the cookie as HttpOnly (inaccessible via JavaScript).
+     *
+     * @return {CookieBuilder} - Returns the current instance for method chaining.
+     */
+    setHttpOnly() {
+        this.httpOnly = true;
+        return this;
+    }
+
+    /**
+     * Sets the SameSite attribute for the cookie.
+     *
+     * @param {string} sameSite - SameSite attribute ('Strict', 'Lax', 'None').
+     * @return {CookieBuilder} - Returns the current instance for method chaining.
+     */
+    setSameSite(sameSite) {
+        this.sameSite = sameSite;
+        return this;
+    }
+
+    /**
+     * Builds the final cookie string with all set attributes.
+     *
+     * @return {string} - The complete cookie string.
+     */
+    build() {
+        let cookieStr = `${this.key}=${this.value}`;
+
+        if (this.expires) {
+            cookieStr += `; expires=${this.expires}`;
+        }
+
+        cookieStr += `; path=${this.path}`;
+
+        if (this.domain) {
+            cookieStr += `; domain=${this.domain}`;
+        }
+
+        if (this.secure) {
+            cookieStr += `; secure`;
+        }
+
+        if (this.httpOnly) {
+            cookieStr += `; HttpOnly`;
+        }
+
+        if (this.sameSite) {
+            cookieStr += `; SameSite=${this.sameSite}`;
+        }
+
+        return cookieStr;
+    }
 }

--- a/src/js/angular/core/services/cookie.service.js
+++ b/src/js/angular/core/services/cookie.service.js
@@ -1,0 +1,76 @@
+const COOKIE_NAME = '_wb=';
+const COOKIE_VERSION = 'WB1';
+const PATH = "; path=/";
+const EXPIRATION = "; expires=Fri, 31 Dec 2099 23:59:59 GMT";
+const EXPIRED = "; Max-Age=-99999999";
+const COOKIE_SEPARATOR = ';';
+
+angular.module('graphdb.framework.core.services.cookieService', [])
+    .service('CookieService', ['$document', CookieService]);
+
+/**
+ * Service to manage cookies for the application. It checks if a specific cookie exists,
+ * sets it if necessary, retrieves it, or deletes it when required.
+ *
+ * @param {Object} $document - AngularJS service to interact with the document object.
+ * @return {Object} - Returns an object with methods to get, set, and delete cookies.
+ */
+function CookieService($document) {
+
+    /**
+     * Checks if the cookie exists and retrieves its value.
+     * @return {string|null} The cookie value if it exists, otherwise null.
+     */
+    const getCookie = () => {
+        const cookieName = COOKIE_NAME;
+        const cookies = $document[0].cookie.split(COOKIE_SEPARATOR);
+        for (let i = 0; i < cookies.length; i++) {
+            let cookie = cookies[i];
+            while (cookie.charAt(0) === ' ') {
+                cookie = cookie.substring(1, cookie.length);
+            }
+            if (cookie.indexOf(cookieName) === 0) {
+                return cookie.substring(cookieName.length, cookie.length);
+            }
+        }
+        return null;
+    };
+
+    /**
+     * Creates and sets a cookie with a specific installation ID and the current timestamp.
+     * The cookie is set to expire on December 31, 2099.
+     *
+     * @param {string} installationId - The unique installation ID to be stored in the cookie.
+     */
+    const setCookie = (installationId) => {
+        const timestamp = Date.now();
+        const cookieValue = `${COOKIE_VERSION}.${installationId}.${timestamp}`;
+        $document[0].cookie = COOKIE_NAME + cookieValue + EXPIRATION + PATH;
+    };
+
+    /**
+     * Checks if the cookie exists, and if it doesn't, creates a new cookie with the specified
+     * installation ID and sets it with the current timestamp.
+     *
+     * @param {string} installationId - The unique installation ID to be stored in the cookie.
+     */
+    const setCookieIfAbsent = (installationId) => {
+        if (!getCookie()) {
+            setCookie(installationId);
+        }
+    };
+
+    /**
+     * Deletes the cookie by setting an expired date, effectively removing it from the browser.
+     */
+    const deleteCookie = () => {
+        $document[0].cookie = COOKIE_NAME + EXPIRED + PATH;
+    };
+
+    return {
+        getCookie,
+        setCookie,
+        setCookieIfAbsent,
+        deleteCookie
+    };
+}

--- a/src/js/angular/core/services/cookie.service.js
+++ b/src/js/angular/core/services/cookie.service.js
@@ -1,39 +1,25 @@
 const COOKIE_NAME = '_wb=';
 const COOKIE_VERSION = 'WB1';
-const PATH = "; path=/";
-const EXPIRATION = "; expires=Fri, 31 Dec 2099 23:59:59 GMT";
-const EXPIRED = "; Max-Age=-99999999";
-const COOKIE_SEPARATOR = ';';
+const EXPIRATION_DATE = new Date('2099-12-31T23:59:59Z');
 
 angular.module('graphdb.framework.core.services.cookieService', [])
-    .service('CookieService', ['$document', CookieService]);
+    .service('CookieService', ['$cookies', CookieService]);
 
 /**
  * Service to manage cookies for the application. It checks if a specific cookie exists,
  * sets it if necessary, retrieves it, or deletes it when required.
  *
- * @param {Object} $document - AngularJS service to interact with the document object.
+ * @param {Object} $cookies - AngularJS service to manage cookies.
  * @return {Object} - Returns an object with methods to get, set, and delete cookies.
  */
-function CookieService($document) {
+function CookieService($cookies) {
 
     /**
      * Checks if the cookie exists and retrieves its value.
      * @return {string|null} The cookie value if it exists, otherwise null.
      */
     const getCookie = () => {
-        const cookieName = COOKIE_NAME;
-        const cookies = $document[0].cookie.split(COOKIE_SEPARATOR);
-        for (let i = 0; i < cookies.length; i++) {
-            let cookie = cookies[i];
-            while (cookie.charAt(0) === ' ') {
-                cookie = cookie.substring(1, cookie.length);
-            }
-            if (cookie.indexOf(cookieName) === 0) {
-                return cookie.substring(cookieName.length, cookie.length);
-            }
-        }
-        return null;
+        return $cookies.get(COOKIE_NAME) || null;
     };
 
     /**
@@ -45,7 +31,7 @@ function CookieService($document) {
     const setCookie = (installationId) => {
         const timestamp = Date.now();
         const cookieValue = `${COOKIE_VERSION}.${installationId}.${timestamp}`;
-        $document[0].cookie = COOKIE_NAME + cookieValue + EXPIRATION + PATH;
+        $cookies.put(COOKIE_NAME, cookieValue, {expires: EXPIRATION_DATE, path: '/'});
     };
 
     /**
@@ -61,10 +47,10 @@ function CookieService($document) {
     };
 
     /**
-     * Deletes the cookie by setting an expired date, effectively removing it from the browser.
+     * Deletes the cookie by removing it.
      */
     const deleteCookie = () => {
-        $document[0].cookie = COOKIE_NAME + EXPIRED + PATH;
+        $cookies.remove(COOKIE_NAME, {path: '/'});
     };
 
     return {

--- a/src/js/angular/core/services/installation-cookie.service.js
+++ b/src/js/angular/core/services/installation-cookie.service.js
@@ -1,0 +1,77 @@
+import 'angular/core/services/cookie.service';
+
+// The name of the cookie that stores installation-related data.
+const INSTALLATION_COOKIE_NAME = '_wb';
+
+// The version of the installation cookie format. This is used to ensure
+// compatibility with future versions of the cookie structure.
+const INSTALLATION_COOKIE_VERSION = 'WB1';
+
+// The number of days the installation cookie will remain valid before it expires.
+// In this case, the cookie is set to expire in 400 days from the date it is created.
+const INSTALLATION_COOKIE_EXPIRATION_IN_DAYS = 400;
+
+const modules = [
+    'graphdb.framework.core.services.cookieService'
+];
+
+angular.module('graphdb.framework.core.services.installationCookieService', modules)
+    .service('InstallationCookieService', ['CookieService', InstallationCookieService]);
+
+/**
+ * Service to manage installation-specific cookies for the application.
+ * It checks if a specific installation cookie exists, sets it if necessary,
+ * retrieves it, or deletes it when required.
+ *
+ * @param {Object} CookieService - AngularJS service to manage cookies.
+ * @return {Object} - Returns an object with methods to get, set, setIfAbsent, and remove installation cookies.
+ */
+function InstallationCookieService(CookieService) {
+
+    /**
+     * Checks if the installation cookie exists and retrieves its value.
+     *
+     * @return {string|undefined} The installation cookie value if it exists, otherwise undefined.
+     */
+    const get = () => {
+        return CookieService.get(INSTALLATION_COOKIE_NAME);
+    };
+
+    /**
+     * Creates and sets an installation cookie with a specific installation ID and the current timestamp.
+     * The cookie value is constructed as `version.installationId.timestamp`, and it is set to expire
+     * in 400 days (based on the `INSTALLATION_COOKIE_EXPIRATION_IN_DAYS` constant).
+     *
+     * @param {string} installationId - The unique installation ID to be stored in the cookie.
+     */
+    const set = (installationId) => {
+        const timestamp = Date.now();
+        const cookieValue = `${INSTALLATION_COOKIE_VERSION}.${installationId}.${timestamp}`;
+        CookieService.set(INSTALLATION_COOKIE_NAME, cookieValue, {expiration: INSTALLATION_COOKIE_EXPIRATION_IN_DAYS});
+    };
+
+    /**
+     * Sets the installation cookie if it does not already exist.
+     *
+     * @param {string} installationId - The unique installation ID to be stored in the cookie.
+     */
+    const setIfAbsent = (installationId) => {
+        if (!get()) {
+            set(installationId);
+        }
+    };
+
+    /**
+     * Deletes the installation cookie by removing it from the browser.
+     */
+    const remove = () => {
+        CookieService.remove(INSTALLATION_COOKIE_NAME);
+    };
+
+    return {
+        get,
+        set,
+        setIfAbsent,
+        remove
+    };
+}

--- a/src/js/angular/core/services/license.service.js
+++ b/src/js/angular/core/services/license.service.js
@@ -89,9 +89,10 @@ function licenseService($window, $document, LicenseRestService, $translate) {
      */
     const isTrackingAllowed = () => {
         const licenseTypeOfUse = _license && _license.typeOfUse.toLowerCase();
-        return _productType === "free" ||
-            licenseTypeOfUse === EVALUATION_TYPE_1 ||
-            licenseTypeOfUse === EVALUATION_TYPE_2;
+        return !$window.wbDevMode &&
+            (_productType === "free" ||
+                licenseTypeOfUse === EVALUATION_TYPE_1 ||
+                licenseTypeOfUse === EVALUATION_TYPE_2);
     };
 
     /**
@@ -144,7 +145,7 @@ function licenseService($window, $document, LicenseRestService, $translate) {
         }
 
         if ($window.dataLayer) {
-            $window.dataLayer.push = function() {
+            $window.dataLayer.push = function () {
                 return null;
             };
         }
@@ -197,6 +198,7 @@ function licenseService($window, $document, LicenseRestService, $translate) {
         isLicenseHardcoded,
         showLicense,
         productType,
-        productTypeHuman
+        productTypeHuman,
+        isTrackingAllowed
     };
 }

--- a/src/template.html
+++ b/src/template.html
@@ -164,6 +164,9 @@
     <object data="img/graphdb-splash.svg"></object>
     <div>GraphDB Workbench is loading...</div>
 </div>
+<script type="application/javascript">
+    window.wbDevMode = <%= devMode %>;
+</script>
 </body>
 
 </html>

--- a/test-cypress/integration/home/workbench.home.spec.js
+++ b/test-cypress/integration/home/workbench.home.spec.js
@@ -1,5 +1,6 @@
 import HomeSteps from '../../steps/home-steps';
 import {LicenseStubs} from "../../stubs/license-stubs";
+import {EnvironmentStubs} from "../../stubs/environment-stubs";
 
 const FILE_TO_IMPORT = 'wine.rdf';
 
@@ -193,33 +194,56 @@ describe('Home screen validation', () => {
     });
 
     context('GA', () => {
-        it('Should set GA tracking code in header when free license', () => {
+        it('Should set GA tracking code in header and a cookie when free license and prodMode', () => {
             LicenseStubs.stubFreeLicense();
             LicenseStubs.stubGoogleCalls();
             HomeSteps.visit();
+            EnvironmentStubs.stubWbProdMode();
+
             cy.document()
                 .get('head script')
                 .should("have.attr", "src")
                 .should('include', 'https://www.googletagmanager.com/gtm.js?id=GTM-WBP6C6Z4');
+
+            // Check if the installation ID cookie is set correctly
+            cy.getCookie('_wb').then((cookie) => {
+                expect(cookie).to.exist;
+                expect(cookie.value).to.match(/^WB1\.[a-zA-Z0-9\-]+\.\d+$/); // Check the cookie structure: WB1.<installationId>.<timestamp>
+            });
         });
 
-        it('Should set GA tracking code in header when evaluation enterprise license', () => {
+        it('Should set GA tracking code in header and cookie when evaluation enterprise license and prodMode', () => {
             LicenseStubs.stubEvaluationLicense();
             LicenseStubs.stubGoogleCalls();
             HomeSteps.visit();
+            EnvironmentStubs.stubWbProdMode();
+
             cy.document()
                 .get('head script')
                 .should("have.attr", "src")
                 .should('include', 'https://www.googletagmanager.com/gtm.js?id=GTM-WBP6C6Z4');
+
+            // Check if the installation ID cookie is set correctly
+            cy.getCookie('_wb').then((cookie) => {
+                expect(cookie).to.exist;
+                expect(cookie.value).to.match(/^WB1\.[a-zA-Z0-9\-]+\.\d+$/); // Check the cookie structure: WB1.<installationId>.<timestamp>
+            });
         });
 
-        it('Should NOT set GA tracking code in header when enterprise license', () => {
+        it('Should NOT set GA tracking code in header and cookie when enterprise license in prodMode', () => {
             LicenseStubs.stubEnterpriseLicense();
             LicenseStubs.stubGoogleCalls();
             HomeSteps.visit();
+            EnvironmentStubs.stubWbProdMode();
+
             cy.document()
                 .get('head script')
                 .should("not.have.attr", "src");
+
+            // Check if the installation ID cookie is set correctly
+            cy.getCookie('_wb').then((cookie) => {
+                expect(cookie).to.not.exist;
+            });
         });
     });
 

--- a/test-cypress/stubs/environment-stubs.js
+++ b/test-cypress/stubs/environment-stubs.js
@@ -1,0 +1,7 @@
+export class EnvironmentStubs {
+    static stubWbProdMode() {
+        cy.window().then((win) => {
+            win.wbDevMode = false;
+        });
+    }
+}

--- a/test-cypress/stubs/license-stubs.js
+++ b/test-cypress/stubs/license-stubs.js
@@ -36,7 +36,8 @@ export class LicenseStubs {
             "licenseCapabilities": [
                 "Lucene connector"
             ],
-            "productType": "free"
+            "productType": "free",
+            "installationId": "1234-abcd-5678"
         };
     }
 
@@ -59,7 +60,9 @@ export class LicenseStubs {
                 "Cluster",
                 "Elasticsearch connector"
             ],
-            productType: "enterprise"
+            productType: "enterprise",
+            installationId: "1234-abcd-5678"
+
         };
     }
 
@@ -82,13 +85,14 @@ export class LicenseStubs {
                 "Cluster",
                 "Elasticsearch connector"
             ],
-            productType: "enterprise"
+            productType: "enterprise",
+            installationId: "1234-abcd-5678"
         };
     }
 
     static stubGoogleCalls() {
         cy.intercept('GET', 'https://www.googletagmanager.com/**', {
-            statusCode: 200
+            statusCode: 503
         });
     }
 }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -34,7 +34,8 @@ module.exports = merge(commonConfig, {
             template: './src/template.html',
             favicon: 'src/img/icon.png',
             templateParameters: {
-                version: PACKAGE.version
+                version: PACKAGE.version,
+                devMode: true
             }
         }),
         new CleanWebpackPlugin()

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -38,7 +38,8 @@ module.exports = merge(commonConfig, {
             template: './src/template.html',
             favicon: 'src/img/icon.png',
             templateParameters: {
-                version: PACKAGE.version
+                version: PACKAGE.version,
+                devMode: false
             }
             // TODO: enable this once completed with the fixes
             // minify: {


### PR DESCRIPTION
## WHAT:
- Introduced a new CookieService for managing cookies
- Modified the license check logic to include setting or deleting cookies based on tracking permissions.
- Updated the run block in app.js to inject the new CookieService.
- Added handling of devMode to distinguish between development and production environments.

## WHY:
- To ensure tracking by using cookies
- The devMode flag was introduced to prevent tracking and cookie management in development environments, ensuring that tracking is only enabled in production.

## HOW:
- Created a CookieService that provides functions to get, set, and delete cookies.
- The cookie structure includes the version, installationId, and timestamp.
- Integrated the CookieService with the license checking logic, allowing cookies to be set or deleted based on whether tracking is permitted.
- The devMode flag was added to the application configuration, and its value (true for development and false for production) is injected dynamically in the HTML template.
- If devMode is true, tracking is disabled, and no cookies are set.
- Added Cypress tests to verify the correct behavior of cookies based on different license types, environments, and the devMode flag.