### PR TITLE
fix(GDB-11129) Add Missing Version Replacement in Webpack Config

### DIFF
--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -124,7 +124,8 @@ module.exports = {
             },
             {
                 from: 'src/js/angular/core/templates',
-                to: 'js/angular/core/templates'
+                to: 'js/angular/core/templates',
+                transform: replaceVersion
             },
             {
                 from: 'src/js/angular/explore/templates',


### PR DESCRIPTION
## What:
Added transform: replaceVersion to the CopyPlugin configuration in webpack.config.common.js specifically for the js/angular/core/templates folder.

## Why:
This omission caused version placeholders to remain unreplaced.

## How:
- Updated the CopyPlugin configuration for the js/angular/core/templates directory to include transform: replaceVersion