### PR TITLE
GDB-10937: Save newly created chat in local store

### DIFF
--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -444,6 +444,7 @@ function TTYGViewCtrl(
                     // Replace the placeholder with the newly created chat
                     const nonPersistedChat = TTYGContextService.getChats().getNonPersistedChat();
                     TTYGContextService.replaceChat(selectedChat, nonPersistedChat);
+                    TTYGStorageService.saveChat(selectedChat);
 
                     // Process the messages
                     updateChatAnswersFirstResponse(selectedChat, chatItem, chatAnswer);

--- a/test-cypress/fixtures/ttyg/chats/create/create-chat-response.json
+++ b/test-cypress/fixtures/ttyg/chats/create/create-chat-response.json
@@ -1,0 +1,16 @@
+{
+    "id": "thread_new_created_chat",
+    "name": "New chat of Han Solo is a character",
+    "timestamp": "creationDate",
+    "messages": [
+        {
+            "id": "msg_Bn07kVDCYT1qmgu1G7Zw0KNeс_",
+            "conversationId": "thread_new_created_chat",
+            "role": "assistant",
+            "agentId": "asst_gAPcrHQQ9ZIxD5eXWH2BNFfo",
+            "message": "Han Solo is a character...",
+            "timestamp": "creationDate",
+            "name": null
+        }
+    ]
+}

--- a/test-cypress/fixtures/ttyg/chats/create/get-chats-after-create.json
+++ b/test-cypress/fixtures/ttyg/chats/create/get-chats-after-create.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "thread_new_created_chat",
+    "name": "New chat of Han Solo is a character",
+    "timestamp": "1725875483"
+  },
+  {
+    "id": "thread_jdQBvbkaU6JPoO48oQaL76dC",
+    "name": "Han Solo is a fictional character in the...",
+    "timestamp": "1725875483"
+  }
+]

--- a/test-cypress/fixtures/ttyg/chats/create/get-chats-before-create.json
+++ b/test-cypress/fixtures/ttyg/chats/create/get-chats-before-create.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "thread_jdQBvbkaU6JPoO48oQaL76dC",
+    "name": "Han Solo is a fictional character in the...",
+    "timestamp": "1725875483"
+  }
+]

--- a/test-cypress/fixtures/ttyg/chats/get-chat.json
+++ b/test-cypress/fixtures/ttyg/chats/get-chat.json
@@ -170,5 +170,30 @@
             }
         ],
         "timestamp": "1725875483"
+    },
+    "thread_new_created_chat": {
+        "id": "thread_new_created_chat",
+        "name": "Han Solo is a character",
+        "messages": [
+            {
+                "id": "msg_A9UeOFT9SF3pKzJzar1HwM7d",
+                "conversationId": "thread_new_created_chat",
+                "agentId": "asst_gAPcrHQQ9ZIxD5eXWH2BNFfo",
+                "role": "user",
+                "message": "Who is Han Solo?",
+                "timestamp": 1725875323,
+                "name": null
+            },
+            {
+                "id": "msg_Bn07kVDCYT1qmgu1G7Zw0KNeс_",
+                "conversationId": "thread_new_created_chat",
+                "role": "assistant",
+                "agentId": "asst_gAPcrHQQ9ZIxD5eXWH2BNFfo",
+                "message": "Han Solo is a character ...",
+                "timestamp": 1725875323,
+                "name": null
+            }
+        ],
+        "timestamp": "1725875483"
     }
 }

