### PR TITLE
GDB-11070 - improve logic for menu toggle and main content resize

### DIFF
--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -142,23 +142,29 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
     $scope.productInfo = productInfo;
     $scope.guidePaused = 'true' === LocalStorageAdapter.get(GUIDE_PAUSE);
 
-    // Check on page load
     $scope.isMenuCollapsedOnLoad = function () {
         return $('.main-menu').hasClass('collapsed');
     };
 
-    $timeout(function () {
-        $scope.menuCollapsed = $scope.isMenuCollapsedOnLoad();
-    }, 0);
-
-    // Check after initial load
     $scope.checkMenu = debounce(function () {
-        return $('.main-menu').hasClass('collapsed');
+        const collapsed = $scope.isMenuCollapsedOnLoad();
+        if ($scope.menuCollapsed !== collapsed) {
+            $scope.menuCollapsed = collapsed;
+        }
     }, 0, {trailing: true});
 
-    const deregisterMenuWatcher = $scope.$watch('menuCollapsed', function () {
-        $scope.menuCollapsed = $scope.checkMenu();
+    const deregisterMenuWatcher = $scope.$watch(function () {
+        return $scope.isMenuCollapsedOnLoad();
+    }, function (newValue, oldValue) {
+        if (newValue !== oldValue || typeof newValue === 'undefined') {
+            // Trigger debounced check on both collapse and expand
+            $scope.checkMenu();
+        }
     });
+
+    $scope.showLabel = function (item) {
+        return item.children ? true : !$scope.menuCollapsed;
+    };
 
     const setYears = function () {
         const date = new Date();

--- a/src/template.html
+++ b/src/template.html
@@ -120,7 +120,7 @@
         <a class="menu-element-root" ng-href="{{::item.hrefFun ? item.hrefFun(productInfo) : item.href}}" ng-if="!item.children.length"
            ng-click="select($index, $event, clicked)">
             <span ng-class=item.icon class="menu-item-icon"></span>
-            <span class="menu-item" ng-show="!menuCollapsed">{{item.label}}</span>
+            <span class="menu-item" ng-show="showLabel(item)">{{item.label}}</span>
         </a>
         <ul ng-if="item.children.length" class="sub-menu">
             <li class="submenu-title">{{item.label}}</li>

--- a/src/template.html
+++ b/src/template.html
@@ -120,7 +120,7 @@
         <a class="menu-element-root" ng-href="{{::item.hrefFun ? item.hrefFun(productInfo) : item.href}}" ng-if="!item.children.length"
            ng-click="select($index, $event, clicked)">
             <span ng-class=item.icon class="menu-item-icon"></span>
-            <span class="menu-item" ng-show="!checkMenu()">{{item.label}}</span>
+            <span class="menu-item" ng-show="!menuCollapsed">{{item.label}}</span>
         </a>
         <ul ng-if="item.children.length" class="sub-menu">
             <li class="submenu-title">{{item.label}}</li>
@@ -146,7 +146,7 @@
     </div>
 
         <div class="container-fluid main-container" ng-show="hasPermission()" ng-view role="main"
-             ng-class="checkMenu() ? 'expanded':''">
+             ng-class="(menuCollapsed || checkMenu()) ? 'expanded':''">
 
         </div>
 


### PR DESCRIPTION
## What?
When the side main menu is collapsed, the main content will always remain at expanded width, even on page refresh.

## Why?
On page refresh/load, the main content wouldn't apply its expanded class and there would be a gap between the collapsed menu and the main content.

## How?
I reworked the logic and added a menu check on page load, while keeping the checks on menu toggle.

## Screenshots?
The gap remains like this when the page loads and the menu is collapsed.
![Screenshot from 2024-10-18 09-37-20](https://github.com/user-attachments/assets/ea738a0e-d6f4-4ccc-b40c-77c27bd7b547)
