### PR TITLE
10937 disable closing of dialog when click outside it

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -312,6 +312,9 @@
                 },
                 "open_in_sparql_editor": {
                     "tooltip": "Open in SPARQL editor"
+                },
+                "proceed": {
+                    "label": "Proceed"
                 }
             },
             "labels": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -312,6 +312,9 @@
                 },
                 "open_in_sparql_editor": {
                     "tooltip": "Ouvrir dans l'éditeur SPARQL"
+                },
+                "proceed": {
+                    "label": "Procéder"
                 }
             },
             "labels": {

--- a/src/js/angular/core/controllers.js
+++ b/src/js/angular/core/controllers.js
@@ -4,11 +4,12 @@ angular
     .controller('SimpleModalCtrl', SimpleModalCtrl)
     .controller('ViewQueryCtrl', ViewQueryCtrl);
 
-SimpleModalCtrl.$inject = ['$scope', '$uibModalInstance', 'title', 'message'];
+SimpleModalCtrl.$inject = ['$scope', '$uibModalInstance', '$sce', 'config'];
 
-function SimpleModalCtrl($scope, $uibModalInstance, title, message) {
-    $scope.title = title;
-    $scope.message = message;
+function SimpleModalCtrl($scope, $uibModalInstance, $sce, config) {
+    $scope.confirmButtonKey = config.confirmButtonKey;
+    $scope.title = config.title;
+    $scope.message = $sce.trustAsHtml(config.message);
 
     $scope.ok = function () {
         $uibModalInstance.close();

--- a/src/js/angular/core/directives/open-in-sparql-editor/open-in-sparql-editor.directive.js
+++ b/src/js/angular/core/directives/open-in-sparql-editor/open-in-sparql-editor.directive.js
@@ -70,9 +70,12 @@ function openInSparqlEditorDirective($repositories, $translate, ModalService, $w
                 const activeRepositoryId = $repositories.getActiveRepository();
                 if (!activeRepositoryId || activeRepositoryId !== $scope.repositoryId) {
                     // Open a confirmation modal before switching the repository
-                    ModalService.openConfirmation(
-                        $translate.instant('common.confirm'),
-                        decodeHTML($translate.instant('ttyg.chat_panel.dialog.confirm_repository_change.body', {repositoryId: $scope.repositoryId})),
+                    ModalService.openConfirmationModal(
+                        {
+                            title: $translate.instant('common.confirm'),
+                            message: decodeHTML($translate.instant('ttyg.chat_panel.dialog.confirm_repository_change.body', {repositoryId: $scope.repositoryId})),
+                            confirmButtonKey: 'ttyg.chat_panel.btn.proceed.label'
+                        },
                         () => {
                             $repositories.setRepository($repositories.getRepository($scope.repositoryId));
                             openInSparqlEditorInNewTab($scope.query);

--- a/src/js/angular/core/services.js
+++ b/src/js/angular/core/services.js
@@ -13,6 +13,13 @@ import 'angular/core/directives';
 import 'angular/core/controllers';
 import 'angular-translate/dist/angular-translate';
 
+const DEFAULT_MODAL_SERVICE_CONFIG = {
+    title: '',
+    message: '',
+    confirmButtonKey: 'common.yes.btn',
+    backdrop: true
+};
+
 const modules = [
     'ui.bootstrap',
     'jlareau.bowser',
@@ -146,6 +153,7 @@ ModalService.$inject = ['$uibModal', '$timeout', '$sce'];
 function ModalService($uibModal, $timeout, $sce) {
     return {
         openSimpleModal: openSimpleModal,
+        openConfirmationModal: openConfirmationModal,
         openModalAlert: openModalAlert,
         openCopyToClipboardModal: openCopyToClipboardModal,
         openConfirmation: openConfirmation
@@ -154,18 +162,48 @@ function ModalService($uibModal, $timeout, $sce) {
     /**
      * Opens a confirmation dialog with provided translated title and message. If provided onConfirm and onCancel
      * handler functions then they will be executed.
+     * Use {@link ModalService#openConfirmationModal} instead of this function.
+     *
      * @param {string} title
      * @param {string} message
      * @param {Function} onConfirm
      * @param {Function} onCancel
      */
     function openConfirmation(title, message, onConfirm = () => {}, onCancel = () => {}) {
-        const dialogConfig = {
-            title,
-            message,
-            warning: true
-        };
-        openSimpleModal(dialogConfig).result.then(onConfirm, onCancel);
+        openConfirmationModal({title, message}, onConfirm, onCancel);
+    }
+
+    /**
+     * Opens a confirmation dialog with the provided translated title and message. If `onConfirm` and `onCancel`
+     * handler functions are provided, they will be executed accordingly.
+     *
+     * @param {Object} config Configuration object for the confirmation dialog.
+     * ```JSON
+     * {
+     *     // The title of the confirmation dialog.
+     *     title: '',
+     *     // The message or body of the dialog.
+     *     message: '',
+     *     // The key for the label of the confirm button. Default value is "common.yes.btn".
+     *     confirmButtonKey: 'common.yes.btn',
+     *     // Controls the dialog backdrop behavior. Possible values:
+     *     // * true (default) - The modal will have a backdrop, and clicking outside the modal (on the backdrop)
+     *     //                   will close the modal.
+     *     // * false - No backdrop is displayed. The modal can only be closed by other means,
+     *     //           such as using a close button or triggering a specific function.
+     *     // * 'static' - The modal will have a backdrop, but clicking outside (on the backdrop)
+     *     //              will not close the modal. It can only be closed via a specific action,
+     *     //              such as a button or programmatic close.
+     *     backdrop: true
+     * }
+     * ```
+     *
+     * @param {Function} onConfirm - A callback function that is called when the user confirms the action.
+     * @param {Function} onCancel - A callback function that is called when the user cancels the action.
+     */
+    function openConfirmationModal(config, onConfirm = () => {}, onCancel = () => {}) {
+        const confirmConfig = _.merge({warning: true}, config);
+        openSimpleModal(confirmConfig).result.then(onConfirm, onCancel);
     }
 
     function openSimpleModal(config) {
@@ -177,13 +215,9 @@ function ModalService($uibModal, $timeout, $sce) {
             controller: 'SimpleModalCtrl',
             size: config.size,
             windowClass: config.dialogClass,
+            backdrop: config.backdrop,
             resolve: {
-                title: function () {
-                    return config.title;
-                },
-                message: function () {
-                    return $sce.trustAsHtml(config.message);
-                }
+                config: () => _.merge({}, DEFAULT_MODAL_SERVICE_CONFIG, config)
             }
         });
     }
@@ -196,12 +230,7 @@ function ModalService($uibModal, $timeout, $sce) {
             size: config.size,
             windowClass,
             resolve: {
-                title: function () {
-                    return config.title;
-                },
-                message: function () {
-                    return $sce.trustAsHtml(config.message);
-                }
+                config: () => _.merge({}, DEFAULT_MODAL_SERVICE_CONFIG, config)
             }
         });
     }

--- a/src/js/angular/core/templates/modal/modal-warning.html
+++ b/src/js/angular/core/templates/modal/modal-warning.html
@@ -10,7 +10,7 @@
 </div>
 <div class="modal-footer">
     <button type="button" class="btn btn-secondary cancel-btn" ng-click="cancel()">{{'common.cancel.btn' | translate}}</button>
-    <button class="btn btn-primary confirm-btn" ng-click="ok()">{{'common.yes.btn' | translate}}</button>
+    <button class="btn btn-primary confirm-btn" ng-click="ok()">{{ (confirmButtonKey || 'common.yes.btn') | translate}}</button>
 </div>
 
 <!-- End confirmDelete -->

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -725,9 +725,11 @@ function TTYGViewCtrl(
         if (payload.repositoryId !== $repositories.getActiveRepository()) {
             const repository = $repositories.getRepository(payload.repositoryId);
             if (repository) {
-                ModalService.openConfirmation(
-                    $translate.instant('common.confirm'),
-                    decodeHTML($translate.instant('ttyg.agent.create_agent_modal.dialog.confirm_repository_change_before_open_similarity.body', {repositoryId: repository.id})),
+                ModalService.openConfirmationModal({
+                        title: $translate.instant('common.confirm'),
+                        message: decodeHTML($translate.instant('ttyg.agent.create_agent_modal.dialog.confirm_repository_change_before_open_similarity.body', {repositoryId: repository.id})),
+                        confirmButtonKey: 'ttyg.chat_panel.btn.proceed.label'
+                    },
                     () => {
                         $repositories.setRepository(repository);
                         openCreateSimilarityView();
@@ -754,9 +756,11 @@ function TTYGViewCtrl(
         if (payload.repositoryId !== $repositories.getActiveRepository()) {
             const repository = $repositories.getRepository(payload.repositoryId);
             if (repository) {
-                ModalService.openConfirmation(
-                    $translate.instant('common.confirm'),
-                    decodeHTML($translate.instant('ttyg.agent.create_agent_modal.dialog.confirm_repository_change_before_open_connectors.body', {repositoryId: repository.id})),
+                ModalService.openConfirmationModal({
+                        title: $translate.instant('common.confirm'),
+                        message: decodeHTML($translate.instant('ttyg.agent.create_agent_modal.dialog.confirm_repository_change_before_open_connectors.body', {repositoryId: repository.id})),
+                        confirmButtonKey: 'ttyg.chat_panel.btn.proceed.label'
+                    },
                     () => {
                         $repositories.setRepository(repository);
                         openConnectorsView();

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -281,6 +281,7 @@ function TTYGViewCtrl(
                     templateUrl: 'js/angular/ttyg/templates/modal/agent-settings-modal.html',
                     controller: 'AgentSettingsModalController',
                     windowClass: 'agent-settings-modal',
+                    backdrop: 'static',
                     resolve: {
                         dialogModel: function () {
                             return new AgentSettingsModal(
@@ -318,6 +319,7 @@ function TTYGViewCtrl(
                     templateUrl: 'js/angular/ttyg/templates/modal/agent-settings-modal.html',
                     controller: 'AgentSettingsModalController',
                     windowClass: 'agent-settings-modal',
+                    backdrop: 'static',
                     resolve: {
                         dialogModel: function () {
                             return new AgentSettingsModal(
@@ -356,6 +358,7 @@ function TTYGViewCtrl(
             templateUrl: 'js/angular/ttyg/templates/modal/agent-settings-modal.html',
             controller: 'AgentSettingsModalController',
             windowClass: 'agent-settings-modal',
+            backdrop: 'static',
             resolve: {
                 dialogModel: function () {
                     return new AgentSettingsModal(

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -312,6 +312,9 @@
                 },
                 "open_in_sparql_editor": {
                     "tooltip": "Open in SPARQL editor"
+                },
+                "proceed": {
+                    "label": "Proceed"
                 }
             },
             "labels": {


### PR DESCRIPTION
10937: Modal Dialog Improvements

## What
- The Edit Agent dialog has been configured to prevent it from closing when a user clicks outside the dialog;
- Updated the confirmation button label when opening a SPARQL query in a different repository.

## Why
- To avoid accidental closures of the dialog when users mistakenly click outside, which could result in unsaved changes or interrupted actions;
- To make the label semantically more aligned with the confirmation action.

## How
 - The modal configuration was modified to disable closing the dialog on outside clicks by setting the backdrop option to 'static';
 - The ModalService was extended to be more configurable. Added the ability to change the confirmation button label. Additionally, the modal dialog can now be configured to remain open when clicking outside of it.