### PR TITLE
Revert "(cherry-pick) GDB-10772 - Show error message on resource edit when user not admin"

### DIFF
--- a/src/js/angular/explore/controllers.js
+++ b/src/js/angular/explore/controllers.js
@@ -517,9 +517,9 @@ function FindResourceCtrl($scope, $http, $location, $repositories, $q, $timeout,
     }
 }
 
-EditResourceCtrl.$inject = ['$scope', '$http', '$location', 'toastr', '$repositories', '$uibModal', '$timeout', 'ClassInstanceDetailsService', 'StatementsService', 'RDF4JRepositoriesRestService', '$translate', '$jwtAuth'];
+EditResourceCtrl.$inject = ['$scope', '$http', '$location', 'toastr', '$repositories', '$uibModal', '$timeout', 'ClassInstanceDetailsService', 'StatementsService', 'RDF4JRepositoriesRestService', '$translate'];
 
-function EditResourceCtrl($scope, $http, $location, toastr, $repositories, $uibModal, $timeout, ClassInstanceDetailsService, StatementsService, RDF4JRepositoriesRestService, $translate, $jwtAuth) {
+function EditResourceCtrl($scope, $http, $location, toastr, $repositories, $uibModal, $timeout, ClassInstanceDetailsService, StatementsService, RDF4JRepositoriesRestService, $translate) {
     $scope.uriParam = $location.search().uri;
     $scope.newRow = {
         subject: $scope.uriParam,
@@ -583,10 +583,6 @@ function EditResourceCtrl($scope, $http, $location, toastr, $repositories, $uibM
             $scope.getClassInstancesDetails();
         }
     });
-
-    $scope.hasAdminRole = () => {
-        return $jwtAuth.isAuthenticated() && $jwtAuth.hasAdminRole();
-    };
 
     $scope.validateUri = function (val) {
         let check = true;

--- a/src/pages/edit.html
+++ b/src/pages/edit.html
@@ -1,7 +1,7 @@
 <link href="css/lib/angular-xeditable/xeditable.min.css?v=[AIV]{version}[/AIV]" rel="stylesheet">
 
-<div core-errors write></div>
-<div class="page" ng-show="getActiveRepository() && hasAdminRole()">
+<div core-errors></div>
+<div class="page" ng-show="getActiveRepository()">
     <div class="resource-info">
         <div class="thumb" ng-show="{{details.img}}">
             <a href="{{details.img}}"><img ng-src="{{details.img}}" alt="details image"/></a>


### PR DESCRIPTION
## What?
Reverting GDB-10772.

## Why?
The fix introduced a new bug, which limits usability and access for all regular users.

## How?
Fix reverted.

Reverts Ontotext-AD/graphdb-workbench#1556