### PR TITLE
10937 Selected Agent Sometimes Empty

### DIFF
--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -890,11 +890,11 @@ function TTYGViewCtrl(
     // =========================
 
     function onInit() {
-        setCurrentAgent();
-        setCurrentChat();
         buildRepositoryList();
         loadAgents().then(() => {
             buildAgentsFilterModel();
+            setCurrentAgent();
+            setCurrentChat();
             return loadChats();
         });
         initView();

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -118,6 +118,12 @@ function TTYGViewCtrl(
     $scope.loadingChat = false;
 
     /**
+     * Flag controls when component is initialized.
+     * @type {boolean}
+     */
+    $scope.initialized = false;
+
+    /**
      * Agents list model.
      * @type {AgentListModel|undefined}
      */
@@ -892,6 +898,7 @@ function TTYGViewCtrl(
     function onInit() {
         buildRepositoryList();
         loadAgents().then(() => {
+            $scope.initialized = true;
             buildAgentsFilterModel();
             setCurrentAgent();
             setCurrentChat();

--- a/src/js/angular/ttyg/templates/ttyg.html
+++ b/src/js/angular/ttyg/templates/ttyg.html
@@ -24,7 +24,7 @@
          size="100">
     </div>
 
-    <no-agents-view ng-cloak ng-if="getActiveRepository() && !loadingAgents && !reloadingAgents && (!agents || agents.isEmpty())"></no-agents-view>
+    <no-agents-view ng-cloak ng-if="initialized && getActiveRepository() && !loadingAgents && !reloadingAgents && (!agents || agents.isEmpty())"></no-agents-view>
 
     <div id="ttyg-container" class="ttyg-container" ng-show="getActiveRepository() && !loadingAgents && agents && !agents.isEmpty()">
 


### PR DESCRIPTION
## What
- Sometimes the selected agent appears to be empty;
- No agent component is briefly displayed when the page is reloaded.

## Why
- The functionality that selects the last used agent depends on the list of agents being loaded. When the page is opened, the system attempts to set the last used agent before the list of agents is fully loaded. As a result, the agent cannot be found in the list;
- Previously, the condition to show the component was based on whether the agents field was undefined or empty. The agents field is undefined when the page is first loaded, and while the agent list is being fetched, the component was displayed briefly.

## How
- The loading of the last used agent has been moved to occur after the agent list is fully loaded;
- The condition was modified to ensure the component is not shown until the agent list is fully initialized.