### PR TITLE
GDB-10937: Explain Response Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
         "jsrsasign": "^11.0.0",
         "lodash": "^4.17.21",
         "markdown-it": "^14.1.0",
-        "markdown-it-code-copy": "^0.2.1",
         "ng-custom-element": "^2.0.3",
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",

--- a/src/css/ttyg/chat-item-details.css
+++ b/src/css/ttyg/chat-item-details.css
@@ -147,7 +147,8 @@
     max-height: 4.5rem; /* fallback if line-clamp doesn't work */
 }
 
-.chat-detail .copy-btn {
+.chat-detail .copy-btn,
+.chat-detail .open-in-sparql-editor-btn {
     color: var(--primary-color);
     border: none;
     background-color: transparent;
@@ -155,11 +156,13 @@
     padding: 0;
 }
 
-.chat-detail .copy-btn:hover {
+.chat-detail .copy-btn:hover,
+.chat-detail .open-in-sparql-editor-btn {
     transform: scale(1.1);
     transition: all 0.1s ease-out;
 }
 
-.chat-detail .copy-btn:focus {
+.chat-detail .copy-btn:focus,
+.chat-detail .open-in-sparql-editor-btn {
     outline: none;
 }

--- a/src/js/angular/core/directives/copy-to-clipboard/copy-to-clipboard.directive.js
+++ b/src/js/angular/core/directives/copy-to-clipboard/copy-to-clipboard.directive.js
@@ -45,7 +45,7 @@ function copyToClipboard($translate, toastr) {
         restrict: 'E',
         scope: {
             tooltipText: '@',
-            textToCopy: '='
+            textToCopy: '@'
         },
         link: function ($scope, element) {
             $scope.copyToClipboard = function() {

--- a/src/js/angular/core/directives/markdown-content/markdown-content.js
+++ b/src/js/angular/core/directives/markdown-content/markdown-content.js
@@ -1,0 +1,77 @@
+import 'angular/core/services/markdown/markdown.service';
+
+const modules = [
+    'graphdb.framework.core.services.markdown-service'
+];
+
+/**
+ * @ngdoc directive
+ * @name graphdb.framework.core.directives.markdown-content:markdownContent
+ * @restrict E
+ *
+ * @description
+ * The `markdownContent` directive is used to render and compile Markdown content inside AngularJS applications.
+ * It dynamically compiles any AngularJS directives within the rendered Markdown content, ensuring that the
+ * directives are properly recognized and executed.
+ *
+ * @param {string=} content The markdown content to be rendered. This can be passed dynamically from the scope.
+ * @param {object=} options Optional configuration object to pass to the Markdown rendering engine, providing
+ * customization for how the Markdown is rendered.
+ *
+ * @example
+ * Usage:
+ * <markdown-content content="markdownText" options="markdownOptions"></markdown-content>
+ */
+angular
+    .module('graphdb.framework.core.directives.markdown-content', modules)
+    .directive('markdownContent', markdownContentDirective);
+
+markdownContentDirective.$inject = ['$compile', 'MarkdownService'];
+
+function markdownContentDirective($compile, MarkdownService) {
+    return {
+        template: '<div class="markdown-content" ng-bind-html="markdownContent"></div>',
+        restrict: 'E',
+        scope: {
+            content: '@',
+            options: '='
+        },
+        link: function ($scope, element) {
+
+            // =========================
+            // Public variables
+            // =========================
+
+            /**
+             * The rendered HTML content generated from the provided Markdown.
+             *
+             * @type {string} markdownContent
+             */
+            $scope.markdownContent = undefined;
+
+            // =========================
+            // Private functions
+            // =========================
+
+            const init = () => {
+                $scope.markdownContent = MarkdownService.renderMarkdown($scope.content, $scope.options);
+                compileMarkdownAnswerContents();
+            };
+
+            /**
+             * Manually compiles AngularJS directives within the dynamically generated markdown HTML content.
+             * AngularJS does not automatically detect and compile directives inside HTML that is dynamically
+             * inserted, so this function ensures that the content is compiled after it is rendered.
+             */
+            const compileMarkdownAnswerContents = () => {
+                $scope.$evalAsync(() => {
+                    // Find the dynamically rendered element that needs to be compiled
+                    const markdownElement = element.find('.markdown-content');
+                    $compile(angular.element(markdownElement).contents())($scope);
+                });
+            };
+
+            init();
+        }
+    };
+}

--- a/src/js/angular/core/directives/open-in-sparql-editor/open-in-sparql-editor.directive.js
+++ b/src/js/angular/core/directives/open-in-sparql-editor/open-in-sparql-editor.directive.js
@@ -1,0 +1,100 @@
+import {decodeHTML} from "../../../../../app";
+
+/**
+ * @ngdoc directive
+ * @name graphdb.framework.core.directives.open-in-sparql-editor.directive:openInSparqlEditor
+ * @restrict E
+ *
+ * @description
+ * This directive provides a button that allows users to open the SPARQL editor with a pre-defined query.
+ * Optionally, it can handle repository switching before opening the editor and executing the query.
+ * The directive can also trigger the query execution automatically if specified.
+ *
+ * @scope
+ *
+ * @param {string} query The SPARQL query to be opened and optionally executed in the SPARQL editor.
+ * @param {string} repositoryId The ID of the repository to be selected before opening the SPARQL editor.
+ * @param {string} executeQuery Flag that determines whether the query should be executed upon opening the editor.
+ *                              It accepts 'true' or 'false'. If 'true', the query will be automatically executed.
+ *
+ * @example
+ * <open-in-sparql-editor
+ *     query="SELECT * WHERE {?s ?p ?o}"
+ *     repository-id="myRepository"
+ *     execute-query="true">
+ * </open-in-sparql-editor>
+ *
+ * @requires $repositories
+ * @requires $translate
+ * @requires ModalService
+ * @requires $window
+ *
+ * @param {string} query The SPARQL query to be executed in the new tab.
+ */
+
+angular
+    .module('graphdb.framework.core.directives.open-in-sparql-editor', [])
+    .directive('openInSparqlEditor', openInSparqlEditorDirective);
+
+openInSparqlEditorDirective.$inject = ['$repositories', '$translate', 'ModalService', '$window'];
+
+function openInSparqlEditorDirective($repositories, $translate, ModalService, $window) {
+    return {
+        template: `<button class="open-in-sparql-editor-btn" gdb-tooltip="{{'ttyg.chat_panel.btn.open_in_sparql_editor.tooltip' | translate}}" ng-click="onGoToSparqlEditorView()"><i class="icon-sparql"></i></button>`,
+        restrict: 'E',
+        scope: {
+            query: '@',
+            repositoryId: '@',
+            executeQuery: '@'
+        },
+        link: function ($scope, element) {
+
+            // =========================
+            // Public variables
+            // =========================
+
+            $scope.tooltipText = 'ttyg.chat_panel.btn.open_in_sparql_editor.tooltip';
+            // =========================
+            // Private functions
+            // =========================
+            const execute = $scope.executeQuery === 'true';
+
+            // =========================
+            // Public functions
+            // =========================
+
+            /**
+             * Opens the SPARQL editor in a new browser tab with the specified query and optional execution.
+             */
+            $scope.onGoToSparqlEditorView = () => {
+                const activeRepositoryId = $repositories.getActiveRepository();
+                if (!activeRepositoryId || activeRepositoryId !== $scope.repositoryId) {
+                    // Open a confirmation modal before switching the repository
+                    ModalService.openConfirmation(
+                        $translate.instant('common.confirm'),
+                        decodeHTML($translate.instant('ttyg.chat_panel.dialog.confirm_repository_change.body', {repositoryId: $scope.repositoryId})),
+                        () => {
+                            $repositories.setRepository($repositories.getRepository($scope.repositoryId));
+                            openInSparqlEditorInNewTab($scope.query);
+                        }
+                    );
+                } else {
+                    // No repository switch needed, just open the SPARQL editor
+                    openInSparqlEditorInNewTab($scope.query);
+                }
+            };
+            // =========================
+            // Private functions
+            // =========================
+
+            /**
+             * Opens SPARQL editor view with passed query and handles repository switch if necessary.
+             * @param {string} query
+             */
+            const openInSparqlEditorInNewTab = (query) => {
+                // Open the SPARQL editor in a new tab and execute the query
+                $window.open(`/sparql?query=${encodeURIComponent(query)}&execute=${execute}`, '_blank');
+            };
+        }
+    };
+}

--- a/src/js/angular/core/services/markdown/markdown.service.js
+++ b/src/js/angular/core/services/markdown/markdown.service.js
@@ -1,11 +1,9 @@
 import markdownIt from 'markdown-it';
-import markdownItCodeCopy from 'markdown-it-code-copy';
+import {markdownCodeCopyPlugin} from "./plugins/markdown-code-copy-plugin";
+import {markdownOpenInSparqlEditorPlugin} from "./plugins/markdown-open-in-sparql-editor-plugin";
 
-const DEFAULT_MARKDOWN_CONFIGURATION = {
-    iconStyle: "",
-    iconClass: "icon-copy",
-    buttonStyle: "position: absolute; top: 0; right: 0;",
-    buttonClass: "btn btn-link btn-sm secondary"
+const OPEN_IN_SPARQL_PLUGIN_OPTIONS = {
+    buttonStyle: 'position: absolute; top: 0; right: 0; margin-right: 24px'
 };
 
 /**
@@ -20,7 +18,9 @@ angular
 MarkdownService.$inject = ['$sce'];
 
 function MarkdownService($sce) {
-    const markdownInstance = markdownIt().use(markdownItCodeCopy, DEFAULT_MARKDOWN_CONFIGURATION);
+    const markdownInstance = markdownIt()
+        .use(markdownCodeCopyPlugin)
+        .use(markdownOpenInSparqlEditorPlugin, OPEN_IN_SPARQL_PLUGIN_OPTIONS);
 
     /**
      * Retrieves a Markdown-it instance with optional custom configuration.
@@ -30,7 +30,10 @@ function MarkdownService($sce) {
      */
     const getMarkdown = (config) => {
         if (config) {
-            return markdownIt().use(markdownItCodeCopy, config);
+            return markdownIt()
+                .use(markdownCodeCopyPlugin, config)
+                .use(markdownOpenInSparqlEditorPlugin, _.merge({}, OPEN_IN_SPARQL_PLUGIN_OPTIONS, config));
+
         }
         return markdownInstance;
     };
@@ -41,9 +44,9 @@ function MarkdownService($sce) {
      * @param {string} text - The Markdown text to render.
      * @return {string} The rendered HTML, or the original text in case of an error.
      */
-    const renderMarkdown = (text) => {
+    const renderMarkdown = (text, config) => {
         try {
-            return $sce.trustAsHtml(getMarkdown().render(text));
+            return $sce.trustAsHtml(getMarkdown(config).render(text));
         } catch (e) {
             console.error('Error rendering markdown:', e);
             // Return the original text in case of an error

--- a/src/js/angular/core/services/markdown/plugins/markdown-code-copy-plugin.js
+++ b/src/js/angular/core/services/markdown/plugins/markdown-code-copy-plugin.js
@@ -1,8 +1,6 @@
 const DEFAULT_MARKDOWN_CONFIGURATION = {
-    iconStyle: "",
-    iconClass: "icon-copy",
     buttonStyle: "position: absolute; top: 0; right: 0;",
-    buttonClass: "btn btn-link btn-sm secondary"
+    buttonClass: ""
 };
 
 /**
@@ -10,10 +8,19 @@ const DEFAULT_MARKDOWN_CONFIGURATION = {
  *
  * @param {Function} origRule The original rule function responsible for rendering code blocks.
  * @param {Object} options The options to customize the rendering. These will be merged with the default configuration.
+ * Options model description:
+ * ```JSON
+ *      {
+ *          // Inline CSS styles applied to position the button inside the code block. Defaults to positioning the button at the top-right of the block.
+ *          buttonStyle: "position: absolute; top: 0; right: 0;",
+ *          // The CSS class for styling the button. The default applies Bootstrap-like styles with a small button size and a secondary theme
+ *          buttonClass: "btn btn-link btn-sm secondary",
+ *      }
+ * ```
  * @return {Function} A function that renders a code block with a "copy to clipboard" button, when a fenced code block is detected.
  */
 function renderCode(origRule, options) {
-    options = _.merge(DEFAULT_MARKDOWN_CONFIGURATION, options);
+    options = _.merge({}, DEFAULT_MARKDOWN_CONFIGURATION, options);
     return (...args) => {
         const [tokens, idx] = args;
         const token = tokens[idx];
@@ -28,7 +35,7 @@ function renderCode(origRule, options) {
                         ${origRendered}
                         <copy-to-clipboard
                             style="${options.buttonStyle}"
-                            class="${options.buttonStyle}"
+                            class="${options.buttonClass}"
                             tooltip-text="ttyg.chat_panel.btn.copy_sparql.tooltip"
                             text-to-copy="${content}">
                         </copy-to-clipboard>

--- a/src/js/angular/core/services/markdown/plugins/markdown-code-copy-plugin.js
+++ b/src/js/angular/core/services/markdown/plugins/markdown-code-copy-plugin.js
@@ -1,0 +1,45 @@
+const DEFAULT_MARKDOWN_CONFIGURATION = {
+    iconStyle: "",
+    iconClass: "icon-copy",
+    buttonStyle: "position: absolute; top: 0; right: 0;",
+    buttonClass: "btn btn-link btn-sm secondary"
+};
+
+/**
+ * This function enhances the rendering of code blocks in markdown by appending a "copy to clipboard" button to each code block.
+ *
+ * @param {Function} origRule The original rule function responsible for rendering code blocks.
+ * @param {Object} options The options to customize the rendering. These will be merged with the default configuration.
+ * @return {Function} A function that renders a code block with a "copy to clipboard" button, when a fenced code block is detected.
+ */
+function renderCode(origRule, options) {
+    options = _.merge(DEFAULT_MARKDOWN_CONFIGURATION, options);
+    return (...args) => {
+        const [tokens, idx] = args;
+        const token = tokens[idx];
+
+        const content = tokens[idx].content
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", "&apos;");
+        const origRendered = origRule(...args);
+
+        if (token.type === 'fence' && origRendered.trim()) {
+            return `<div style="position: relative">
+                        ${origRendered}
+                        <copy-to-clipboard
+                            style="${options.buttonStyle}"
+                            class="${options.buttonStyle}"
+                            tooltip-text="ttyg.chat_panel.btn.copy_sparql.tooltip"
+                            text-to-copy="${content}">
+                        </copy-to-clipboard>
+                    </div>`;
+        } else {
+            return origRendered;
+        }
+    };
+}
+
+export const markdownCodeCopyPlugin = (md, options) => {
+    md.renderer.rules.code_block = renderCode(md.renderer.rules.code_block, options);
+    md.renderer.rules.fence = renderCode(md.renderer.rules.fence, options);
+};

--- a/src/js/angular/core/services/markdown/plugins/markdown-open-in-sparql-editor-plugin.js
+++ b/src/js/angular/core/services/markdown/plugins/markdown-open-in-sparql-editor-plugin.js
@@ -1,7 +1,6 @@
 const DEFAULT_MARKDOWN_CONFIGURATION = {
-    iconClass: 'icon-sparql',
     buttonStyle: "position: absolute; top: 0; right: 0;",
-    buttonClass: "btn btn-link btn-sm secondary"
+    buttonClass: ""
 };
 
 /**
@@ -10,10 +9,24 @@ const DEFAULT_MARKDOWN_CONFIGURATION = {
  *
  * @param {Function} origRule The original rule function responsible for rendering code blocks.
  * @param {Object} options The options to customize the rendering. These will be merged with the default configuration.
+ * Options model description:
+ * ```JSON
+ *      {
+ *          // Inline CSS styles applied to position the button inside the code block. Defaults to positioning the button at the top-right of the block.
+ *          buttonStyle: "position: absolute; top: 0; right: 0;",
+ *          // The CSS class for styling the button.
+ *          buttonClass: "",
+ *          // A flag that determines whether the SPARQL query should be automatically executed when opened in the SPARQL editor. Defaults to `false`.
+ *          executeQuery: false,
+ *          // The ID of the repository that the SPARQL query will be executed against.
+ *          repositoryId: ''
+ *      }
+ * ```
+ *
  * @return {Function} A function that renders a fenced code block with an "open in SPARQL editor" button when the block is recognized as containing SPARQL code.
  */
 function renderCode(origRule, options) {
-    options = _.merge(DEFAULT_MARKDOWN_CONFIGURATION, options);
+    options = _.merge({}, DEFAULT_MARKDOWN_CONFIGURATION, options);
     return (...args) => {
         const [tokens, idx] = args;
         const token = tokens[idx];
@@ -28,7 +41,7 @@ function renderCode(origRule, options) {
                         ${origRendered}
                         <open-in-sparql-editor
                             style="${options.buttonStyle}"
-                            class="${options.buttonStyle}"
+                            class="${options.buttonClass}"
                             execute-query="${options.executeQuery}"
                             repository-id="${options.repositoryId}"
                             query="${content}">

--- a/src/js/angular/core/services/markdown/plugins/markdown-open-in-sparql-editor-plugin.js
+++ b/src/js/angular/core/services/markdown/plugins/markdown-open-in-sparql-editor-plugin.js
@@ -1,0 +1,46 @@
+const DEFAULT_MARKDOWN_CONFIGURATION = {
+    iconClass: 'icon-sparql',
+    buttonStyle: "position: absolute; top: 0; right: 0;",
+    buttonClass: "btn btn-link btn-sm secondary"
+};
+
+/**
+ * This function enhances the rendering of fenced code blocks in markdown that contain SPARQL queries
+ * by appending an "open in SPARQL editor" button to each SPARQL code block.
+ *
+ * @param {Function} origRule The original rule function responsible for rendering code blocks.
+ * @param {Object} options The options to customize the rendering. These will be merged with the default configuration.
+ * @return {Function} A function that renders a fenced code block with an "open in SPARQL editor" button when the block is recognized as containing SPARQL code.
+ */
+function renderCode(origRule, options) {
+    options = _.merge(DEFAULT_MARKDOWN_CONFIGURATION, options);
+    return (...args) => {
+        const [tokens, idx] = args;
+        const token = tokens[idx];
+
+        const content = tokens[idx].content
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", "&apos;");
+        const origRendered = origRule(...args);
+
+        if (token.type === 'fence' && token.info === 'sparql' && origRendered.trim()) {
+            return `<div style="position: relative">
+                        ${origRendered}
+                        <open-in-sparql-editor
+                            style="${options.buttonStyle}"
+                            class="${options.buttonStyle}"
+                            execute-query="${options.executeQuery}"
+                            repository-id="${options.repositoryId}"
+                            query="${content}">
+                        </open-in-sparql-editor>
+                    </div>`;
+        } else {
+            return origRendered;
+        }
+    };
+}
+
+export const markdownOpenInSparqlEditorPlugin = (md, options) => {
+    md.renderer.rules.code_block = renderCode(md.renderer.rules.code_block, options);
+    md.renderer.rules.fence = renderCode(md.renderer.rules.fence, options);
+};

--- a/src/js/angular/rest/ttyg.rest.service.fake.backend.js
+++ b/src/js/angular/rest/ttyg.rest.service.fake.backend.js
@@ -71,7 +71,7 @@ export class TtygRestServiceFakeBackend {
                     conversationId: askRequestData.conversationId,
                     role: CHAT_MESSAGE_ROLE.ASSISTANT,
                     agentId: askRequestData.agentId,
-                    message: `Reply to '${askRequestData.question}' Han Solo is a character in the Star Wars universe.`,
+                    message: "Certainly! Here's a random example that incorporates code, JSON, and a SPARQL query:\n\n### Code (Python)\n\n```python\ndef greet(name):\n    return f\"Hello, {name}!\"\n\nprint(greet(\"World\"))\n```\n\n### JSON\n\n```json\n{\n    \"greeting\": \"Hello\",\n    \"target\": \"World\",\n    \"language\": \"English\"\n}\n```\n\n### SPARQL Query\n\n```sparql\nSELECT ?person ?name\nWHERE {\n    ?person a ex:Person .\n    ?person ex:hasName ?name .\n}\nLIMIT 10\n```\n\nThis example demonstrates a simple Python function for greeting, a JSON object representing a greeting structure, and a SPARQL query to retrieve names of persons from a dataset.",
                     timestamp: Math.floor(Date.now() / 1000),
                     name: null
                 },

--- a/src/js/angular/ttyg/directives/chat-item-detail.directive.js
+++ b/src/js/angular/ttyg/directives/chat-item-detail.directive.js
@@ -1,20 +1,22 @@
-import 'angular/core/services/markdown.service';
+import 'angular/core/directives/markdown-content/markdown-content';
+import 'angular/core/directives/open-in-sparql-editor/open-in-sparql-editor.directive';
 import {TTYGEventName} from "../services/ttyg-context.service";
 import {ExplainQueryType} from "../../models/ttyg/explain-response";
 
 const modules = [
-    'graphdb.framework.core.services.markdown-service'
+    'graphdb.framework.core.directives.open-in-sparql-editor',
+    'graphdb.framework.core.directives.markdown-content'
 ];
 
 angular
     .module('graphdb.framework.ttyg.directives.chat-item-detail', modules)
     .directive('chatItemDetail', ChatItemDetailComponent);
 
-ChatItemDetailComponent.$inject = ['toastr', '$translate', 'TTYGContextService', 'MarkdownService', 'TTYGService'];
+ChatItemDetailComponent.$inject = ['toastr', '$translate', 'TTYGContextService', 'TTYGService'];
 
 /**
  * @ngdoc directive
- * @name graphdb.framework.ttyg.directives.chat-detail:chatDetail
+ * @name graphdb.framework.ttyg.directives.chat-detail:chatItemDetail
  * @restrict E
  * @description
  *
@@ -23,7 +25,7 @@ ChatItemDetailComponent.$inject = ['toastr', '$translate', 'TTYGContextService',
  * @example
  * <chat-item-detail chat-item="chatItem"></chat-item-detail>
  */
-function ChatItemDetailComponent(toastr, $translate, TTYGContextService, MarkdownService, TTYGService) {
+function ChatItemDetailComponent(toastr, $translate, TTYGContextService, TTYGService) {
     return {
         restrict: 'E',
         templateUrl: 'js/angular/ttyg/templates/chat-item-detail.html',
@@ -41,8 +43,9 @@ function ChatItemDetailComponent(toastr, $translate, TTYGContextService, Markdow
             // Public variables
             // =========================
 
-            $scope.MarkdownService = MarkdownService;
             $scope.ExplainQueryType = ExplainQueryType;
+            $scope.repositoryId = undefined;
+            $scope.markdownContentOptions = undefined;
 
             /**
              * Mapping of agent id to agent name which is used to display the agent name in the UI.
@@ -106,10 +109,9 @@ function ChatItemDetailComponent(toastr, $translate, TTYGContextService, Markdow
              */
             $scope.onOpenInSparqlEditor = (query) => {
                 if ($scope.chatItemDetail.agentId) {
-                    const agent = TTYGContextService.getAgent($scope.chatItemDetail.agentId);
                     TTYGContextService.emit(TTYGEventName.GO_TO_SPARQL_EDITOR, {
                         query,
-                        repositoryId: agent.repositoryId
+                        repositoryId: $scope.repositoryId
                     });
                 }
             };
@@ -121,10 +123,17 @@ function ChatItemDetailComponent(toastr, $translate, TTYGContextService, Markdow
                 return rawQueryNoSpaces && rawQueryNoSpaces !== queryNoSpaces;
             };
 
+            $scope.getRepositoryId = (f) => {
+                const agent = TTYGContextService.getAgent($scope.chatItemDetail.agentId);
+                return agent ? agent.repositoryId : '';
+            };
+
             // =========================
             // Private functions
             // =========================
             const init = () => {
+                $scope.repositoryId = $scope.getRepositoryId();
+                $scope.markdownContentOptions = {repositoryId: $scope.repositoryId};
                 updateExplainResponseModel();
             };
 

--- a/src/js/angular/ttyg/templates/chat-item-detail.html
+++ b/src/js/angular/ttyg/templates/chat-item-detail.html
@@ -13,7 +13,7 @@
                 <i class="fa-regular fa-message-bot"></i>
             </div>
             <div class="assistant-message">
-                <div class="answer" ng-bind-html="MarkdownService.renderMarkdown(answer.message)"></div>
+                <markdown-content class="answer" content="{{answer.message}}" options="markdownContentOptions"></markdown-content>
                 <div class="actions" ng-class="{'hidden-actions': !explainResponseModel[answer.id].expanded && (!showActions || !$last)}">
                     <button class="btn btn-link btn-sm regenerate-question-btn"
                             ng-click="regenerateQuestion()"
@@ -57,13 +57,14 @@
                                     </span>
                                 </div>
                                 <div class="actions">
+                                    <open-in-sparql-editor
+                                        ng-if="queryMethod.queryType === ExplainQueryType.SPARQL"
+                                        execute-query="{{!queryMethod.errorMessage}}"
+                                        repository-id="{{repositoryId}}"
+                                        query="{{queryMethod.query}}">
+                                    </open-in-sparql-editor>
                                     <copy-to-clipboard tooltip-text="ttyg.chat_panel.btn.copy_{{ queryMethod.queryType }}.tooltip"
                                                        text-to-copy="queryMethod.query"></copy-to-clipboard>
-                                    <button ng-if="queryMethod.queryType === ExplainQueryType.SPARQL" class="btn btn-link btn-sm"
-                                            ng-click="onOpenInSparqlEditor(queryMethod.query)"
-                                            gdb-tooltip="{{'ttyg.chat_panel.btn.open_in_sparql_editor.tooltip' | translate}}">
-                                        <i class="icon-sparql"></i>
-                                    </button>
                                 </div>
                             </div>
                             <div class="query">

--- a/test-cypress/fixtures/ttyg/chats/get-chat.json
+++ b/test-cypress/fixtures/ttyg/chats/get-chat.json
@@ -94,7 +94,7 @@
                 "conversationId": "thread_gy2K7D3efStfchq2v5VvpEvn",
                 "agentId": "asst_gAPcrHQQ9ZIxD5eXWH2BNFfo",
                 "role": "assistant",
-                "message": "Han Solo is a fictional character in the Star ",
+                "message": "Certainly! Here's a random example that incorporates code, JSON, and a SPARQL query:\n\n### Code (Python)\n\n```python\ndef greet(name):\n    return f\"Hello, {name}!\"\n\nprint(greet(\"World\"))\n```\n\n### JSON\n\n```json\n{\n    \"greeting\": \"Hello\",\n    \"target\": \"World\",\n    \"language\": \"English\"\n}\n```\n\n### SPARQL Query\n\n```sparql\nSELECT ?person ?name\nWHERE {\n    ?person a ex:Person .\n    ?person ex:hasName ?name .\n}\nLIMIT 10\n```\n\nThis example demonstrates a simple Python function for greeting, a JSON object representing a greeting structure, and a SPARQL query to retrieve names of persons from a dataset.",
                 "timestamp": "1725875332",
                 "name": null
             },
@@ -105,24 +105,6 @@
                 "role": "user",
                 "message": "Who are the Han Solo's children?",
                 "timestamp": "1725875483",
-                "name": null
-            },
-            {
-                "id": "msg_YbtWCL64HPu9Kf7SbeRlrwCc",
-                "conversationId": "thread_gy2K7D3efStfchq2v5VvpEvn",
-                "agentId": "asst_gAPcrHQQ9ZIxD5eXWH2BNFfo",
-                "role": "assistant",
-                "message": "Han Solo is a fictional character in the Star Wars franchise.",
-                "timestamp": "1725875332",
-                "name": null
-            },
-            {
-                "id": "msg_A9UeOFT9SF3pKzJzar1HwM7d",
-                "conversationId": "thread_gy2K7D3efStfchq2v5VvpEvn",
-                "agentId": null,
-                "role": "user",
-                "message": "Who is Han Solo?",
-                "timestamp": "1725875323",
                 "name": null
             }
         ],

--- a/test-cypress/steps/ttyg/chat-panel-steps.js
+++ b/test-cypress/steps/ttyg/chat-panel-steps.js
@@ -43,4 +43,20 @@ export class ChatPanelSteps {
     static getAgentInfoMessage(index = 0) {
         return ChatPanelSteps.getAgentInfoMessages().eq(index);
     }
+
+    static getOpenInSparqlEditorElements() {
+        return ChatPanelSteps.getChatPanel().find('open-in-sparql-editor');
+    }
+
+    static getOpenInSparqlEditorElement(index = 0) {
+        return ChatPanelSteps.getOpenInSparqlEditorElements().eq(index);
+    }
+
+    static getCopyToClipboardElements() {
+        return ChatPanelSteps.getChatPanel().find('copy-to-clipboard');
+    }
+
+    static getCopyToClipboardElement(index = 0) {
+        return ChatPanelSteps.getCopyToClipboardElements().eq(index);
+    }
 }


### PR DESCRIPTION
## What
- A custom plugin has been added to enable code copying from markdown content;
- A custom plugin allows SPARQL code embedded in Markdown content to be opened directly in the SPARQL editor;
- A markdown content component has been implemented.

## Why
- To provide clients with the ability to easily copy code from markdown blocks;
- To enhance usability by allowing clients to open and execute SPARQL queries written in Markdown directly in the SPARQL editor, streamlining their workflow;
- To enable visualization of markdown content within the application.

## How
- The markdown-it-code-copy plugin was removed because it used a different tooltip style than the workbench and had a hardcoded, non-customizable label. A custom plugin was implemented to address these issues;
- A custom plugin was developed and integrated to identify SPARQL code blocks within Markdown content and provide a direct option to open those queries in the SPARQL editor;
- This functionality has been implemented as an AngularJS directive, integrating two plugins:
 - One for copying markdown code to the clipboard;
 - Another for opening SPARQL code blocks directly in the SPARQL editor.