--- a/test-cypress/integration/ttyg/create-chat.spec.js
+++ b/test-cypress/integration/ttyg/create-chat.spec.js
@@ -1,0 +1,69 @@
+import {RepositoriesStubs} from "../../stubs/repositories/repositories-stubs";
+import {RepositoriesStub} from "../../stubs/repositories-stub";
+import {TTYGStubs} from "../../stubs/ttyg/ttyg-stubs";
+import {TTYGViewSteps} from "../../steps/ttyg/ttyg-view-steps";
+import {ChatPanelSteps} from "../../steps/ttyg/chat-panel-steps";
+import HomeSteps from "../../steps/home-steps";
+
+describe('Ttyg ChatPanel', () => {
+    beforeEach(() => {
+        // Create an actual repository to prevent stubbing all background requests that are not related to the ttyg view
+        RepositoriesStubs.stubRepositories(0, '/repositories/get-ttyg-repositories.json');
+        RepositoriesStub.stubBaseEndpoints('starwars');
+        cy.presetRepository('starwars');
+        TTYGStubs.stubChatsListGet("/ttyg/chats/create/get-chats-before-create.json");
+        TTYGStubs.stubAgentListGet();
+        TTYGStubs.stubChatGet();
+
+        // When visiting the TTYG page where there is a chat with questions and answers
+        TTYGViewSteps.visit();
+        cy.wait('@get-chat-list');
+        cy.wait('@get-agent-list');
+        cy.wait('@get-chat');
+        cy.wait('@get-all-repositories');
+    });
+
+    it('Should persist the newly created chat in local store', () => {
+        // When I visit the TTYG page
+        // the first chat should be selected
+        TTYGViewSteps.getChatFromGroup(0, 0).should('have.class', 'selected');
+        TTYGViewSteps.getChatsFromGroup(0).should('have.length', 1);
+
+        // When I click on "Create a new chat" button
+        TTYGViewSteps.createANewChat();
+        // Then I expect no new chat be created
+        TTYGViewSteps.getChatFromGroup(0, 0).should('have.not.class', 'selected');
+        TTYGViewSteps.getChatsFromGroup(0).should('have.length', 1);
+
+        // When I type a question
+        ChatPanelSteps.getQuestionInputElement()
+            .should('be.visible')
+            .and('not.be.disabled')
+            .type('Who is Han Solo?');
+
+        // Then I expect the "Ask" button be active.
+        ChatPanelSteps.getAskButtonElement().should('be.enabled');
+
+        // When I click on "Ask" button.
+        TTYGStubs.stubCrateNewChat();
+        ChatPanelSteps.getAskButtonElement().scrollIntoView().click();
+        cy.wait('@create-chat');
+
+        // Then I expect new chat to be created in a new group "Today" and be selected
+        TTYGViewSteps.getChatGroup(0).should('contain', 'Today');
+        TTYGViewSteps.getChatFromGroup(0, 0).should('have.class', 'selected');
+        TTYGViewSteps.getChatsFromGroup(1).should('have.length', 1);
+
+        // When I go to another page
+        HomeSteps.visit();
+        // and returns to the TTYG page
+        TTYGStubs.stubChatsListGet("/ttyg/chats/create/get-chats-after-create.json");
+        TTYGStubs.stubAgentGet();
+        TTYGViewSteps.visit();
+        cy.wait('@get-chat-list');
+        cy.wait('@get-agent');
+        // Then I expect newly created chat be selected.
+        TTYGViewSteps.getChatFromGroup(0, 0).should('contain', 'New chat of Han Solo is a character');
+        TTYGViewSteps.getChatFromGroup(0, 0).should('have.class', 'selected');
+    });
+});

--- a/test-cypress/integration/ttyg/create-chat.spec.js
+++ b/test-cypress/integration/ttyg/create-chat.spec.js
@@ -5,7 +5,7 @@ import {TTYGViewSteps} from "../../steps/ttyg/ttyg-view-steps";
 import {ChatPanelSteps} from "../../steps/ttyg/chat-panel-steps";
 import HomeSteps from "../../steps/home-steps";
 
-describe('Ttyg ChatPanel', () => {
+describe('TTYG create chat', () => {
     beforeEach(() => {
         // Create an actual repository to prevent stubbing all background requests that are not related to the ttyg view
         RepositoriesStubs.stubRepositories(0, '/repositories/get-ttyg-repositories.json');

--- a/test-cypress/steps/ttyg/ttyg-view-steps.js
+++ b/test-cypress/steps/ttyg/ttyg-view-steps.js
@@ -110,6 +110,10 @@ export class TTYGViewSteps {
         return this.getChatsSidebar().find('.create-chat-btn');
     }
 
+    static createANewChat() {
+        TTYGViewSteps.getCreateChatButton().click();
+    }
+
     static getAgentsSidebar() {
         return cy.get('.right-sidebar');
     }

--- a/test-cypress/stubs/ttyg/ttyg-stubs.js
+++ b/test-cypress/stubs/ttyg/ttyg-stubs.js
@@ -28,7 +28,6 @@ export class TTYGStubs extends Stubs {
     /**
      * Loads the specified <code>fixture</code> and updates the chatId in the fixture with the actual ID passed in the endpoint call.
      *
-     * @param {string} fixture - Path to the JSON file containing the chat conversation.
      * @param {number} delay - Optional delay in milliseconds before responding with the fixture.
      */
     static stubChatGet(delay = 0) {
@@ -144,6 +143,18 @@ export class TTYGStubs extends Stubs {
             fixture,
             statusCode: 200
         }).as('get-agent-defaults');
+    }
+
+    static stubCrateNewChat(fixture = 'ttyg/chats/create/create-chat-response.json') {
+        cy.fixture(fixture).then((fixtureData) => {
+            const today = Math.floor(Date.now() / 1000) + '';
+            const body = JSON.stringify(fixtureData).replace(/"creationDate"/g, today);
+            cy.intercept('POST', '/rest/chat/conversations', {
+                statusCode: 200,
+                body: JSON.parse(body)
+            }).as('create-chat');
+        });
+
     }
 
     static stubExplainResponse(fixture = '/ttyg/chats/explain-response-1.json') {


### PR DESCRIPTION
## What
The ID of a newly created chat was not being persisted in the local store.

## Why
This was missed during the implementation.

## How
After a new chat is created and its ID is retrieved, the ID is now persisted in the local store.