### PR TITLE
GDB-10937 add missing namespaces option to sparql method

### DIFF
--- a/src/css/ttyg/agent-settings-modal.css
+++ b/src/css/ttyg/agent-settings-modal.css
@@ -14,6 +14,11 @@
     font-weight: var(--field-label-weight);
 }
 
+.agent-settings-modal .agent-settings-form [type="checkbox"],
+.agent-settings-modal .agent-settings-form [type="checkbox"] + label {
+    cursor: pointer;
+}
+
 .agent-settings-modal .agent-settings-form .extraction-methods {
     display: flex;
     flex-direction: column;

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -424,6 +424,10 @@
                         "label": "Fetch ontology from a named graph",
                         "tooltip": "The named graph that contains the entire ontology or a subset sufficient to generate useful SPARQL queries."
                     },
+                    "add_missing_namespaces": {
+                        "label": "Auto-add missing namespaces",
+                        "tooltip": "Automatically insert missing namespaces in SPARQL queries. This helps avoid errors when a query doesn't include necessary namespaces. In many cases, the model corrects itself after the missing namespaces error is returned, but enabling this option ensures GraphDB resolves the issue automatically."
+                    },
                     "construct_query": {
                         "label": "Provide a SPARQL CONSTRUCT query that fetches the ontology",
                         "tooltip": "A SPARQL CONSTRUCT query that returns the entire ontology or a subset sufficient to generate useful SPARQL queries."

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -424,6 +424,10 @@
                         "label": "Récupérer l'ontologie à partir d'un graphe nommé",
                         "tooltip": "Le graphe nommé qui contient l'ensemble de l'ontologie ou un sous-ensemble suffisant pour générer des requêtes SPARQL utiles."
                     },
