### PR TITLE
GDB-10937 prevent renaming new chats and other fixes

### DIFF
--- a/src/js/angular/ttyg/directives/chat-list.directive.js
+++ b/src/js/angular/ttyg/directives/chat-list.directive.js
@@ -2,9 +2,6 @@ import 'angular/core/directives/inline-editable-text/inline-editable-text.direct
 import {decodeHTML} from "../../../../app";
 import {TTYGEventName} from "../services/ttyg-context.service";
 
-import {ChatModel} from "../../models/ttyg/chats";
-import {md5HashGenerator} from "../../utils/hash-utils";
-
 const modules = [
     'graphdb.framework.core.directives.inline-editable-text'
 ];
@@ -19,7 +16,7 @@ function ChatListComponent(TTYGContextService, ModalService, $translate, $filter
     return {
         restrict: 'E',
         templateUrl: 'js/angular/ttyg/templates/chat-list.html',
-        link: ($scope, element, attrs) => {
+        link: ($scope) => {
 
             // =========================
             // Public variables

--- a/src/js/angular/ttyg/services/ttyg-context.service.js
+++ b/src/js/angular/ttyg/services/ttyg-context.service.js
@@ -346,6 +346,7 @@ function TTYGContextService(EventEmitterService) {
         resetContext,
         emit,
         subscribe,
+        // chats
         getChats,
         updateChats,
         addChat,
@@ -357,6 +358,7 @@ function TTYGContextService(EventEmitterService) {
         onSelectedChatChanged,
         updateSelectedChat,
         onSelectedChatUpdated,
+        // agents
         updateAgents,
         onAgentsListChanged,
         getAgents,
@@ -364,16 +366,17 @@ function TTYGContextService(EventEmitterService) {
         selectAgent,
         getSelectedAgent,
         onSelectedAgentChanged,
+        getDefaultAgent,
+        setDefaultAgent,
+        setCanModifyAgent,
+        getCanModifyAgent,
+        onCanUpdateAgentUpdated,
+        // chat explain
         hasExplainResponse,
         toggleExplainResponse,
         getExplainResponse,
         addExplainResponseCache,
         onExplainResponseCacheUpdated,
-        getDefaultAgent,
-        setDefaultAgent,
-        setCanModifyAgent,
-        getCanModifyAgent,
-        onCanUpdateAgentUpdated
     };
 }
 

--- a/src/js/angular/ttyg/templates/chat-list.html
+++ b/src/js/angular/ttyg/templates/chat-list.html
@@ -12,7 +12,7 @@
                             <inline-editable-text
                                 field-name="name"
                                 source="chat"
-                                is-editing="renamedChat && chat.id === renamedChat.id"
+                                is-editing="chat.id && renamedChat && chat.id === renamedChat.id"
                                 on-save="onRenameChat(newText, source)"
                                 on-cancel="onCancelChatRenaming()"
                                 on-dblclick="onSelectChatForRenaming(chat)"


### PR DESCRIPTION
## What
* Prevent renaming new chats.

## Why
* New chat should not be possible to be renamed because it has no id and would cause error.

## How
* Added additional check to the editable field for the chat name to prevent it to enter in edit mode for new chats.