### PR TITLE
GDB-10937 ttyg view improvements

### DIFF
--- a/scripts/validate-translations.js
+++ b/scripts/validate-translations.js
@@ -16,6 +16,7 @@ const identicalTranslations = [
     "ChatGPT Retrieval",
     "ClientID*",
     "Cluster",
+    "Cookies",
     "Document",
     "Documentation",
     "Format",
@@ -34,6 +35,7 @@ const identicalTranslations = [
     "Top P",
     "Type:",
     "type",
+    "Google Analytics (GA4)",
 
     // File formats:
     "JSON",

--- a/src/js/angular/core/services/repositories.service.js
+++ b/src/js/angular/core/services/repositories.service.js
@@ -271,6 +271,14 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
             });
         };
 
+        /**
+         * Returns all readable repositories that are local.
+         * @return {*}
+         */
+        this.getLocalReadableRepositories = function () {
+            return this.getReadableRepositories().filter((repository) => repository.local === true);
+        };
+
         this.getReadableGraphdbRepositories = function () {
             return this.getReadableRepositories()
                 .filter((repo) => repo.type === 'graphdb');

--- a/src/js/angular/core/services/repositories.service.js
+++ b/src/js/angular/core/services/repositories.service.js
@@ -271,17 +271,21 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
             });
         };
 
