### PR TITLE
TTYG support for the now function

### DIFF
--- a/src/css/ttyg/chat-item-details.css
+++ b/src/css/ttyg/chat-item-details.css
@@ -21,6 +21,7 @@
 .chat-detail .assistant-message .answer img {
     max-width: 100%;
     height: auto;
+    vertical-align: top;
 }
 
 .chat-detail .assistant-icon {

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -389,14 +389,16 @@
                 "json": "JSON",
                 "error_message": "Error message sent to model",
                 "explain_no_methods": "No query methods were called.",
-                "called": "Called {{('ttyg.chat_panel.query_name.' + name) | translate}}"
+                "called": "Called {{('ttyg.chat_panel.query_name.' + name) | translate}}",
+                "no_query": "There is no query."
             },
             "query_name": {
                 "sparql_query":"SPARQL",
                 "fts_search": "Full-text search",
                 "similarity_search": "Similarity search",
                 "retrieval_search": "ChatGPT Retrieval",
-                "iri_discovery": "FTS for IRI discovery"
+                "iri_discovery": "FTS for IRI discovery",
+                "now": "the Now function"
             },
             "query_colon": ":",
             "query_desc": {
@@ -404,7 +406,8 @@
                 "fts_search": "Full-text search via SPARQL",
                 "similarity_search": "Similarity search via SPARQL",
                 "retrieval_search": "Direct JSON query",
-                "iri_discovery": "Full-text search via SPARQL"
+                "iri_discovery": "Full-text search via SPARQL",
+                "now": "returns the system time"
             },
             "dialog": {
                 "confirm_repository_change": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -389,14 +389,16 @@
                 "json": "JSON",
                 "error_message": "Message d'erreur envoyée au modèle",
                 "explain_no_methods": "Aucune méthode de requête n'a été appelée.",
-                "called": "{{('ttyg.chat_panel.query_name.' + name) | translate}} a été appelé"
+                "called": "{{('ttyg.chat_panel.query_name.' + name) | translate}} a été appelé",
+                "no_query": "Il n'y a pas de requête."
             },
             "query_name": {
                 "sparql_query": "SPARQL",
                 "fts_search": "Recherche en texte intégral",
                 "similarity_search": "Recherche de similarité",
                 "retrieval_search": "ChatGPT Retrieval",
-                "iri_discovery": "FTS pour la découverte IRI"
+                "iri_discovery": "FTS pour la découverte IRI",
+                "now": "La fonction \"Maintenant\""
             },
             "query_colon": " :",
             "query_desc": {
@@ -404,7 +406,8 @@
                 "fts_search": "Recherche en texte intégral via SPARQL",
                 "similarity_search": "Recherche de similarité via SPARQL",
                 "retrieval_search": "Requête JSON directe",
-                "iri_discovery": "Recherche en texte intégral via SPARQL"
+                "iri_discovery": "Recherche en texte intégral via SPARQL",
+                "now": "Renvoie l'heure système"
             },
             "dialog": {
                 "confirm_repository_change": {

--- a/src/js/angular/models/ttyg/chat-answer.js
+++ b/src/js/angular/models/ttyg/chat-answer.js
@@ -85,8 +85,8 @@ export class ContinueChatRun {
         return {
             conversationId: this.chatId,
             runId: this._runId,
-            lastMessageId: this._chatItem.answers[this._chatItem.answers.length - 1].id,
-            agentId: this._chatItem.agentId
+            agentId: this._chatItem.agentId,
+            tzOffset: -new Date().getTimezoneOffset() // offsets are reversed here hence the minus
         };
     }
 }

--- a/src/js/angular/models/ttyg/chat-item.js
+++ b/src/js/angular/models/ttyg/chat-item.js
@@ -119,7 +119,8 @@ export class ChatItemModel {
         return {
             conversationId: this._chatId,
             agentId: this._agentId,
-            question: this._question.message
+            question: this._question.message,
+            tzOffset: -new Date().getTimezoneOffset() // offsets are reversed here hence the minus
         };
     }
 

--- a/src/js/angular/ttyg/templates/chat-item-detail.html
+++ b/src/js/angular/ttyg/templates/chat-item-detail.html
@@ -57,7 +57,7 @@
                                     <span class="query-method-details" ng-bind="('ttyg.chat_panel.query_desc.' + queryMethod.name) | translate">
                                     </span>
                                 </div>
-                                <div class="actions">
+                                <div ng-if="queryMethod.query" class="actions">
                                     <open-in-sparql-editor
                                         ng-if="queryMethod.queryType === ExplainQueryType.SPARQL"
                                         execute-query="{{!queryMethod.errorMessage}}"
@@ -69,7 +69,8 @@
                                 </div>
                             </div>
                             <div class="query">
-                                <pre><code>{{queryMethod.query}}</code></pre>
+                                <div ng-if="!queryMethod.query" class="mb-1">{{ 'ttyg.chat_panel.labels.no_query' | translate }}</code></div>
+                                <pre ng-if="queryMethod.query"><code>{{queryMethod.query}}</code></pre>
                             </div>
                             <div ng-if="showRawQuery(queryMethod)" class="raw-query">
                                 <span class="label">{{'ttyg.chat_panel.labels.raw_query' | translate}}:</span>


### PR DESCRIPTION
## What
- Added support for the now function (a hidden always-enabled additional query method)

## Why
- The model needs to be aware of the current time in order to answer time-relative questions

## How
- Added translation keys for "now"
- Added support for explaining tools without queries (such as "now")
- Send browser time zone offset so the model sees the same time zone as the browser/user (note that lastMessageId is removed from ContinueChatRun because it's no longer used)

Other changes: fix alignment of images in HTML produced from model markdown