### PR TITLE
10937: Disable the Create/Edit Agent Buttons

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -552,7 +552,8 @@
             },
             "fat_btn": {
                 "create_agent": {
-                    "label": "Create your first agent"
+                    "label": "Create your first agent",
+                    "tooltip_disabled": "You do not have permission to create an agent"
                 }
             },
             "btn": {
@@ -562,7 +563,8 @@
                 },
                 "edit_agent": {
                     "label": "Agent settings",
-                    "tooltip": "Edit agent settings"
+                    "tooltip": "Edit agent settings",
+                    "tooltip_disabled": "You do not have permission to edit the agent"
                 },
                 "clone_agent": {
                     "label": "Clone",
@@ -574,7 +576,8 @@
                 },
                 "create_agent": {
                     "label": "Create Agent",
-                    "tooltip": "Create a new agent"
+                    "tooltip": "Create a new agent",
+                    "tooltip_disabled": "You do not have permission to create an agent"
                 },
                 "open_sidebar": {
                     "tooltip": "Manage agents"
@@ -584,6 +587,9 @@
                 },
                 "copy_gpt_token_prop": {
                     "tooltip": "Copy GPT token property"
+                },
+                "open-agent-actions": {
+                    "label_disabled": "You do not have permission to modify the agent"
                 }
             },
             "messages": {

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -580,7 +580,8 @@
                     "tooltip_disabled": "You do not have permission to create an agent"
                 },
                 "open_sidebar": {
-                    "tooltip": "Manage agents"
+                    "tooltip": "Manage agents",
+                    "tooltip_disabled": "You do not have permission to modify the agent"
                 },
                 "close_sidebar": {
                     "tooltip": "Close sidebar"

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -580,7 +580,8 @@
                     "tooltip_disabled": "Vous n'avez pas la permission de créer un agent"
                 },
                 "open_sidebar": {
-                    "tooltip": "Gérer les agents"
+                    "tooltip": "Gérer les agents",
+                    "tooltip_disabled": "Vous n'avez pas la permission de modifier l'agent"
                 },
                 "close_sidebar": {
                     "tooltip": "Fermer la barre latérale"

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -552,7 +552,8 @@
             },
             "fat_btn": {
                 "create_agent": {
-                    "label": "Créez votre premier agent"
+                    "label": "Créez votre premier agent",
+                    "tooltip_disabled": "Vous n'avez pas l'autorisation de créer un agent"
                 }
             },
             "btn": {
@@ -562,7 +563,8 @@
                 },
                 "edit_agent": {
                     "label": "Paramètres de l'agent",
-                    "tooltip": "Paramètres de l'agent"
+                    "tooltip": "Paramètres de l'agent",
+                    "tooltip_disabled": "Vous n'avez pas l'autorisation de modifier l'agent."
                 },
                 "clone_agent": {
                     "label": "Cloner",
@@ -574,7 +576,8 @@
                 },
                 "create_agent": {
                     "label": "Créer un agent",
-                    "tooltip": "Créer un nouvel agent"
+                    "tooltip": "Créer un nouvel agent",
+                    "tooltip_disabled": "Vous n'avez pas la permission de créer un agent"
                 },
                 "open_sidebar": {
                     "tooltip": "Gérer les agents"
@@ -584,6 +587,9 @@
                 },
                 "copy_gpt_token_prop": {
                     "tooltip": "Copier la propriété du jeton GPT"
+                },
+                "open-agent-actions": {
+                    "label_disabled": "Vous n'avez pas la permission de modifier l'agent"
                 }
             },
             "messages": {

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -140,6 +140,10 @@ function TTYGViewCtrl(
 
     $scope.connectorID = undefined;
 
+    /**
+     * A flag that determines whether buttons that modify an agent should be disabled.
+     * @type {boolean}
+     */
     $scope.canModifyAgent = false;
 
     /**

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -103,7 +103,7 @@ function TTYGViewCtrl(
      * Controls the visibility of the agents list sidebar.
      * @type {boolean}
      */
-    $scope.showAgents = true;
+    $scope.showAgents = false;
     /**
      * Chats list.
      * @type {ChatsListModel|undefined}
@@ -628,7 +628,6 @@ function TTYGViewCtrl(
      */
     const onAgentListChanged = (agents) => {
         $scope.agents = agents;
-        $scope.showAgents = !agents.isEmpty();
     };
 
     /**

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -39,6 +39,7 @@ angular
     .controller('TTYGViewCtrl', TTYGViewCtrl);
 
 TTYGViewCtrl.$inject = [
+    '$jwtAuth',
     '$window',
     '$rootScope',
     '$scope',
@@ -55,6 +56,7 @@ TTYGViewCtrl.$inject = [
     'TTYGStorageService'];
 
 function TTYGViewCtrl(
+    $jwtAuth,
     $window,
     $rootScope,
     $scope,
@@ -137,6 +139,8 @@ function TTYGViewCtrl(
     $scope.reloadingAgents = false;
 
     $scope.connectorID = undefined;
+
+    $scope.canModifyAgent = false;
 
     /**
      * A list of available repository IDs as a model for the agent list filter.
@@ -464,6 +468,12 @@ function TTYGViewCtrl(
                 }
             }
         }
+
+        updateCanModifyAgent();
+    };
+
+    const updateCanModifyAgent = () => {
+        TTYGContextService.setCanModifyAgent($jwtAuth.isRepoManager());
     };
 
     const getActiveRepositoryObjectHandler = (activeRepo) => {
@@ -556,6 +566,10 @@ function TTYGViewCtrl(
     const onChatsChanged = (chats) => {
         $scope.chats = chats;
         setupChatListPanel(chats);
+    };
+
+    const onCanUpdateAgentUpdated = (canModifyAgent) => {
+        $scope.canModifyAgent = canModifyAgent;
     };
 
     /**
@@ -849,6 +863,7 @@ function TTYGViewCtrl(
     subscriptions.push($scope.$watch($scope.getActiveRepositoryObject, getActiveRepositoryObjectHandler));
     subscriptions.push(TTYGContextService.onSelectedChatChanged(onSelectedChatChanged));
     subscriptions.push(TTYGContextService.onChatsListChanged(onChatsChanged));
+    subscriptions.push(TTYGContextService.onCanUpdateAgentUpdated(onCanUpdateAgentUpdated));
     subscriptions.push(TTYGContextService.subscribe(TTYGContextService.onAgentsListChanged(onAgentListChanged)));
     subscriptions.push(TTYGContextService.subscribe(TTYGEventName.CREATE_CHAT, onCreateNewChat));
     subscriptions.push(TTYGContextService.subscribe(TTYGEventName.RENAME_CHAT, onRenameChat));
@@ -865,8 +880,8 @@ function TTYGViewCtrl(
     subscriptions.push(TTYGContextService.subscribe(TTYGEventName.GO_TO_CONNECTORS_VIEW, onGoToConnectorsView));
     subscriptions.push(TTYGContextService.subscribe(TTYGEventName.GO_TO_SPARQL_EDITOR, onGoToSparqlEditorView));
     subscriptions.push($rootScope.$on('$translateChangeSuccess', updateLabels));
+    subscriptions.push($rootScope.$on('securityInit', updateCanModifyAgent));
     $scope.$on('$destroy', cleanUp);
-
     // =========================
     // Initialization
     // =========================

--- a/src/js/angular/ttyg/directives/agent-list.directive.js
+++ b/src/js/angular/ttyg/directives/agent-list.directive.js
@@ -42,6 +42,8 @@ function AgentListComponent(TTYGContextService, ModalService, $translate) {
              */
             $scope.deletingAgent = undefined;
 
+            $scope.canModifyAgent = false;
+
             // =========================
             // Private variables
             // =========================
@@ -113,6 +115,10 @@ function AgentListComponent(TTYGContextService, ModalService, $translate) {
                 $scope.selectedAgent = agent;
             };
 
+            const onCanUpdateAgentUpdated = (canModifyAgent) => {
+                $scope.canModifyAgent = canModifyAgent;
+            };
+
             // =========================
             // Subscriptions
             // =========================
@@ -126,6 +132,7 @@ function AgentListComponent(TTYGContextService, ModalService, $translate) {
             subscriptions.push($scope.$watch('agentListFilterModel', updateSelectedAgentsFilter));
             subscriptions.push(TTYGContextService.subscribe(TTYGEventName.DELETING_AGENT, onDeletingAgent));
             subscriptions.push(TTYGContextService.onSelectedAgentChanged(onSelectedAgentChanged));
+            subscriptions.push(TTYGContextService.onCanUpdateAgentUpdated(onCanUpdateAgentUpdated));
 
             // Deregister the watcher when the scope/directive is destroyed
             $scope.$on('$destroy', removeAllSubscribers);

--- a/src/js/angular/ttyg/directives/agent-list.directive.js
+++ b/src/js/angular/ttyg/directives/agent-list.directive.js
@@ -42,8 +42,6 @@ function AgentListComponent(TTYGContextService, ModalService, $translate) {
              */
             $scope.deletingAgent = undefined;
 
-            $scope.canModifyAgent = false;
-
             // =========================
             // Private variables
             // =========================
@@ -115,10 +113,6 @@ function AgentListComponent(TTYGContextService, ModalService, $translate) {
                 $scope.selectedAgent = agent;
             };
 
-            const onCanUpdateAgentUpdated = (canModifyAgent) => {
-                $scope.canModifyAgent = canModifyAgent;
-            };
-
             // =========================
             // Subscriptions
             // =========================
@@ -132,7 +126,6 @@ function AgentListComponent(TTYGContextService, ModalService, $translate) {
             subscriptions.push($scope.$watch('agentListFilterModel', updateSelectedAgentsFilter));
             subscriptions.push(TTYGContextService.subscribe(TTYGEventName.DELETING_AGENT, onDeletingAgent));
             subscriptions.push(TTYGContextService.onSelectedAgentChanged(onSelectedAgentChanged));
-            subscriptions.push(TTYGContextService.onCanUpdateAgentUpdated(onCanUpdateAgentUpdated));
 
             // Deregister the watcher when the scope/directive is destroyed
             $scope.$on('$destroy', removeAllSubscribers);

--- a/src/js/angular/ttyg/directives/no-agents-view.directive.js
+++ b/src/js/angular/ttyg/directives/no-agents-view.directive.js
@@ -15,12 +15,37 @@ function NoAgentsView(TTYGContextService) {
         link: ($scope, element, attrs) => {
 
             // =========================
+            // Public variables
+            // =========================
+
+            $scope.canModifyAgent = false;
+
+            // =========================
             // Public functions
             // =========================
 
             $scope.onCreateAgent = () => {
                 TTYGContextService.emit(TTYGEventName.OPEN_AGENT_SETTINGS);
             };
+
+            // =========================
+            // Private functions
+            // =========================
+
+            const onCanUpdateAgentUpdated = (canModifyAgent) => {
+                $scope.canModifyAgent = canModifyAgent;
+            };
+
+            // =========================
+            // Subscriptions
+            // =========================
+            const subscriptions = [];
+
+            const onDestroy = () => {
+                subscriptions.forEach((subscription) => subscription());
+            };
+            subscriptions.push(TTYGContextService.onCanUpdateAgentUpdated(onCanUpdateAgentUpdated));
+            $scope.$on('$destroy', onDestroy);
         }
     };
 }

--- a/src/js/angular/ttyg/services/ttyg-context.service.js
+++ b/src/js/angular/ttyg/services/ttyg-context.service.js
@@ -318,7 +318,7 @@ function TTYGContextService(EventEmitterService) {
         if (angular.isFunction(callback)) {
             callback(getCanModifyAgent());
         }
-        return subscribe(TTYGEventName.CAN_MODIFY_AGENT_UPDATED, (explainResponses) => callback(explainResponses));
+        return subscribe(TTYGEventName.CAN_MODIFY_AGENT_UPDATED, (canModifyAgent) => callback(canModifyAgent));
     };
 
     /**

--- a/src/js/angular/ttyg/services/ttyg-context.service.js
+++ b/src/js/angular/ttyg/services/ttyg-context.service.js
@@ -51,6 +51,8 @@ function TTYGContextService(EventEmitterService) {
      */
     let _defaultAgent = undefined;
 
+    let _canModifyAgent = false;
+
     const resetContext = () => {
         _agents = undefined;
         _chats = undefined;
@@ -58,6 +60,7 @@ function TTYGContextService(EventEmitterService) {
         _selectedAgent = undefined;
         _explainCache = {};
         _defaultAgent = undefined;
+        _canModifyAgent = false;
     };
 
     /**
@@ -292,6 +295,33 @@ function TTYGContextService(EventEmitterService) {
     };
 
     /**
+     * Updates the "canModifyAgent" flag and emits the 'canModifyAgentUpdated' event to notify listeners that the canModifyAgent flag is changed.
+     *
+     * @param {boolean} canModifyAgent
+     */
+    const setCanModifyAgent = (canModifyAgent) => {
+        _canModifyAgent = cloneDeep(canModifyAgent);
+        emit(TTYGEventName.CAN_MODIFY_AGENT_UPDATED, getCanModifyAgent());
+    };
+
+    const getCanModifyAgent = () => {
+        return _canModifyAgent;
+    };
+
+    /**
+     * Subscribes to the 'canModifyAgentUpdated' event.
+     * @param {function} callback - The callback to be called when the event is fired.
+     *
+     * @return {function} unsubscribe function.
+     */
+    const onCanUpdateAgentUpdated = (callback) => {
+        if (angular.isFunction(callback)) {
+            callback(getCanModifyAgent());
+        }
+        return subscribe(TTYGEventName.CAN_MODIFY_AGENT_UPDATED, (explainResponses) => callback(explainResponses));
+    };
+
+    /**
      * Emits an event with a deep-cloned payload using the EventEmitterService.
      *
      * @param {string} tTYGEventName - The name of the event to emit. It must be a value from {@link TTYGEventName}.
@@ -340,7 +370,10 @@ function TTYGContextService(EventEmitterService) {
         addExplainResponseCache,
         onExplainResponseCacheUpdated,
         getDefaultAgent,
-        setDefaultAgent
+        setDefaultAgent,
+        setCanModifyAgent,
+        getCanModifyAgent,
+        onCanUpdateAgentUpdated
     };
 }
 
@@ -483,5 +516,7 @@ export const TTYGEventName = {
     /**
      * This event will trigger the opening of the sparql view.
      */
-    GO_TO_SPARQL_EDITOR: "openQueryInSparqlEditor"
+    GO_TO_SPARQL_EDITOR: "openQueryInSparqlEditor",
+
+    CAN_MODIFY_AGENT_UPDATED: "canModifyAgentUpdated"
 };

--- a/src/js/angular/ttyg/templates/agent-list.html
+++ b/src/js/angular/ttyg/templates/agent-list.html
@@ -44,7 +44,8 @@
                             data-toggle="dropdown" aria-expanded="false"
                             ng-if="true"
                             ng-click="openAgentActionMenu()"
-                            ng-disabled="false">
+                            gdb-tooltip="{{ (!canModifyAgent ? ('ttyg.agent.btn.open-agent-actions.label_disabled' | translate) : '') }}"
+                            ng-disabled="!canModifyAgent">
                         <i class="fa-regular fa-ellipsis"></i>
                     </button>
                     <div class="dropdown-menu dropdown-menu-right agent-actions-menu">

--- a/src/js/angular/ttyg/templates/agent-list.html
+++ b/src/js/angular/ttyg/templates/agent-list.html
@@ -44,8 +44,7 @@
                             data-toggle="dropdown" aria-expanded="false"
                             ng-if="true"
                             ng-click="openAgentActionMenu()"
-                            gdb-tooltip="{{ (!canModifyAgent ? ('ttyg.agent.btn.open-agent-actions.label_disabled' | translate) : '') }}"
-                            ng-disabled="!canModifyAgent">
+                            ng-disabled="false">
                         <i class="fa-regular fa-ellipsis"></i>
                     </button>
                     <div class="dropdown-menu dropdown-menu-right agent-actions-menu">

--- a/src/js/angular/ttyg/templates/chat-item-detail.html
+++ b/src/js/angular/ttyg/templates/chat-item-detail.html
@@ -22,7 +22,7 @@
                         <i class="fa-regular fa-arrows-rotate"></i>
                     </button>
                     <copy-to-clipboard class="btn-sm" tooltip-text="ttyg.chat_panel.btn.copy_answer.tooltip"
-                                       text-to-copy="answer.message"></copy-to-clipboard>
+                                       text-to-copy="{{answer.message}}"></copy-to-clipboard>
                     <button class="btn btn-link btn-link-only-icons btn-sm explain-response-btn"
                             ng-click="explainResponse(answer.id)"
                             ng-disabled="disabled && !explainResponseModel[answer.id]"
@@ -64,7 +64,7 @@
                                         query="{{queryMethod.query}}">
                                     </open-in-sparql-editor>
                                     <copy-to-clipboard tooltip-text="ttyg.chat_panel.btn.copy_{{ queryMethod.queryType }}.tooltip"
-                                                       text-to-copy="queryMethod.query"></copy-to-clipboard>
+                                                       text-to-copy="{{queryMethod.query}}"></copy-to-clipboard>
                                 </div>
                             </div>
                             <div class="query">
@@ -74,13 +74,13 @@
                                 <span class="label">{{'ttyg.chat_panel.labels.raw_query' | translate}}:</span>
                                 <span class="content">{{queryMethod.rawQuery}}</span>
                                 <copy-to-clipboard class="copy-to-clipboard-btn" tooltip-text="ttyg.chat_panel.btn.copy_raw_query.tooltip"
-                                                   text-to-copy="queryMethod.rawQuery"></copy-to-clipboard>
+                                                   text-to-copy="{{queryMethod.rawQuery}}"></copy-to-clipboard>
                             </div>
                             <div ng-if="queryMethod.errorMessage" class="alert no-icon alert-warning error-message">
                                 <div class="error-header">
                                     <div class="label">{{'ttyg.chat_panel.labels.error_message' | translate}}:</div>
                                     <copy-to-clipboard class="copy-to-clipboard-btn" tooltip-text="ttyg.chat_panel.btn.copy_error_message.tooltip"
-                                                       text-to-copy="queryMethod.errorMessage"></copy-to-clipboard>
+                                                       text-to-copy="{{queryMethod.errorMessage}}"></copy-to-clipboard>
                                 </div>
                                 <div class="error-content">{{queryMethod.errorMessage}}</div>
                             </div>

--- a/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -379,7 +379,7 @@
                 <div class="actions">
                     <copy-to-clipboard
                         tooltip-text="ttyg.agent.create_agent_modal.form.user_instruction.btn.copy_instruction.tooltip"
-                        text-to-copy="agentFormModel.instructions.userInstruction"></copy-to-clipboard>
+                        text-to-copy="{{agentFormModel.instructions.userInstruction}}"></copy-to-clipboard>
                     <button class="btn btn-link btn-sm create-chat-btn"
                             ng-click="onRestoreDefaultUserInstructions()"
                             gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.user_instruction.btn.restore_default.tooltip' | translate}}">
@@ -414,7 +414,7 @@
                     <div class="actions">
                         <copy-to-clipboard
                             tooltip-text="ttyg.agent.create_agent_modal.form.system_instruction.btn.copy_instruction.tooltip"
-                            text-to-copy="agentFormModel.instructions.systemInstruction"></copy-to-clipboard>
+                            text-to-copy="{{agentFormModel.instructions.systemInstruction}}"></copy-to-clipboard>
                         <button class="btn btn-link btn-sm create-chat-btn"
                                 ng-click="onRestoreDefaultSystemInstructions()"
                                 gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.system_instruction.btn.restore_default.tooltip' | translate}}">

--- a/src/js/angular/ttyg/templates/no-agents-view.html
+++ b/src/js/angular/ttyg/templates/no-agents-view.html
@@ -14,7 +14,10 @@
         </div>
 
         <div class="actions">
-            <button class="btn btn-outline-primary btn-lg text-xs-left create-agent-btn" ng-click="onCreateAgent()">
+            <button class="btn btn-outline-primary btn-lg text-xs-left create-agent-btn"
+                    gdb-tooltip="{{!canModifyAgent ? ('ttyg.agent.fat_btn.create_agent.tooltip_disabled' | translate) : ''}}"
+                    ng-disabled="!canModifyAgent"
+                    ng-click="onCreateAgent()">
                 <i class="fa-regular fa-message-bot fa-xl"></i>
                 <span class="text ml-1">{{'ttyg.agent.fat_btn.create_agent.label' | translate}}</span>
             </button>

--- a/src/js/angular/ttyg/templates/ttyg.html
+++ b/src/js/angular/ttyg/templates/ttyg.html
@@ -103,18 +103,18 @@
                     <i class="icon-plus"></i>
                 </button>
                 <button class="btn btn-link btn-sm toggle-agents-sidebar-btn"
+                        ng-if="!showAgents"
+                        ng-click="toggleAgentsListSidebar()"
+                        ng-disabled="!canModifyAgent"
+                        gdb-tooltip="{{'ttyg.agent.btn.open_sidebar.' + (canModifyAgent ? 'tooltip' : 'tooltip_disabled') | translate}}">
+                    <i class="fa-regular fa-message-bot"></i>
+                </button>
+                <button class="btn btn-link btn-sm toggle-agents-sidebar-btn"
                         ng-if="showAgents"
                         ng-click="toggleAgentsListSidebar()"
                         ng-disabled="false"
-                        gdb-tooltip="{{'ttyg.agent.btn.' + (showAgents ? 'close_sidebar' : 'open_sidebar') + '.tooltip' | translate}}">
+                        gdb-tooltip="{{'ttyg.agent.btn.close_sidebar' + '.tooltip' | translate}}">
                     <i class="icon-close"></i>
-                </button>
-                <button class="btn btn-link btn-sm toggle-agents-sidebar-btn"
-                        ng-if="!showAgents"
-                        ng-click="toggleAgentsListSidebar()"
-                        ng-disabled="false"
-                        gdb-tooltip="{{'ttyg.agent.btn.' + (showAgents ? 'close_sidebar' : 'open_sidebar') + '.tooltip' | translate}}">
-                    <i class="fa-regular fa-message-bot"></i>
                 </button>
             </div>
 

--- a/src/js/angular/ttyg/templates/ttyg.html
+++ b/src/js/angular/ttyg/templates/ttyg.html
@@ -69,8 +69,8 @@
                     <button class="btn btn-link btn-sm edit-current-agent-btn mr-1"
                             ng-if="selectedAgent"
                             ng-click="onOpenAgentSettings()"
-                            ng-disabled="false"
-                            gdb-tooltip="{{'ttyg.agent.btn.edit_agent.tooltip' | translate}}">
+                            ng-disabled="!canModifyAgent"
+                            gdb-tooltip="{{ (canModifyAgent ? 'ttyg.agent.btn.edit_agent.tooltip' : 'ttyg.agent.btn.edit_agent.tooltip_disabled') | translate}}">
                         <i class="icon-settings"></i>
                     </button>
                 </div>
@@ -96,10 +96,10 @@
                     <i class="icon-help"></i>
                 </button>
                 <button class="btn btn-link btn-sm create-agent-btn"
-                        ng-if="true"
+                        ng-disabled="!canModifyAgent"
                         ng-click="onOpenNewAgentSettings()"
                         ng-disabled="false"
-                        gdb-tooltip="{{'ttyg.agent.btn.create_agent.tooltip' | translate}}">
+                        gdb-tooltip="{{ (canModifyAgent ? 'ttyg.agent.btn.create_agent.tooltip' : 'ttyg.agent.btn.create_agent.tooltip_disabled') | translate}}">
                     <i class="icon-plus"></i>
                 </button>
                 <button class="btn btn-link btn-sm toggle-agents-sidebar-btn"

--- a/src/js/angular/ttyg/templates/ttyg.html
+++ b/src/js/angular/ttyg/templates/ttyg.html
@@ -103,12 +103,18 @@
                     <i class="icon-plus"></i>
                 </button>
                 <button class="btn btn-link btn-sm toggle-agents-sidebar-btn"
-                        ng-if="true"
+                        ng-if="showAgents"
                         ng-click="toggleAgentsListSidebar()"
                         ng-disabled="false"
                         gdb-tooltip="{{'ttyg.agent.btn.' + (showAgents ? 'close_sidebar' : 'open_sidebar') + '.tooltip' | translate}}">
-                    <i ng-if="!showAgents" class="fa-regular fa-message-bot"></i>
-                    <i ng-if="showAgents" class="icon-close"></i>
+                    <i class="icon-close"></i>
+                </button>
+                <button class="btn btn-link btn-sm toggle-agents-sidebar-btn"
+                        ng-if="!showAgents"
+                        ng-click="toggleAgentsListSidebar()"
+                        ng-disabled="false"
+                        gdb-tooltip="{{'ttyg.agent.btn.' + (showAgents ? 'close_sidebar' : 'open_sidebar') + '.tooltip' | translate}}">
+                    <i class="fa-regular fa-message-bot"></i>
                 </button>
             </div>
 

--- a/src/js/angular/ttyg/templates/ttyg.html
+++ b/src/js/angular/ttyg/templates/ttyg.html
@@ -24,7 +24,7 @@
          size="100">
     </div>
 
-    <no-agents-view ng-cloak ng-if="!loadingAgents && !reloadingAgents && (!agents || agents.isEmpty())"></no-agents-view>
+    <no-agents-view ng-cloak ng-if="getActiveRepository() && !loadingAgents && !reloadingAgents && (!agents || agents.isEmpty())"></no-agents-view>
 
     <div id="ttyg-container" class="ttyg-container" ng-show="getActiveRepository() && !loadingAgents && agents && !agents.isEmpty()">
 

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -552,7 +552,8 @@
             },
             "fat_btn": {
                 "create_agent": {
-                    "label": "Create your first agent"
+                    "label": "Create your first agent",
+                    "tooltip_disabled": "You do not have permission to create an agent"
                 }
             },
             "btn": {
@@ -562,7 +563,8 @@
                 },
                 "edit_agent": {
                     "label": "Agent settings",
-                    "tooltip": "Edit agent settings"
+                    "tooltip": "Edit agent settings",
+                    "tooltip_disabled": "You do not have permission to edit the agent"
                 },
                 "clone_agent": {
                     "label": "Clone",
@@ -574,7 +576,8 @@
                 },
                 "create_agent": {
                     "label": "Create Agent",
-                    "tooltip": "Create a new agent"
+                    "tooltip": "Create a new agent",
+                    "tooltip_disabled": "You do not have permission to create an agent"
                 },
                 "open_sidebar": {
                     "tooltip": "Manage agents"
@@ -584,6 +587,9 @@
                 },
                 "copy_gpt_token_prop": {
                     "tooltip": "Copy GPT token property"
+                },
+                "open-agent-actions": {
+                    "label_disabled": "You do not have permission to modify the agent"
                 }
             },
             "messages": {

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -580,7 +580,8 @@
                     "tooltip_disabled": "You do not have permission to create an agent"
                 },
                 "open_sidebar": {
-                    "tooltip": "Manage agents"
+                    "tooltip": "Manage agents",
+                    "tooltip_disabled": "You do not have permission to modify the agent"
                 },
                 "close_sidebar": {
                     "tooltip": "Close sidebar"

--- a/test-cypress/integration/ttyg/agent-list.spec.js
+++ b/test-cypress/integration/ttyg/agent-list.spec.js
@@ -10,7 +10,7 @@ describe('TTYG agent list', () => {
         cy.presetRepository('starwars');
     });
 
-    it('Should render the agent list', () => {
+    it('Should be able to toggle agents panel', () => {
         TTYGStubs.stubAgentListGet();
         TTYGStubs.stubChatsListGet();
         TTYGStubs.stubChatGet();
@@ -21,36 +21,22 @@ describe('TTYG agent list', () => {
         cy.wait('@get-chat');
         cy.wait('@get-all-repositories');
         // When the ttyg page is loaded
+        // Then I expect tha agent list be closed by default.
+        TTYGViewSteps.getAgentsPanel().should('not.be.visible');
+
+        // When I click on "Manage agents"
+        TTYGViewSteps.expandAgentsSidebar();
         // Then I should see the agent list with agents filtered by the current repository
-        TTYGViewSteps.getAgentsPanel().should('be.visible');
+        TTYGViewSteps.getAgentsPanel().should('not.be.visible');
         TTYGViewSteps.verifyAgentList([
             {name: 'agent-1', repositoryId: 'starwars'},
             {name: 'Databricks-general-unbiased', repositoryId: 'starwars'}
         ]);
-    });
 
-    it('Should be able to toggle agents panel', () => {
-        TTYGStubs.stubChatsListGet();
-        TTYGStubs.stubChatGet();
-        TTYGStubs.stubAgentListGet();
-        // Given I have opened the ttyg page
-        TTYGViewSteps.visit();
-        cy.wait('@get-chat');
-        cy.wait('@get-agent-list');
-        cy.wait('@get-chat-list');
-        cy.wait('@get-all-repositories');
-        // When the ttyg page is loaded
-        // Then I should see the agent list
-        TTYGViewSteps.getAgents().should('have.length', 2);
         // When I close the agent list panel
         TTYGViewSteps.collapseAgentsSidebar();
         // Then I expect agent list panel to be closed
         TTYGViewSteps.getAgentsPanel().should('be.hidden');
-        // When I open the agent list panel
-        TTYGViewSteps.expandAgentsSidebar();
-        // Then I should see no agents
-        TTYGViewSteps.getAgentsPanel().should('be.visible');
-        TTYGViewSteps.getAgents().should('have.length', 2);
     });
 
     it('Should be able to filter the agent list by repository', () => {

--- a/test-cypress/integration/ttyg/agent-list.spec.js
+++ b/test-cypress/integration/ttyg/agent-list.spec.js
@@ -27,7 +27,7 @@ describe('TTYG agent list', () => {
         // When I click on "Manage agents"
         TTYGViewSteps.expandAgentsSidebar();
         // Then I should see the agent list with agents filtered by the current repository
-        TTYGViewSteps.getAgentsPanel().should('not.be.visible');
+        TTYGViewSteps.getAgentsPanel().should('be.visible');
         TTYGViewSteps.verifyAgentList([
             {name: 'agent-1', repositoryId: 'starwars'},
             {name: 'Databricks-general-unbiased', repositoryId: 'starwars'}

--- a/test-cypress/integration/ttyg/agent-select-menu.spec.js
+++ b/test-cypress/integration/ttyg/agent-select-menu.spec.js
@@ -61,6 +61,7 @@ describe('TTYG agent select menu', () => {
         TTYGViewSteps.visit();
         cy.wait('@get-agent-list');
         // When I delete an agent from the sidebar
+        TTYGViewSteps.expandAgentsSidebar();
         TTYGStubs.stubAgentDelete();
         TTYGStubs.stubAgentListGet('/ttyg/agent/get-agent-list-after-deleted.json');
         TTYGViewSteps.selectAllAgentsFilter();

--- a/test-cypress/integration/ttyg/clone-agent.spec.js
+++ b/test-cypress/integration/ttyg/clone-agent.spec.js
@@ -24,6 +24,7 @@ describe('TTYG clone an agent', () => {
         cy.wait('@get-chat');
         cy.wait('@get-agent-list');
         // When I select to clone an agent
+        TTYGViewSteps.expandAgentsSidebar();
         TTYGViewSteps.triggerCloneAgentActionMenu(0);
         // Then I expect to see the clone agent settings modal
         TtygAgentSettingsModalSteps.getDialog().should('be.visible');

--- a/test-cypress/integration/ttyg/delete-agent.spec.js
+++ b/test-cypress/integration/ttyg/delete-agent.spec.js
@@ -18,6 +18,7 @@ describe('TTYG delete agent', () => {
         TTYGStubs.stubAgentListGet();
         // Given I have opened the ttyg page
         TTYGViewSteps.visit();
+        TTYGViewSteps.expandAgentsSidebar();
         TTYGViewSteps.getAgents().should('have.length', 2);
         TTYGViewSteps.filterAgentsByRepository('All');
         TTYGViewSteps.getAgents().should('have.length', 4);

--- a/test-cypress/integration/ttyg/edit-agent.spec.js
+++ b/test-cypress/integration/ttyg/edit-agent.spec.js
@@ -30,6 +30,7 @@ describe('TTYG edit an agent', () => {
         cy.wait('@get-agent-list');
         cy.wait('@get-chat');
         // When I select an agent that don't have activated additional extraction method
+        TTYGViewSteps.expandAgentsSidebar();
         TTYGViewSteps.openAgentsMenu();
         TTYGViewSteps.selectAgent(0);
         TTYGViewSteps.editCurrentAgent();

--- a/test-cypress/integration/ttyg/ttyg-permission.spec.js
+++ b/test-cypress/integration/ttyg/ttyg-permission.spec.js
@@ -1,0 +1,66 @@
+import {RepositoriesStubs} from "../../stubs/repositories/repositories-stubs";
+import {RepositoriesStub} from "../../stubs/repositories-stub";
+import {UserAndAccessSteps} from "../../steps/setup/user-and-access-steps";
+import {TTYGStubs} from "../../stubs/ttyg/ttyg-stubs";
+import {TTYGViewSteps} from "../../steps/ttyg/ttyg-view-steps";
+
+const USER_WITH_ROLE_USER = 'ttyg_user';
+const USER_WITH_ROLE_REPO_MANAGER = 'ttyg_repo_manager';
+const USER_ADMINISTRATOR = 'admin';
+const PASSWORD = 'root';
+const ENABLED = true;
+const DISABLED = false;
+
+describe('TTYG permissions', () => {
+
+
+    before(() => {
+        RepositoriesStubs.stubRepositories(0, '/repositories/get-ttyg-repositories.json');
+        RepositoriesStub.stubBaseEndpoints('starwars');
+        cy.presetRepository('starwars');
+        cy.createUser({username: USER_WITH_ROLE_USER, password: PASSWORD});
+        cy.createUser({
+            username: USER_WITH_ROLE_REPO_MANAGER,
+            password: PASSWORD,
+            grantedAuthorities: ["ROLE_REPO_MANAGER", "WRITE_REPO_*", "READ_REPO_*"]
+        });
+        UserAndAccessSteps.visit();
+        UserAndAccessSteps.toggleSecurity();
+    });
+
+    after(() => {
+        UserAndAccessSteps.visit();
+        UserAndAccessSteps.loginWithUser(USER_ADMINISTRATOR, PASSWORD);
+        UserAndAccessSteps.toggleSecurity();
+        cy.deleteUser(USER_WITH_ROLE_USER);
+        cy.deleteUser(USER_WITH_ROLE_REPO_MANAGER);
+    });
+
+    it('should disable all buttons that can modify the agent', () => {
+
+        // When I log in with a user who has the ROLE_USER role, I expect all buttons modifying the agent to be disabled.
+        verifyCanCreateAgentForFirstTime(USER_WITH_ROLE_USER, PASSWORD, DISABLED);
+
+        // When I log in with a user who has the ROLE_REPO_MANAGER role, I expect all buttons modifying the agent to be enabled.
+        verifyCanCreateAgentForFirstTime(USER_WITH_ROLE_REPO_MANAGER, PASSWORD, ENABLED);
+
+        // When I log in with a user who is administrator, I expect all buttons modifying the agent to be enabled.
+        verifyCanCreateAgentForFirstTime(USER_ADMINISTRATOR, PASSWORD, ENABLED);
+    });
+
+    function verifyCanCreateAgentForFirstTime(user, password, enable) {
+        const shouldBe = enable ? 'be.enabled' : 'be.disabled';
+        TTYGStubs.stubAgentListGet('/ttyg/agent/get-agent-list-0.json');
+        TTYGViewSteps.visit();
+        UserAndAccessSteps.loginWithUser(user, password);
+        TTYGViewSteps.getCreateFirstAgentButton().should(shouldBe);
+        TTYGStubs.stubChatsListGet();
+        TTYGStubs.stubAgentListGet();
+        TTYGStubs.stubChatGet();
+        TTYGViewSteps.visit();
+        TTYGViewSteps.getCreateAgentButton().should(shouldBe);
+        TTYGViewSteps.getEditCurrentAgentButton().should(shouldBe);
+        TTYGViewSteps.getOpenAgentActionsButton(1).should(shouldBe);
+        UserAndAccessSteps.logout();
+    }
+});

--- a/test-cypress/integration/ttyg/ttyg-permission.spec.js
+++ b/test-cypress/integration/ttyg/ttyg-permission.spec.js
@@ -60,7 +60,7 @@ describe('TTYG permissions', () => {
         TTYGViewSteps.visit();
         TTYGViewSteps.getCreateAgentButton().should(shouldBe);
         TTYGViewSteps.getEditCurrentAgentButton().should(shouldBe);
-        TTYGViewSteps.getOpenAgentActionsButton(1).should(shouldBe);
+        TTYGViewSteps.getToggleAgentsSidebarButton().should(shouldBe);
         UserAndAccessSteps.logout();
     }
 });

--- a/test-cypress/integration/ttyg/ttyg-view.spec.js
+++ b/test-cypress/integration/ttyg/ttyg-view.spec.js
@@ -31,7 +31,7 @@ describe('TTYG view', () => {
         // The create chat button is visible when there are chats
         TTYGViewSteps.getCreateChatButton().should('exist');
         // Verify the agents sidebar
-        TTYGViewSteps.getAgentsPanel().should('be.visible');
+        TTYGViewSteps.getAgentsPanel().should('not.be.visible');
         TTYGViewSteps.getHelpButton().should('be.visible');
         TTYGViewSteps.getCreateAgentButton().should('be.visible');
         TTYGViewSteps.getToggleAgentsSidebarButton().should('be.visible');

--- a/test-cypress/steps/ttyg/ttyg-view-steps.js
+++ b/test-cypress/steps/ttyg/ttyg-view-steps.js
@@ -214,7 +214,7 @@ export class TTYGViewSteps {
     }
 
     static openAgentActionMenu(index) {
-        this.getOpenAgentActionsButton.click();
+        this.getOpenAgentActionsButton(index).click();
     }
 
     static triggerCloneAgentActionMenu(index) {

--- a/test-cypress/steps/ttyg/ttyg-view-steps.js
+++ b/test-cypress/steps/ttyg/ttyg-view-steps.js
@@ -209,8 +209,12 @@ export class TTYGViewSteps {
         return this.getChatPanel().find('.chat');
     }
 
+    static getOpenAgentActionsButton(index) {
+        return this.getAgent(index).realHover().find('.open-agent-actions-btn');
+    }
+
     static openAgentActionMenu(index) {
-        this.getAgent(index).realHover().find('.open-agent-actions-btn').click();
+        this.getOpenAgentActionsButton.click();
     }
 
     static triggerCloneAgentActionMenu(index) {

--- a/test-cypress/support/commands.js
+++ b/test-cypress/support/commands.js
@@ -4,6 +4,8 @@ import './sparql-commands';
 import './import-commands';
 import './settings-commands';
 import './visual-graph-commands';
+import './user-commands';
+import './security-command';
 import 'cypress-wait-until';
 
 /**

--- a/test-cypress/support/security-command.js
+++ b/test-cypress/support/security-command.js
@@ -1,0 +1,25 @@
+Cypress.Commands.add('switchOnSecurity', () => {
+    cy.request({
+        method: 'POST',
+        url: `/rest/security`,
+        body: 'true',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        // Prevent Cypress from failing the test on non-2xx status codes
+        failOnStatusCode: false
+    });
+});
+
+Cypress.Commands.add('switchOffSecurity', () => {
+    cy.request({
+        method: 'POST',
+        url: `/rest/security`,
+        body: 'false',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        // Prevent Cypress from failing the test on non-2xx status codes
+        failOnStatusCode: true
+    });
+});

--- a/test-cypress/support/user-commands.js
+++ b/test-cypress/support/user-commands.js
@@ -1,0 +1,31 @@
+Cypress.Commands.add('createUser', (options = {}) => {
+    cy.request({
+        method: 'POST',
+        url: `/rest/security/users/${options.username}`,
+        body: {
+            "password": options.password || "root",
+            "appSettings": {
+                "DEFAULT_SAMEAS": true,
+                "DEFAULT_INFERENCE": true,
+                "EXECUTE_COUNT": true,
+                "IGNORE_SHARED_QUERIES": false,
+                "DEFAULT_VIS_GRAPH_SCHEMA": true
+            },
+            "grantedAuthorities": options.grantedAuthorities || ["ROLE_USER", "WRITE_REPO_*", "READ_REPO_*"]
+        },
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    }).then((response) => {
+        cy.waitUntil(() => response && response.status === 201); // 201 Created
+    });
+});
+
+Cypress.Commands.add('deleteUser', (username = {}) => {
+    cy.request({
+        method: 'DELETE',
+        url: `/rest/security/users/${username}`,
+        // Prevent Cypress from failing the test on non-2xx status codes
+        failOnStatusCode: false
+    });
+});


### PR DESCRIPTION
## What
Users cannot create or edit agents.

## Why
Only admin users are allowed to perform these actions.

## How
The create/edit buttons are disabled if the user is not an admin or have ROLE_REPO_MANAGER.