### PR TITLE
GDB-11055 - Disable browser form validation for login page

### DIFF
--- a/src/pages/login.html
+++ b/src/pages/login.html
@@ -3,7 +3,7 @@
 		<div class="card">
 			<div class="card-block">
 				<h1>{{'view.login.title' | translate}}</h1>
-				<form class="form-horizontal loginForm"  ng-submit="login()" ng-if="isGDBLoginEnabled()">
+				<form class="form-horizontal loginForm"  ng-submit="login()" ng-if="isGDBLoginEnabled()" novalidate>
 					<div ng-if="error" class="alert alert-danger">
 						{{'pass.or.username.mismatch' | translate}}
 					</div>


### PR DESCRIPTION
## What?
The browser won't show its own form field tooltips on the login page.

## Why?
This change is required because the browser's tooltips are in English. So if the user is using the Workbench in French, the tooltips will not be in French.

## How?
I added the `novalidate` attribute to the HTML `form`. 