-        /**
-         * Returns all readable repositories that are local.
-         * @return {*}
-         */
-        this.getLocalReadableRepositories = function () {
-            return this.getReadableRepositories().filter((repository) => repository.local === true);
-        };
-
         this.getReadableGraphdbRepositories = function () {
             return this.getReadableRepositories()
                 .filter((repo) => repo.type === 'graphdb');
+        };
+
+        /**
+         * Returns all readable graphdb repositories that are local.
+         * @return {*}
+         */
+        this.getLocalReadableGraphdbRepositories = function () {
+            return this.getReadableGraphdbRepositories().filter((repository) => repository.local === true);
+        };
+
+        this.getLocalReadablGraphdbRepositoryIds = function () {
+            return this.getLocalReadableGraphdbRepositories().map((repository) => repository.id);
         };
 
         this.getWritableRepositories = function () {

--- a/src/js/angular/core/services/ttyg.service.js
+++ b/src/js/angular/core/services/ttyg.service.js
@@ -10,9 +10,9 @@ angular
     .module('graphdb.framework.core.services.ttyg-service', modules)
     .factory('TTYGService', TTYGService);
 
-TTYGService.$inject = ['TTYGRestService'];
+TTYGService.$inject = ['TTYGRestService', '$repositories'];
 
-function TTYGService(TTYGRestService) {
+function TTYGService(TTYGRestService, $repositories) {
 
     const getConversations = (savedQueryName, owner) => {
         return TTYGRestService.getConversations()
@@ -95,9 +95,10 @@ function TTYGService(TTYGRestService) {
      * @return {Promise<AgentListModel>}
      */
     const getAgents = () => {
+        const localRepositories = $repositories.getLocalReadablGraphdbRepositoryIds();
         return TTYGRestService.getAgents()
             .then((response) => {
-                return agentListMapper(response.data);
+                return agentListMapper(response.data, localRepositories);
             });
     };
 

--- a/src/js/angular/models/ttyg/chats.js
+++ b/src/js/angular/models/ttyg/chats.js
@@ -140,6 +140,20 @@ export class ChatsListModel {
     }
 
     /**
+     * Updates the timestamp of a chat in the list.
+     * @param {string} chatId
+     * @param {number} timestamp
+     */
+    updateChatTimestamp(chatId, timestamp) {
+        const chat = this._chats.find((c) => c.id === chatId);
+        if (chat) {
+            chat.timestamp = timestamp;
+        }
+        this.sortByTime();
+        this.updateChatsByDay();
+    }
+
+    /**
      * Deletes a chat from the chat list.
      * @param {ChatModel} chatToBeDeleted
      */

--- a/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -6,7 +6,7 @@ import 'angular/core/services/ttyg.service';
 import 'angular/rest/repositories.rest.service';
 import {REPOSITORY_PARAMS} from "../../models/repository/repository";
 import {TTYGEventName} from "../services/ttyg-context.service";
-import {AGENT_OPERATION} from "../services/constants";
+import {AGENT_OPERATION, TTYG_ERROR_MSG_LENGTH} from "../services/constants";
 
 angular
     .module('graphdb.framework.ttyg.controllers.agent-settings-modal', [
@@ -250,12 +250,12 @@ function AgentSettingsModalController(
         RepositoriesRestService.getRepositoryModel({id: $scope.agentFormModel.repositoryId}).then((repositoryModel) => {
             $scope.ftsEnabled = repositoryModel.getParamValue(REPOSITORY_PARAMS.enableFtsIndex);
         })
-            .catch((error) => {
-                logAndShowError(error, 'ttyg.agent.messages.error_repository_config_loading');
-            })
-            .finally(() => {
-                $scope.extractionMethodLoaderFlags[ExtractionMethod.FTS_SEARCH] = false;
-            });
+        .catch((error) => {
+            logAndShowError(error, 'ttyg.agent.messages.error_repository_config_loading');
+        })
+        .finally(() => {
+            $scope.extractionMethodLoaderFlags[ExtractionMethod.FTS_SEARCH] = false;
+        });
     };
 
     /**
@@ -310,7 +310,7 @@ function AgentSettingsModalController(
                 toastr.success($translate.instant('ttyg.agent.messages.agent_save_successfully', {agentName: agentModel.name}));
             })
             .catch((error) => {
-                toastr.error($translate.instant('ttyg.agent.messages.agent_save_failure', {agentName: newAgentPayload.name}));
+                toastr.error(getError(error, 0, TTYG_ERROR_MSG_LENGTH));
             })
             .finally(() => {
                 $scope.savingAgent = false;

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -8,7 +8,7 @@ import 'angular/core/services/ttyg.service';
 import 'angular/ttyg/services/ttyg-context.service';
 import 'angular/ttyg/services/ttyg-storage.service';
 import {TTYGEventName} from '../services/ttyg-context.service';
-import {AGENT_OPERATION, AGENTS_FILTER_ALL_KEY} from '../services/constants';
+import {AGENT_OPERATION, AGENTS_FILTER_ALL_KEY, TTYG_ERROR_MSG_LENGTH} from '../services/constants';
 import {AgentListFilterModel, AgentModel} from '../../models/ttyg/agents';
 import {ChatModel, ChatsListModel} from '../../models/ttyg/chats';
 import {agentFormModelMapper} from '../services/agents.mapper';
@@ -417,7 +417,7 @@ function TTYGViewCtrl(
                 return TTYGContextService.updateChats(chats);
             })
             .catch((error) => {
-                toastr.error(getError(error, 0, 100));
+                toastr.error(getError(error, 0, TTYG_ERROR_MSG_LENGTH));
                 setupChatListPanel(new ChatsListModel());
             })
             .finally(() => {
@@ -437,7 +437,7 @@ function TTYGViewCtrl(
                 return TTYGContextService.updateAgents(agents);
             })
             .catch((error) => {
-                toastr.error(getError(error, 0, 100));
+                toastr.error(getError(error, 0, TTYG_ERROR_MSG_LENGTH));
             })
             .finally(() => {
                 $scope.loadingAgents = false;
@@ -456,7 +456,7 @@ function TTYGViewCtrl(
                 return TTYGContextService.updateAgents(agents);
             })
             .catch((error) => {
-                toastr.error(getError(error, 0, 100));
+                toastr.error(getError(error, 0, TTYG_ERROR_MSG_LENGTH));
             })
             .finally(() => {
                 $scope.reloadingAgents = false;
@@ -551,7 +551,7 @@ function TTYGViewCtrl(
             })
             .catch((error) => {
                 TTYGContextService.emit(TTYGEventName.ASK_QUESTION_FAILURE);
-                toastr.error(getError(error, 0, 100));
+                toastr.error(getError(error, 0, TTYG_ERROR_MSG_LENGTH));
             });
     };
 
@@ -663,7 +663,7 @@ function TTYGViewCtrl(
                 }
             })
             .catch((error) => {
-                toastr.error(getError(error, 0, 100));
+                toastr.error(getError(error, 0, TTYG_ERROR_MSG_LENGTH));
             })
             .finally(() => {
                 TTYGContextService.emit(TTYGEventName.DELETING_AGENT, {agentId: agent.id, inProgress: false});
@@ -741,7 +741,7 @@ function TTYGViewCtrl(
                 TTYGContextService.selectAgent(agent);
             }
         }).catch((error) => {
-            toastr.error(getError(error, 0, 100));
+            toastr.error(getError(error, 0, TTYG_ERROR_MSG_LENGTH));
         });
     };
 

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -606,7 +606,6 @@ function TTYGViewCtrl(
         TTYGService.deleteConversation(chat.id)
             .then(() => {
                 TTYGContextService.emit(TTYGEventName.DELETE_CHAT_SUCCESSFUL, chat);
-                TTYGContextService.emit(TTYGEventName.LOAD_CHATS);
             })
             .catch(() => {
                 TTYGContextService.emit(TTYGEventName.DELETE_CHAT_FAILURE);
@@ -624,7 +623,6 @@ function TTYGViewCtrl(
             .then(function ({data, filename}) {
                 saveAs(data, filename);
                 TTYGContextService.emit(TTYGEventName.CHAT_EXPORT_SUCCESSFUL, chat);
-                TTYGContextService.emit(TTYGEventName.LOAD_CHATS);
             })
             .catch(() => {
                 TTYGContextService.emit(TTYGEventName.CHAT_EXPORT_FAILURE);

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -725,7 +725,6 @@ function TTYGViewCtrl(
      */
     const onAgentSelected = (agent) => {
         $scope.selectedAgent = agent;
-        console.log(`save agent`, agent);
         TTYGStorageService.saveAgent(agent);
     };
 
@@ -734,17 +733,15 @@ function TTYGViewCtrl(
      */
     const setCurrentAgent = () => {
         const agentId = TTYGStorageService.getAgentId();
-        console.log(`1 setCurrentAgent`, agentId);
         if (!agentId) {
             return;
         }
         TTYGService.getAgent(agentId).then((agent) => {
-            console.log(`2 setCurrentAgent`, agent);
             if (agent) {
                 TTYGContextService.selectAgent(agent);
             }
         }).catch((error) => {
-
+            toastr.error(getError(error, 0, 100));
         });
     };
 

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -668,7 +668,7 @@ function TTYGViewCtrl(
     const buildAgentsFilterModel = () => {
         const currentRepository = $repositories.getActiveRepository();
         // TODO: this should be refreshed automatically when the repositories change
-        const repositoryObjects = $repositories.getReadableGraphdbRepositories()
+        const repositoryObjects = $repositories.getLocalReadableRepositories()
             .map((repo) => (
            new AgentListFilterModel(repo.id, repo.id, repo.id === currentRepository)
         ));
@@ -845,7 +845,7 @@ function TTYGViewCtrl(
     };
 
     const buildRepositoryList = () => {
-        $scope.activeRepositoryList = $repositories.getReadableGraphdbRepositories()
+        $scope.activeRepositoryList = $repositories.getLocalReadableRepositories()
             .map((repo) => (
                 new SelectMenuOptionsModel({
                     value: repo.id,

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -611,6 +611,9 @@ function TTYGViewCtrl(
         TTYGService.deleteConversation(chat.id)
             .then(() => {
                 TTYGContextService.emit(TTYGEventName.DELETE_CHAT_SUCCESSFUL, chat);
+                const chats = TTYGContextService.getChats();
+                chats.deleteChat(chat);
+                TTYGContextService.updateChats(chats);
             })
             .catch(() => {
                 TTYGContextService.emit(TTYGEventName.DELETE_CHAT_FAILURE);
@@ -722,6 +725,7 @@ function TTYGViewCtrl(
      */
     const onAgentSelected = (agent) => {
         $scope.selectedAgent = agent;
+        console.log(`save agent`, agent);
         TTYGStorageService.saveAgent(agent);
     };
 
@@ -730,13 +734,17 @@ function TTYGViewCtrl(
      */
     const setCurrentAgent = () => {
         const agentId = TTYGStorageService.getAgentId();
+        console.log(`1 setCurrentAgent`, agentId);
         if (!agentId) {
             return;
         }
         TTYGService.getAgent(agentId).then((agent) => {
+            console.log(`2 setCurrentAgent`, agent);
             if (agent) {
                 TTYGContextService.selectAgent(agent);
             }
+        }).catch((error) => {
+
         });
     };
 

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -676,7 +676,7 @@ function TTYGViewCtrl(
     const buildAgentsFilterModel = () => {
         const currentRepository = $repositories.getActiveRepository();
         // TODO: this should be refreshed automatically when the repositories change
-        const repositoryObjects = $repositories.getLocalReadableRepositories()
+        const repositoryObjects = $repositories.getLocalReadableGraphdbRepositories()
             .map((repo) => (
            new AgentListFilterModel(repo.id, repo.id, repo.id === currentRepository)
         ));
@@ -855,7 +855,7 @@ function TTYGViewCtrl(
     };
 
     const buildRepositoryList = () => {
-        $scope.activeRepositoryList = $repositories.getLocalReadableRepositories()
+        $scope.activeRepositoryList = $repositories.getLocalReadableGraphdbRepositories()
             .map((repo) => (
                 new SelectMenuOptionsModel({
                     value: repo.id,
@@ -899,6 +899,7 @@ function TTYGViewCtrl(
     subscriptions.push($rootScope.$on('$translateChangeSuccess', updateLabels));
     subscriptions.push($rootScope.$on('securityInit', updateCanModifyAgent));
     $scope.$on('$destroy', cleanUp);
+
     // =========================
     // Initialization
     // =========================

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -509,7 +509,7 @@ function TTYGViewCtrl(
         TTYGService.createConversation(chatItem)
             .then((chatAnswer) => {
                 TTYGContextService.emit(TTYGEventName.CREATE_CHAT_SUCCESSFUL);
-                // TODO discuse we have all answers id and can update selected chats without loading it.
+                // TODO: To discus: If we have all answer ids, can we update selected chats without loading it?
                 return TTYGService.getConversation(chatAnswer.chatId);
             })
             .then((chat) => {
@@ -542,6 +542,11 @@ function TTYGViewCtrl(
                     selectedChat.chatHistory.appendItem(item);
                     TTYGContextService.updateSelectedChat(selectedChat);
                     // TODO reorder the list of chats
+                    // Update the timestamp of the chat to which the last question was added in the chats list and
+                    // update the list so that the chat is moved to the top.
+                    const chats = TTYGContextService.getChats();
+                    chats.updateChatTimestamp(selectedChat.id, chatAnswer.timestamp);
+                    TTYGContextService.updateChats(chats);
                 }
             })
             .catch((error) => {

--- a/src/js/angular/ttyg/services/agents.mapper.js
+++ b/src/js/angular/ttyg/services/agents.mapper.js
@@ -80,7 +80,9 @@ const extractionMethodsFormMapper = (agentFormModel, isNew, defaultData, data = 
                 maxValue: 1,
                 step: 0.1
             }),
-            maxNumberOfTriplesPerCall: extractionMethod.maxNumberOfTriplesPerCall,
+            // In case backend returns 0 as a default value this means that there is no limit, so we set the null in order
+            // to show the placeholder in the input field.
+            maxNumberOfTriplesPerCall: extractionMethod.maxNumberOfTriplesPerCall === 0 ? null : extractionMethod.maxNumberOfTriplesPerCall,
             queryTemplate: extractionMethod.queryTemplate && new TextFieldModel({
                 value: extractionMethod.queryTemplate,
                 minLength: 1,

--- a/src/js/angular/ttyg/services/agents.mapper.js
+++ b/src/js/angular/ttyg/services/agents.mapper.js
@@ -97,13 +97,23 @@ const extractionMethodsFormMapper = (agentFormModel, isNew, defaultData, data = 
 /**
  * Converts the response from the server to a list of AgentModel.
  * @param {*[]} data
+ * @param {string[]} localRepositoryIds
  * @return {AgentListModel}
  */
-export const agentListMapper = (data) => {
+export const agentListMapper = (data, localRepositoryIds) => {
     if (!data) {
         return new AgentListModel();
     }
-    const agentModels = data.map((agent) => agentModelMapper(agent));
+    const agentModels = data
+        .map((agent) => agentModelMapper(agent))
+        .map((agent) => {
+            // If the agent is not in the list of local repositories, then set the repositoryId to null in order to show
+            // the agent is not assigned to any repository in this GDB instance.
+            if (!localRepositoryIds.includes(agent.repositoryId)) {
+                agent.repositoryId = null;
+            }
+            return agent;
+        });
     return new AgentListModel(agentModels);
 };
 

--- a/src/js/angular/ttyg/services/constants.js
+++ b/src/js/angular/ttyg/services/constants.js
@@ -1,4 +1,11 @@
 /**
+ * The length of the message to be cut and displayed to the user from the error
+ * server's response.
+ * @type {number}
+ */
+export const TTYG_ERROR_MSG_LENGTH = 100;
+
+/**
  * The key to use when filtering agents indicating that all agents should be shown.
  * @type {string}
  */

--- a/test-cypress/integration/ttyg/agent-list.spec.js
+++ b/test-cypress/integration/ttyg/agent-list.spec.js
@@ -56,6 +56,7 @@ describe('TTYG agent list', () => {
         TTYGViewSteps.getAgentFilter().click();
         TTYGViewSteps.verifyRepositoryOptionNotExist('Fedx_repository');
         TTYGViewSteps.verifyRepositoryOptionNotExist('Ontop_repository');
+        TTYGViewSteps.getAgentFilter().click();
         // When I filter the agents by repository 'biomarkers'
         TTYGViewSteps.filterAgentsByRepository('biomarkers');
         // Then I should see only 1 agent

--- a/test-cypress/integration/ttyg/agent-list.spec.js
+++ b/test-cypress/integration/ttyg/agent-list.spec.js
@@ -53,10 +53,9 @@ describe('TTYG agent list', () => {
         TTYGViewSteps.getAgents().should('have.length', 2);
         // Then Agent list filter should be set to All
         TTYGViewSteps.getSelectedAgentFilter().should('contain', 'starwars');
-        // TTYGViewSteps.getAgentFilter().click();
-        // TODO: Ask Boyan what are these lines for?
-        // TTYGViewSteps.verifyRepositoryOptionNotExist('Fedx_repository');
-        // TTYGViewSteps.verifyRepositoryOptionNotExist('Ontop_repository');
+        TTYGViewSteps.getAgentFilter().click();
+        TTYGViewSteps.verifyRepositoryOptionNotExist('Fedx_repository');
+        TTYGViewSteps.verifyRepositoryOptionNotExist('Ontop_repository');
         // When I filter the agents by repository 'biomarkers'
         TTYGViewSteps.filterAgentsByRepository('biomarkers');
         // Then I should see only 1 agent

--- a/test-cypress/integration/ttyg/agent-list.spec.js
+++ b/test-cypress/integration/ttyg/agent-list.spec.js
@@ -53,8 +53,10 @@ describe('TTYG agent list', () => {
         TTYGViewSteps.getAgents().should('have.length', 2);
         // Then Agent list filter should be set to All
         TTYGViewSteps.getSelectedAgentFilter().should('contain', 'starwars');
-        TTYGViewSteps.verifyRepositoryOptionNotExist('Fedx_repository');
-        TTYGViewSteps.verifyRepositoryOptionNotExist('Ontop_repository');
+        // TTYGViewSteps.getAgentFilter().click();
+        // TODO: Ask Boyan what are these lines for?
+        // TTYGViewSteps.verifyRepositoryOptionNotExist('Fedx_repository');
+        // TTYGViewSteps.verifyRepositoryOptionNotExist('Ontop_repository');
         // When I filter the agents by repository 'biomarkers'
         TTYGViewSteps.filterAgentsByRepository('biomarkers');
         // Then I should see only 1 agent

--- a/test-cypress/integration/ttyg/create-agent.spec.js
+++ b/test-cypress/integration/ttyg/create-agent.spec.js
@@ -377,9 +377,8 @@ describe('TTYG create new agent', () => {
         // Then I expect the selected repository to be set as the repository ID in the form.
         TtygAgentSettingsModalSteps.verifyRepositorySelected('starwars');
         // and all options are exclusively for GraphDB repositories.
-        // TODO: There is something wrong with these. Check them.
-        // TtygAgentSettingsModalSteps.verifyRepositoryOptionNotExist('Fedx_repository');
-        // TtygAgentSettingsModalSteps.verifyRepositoryOptionNotExist('Ontop_repository');
+        TtygAgentSettingsModalSteps.verifyRepositoryOptionNotExist('Fedx_repository');
+        TtygAgentSettingsModalSteps.verifyRepositoryOptionNotExist('Ontop_repository');
 
         // When I open ChatGPT retrieval connector panel
         TtygAgentSettingsModalSteps.enableRetrievalMethodPanel();

--- a/test-cypress/integration/ttyg/create-agent.spec.js
+++ b/test-cypress/integration/ttyg/create-agent.spec.js
@@ -377,8 +377,9 @@ describe('TTYG create new agent', () => {
         // Then I expect the selected repository to be set as the repository ID in the form.
         TtygAgentSettingsModalSteps.verifyRepositorySelected('starwars');
         // and all options are exclusively for GraphDB repositories.
-        TtygAgentSettingsModalSteps.verifyRepositoryOptionNotExist('Fedx_repository');
-        TtygAgentSettingsModalSteps.verifyRepositoryOptionNotExist('Ontop_repository');
+        // TODO: There is something wrong with these. Check them.
+        // TtygAgentSettingsModalSteps.verifyRepositoryOptionNotExist('Fedx_repository');
+        // TtygAgentSettingsModalSteps.verifyRepositoryOptionNotExist('Ontop_repository');
 
         // When I open ChatGPT retrieval connector panel
         TtygAgentSettingsModalSteps.enableRetrievalMethodPanel();

--- a/test-cypress/integration/ttyg/create-agent.spec.js
+++ b/test-cypress/integration/ttyg/create-agent.spec.js
@@ -267,7 +267,7 @@ describe('TTYG create new agent', () => {
         TtygAgentSettingsModalSteps.getSimilarityIndexThresholdField().should('have.value', '0.6');
         TtygAgentSettingsModalSteps.setSimilarityIndexThreshold('0.8');
         // And I set the max triples per call
-        TtygAgentSettingsModalSteps.getSimilarityIndexMaxTriplesField().should('have.value', '0');
+        TtygAgentSettingsModalSteps.getSimilarityIndexMaxTriplesField().should('have.value', '');
         TtygAgentSettingsModalSteps.setSimilarityIndexMaxTriples('100');
         // When I save the agent
         TTYGStubs.stubAgentCreate();
@@ -346,7 +346,7 @@ describe('TTYG create new agent', () => {
         // Then the save button should be enabled
         TtygAgentSettingsModalSteps.getSaveAgentButton().should('be.enabled');
         // When I set the max triples per call
-        TtygAgentSettingsModalSteps.getRetrievalMaxTriplesField().should('have.value', '0');
+        TtygAgentSettingsModalSteps.getRetrievalMaxTriplesField().should('have.value', '');
         TtygAgentSettingsModalSteps.setRetrievalMaxTriples('100');
         // When I save the agent
         TTYGStubs.stubAgentCreate();


### PR DESCRIPTION
## What
* Stop reloading of chat list after chat is deleted or exported.
* In the agent list filter menu and in agent create dialog are visible repositories from other locations.
* New chats or chats that were recently used should stay on top of the chat list.

## Why
* Reloading chat list is not necesarry after these operations.
* Repositories and locations from other instances should not be allowed when agent is being created and in the agent list filter.
* The recent chats should be on top of the list because this is the expected order and also the backend actually returns them in this way, but as we don't reload the chat list after each answer, the list remains in the initial order which is inconvenient.

## How
* Removed emitting of load chats event from the delete and export chat handers. Replaced the chats reloading after delete operation with a chat list local refresh only.
* Added additional method in the repository service to filter repositories by the `local` property and used the method in the ttyg view.
* Updated the selected chat with the timestamp returned by the backend and refreshed the list locally.
