### PR TITLE
GDB-10937: Fixes double loading of selected chat when loading the TTYG page

### DIFF
--- a/src/css/ttyg/agent-list.css
+++ b/src/css/ttyg/agent-list.css
@@ -7,6 +7,8 @@
 
 .agent-list-component .agent-list {
     margin-top: 1rem;
+    height: 75vh;
+    max-height: 75vh;
     overflow-y: hidden;
     scrollbar-gutter: stable;
 }
@@ -84,7 +86,7 @@
     margin-top: 4px;
 }
 
-.agent-list-component .agent-item .btn-group .dropdown-menu-right {
+.agent-list-component .agent-item .btn-group .agent-actions-menu {
     margin-top: 4px;
 }
 

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -595,7 +595,7 @@ function TTYGViewCtrl(
             $scope.showChats = false;
         } else {
             $scope.showChats = true;
-            if (!TTYGContextService.getSelectedChat()) {
+            if (!TTYGContextService.getSelectedChat() && !TTYGStorageService.getChatId()) {
                 TTYGContextService.selectChat($scope.chats.getFirstChat());
             }
         }
@@ -841,11 +841,7 @@ function TTYGViewCtrl(
         if (!chatId) {
             return;
         }
-        TTYGService.getConversation(chatId).then((chat) => {
-            if (chat) {
-                TTYGContextService.selectChat(chat);
-            }
-        });
+        TTYGContextService.selectChat(TTYGContextService.getChats().getChat(chatId));
     };
 
     const updateLabels = () => {
@@ -910,9 +906,9 @@ function TTYGViewCtrl(
             $scope.initialized = true;
             buildAgentsFilterModel();
             setCurrentAgent();
-            setCurrentChat();
             return loadChats();
-        });
+        })
+            .then(setCurrentChat);
         initView();
     }
 }


### PR DESCRIPTION
## What
There is a double loading of the selected chat when the TTYG page is loaded.

## Why
When the page loads, we retrieve the persisted chat ID and load it from the server. After the chat is loaded, we call the TTYGContextService.selectChat function with the loaded chat, which triggers a second loading of the selected chat.

## How
The setup of the selected chat has been moved to occur after the chat list (chats without messages) is loaded. Then, the chat is fetched from the list using the persisted chat ID, followed by calling TTYGContextService.selectChat. In short, the initial loading of the persisted chat has been removed.