+                    "add_missing_namespaces": {
+                        "label": "Ajouter automatiquement les espaces de noms manquants",
+                        "tooltip": "Insérez automatiquement les espaces de noms manquants dans les requêtes SPARQL. Cela aide à éviter les erreurs lorsque des espaces de noms nécessaires ne sont pas inclus. Dans de nombreux cas, le modèle se corrige après le retour de l'erreur d'espaces de noms manquants, mais activer cette option garantit que GraphDB résout le problème automatiquement."
+                    },
                     "construct_query": {
                         "label": "Fournir une requête SPARQL CONSTRUCT qui récupère l'ontologie",
                         "tooltip": "A SPARQL CONSTRUCT query that returns the entire ontology or a subset sufficient to generate useful SPARQL queries."

--- a/src/js/angular/models/ttyg/agent-form.js
+++ b/src/js/angular/models/ttyg/agent-form.js
@@ -279,6 +279,12 @@ export class ExtractionMethodFormModel {
          */
         this._sparqlOption = data.sparqlOption;
         /**
+         * Whether to add missing namespaces to the generated SPARQL query.
+         * @type {boolean}
+         * @private
+         */
+        this._addMissingNamespaces = data.addMissingNamespaces;
+        /**
          * @type {string}
          * @private
          */
@@ -328,6 +334,12 @@ export class ExtractionMethodFormModel {
             payload.ontologyGraph = this._ontologyGraph ? this._ontologyGraph : null;
         } else if (this._sparqlOption === 'sparqlQuery') {
             payload.sparqlQuery = this._sparqlQuery ? this._sparqlQuery.value : null;
+        }
+        if (this._method === ExtractionMethod.SPARQL) {
+            // this is used only in the sparql method
+            if (this._addMissingNamespaces !== undefined) {
+                payload.addMissingNamespaces = this._addMissingNamespaces;
+            }
         }
         // this is used for all but the SPARQL method
         if (this._maxNumberOfTriplesPerCall) {
@@ -380,6 +392,14 @@ export class ExtractionMethodFormModel {
 
     set sparqlQuery(value) {
         this._sparqlQuery = value;
+    }
+
+    get addMissingNamespaces() {
+        return this._addMissingNamespaces;
+    }
+
+    set addMissingNamespaces(value) {
+        this._addMissingNamespaces = value;
     }
 
     get ontologyGraph() {

--- a/src/js/angular/models/ttyg/agents.js
+++ b/src/js/angular/models/ttyg/agents.js
@@ -191,6 +191,12 @@ export class ExtractionMethodModel {
          */
         this._method = data.method;
         /**
+         * Whether to add missing namespaces to the generated SPARQL query.
+         * @type {boolean}
+         * @private
+         */
+        this._addMissingNamespaces = data.addMissingNamespaces;
+        /**
          * The ontology graph used for the extraction method.
          * @type {string}
          * @private
@@ -239,6 +245,14 @@ export class ExtractionMethodModel {
 
     set method(value) {
         this._method = value;
+    }
+
+    get addMissingNamespaces() {
+        return this._addMissingNamespaces;
+    }
+
+    set addMissingNamespaces(value) {
+        this._addMissingNamespaces = value;
     }
 
     get sparqlQuery() {

--- a/src/js/angular/ttyg/services/agents.mapper.js
+++ b/src/js/angular/ttyg/services/agents.mapper.js
@@ -68,6 +68,7 @@ const extractionMethodsFormMapper = (agentFormModel, isNew, defaultData, data = 
             method: extractionMethod.method,
             sparqlOption: sparqlOption,
             ontologyGraph: extractionMethod.ontologyGraph,
+            addMissingNamespaces: extractionMethod.addMissingNamespaces,
             sparqlQuery: extractionMethod.sparqlQuery && new TextFieldModel({
                 value: extractionMethod.sparqlQuery,
                 minLength: 1,
@@ -150,6 +151,7 @@ const extractionMethodMapper = (data) => {
     return new ExtractionMethodModel({
         method: data.method,
         ontologyGraph: data.ontologyGraph,
+        addMissingNamespaces: data.addMissingNamespaces,
         sparqlQuery: data.sparqlQuery,
         similarityIndex: data.similarityIndex,
         similarityIndexThreshold: data.similarityIndexThreshold,

--- a/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -120,6 +120,15 @@
                                  ng-if="extractionMethod.selected && !extractionMethod.sparqlOption">
                                 {{'ttyg.agent.create_agent_modal.form.sparql_search.required_option' | translate}}
                             </div>
+                            <div class="add-missing-namespaces-option mt-1">
+                                <input id="addMissingNamespaces" name="addMissingNamespaces" type="checkbox"
+                                       ng-model="extractionMethod.addMissingNamespaces">
+                                <label for="addMissingNamespaces"
+                                       uib-popover="{{'ttyg.agent.create_agent_modal.form.add_missing_namespaces.tooltip' | translate}}"
+                                       popover-trigger="mouseenter">{{
+                                    'ttyg.agent.create_agent_modal.form.add_missing_namespaces.label' | translate
+                                    }}</label>
+                            </div>
                         </div>
 
                         <!-- FTS method settings -->
@@ -321,7 +330,8 @@
                 <label for="{{additionalExtractionMethod.method + '_checkbox'}}"></label>
                 <a class="btn btn-link extraction-method-label" uib-popover="{{'ttyg.agent.create_agent_modal.form.additional_query_methods.method.' +
                     additionalExtractionMethod.method + '.tooltip' | translate}}"
-                   popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.additional_query_methods.method.' +
+                   popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.additional_query_methods.method.'
+                    +
                     additionalExtractionMethod.method + '.label' | translate}}</a>
             </div>
         </div>
@@ -345,7 +355,8 @@
                 <label for="temperature">
                     <span uib-popover="{{'ttyg.agent.create_agent_modal.form.temperature.tooltip' | translate}}"
                           popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.temperature.label' | translate}}</span>
-                    <i class="fa-regular fa-triangle-exclamation text-warning high-temperature-warning" ng-if="showHighTemperatureWarning"
+                    <i class="fa-regular fa-triangle-exclamation text-warning high-temperature-warning"
+                       ng-if="showHighTemperatureWarning"
                        uib-popover="{{'ttyg.agent.create_agent_modal.form.temperature.high_temperature_warning' | translate}}"
                        popover-trigger="mouseenter"></i>
                 </label>
@@ -416,7 +427,8 @@
                         <span
                             uib-popover="{{'ttyg.agent.create_agent_modal.form.system_instruction.tooltip' | translate}}"
                             popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.system_instruction.label' | translate}}</span>
-                        <i class="fa-regular fa-triangle-exclamation text-warning overriding-system-instructions-warning" ng-if="showSystemInstructionWarning"
+                        <i class="fa-regular fa-triangle-exclamation text-warning overriding-system-instructions-warning"
+                           ng-if="showSystemInstructionWarning"
                            uib-popover="{{'ttyg.agent.create_agent_modal.form.system_instruction.overriding_system_instruction_warning.body' | translate}}"
                            popover-trigger="mouseenter"></i>
                     </label>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -424,6 +424,10 @@
                         "label": "Fetch ontology from a named graph",
                         "tooltip": "The named graph that contains the entire ontology or a subset sufficient to generate useful SPARQL queries."
                     },
+                    "add_missing_namespaces": {
+                        "label": "Auto-add missing namespaces",
+                        "tooltip": "Automatically insert missing namespaces in SPARQL queries. This helps avoid errors when a query doesn't include necessary namespaces. In many cases, the model corrects itself after the missing namespaces error is returned, but enabling this option ensures GraphDB resolves the issue automatically."
+                    },
                     "construct_query": {
                         "label": "Provide a SPARQL CONSTRUCT query that fetches the ontology",
                         "tooltip": "A SPARQL CONSTRUCT query that returns the entire ontology or a subset sufficient to generate useful SPARQL queries."

--- a/test-cypress/fixtures/ttyg/agent/create-agent.json
+++ b/test-cypress/fixtures/ttyg/agent/create-agent.json
@@ -13,7 +13,8 @@
     "assistantExtractionMethods": [
         {
             "method": "sparql_search",
-            "sparqlQuery": "select ?s ?p ?o where {?s ?p ?o .}"
+            "sparqlQuery": "select ?s ?p ?o where {?s ?p ?o .}",
+            "addMissingNamespaces": true
         }
     ]
 }

--- a/test-cypress/fixtures/ttyg/agent/get-agent-defaults.json
+++ b/test-cypress/fixtures/ttyg/agent/get-agent-defaults.json
@@ -14,7 +14,8 @@
         {
             "method": "sparql_search",
             "ontologyGraph": "http://example.com",
-            "sparqlQuery": "CONSTRUCT {?s ?p ?o} WHERE {GRAPH <http://example.org/ontology> {?s ?p ?o .}}"
+            "sparqlQuery": "CONSTRUCT {?s ?p ?o} WHERE {GRAPH <http://example.org/ontology> {?s ?p ?o .}}",
+            "addMissingNamespaces": false
         },
         {
             "method": "fts_search",

--- a/test-cypress/fixtures/ttyg/agent/get-agent-list-new-agent.json
+++ b/test-cypress/fixtures/ttyg/agent/get-agent-list-new-agent.json
@@ -14,7 +14,8 @@
         "assistantExtractionMethods": [
             {
                 "method": "sparql_search",
-                "sparqlQuery": "select ?s ?p ?o where {?s ?p ?o .}"
+                "sparqlQuery": "select ?s ?p ?o where {?s ?p ?o .}",
+                "addMissingNamespaces": true
             }
         ]
     }

--- a/test-cypress/fixtures/ttyg/agent/get-agent.json
+++ b/test-cypress/fixtures/ttyg/agent/get-agent.json
@@ -13,7 +13,8 @@
         {
             "method": "sparql_search",
             "ontologyGraph": null,
-            "sparqlQuery": "CONSTRUCT {\n    ?s ?p ?o\n} WHERE {\n    GRAPH <http://example.com/sw-ont> {\n        ?s ?p ?o\n    }\n}"
+            "sparqlQuery": "CONSTRUCT {\n    ?s ?p ?o\n} WHERE {\n    GRAPH <http://example.com/sw-ont> {\n        ?s ?p ?o\n    }\n}",
+            "addMissingNamespaces": false
         }
     ],
     "additionalExtractionMethods": [

--- a/test-cypress/steps/ttyg/ttyg-agent-settings-modal.steps.js
+++ b/test-cypress/steps/ttyg/ttyg-agent-settings-modal.steps.js
@@ -142,6 +142,14 @@ export class TtygAgentSettingsModalSteps extends ModalDialogSteps {
         return this.getSparqlMethodSparqlQueryField().type(value, {parseSpecialCharSequences: false});
     }
 
+    static getAddMissingNamespacesCheckbox() {
+        return cy.get('#addMissingNamespaces');
+    }
+
+    static toggleAddMissingNamespacesCheckbox() {
+        this.getAddMissingNamespacesCheckbox().click();
+    }
+
     // FTS extraction method
 
     static enableFtsExtractionMethod() {


### PR DESCRIPTION
## What
Added additional option to sparql method for automatic insertion of the needed namespaces in generated sparql query.

## Why
This prevents errors when the agent generated a query without namespaces.

## How
* Extended the agent models and mappers with the new option.
* Added the checkbox field in the sparql method section.