### PR TITLE
fix(GDB-11096) Fix injection issue in secondary modal controller for multi-region cluster configuration

### DIFF
--- a/src/js/angular/clustermanagement/directives/cluster-configuration/multi-region.directive.js
+++ b/src/js/angular/clustermanagement/directives/cluster-configuration/multi-region.directive.js
@@ -161,7 +161,7 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
                 const secondaryModalConfig = {
                     title: $translate.instant('cluster_management.cluster_configuration_multi_region.secondary_cluster_settings'),
                     templateUrl: 'js/angular/clustermanagement/templates/modal/secondary-mode-modal.html',
-                    controller: secondaryModeModalController,
+                    controller:  ['$scope', '$uibModalInstance', 'config', secondaryModeModalController],
                     size: 'lg',
                     warning: true,
                     backdrop: 'static'


### PR DESCRIPTION
## What:
Updated the controller property in secondaryModalConfig to use array syntax for dependency injection, ensuring $scope, $uibModalInstance, and config are correctly injected into secondaryModeModalController.

## Why:
This change prevents minification errors that occurred due to missing dependency injection, causing the controller function to fail in production.

## How:
Wrapped the secondaryModeModalController in an array syntax to ensure AngularJS correctly injects dependencies even after minification.