### PR TITLE
Fixed various issues with FontAwesome vs our icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
                 "autofill-event": "0.0.1",
                 "d3": "^7.8.5",
                 "echarts": "^5.4.3",
-                "font-awesome": "^4.7.0",
                 "jquery": "^3.4.1",
                 "jsonld": "^8.3.2",
                 "jsrsasign": "^11.0.0",
@@ -5893,14 +5892,6 @@
                 "debug": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/font-awesome": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-            "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==",
-            "engines": {
-                "node": ">=0.10.3"
             }
         },
         "node_modules/for-each": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
         "autofill-event": "0.0.1",
         "d3": "^7.8.5",
         "echarts": "^5.4.3",
-        "font-awesome": "^4.7.0",
         "jquery": "^3.4.1",
         "jsonld": "^8.3.2",
         "jsrsasign": "^11.0.0",

--- a/src/css/bootstrap-graphdb-theme.css
+++ b/src/css/bootstrap-graphdb-theme.css
@@ -48,6 +48,23 @@
     font-style: normal;
 }
 
+.fa, .fa-regular, .fa-light, .fa-thin {
+    /*
+    General fix for FontAwesome icons being somewhat larger than our icons font.
+    font-size-adjust has other ways to do this (ex-height N) but that doesn't work well
+    with this font in Firefox. This magic value works identically in all browsers.
+    */
+    font-size-adjust: ch-width 0.52;
+}
+
+.pull-right {
+    float: right
+}
+
+.pull-left {
+    float: left
+}
+
 [class^="icon-"], [class*=" icon-"], .icon-any, .fa-d3 {
     speak: none;
     font-style: normal;
@@ -687,6 +704,8 @@ main menu height*/
 
 .main-menu .menu-item-icon {
     font-size: 2.5rem;
+    width: 2.5rem;
+    text-align: center;
     vertical-align: middle;
     color: var(--primary-color);
     transform: scale(0.9);
@@ -696,12 +715,6 @@ main menu height*/
     -webkit-transition: all 0.18s ease-out; /* Saf3.2+, Chrome */
     transition: all 0.18s ease-out;
     pointer-events: none;
-}
-
-.main-menu .menu-item-icon.fa-flask {
-    /* Temporary: until we get our own icon */
-    font-size: 2rem;
-    padding: 4px 5px;
 }
 
 .main-menu .menu-element-root .menu-item {
@@ -1081,13 +1094,16 @@ main menu height*/
     transition: transform 0.15s ease-out;
 }
 
-.btn [class^="icon-"] {
-    font-size: 1.4em;
+.btn [class^="icon-"],
+.btn .fa {
     line-height: 0.75;
+    font-size: 1.4em;
     display: inline-block;
+    vertical-align: middle;
 }
 
-.btn.btn-inline [class^="icon-"] {
+.btn.btn-inline [class^="icon-"],
+.btn.btn-inline .fa {
      font-size: inherit;
      line-height: inherit;
      vertical-align: inherit;

--- a/src/css/common.css
+++ b/src/css/common.css
@@ -7,6 +7,7 @@
     --main-font: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
     --main-font-weight: 300;
     --mono-font: 'JetBrains Mono', Menlo, Consolas, 'Ubuntu Mono', monospace;
+    --fa-style: 400;
 }
 
 /*-------------------------------------------------------------

--- a/src/css/ttyg/chat-item-details.css
+++ b/src/css/ttyg/chat-item-details.css
@@ -12,6 +12,8 @@
     flex-direction: column;
     gap: 1rem;
     flex-grow: 1;
+    /* 2.5rem bot icon + 1rem gap */
+    max-width: calc(100% - 3.5rem);
 }
 
 .chat-detail .assistant-message .answer {
@@ -85,6 +87,7 @@
 
 .chat-detail .assistant-message pre {
     text-wrap: wrap;
+    font-variant-ligatures: none;
 }
 
 .chat-detail .explain-response {
@@ -151,24 +154,4 @@
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     max-height: 4.5rem; /* fallback if line-clamp doesn't work */
-}
-
-.chat-detail .copy-btn,
-.chat-detail .open-in-sparql-editor-btn {
-    color: var(--primary-color);
-    border: none;
-    background-color: transparent;
-    cursor: pointer;
-    padding: 0;
-}
-
-.chat-detail .copy-btn:hover,
-.chat-detail .open-in-sparql-editor-btn {
-    transform: scale(1.1);
-    transition: all 0.1s ease-out;
-}
-
-.chat-detail .copy-btn:focus,
-.chat-detail .open-in-sparql-editor-btn {
-    outline: none;
 }

--- a/src/css/ttyg/ttyg.css
+++ b/src/css/ttyg/ttyg.css
@@ -21,7 +21,6 @@ page layout styles
 /*override btn-small to properly center the icons */
 .ttyg-view .btn-sm {
     padding: 0 !important;
-    line-height: 1 !important;
 }
 
 .ttyg-view .toolbar {
@@ -60,26 +59,6 @@ common sidebar and slidepanel styles
 /*
 left sidebar
 */
-
-/* style font awesome icons to look more like our icons */
-.ttyg-view .left-sidebar .fa-regular {
-    font-size: 1.05em;
-}
-
-.ttyg-view .left-sidebar .btn:hover .fa-regular {
-    transform: scale(1.2);
-}
-
-.ttyg-view .left-sidebar .btn .fa-regular {
-    -moz-transition: transform 0.15s ease-out;
-    -o-transition: transform 0.15s ease-out;
-    -webkit-transition: transform 0.15s ease-out;
-    transition: transform 0.15s ease-out;
-}
-
-.ttyg-view .left-sidebar .fa-regular {
-    font-size: 1.2em;
-}
 
 .ttyg-view .left-sidebar .toolbar {
     justify-content: space-between;

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -340,7 +340,7 @@
         "chat_panel": {
             "hint1": "<div><span class=\"graph\">GRAPH</span><span class=\"wise\">WISE</span></div><div class=\"thrives\">AI THRIVES ON WHOLE DATA</div>",
             "hint2": "Simply ask a question!",
-            "deleted_agent": "<span class=\"text-warning\"><i class=\"fa-regular fa-triangle-exclamation fa-xs\"></i> deleted agent</span>",
+            "deleted_agent": "<span class=\"text-warning\"><i class=\"fa fa-triangle-exclamation fa-xs\"></i> deleted agent</span>",
             "btn": {
                 "ask": {
                     "label": "Ask"

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -340,7 +340,7 @@
         "chat_panel": {
             "hint1": "<div><span class=\"graph\">GRAPH</span><span class=\"wise\">WISE</span></div><div class=\"thrives\">AI THRIVES ON WHOLE DATA</div>",
             "hint2": "Posez simplement une question !",
-            "deleted_agent": "<span class=\"text-warning\"><i class=\"fa-regular fa-triangle-exclamation fa-xs\"></i> agent supprimé</span>",
+            "deleted_agent": "<span class=\"text-warning\"><i class=\"fa fa-triangle-exclamation fa-xs\"></i> agent supprimé</span>",
             "btn": {
                 "ask": {
                     "label": "Demander"

--- a/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
+++ b/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
@@ -8,13 +8,13 @@
                     ng-click="add()"
                     gdb-tooltip="{{'cluster_management.cluster_configuration_multi_region.create_tag_tooltip' | translate}}"
                     tooltip-placement="bottom">
-                <i class="fa-regular fa-plus"></i> {{'cluster_management.cluster_configuration_multi_region.create_tag' | translate}}
+                <i class="fa fa-plus"></i> {{'cluster_management.cluster_configuration_multi_region.create_tag' | translate}}
             </button>
             <button type="button" class="btn btn-secondary enable-secondary-mode-btn mr-1"
                     ng-click="enableSecondaryMode()"
                     gdb-tooltip="{{'cluster_management.cluster_configuration_multi_region.enable_secondary_mode_tooltip' | translate}}"
                     tooltip-placement="bottom">
-                <i class="fa-regular fa-circle-arrow-down-right"></i>
+                <i class="fa fa-circle-arrow-down-right"></i>
                 {{'cluster_management.cluster_configuration_multi_region.enable_secondary_mode' | translate}}
             </button>
         </div>
@@ -58,13 +58,13 @@
                                 <button ng-click="cancel()"
                                         class="btn btn-link cancel-tag-add-btn secondary"
                                         gdb-tooltip="{{'cluster_management.cluster_configuration_multi_region.cancel_tooltip' | translate}}">
-                                    <i class="fa-regular fa-xmark"></i>
+                                    <i class="fa fa-xmark"></i>
                                 </button>
                                 <button ng-click="createTag(asciiInput)"
                                         class="btn btn-link save-rule-btn"
                                         ng-disabled="!tagForm.$valid"
                                         gdb-tooltip="{{'cluster_management.cluster_configuration_multi_region.create_tag' | translate}}">
-                                    <i class="fa-regular fa-check"></i>
+                                    <i class="fa fa-check"></i>
                                 </button>
                             </div>
                         </td>
@@ -86,7 +86,7 @@
                                         class="btn btn-link delete-tag-btn secondary"
                                         gdb-tooltip="{{ 'cluster_management.cluster_configuration_multi_region.delete_tag_tooltip' | translate }}"
                                         title-class="delete-tag-tooltip">
-                                    <i class="fa-regular fa-trash-can"></i>
+                                    <i class="fa fa-trash-can"></i>
                                 </button>
                             </div>
                         </td>
@@ -113,7 +113,7 @@
                     ng-click="disableSecondaryMode()"
                     gdb-tooltip="{{'cluster_management.cluster_configuration_multi_region.disable_secondary_mode_tooltip' | translate}}"
                     tooltip-placement="bottom">
-                <i class="fa-regular fa-arrow-up-left-from-circle"></i>
+                <i class="fa fa-arrow-up-left-from-circle"></i>
                 {{'cluster_management.cluster_configuration_multi_region.disable_secondary_mode' | translate}}
             </button>
         </div>

--- a/src/js/angular/clustermanagement/templates/cluster-nodes-configuration.html
+++ b/src/js/angular/clustermanagement/templates/cluster-nodes-configuration.html
@@ -5,7 +5,7 @@
     <button ng-click="addNode()" ng-disabled="editedNodeIndex !== undefined"
             class="btn btn-primary add-node-btn"
             gdb-tooltip="{{'cluster_management.update_cluster_group_dialog.actions.add_node_tooltip' | translate}}">
-        <i class="fa-regular fa-plus"></i> {{'cluster_management.update_cluster_group_dialog.actions.add_node' |
+        <i class="fa fa-plus"></i> {{'cluster_management.update_cluster_group_dialog.actions.add_node' |
         translate}}
     </button>
 </div>
@@ -59,11 +59,11 @@
                 </td>
                 <td class="status-cell data">
                     <div ng-if="!node.item.address" class="adding">
-                        <i class="fa-regular fa-circle-check status-icon"></i>
+                        <i class="fa fa-circle-check status-icon"></i>
                         {{'cluster_management.update_cluster_group_dialog.new_node' | translate}}
                     </div>
                     <div ng-if="node.isDeleted" class="deleting">
-                        <i class="fa-regular fa-xmark status-icon"></i>
+                        <i class="fa fa-xmark status-icon"></i>
                         {{'cluster_management.update_cluster_group_dialog.deleted_node' | translate}}
                     </div>
                 </td>
@@ -74,18 +74,18 @@
                                 class="btn btn-link delete-node-btn secondary"
                                 gdb-tooltip="{{ canDeleteNode ? ('cluster_management.update_cluster_group_dialog.actions.delete_node' | translate) : ('cluster_management.update_cluster_group_dialog.actions.cannot_delete_node' | translate) }}"
                                 title-class="delete-node-tooltip">
-                            <i class="fa-regular fa-xmark"></i>
+                            <i class="fa fa-xmark"></i>
                         </button>
                         <button ng-click="replaceNode($index, node)" class="btn btn-link replace-node-btn"
                                 gdb-tooltip="{{'cluster_management.update_cluster_group_dialog.actions.replace_node' | translate}}">
-                            <i class="fa-regular fa-arrow-right-arrow-left"></i>
+                            <i class="fa fa-arrow-right-arrow-left"></i>
                         </button>
                     </div>
                     <div ng-if="editedNodeIndex === undefined && node.isDeleted" class="actions-group">
                         <button ng-click="restoreNode(node)"
                                 class="btn btn-link restore-node-btn secondary"
                                 gdb-tooltip="{{'cluster_management.update_cluster_group_dialog.actions.restore_node' | translate}}">
-                            <i class="fa-regular fa-rotate-left"></i>
+                            <i class="fa fa-rotate-left"></i>
                         </button>
                     </div>
                 </td>
@@ -136,13 +136,13 @@
                         <button ng-click="cancel()"
                                 class="btn btn-link cancel-node-replace-btn secondary"
                                 gdb-tooltip="{{'cluster_management.update_cluster_group_dialog.actions.cancel' | translate}}">
-                            <i class="fa-regular fa-xmark"></i>
+                            <i class="fa fa-xmark"></i>
                         </button>
                         <button ng-click="saveNode(node.endpoint)"
                                 class="btn btn-link save-rule-btn"
                                 ng-disabled="!form.location.$valid"
                                 gdb-tooltip="{{form.location.$valid ? 'cluster_management.update_cluster_group_dialog.actions.add_node' : 'cluster_management.update_cluster_group_dialog.messages.invalid_form' | translate}}">
-                            <i class="fa-regular fa-check"></i>
+                            <i class="fa fa-check"></i>
                         </button>
                     </div>
                 </td>
@@ -183,13 +183,13 @@
                         <button ng-click="cancel()"
                                 class="btn btn-link cancel-node-replace-btn secondary"
                                 gdb-tooltip="{{'cluster_management.update_cluster_group_dialog.actions.cancel' | translate}}">
-                            <i class="fa-regular fa-xmark"></i>
+                            <i class="fa fa-xmark"></i>
                         </button>
                         <button ng-click="saveNode(newLocation.endpoint)"
                                 class="btn btn-link save-rule-btn"
                                 ng-disabled="!form.location.$valid"
                                 gdb-tooltip="{{form.location.$valid ? 'cluster_management.update_cluster_group_dialog.actions.add_node' : 'cluster_management.update_cluster_group_dialog.messages.invalid_form' | translate}}">
-                            <i class="fa-regular fa-check"></i>
+                            <i class="fa fa-check"></i>
                         </button>
                     </div>
                 </td>

--- a/src/js/angular/core/directives/copy-to-clipboard/copy-to-clipboard.directive.js
+++ b/src/js/angular/core/directives/copy-to-clipboard/copy-to-clipboard.directive.js
@@ -41,24 +41,14 @@ copyToClipboard.$inject = ['$translate', 'toastr'];
  */
 function copyToClipboard($translate, toastr) {
     return {
+        // Note: the line-height of the element must match the line-height of the icon
         template: `
             <style>
                 .copy-btn {
-                    border: none;
-                    background-color: transparent;
-                    cursor: pointer;
-                    padding: 0;
-                    color: var(--secondary-color);
-                }
-                .copy-btn:hover {
-                    transform: scale(1.1);
-                    transition: all 0.1s ease-out;
-                }
-                .copy-btn:focus {
-                    outline: none;
+                    line-height: 0.75;
                 }
             </style>
-            <button class="copy-btn" gdb-tooltip="{{tooltipText | translate}}" ng-click="copyToClipboard()"><i class="fa-regular fa-clone"></i></button>
+            <button class="btn btn-link btn-sm copy-btn" gdb-tooltip="{{tooltipText | translate}}" ng-click="copyToClipboard()"><i class="fa fa-clone"></i></button>
         `,
         restrict: 'E',
         scope: {

--- a/src/js/angular/core/directives/open-in-sparql-editor/open-in-sparql-editor.directive.js
+++ b/src/js/angular/core/directives/open-in-sparql-editor/open-in-sparql-editor.directive.js
@@ -40,7 +40,23 @@ openInSparqlEditorDirective.$inject = ['$repositories', '$translate', 'ModalServ
 
 function openInSparqlEditorDirective($repositories, $translate, ModalService, $window) {
     return {
-        template: `<button class="open-in-sparql-editor-btn" gdb-tooltip="{{'ttyg.chat_panel.btn.open_in_sparql_editor.tooltip' | translate}}" ng-click="onGoToSparqlEditorView()"><i class="icon-sparql"></i></button>`,
+        // Note: the line-height of the element must match the line-height of the icon.
+        // This defines a composite FontAwesome icon to match the style of the surrounding icons.
+        template: `
+            <style>
+                .open-in-sparql-editor-btn {
+                    line-height: 0.75;
+                }
+                .open-in-sparql-editor-btn .fa:nth-child(2) {
+                    margin-left: -0.2em;
+                    margin-right: -0.2em;
+                    font-size: 0.9em;
+                }
+            </style>
+            <button class="btn btn-link btn-sm open-in-sparql-editor-btn" gdb-tooltip="{{'ttyg.chat_panel.btn.open_in_sparql_editor.tooltip' | translate}}" ng-click="onGoToSparqlEditorView()">
+                <i class="fa fa-bracket-curly"></i><i class="fa fa-ellipsis"></i><i class="fa fa-bracket-curly-right"></i>
+            </button>
+        `,
         restrict: 'E',
         scope: {
             query: '@',

--- a/src/js/angular/templates/titlePopoverTemplate.html
+++ b/src/js/angular/templates/titlePopoverTemplate.html
@@ -5,6 +5,6 @@
         </p>
     </div>
     <div ng-if="documentationUrl">
-        <a ng-href="{{documentationUrl}}" target="_blank" rel="noopener">{{'common.learn_more_in_documentation' | translate}}</a> <i class="fa-regular fa-arrow-up-right-from-square"></i>
+        <a ng-href="{{documentationUrl}}" target="_blank" rel="noopener">{{'common.learn_more_in_documentation' | translate}}</a> <i class="fa fa-arrow-up-right-from-square"></i>
     </div>
 </div>

--- a/src/js/angular/ttyg/templates/agent-list.html
+++ b/src/js/angular/ttyg/templates/agent-list.html
@@ -5,7 +5,7 @@
         <button type="button" uib-dropdown-toggle class="btn btn-outline-primary dropdown-toggle">
             <i class="fa-kit fa-gdb-repo-graphdb mr-1"></i>
             <span class="selected-filter">{{selectedAgentsFilter.label}}</span>
-            <i class="fa-regular fa-filter" gdb-tooltip="{{'ttyg.agent.btn.filter.tooltip' | translate}}"></i>
+            <i class="fa fa-filter" gdb-tooltip="{{'ttyg.agent.btn.filter.tooltip' | translate}}"></i>
         </button>
         <ul class="dropdown-menu" role="menu">
             <li ng-repeat="filterModel in agentListFilterModel">
@@ -30,7 +30,7 @@
                     <div class="related-repository">
                         <i ng-if="!agent.isRepositoryDeleted" class="fa-kit fa-gdb-repo-graphdb"></i>
                         <i ng-if="agent.isRepositoryDeleted"
-                           class="fa-regular fa-triangle-exclamation text-warning agent-with-deleted-repository"
+                           class="fa fa-triangle-exclamation text-warning agent-with-deleted-repository"
                            gdb-tooltip="{{'ttyg.agent.deleted_repository' | translate}}">
                         </i>
                         {{agent.repositoryId}}
@@ -42,20 +42,20 @@
                             ng-if="true"
                             ng-click="openAgentActionMenu()"
                             ng-disabled="false">
-                        <i class="fa-regular fa-ellipsis"></i>
+                        <i class="fa fa-ellipsis"></i>
                     </button>
                     <div class="dropdown-menu dropdown-menu-right agent-actions-menu">
                         <button class="dropdown-item edit-agent-btn" type="button" ng-click="onEditAgent(agent)">
-                            <i class="fa-regular fa-gear"></i>
+                            <i class="fa fa-gear"></i>
                             <span>{{'ttyg.agent.btn.edit_agent.label' | translate}}</span>
                         </button>
                         <button class="dropdown-item clone-agent-btn" type="button" ng-click="onCloneAgent(agent)">
-                            <i class="fa-regular fa-clone"></i>
+                            <i class="fa fa-clone"></i>
                             <span>{{'ttyg.agent.btn.clone_agent.label' | translate}}</span>
                         </button>
                         <div class="dropdown-divider"></div>
                         <button class="dropdown-item delete-agent-btn" type="button" ng-click="onDeleteAgent(agent)">
-                            <i class="fa-regular fa-trash-can"></i>
+                            <i class="fa fa-trash-can"></i>
                             <span>{{'ttyg.agent.btn.delete_agent.label' | translate}}</span>
                         </button>
                     </div>

--- a/src/js/angular/ttyg/templates/agent-select-menu.html
+++ b/src/js/angular/ttyg/templates/agent-select-menu.html
@@ -7,13 +7,13 @@
         <span ng-if="selectedAgent && !selectedAgent.isDeleted">
             <span class="agent-name">{{selectedAgent.name}}</span> &middot;
             <i ng-if="selectedAgent.isRepositoryDeleted"
-               class="fa-regular fa-triangle-exclamation text-warning agent-with-deleted-repository"
+               class="fa fa-triangle-exclamation text-warning agent-with-deleted-repository"
                gdb-tooltip="{{'ttyg.agent.deleted_repository' | translate}}">
             </i>
             {{selectedAgent.repositoryId}}
         </span>
         <span ng-if="selectedAgent && selectedAgent.isDeleted" class="text-warning">
-            <i class="fa-regular fa-triangle-exclamation"></i>
+            <i class="fa fa-triangle-exclamation"></i>
             {{'ttyg.agent.agent_select_menu.deleted_agent' | translate}}
         </span>
         <span class="caret"></span>
@@ -25,7 +25,7 @@
                ng-click="onAgentSelected(agentOption.data.agent)">
                 <span class="agent-name">{{agentOption.label}}</span> &middot;
                 <i ng-if="agentOption.data.agent.isRepositoryDeleted"
-                   class="fa-regular fa-triangle-exclamation text-warning agent-with-deleted-repository"
+                   class="fa fa-triangle-exclamation text-warning agent-with-deleted-repository"
                    gdb-tooltip="{{'ttyg.agent.deleted_repository' | translate}}">
                 </i>
                 <span class="repository-id">{{agentOption.data.agent.repositoryId}}</span>

--- a/src/js/angular/ttyg/templates/chat-item-detail.html
+++ b/src/js/angular/ttyg/templates/chat-item-detail.html
@@ -11,7 +11,7 @@
         <div class="assistant">
             <div class="assistant-icon alert-help"
                  gdb-tooltip="{{'ttyg.chat_panel.labels.agent_name' | translate : { agentName: agentNameByIdMap[chatItemDetail.agentId], date: getHumanReadableQuestionTimestamp(chatItemDetail.question.timestamp), time: (chatItemDetail.question.timestamp | date:'HH:mm') } }}">
-                <i class="fa-regular fa-message-bot"></i>
+                <i class="fa fa-lg fa-message-bot"></i>
             </div>
             <div class="assistant-message">
                 <markdown-content class="answer" content="{{answer.message}}" options="markdownContentOptions"></markdown-content>
@@ -20,16 +20,16 @@
                             ng-click="regenerateQuestion()"
                             ng-disabled="disabled"
                             gdb-tooltip="{{'ttyg.chat_panel.btn.regenerate.tooltip' | translate}}">
-                        <i class="fa-regular fa-arrows-rotate"></i>
+                        <i class="fa fa-arrows-rotate"></i>
                     </button>
-                    <copy-to-clipboard class="btn-sm" tooltip-text="ttyg.chat_panel.btn.copy_answer.tooltip"
+                    <copy-to-clipboard tooltip-text="ttyg.chat_panel.btn.copy_answer.tooltip"
                                        text-to-copy="{{answer.message}}"></copy-to-clipboard>
                     <button class="btn btn-link btn-link-only-icons btn-sm explain-response-btn"
                             ng-click="explainResponse(answer.id)"
                             ng-disabled="disabled && !explainResponseModel[answer.id]"
                             gdb-tooltip="{{'ttyg.chat_panel.btn.explain_response.tooltip' | translate}}">
-                        <i class="fa-regular fa-wand-magic-sparkles"></i>
-                        <i class="fa-regular fa-chevron-up toggle-explain-response-icon"
+                        <i class="fa fa-wand-magic-sparkles"></i>
+                        <i class="fa fa-chevron-up toggle-explain-response-icon"
                            ng-class="{expanded: explainResponseModel[answer.id] && explainResponseModel[answer.id].expanded}"></i>
                     </button>
                 </div>

--- a/src/js/angular/ttyg/templates/chat-list.html
+++ b/src/js/angular/ttyg/templates/chat-list.html
@@ -25,20 +25,20 @@
                                     ng-if="true"
                                     ng-click="openChatActionMenu()"
                                     ng-disabled="false">
-                                <i class="fa-regular fa-ellipsis"></i>
+                                <i class="fa fa-ellipsis"></i>
                             </button>
                             <div class="dropdown-menu dropdown-menu-right chat-actions-menu">
                                 <button class="dropdown-item export-chat-btn" type="button" ng-click="onExportChat(chat)">
-                                    <i class="fa-regular fa-arrow-down-to-line"></i>
+                                    <i class="fa fa-arrow-down-to-line"></i>
                                     <span>{{'ttyg.chat.btn.export_chat.label' | translate}}</span>
                                 </button>
                                 <button class="dropdown-item rename-chat-btn" type="button" ng-click="onSelectChatForRenaming(chat)">
-                                    <i class="fa-regular fa-pen"></i>
+                                    <i class="fa fa-pen"></i>
                                     <span>{{'ttyg.chat.btn.rename_chat.label' | translate}}</span>
                                 </button>
                                 <div class="dropdown-divider"></div>
                                 <button class="dropdown-item delete-chat-btn" type="button" ng-click="onDeleteChat(chat)">
-                                    <i class="fa-regular fa-trash-can"></i>
+                                    <i class="fa fa-trash-can"></i>
                                     <span>{{'ttyg.chat.btn.delete_chat.label' | translate}}</span>
                                 </button>
                             </div>

--- a/src/js/angular/ttyg/templates/chat-panel.html
+++ b/src/js/angular/ttyg/templates/chat-panel.html
@@ -44,7 +44,7 @@
         <button class="btn btn-primary ask-button"
                 ng-disabled="!chatItem.question.message || !selectedAgent || selectedAgent.isDeleted || waitingForLastMessage || loadingChat"
                 ng-click="ask()">
-            <i class="fa-regular fa-arrow-turn-left-up"></i>
+            <i class="fa fa-arrow-turn-left-up"></i>
             {{ 'ttyg.chat_panel.btn.ask.label ' | translate }}
         </button>
     </div>

--- a/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -62,7 +62,7 @@
                             <span class="mr-1"
                                   uib-popover="{{'ttyg.agent.create_agent_modal.form.' + extractionMethod.method + '.tooltip' | translate}}"
                                   popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.' + extractionMethod.method + '.label' | translate}}</span>
-                            <i class="fa-regular fa-chevron-down toggle-icon"
+                            <i class="fa fa-chevron-down toggle-icon"
                                ng-class="{'expanded': extractionMethod.expanded}">
                             </i>
                         </a>
@@ -138,7 +138,7 @@
                             <button class="btn btn-link btn-sm pull-right"
                                     ng-click="checkIfFTSEnabled()"
                                     gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.fts_search.btn.reload.tooltip' | translate}}">
-                                <i class="fa-regular fa-arrows-rotate"></i>
+                                <i class="fa fa-arrows-rotate"></i>
                             </button>
                             <div class="alert alert-danger missing-repositoryid-error mb-0"
                                  ng-if="!agentFormModel.repositoryId">
@@ -172,7 +172,7 @@
                                     ng-click="updateSimilaritySearchPanel()"
                                     ng-disabled="disabled"
                                     gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.similarity_index.btn.reload.tooltip' | translate}}">
-                                <i class="fa-regular fa-arrows-rotate"></i>
+                                <i class="fa fa-arrows-rotate"></i>
                             </button>
                             <div ng-if="!similarityIndexes.length" class="no-similarity-index-message">
                                 {{'ttyg.agent.create_agent_modal.form.similarity_index.no_similarity_index.message_1' |
@@ -243,7 +243,7 @@
                                     ng-click="updateRetrievalConnectorPanel()"
                                     ng-disabled="disabled"
                                     gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.retrieval_search.btn.reload.tooltip' | translate}}">
-                                <i class="fa-regular fa-arrows-rotate"></i>
+                                <i class="fa fa-arrows-rotate"></i>
                             </button>
                             <div ng-if="!retrievalConnectors.length" class="no-retrieval-connector-message">
                                 {{'ttyg.agent.create_agent_modal.form.retrieval_search.no_retrieval_connectors.message_1'
@@ -354,7 +354,7 @@
                 <label for="temperature">
                     <span uib-popover="{{'ttyg.agent.create_agent_modal.form.temperature.tooltip' | translate}}"
                           popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.temperature.label' | translate}}</span>
-                    <i class="fa-regular fa-triangle-exclamation text-warning high-temperature-warning"
+                    <i class="fa fa-triangle-exclamation text-warning high-temperature-warning"
                        ng-if="showHighTemperatureWarning"
                        uib-popover="{{'ttyg.agent.create_agent_modal.form.temperature.high_temperature_warning' | translate}}"
                        popover-trigger="mouseenter"></i>
@@ -399,7 +399,7 @@
                     <button class="btn btn-link btn-sm create-chat-btn"
                             ng-click="onRestoreDefaultUserInstructions()"
                             gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.user_instruction.btn.restore_default.tooltip' | translate}}">
-                        <i class="fa-regular fa-arrow-rotate-left"></i>
+                        <i class="fa fa-arrow-rotate-left"></i>
                     </button>
                 </div>
             </div>
@@ -426,7 +426,7 @@
                         <span
                             uib-popover="{{'ttyg.agent.create_agent_modal.form.system_instruction.tooltip' | translate}}"
                             popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.system_instruction.label' | translate}}</span>
-                        <i class="fa-regular fa-triangle-exclamation text-warning overriding-system-instructions-warning"
+                        <i class="fa fa-triangle-exclamation text-warning overriding-system-instructions-warning"
                            ng-if="showSystemInstructionWarning"
                            uib-popover="{{'ttyg.agent.create_agent_modal.form.system_instruction.overriding_system_instruction_warning.body' | translate}}"
                            popover-trigger="mouseenter"></i>
@@ -438,7 +438,7 @@
                         <button class="btn btn-link btn-sm create-chat-btn"
                                 ng-click="onRestoreDefaultSystemInstructions()"
                                 gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.system_instruction.btn.restore_default.tooltip' | translate}}">
-                            <i class="fa-regular fa-arrow-rotate-left"></i>
+                            <i class="fa fa-arrow-rotate-left"></i>
                         </button>
                     </div>
                 </div>

--- a/src/js/angular/ttyg/templates/no-agents-view.html
+++ b/src/js/angular/ttyg/templates/no-agents-view.html
@@ -10,7 +10,7 @@
                     gdb-tooltip="{{!canModifyAgent ? ('ttyg.agent.fat_btn.create_agent.tooltip_disabled' | translate) : ''}}"
                     ng-disabled="!canModifyAgent"
                     ng-click="onCreateAgent()">
-                <i class="fa-regular fa-message-bot fa-xl"></i>
+                <i class="fa fa-message-bot fa-xl"></i>
                 <span class="text">{{'ttyg.agent.fat_btn.create_agent.label' | translate}}</span>
             </button>
         </div>

--- a/src/js/angular/ttyg/templates/ttyg.html
+++ b/src/js/angular/ttyg/templates/ttyg.html
@@ -31,14 +31,14 @@
                         ng-click="toggleChatsListSidebar()"
                         ng-disabled="false"
                         gdb-tooltip="{{'ttyg.chat.btn.' + (showChats ? 'close_sidebar' : 'open_sidebar') + '.tooltip' | translate}}">
-                    <i class="fa-regular fa-sidebar"></i>
+                    <i class="fa fa-sidebar"></i>
                 </button>
                 <button class="btn btn-link btn-sm create-chat-btn"
                         ng-if="chats && !chats.isEmpty()"
                         ng-click="startNewChat()"
                         ng-disabled="false"
                         gdb-tooltip="{{'ttyg.chat.btn.create_chat.tooltip' | translate}}">
-                    <i class="fa-regular fa-pen-to-square"></i>
+                    <i class="fa fa-pen-to-square"></i>
                 </button>
             </div>
             <pageslide
@@ -105,7 +105,7 @@
                         ng-click="toggleAgentsListSidebar()"
                         ng-disabled="!canModifyAgent"
                         gdb-tooltip="{{'ttyg.agent.btn.open_sidebar.' + (canModifyAgent ? 'tooltip' : 'tooltip_disabled') | translate}}">
-                    <i class="fa-regular fa-message-bot"></i>
+                    <i class="fa fa-message-bot"></i>
                 </button>
                 <button class="btn btn-link btn-sm toggle-agents-sidebar-btn"
                         ng-if="showAgents"

--- a/src/pages/cluster-management/clusterInfo.html
+++ b/src/pages/cluster-management/clusterInfo.html
@@ -22,7 +22,7 @@
             <button type="button" class="btn btn-primary edit-cluster-nodes-modal-btn" ng-if="currentLeader"
                     ng-click="showUpdateClusterGroupDialog()"
                     gdb-tooltip="{{'cluster_management.buttons.update_nodes_group_btn_tooltip' | translate}}" tooltip-placement="bottom">
-                <i class="fa-regular fa-plus"></i> {{'cluster_management.buttons.update_nodes_group_btn' | translate}}
+                <i class="fa fa-plus"></i> {{'cluster_management.buttons.update_nodes_group_btn' | translate}}
             </button>
         </div>
     </div>

--- a/src/pages/export.html
+++ b/src/pages/export.html
@@ -106,7 +106,7 @@
 										ng-click="dropContext()"
 											gdb-tooltip="{{'remove.data.from.selected.graph.tooltip' | translate}}" tooltip-placement="top"
 										ng-disabled="!canWriteActiveRepo(true) || !hasMultipleSelected()">
-										<span class="fa fa-trash-o"></span>
+										<span class="fa fa-trash-can"></span>
 									</button>
 								</th>
 								<th id="graphColumn">{{'graphs.label' | translate}}</th>
@@ -157,7 +157,7 @@
 										ng-click="dropContext(graph)"
 										gdb-tooltip="{{'remove.data.from.this.graph.tooltip' | translate}}" tooltip-placement="top"
 										ng-disabled="!canWriteActiveRepo(true) || !graph.contextID.uri">
-									<span class="fa fa-trash-o fa-lg"></span>
+									<span class="fa fa-trash-can"></span>
 								</button>
 
 							</td>

--- a/src/pages/ux-test2.html
+++ b/src/pages/ux-test2.html
@@ -14,4 +14,35 @@
         In varius posuere justo, at luctus arcu pellentesque ac. Orci varius natoque penatibus
         et magnis dis parturient montes, nascetur ridiculus mus. Phasellus lacinia velit ut nunc eleifend placerat.
     </div>
+
+    <div>
+        <button class="btn btn-link btn-link-only-icons">
+            <i class="icon-trash"></i>
+            <i class="fa fa-trash-can"></i>
+            &nbsp;
+            <i class="icon-reload"></i>
+            <i class="fa fa-arrows-rotate"></i>
+            &nbsp;
+            <i class="icon-copy"></i>
+            <i class="fa fa-clone"></i>
+            &nbsp;
+            <i class="icon-plus"></i>
+            <i class="fa fa-circle-plus"></i>
+        </button>
+    </div>
+    <div>
+        <button class="btn btn-sm btn-link btn-link-only-icons">
+            <i class="icon-trash"></i>
+            <i class="fa fa-trash-can"></i>
+            &nbsp;
+            <i class="icon-reload"></i>
+            <i class="fa fa-arrows-rotate"></i>
+            &nbsp;
+            <i class="icon-copy"></i>
+            <i class="fa fa-clone"></i>
+            &nbsp;
+            <i class="icon-plus"></i>
+            <i class="fa fa-circle-plus"></i>
+        </button>
+    </div>
 </div>

--- a/src/vendor.js
+++ b/src/vendor.js
@@ -1,9 +1,8 @@
 import 'lib/bootstrap/bootstrap.min.css';
 import 'angular-toastr/dist/angular-toastr.min.css';
-// TODO: remove this if no issues are found
-import 'font-awesome/css/font-awesome.min.css';
 import 'lib/awesome_me/css/fontawesome.min.css';
 import 'lib/awesome_me/css/regular.min.css';
+import 'lib/awesome_me/css/sharp-regular.min.css';
 import 'lib/awesome_me/css/custom-icons.min.css';
 import './css/lib/animate/animate.css';
 import 'shepherd.js/dist/css/shepherd.css';

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -340,7 +340,7 @@
         "chat_panel": {
             "hint1": "<div><span class=\"graph\">GRAPH</span><span class=\"wise\">WISE</span></div><div class=\"thrives\">AI THRIVES ON WHOLE DATA</div>",
             "hint2": "Simply ask a question!",
-            "deleted_agent": "<span class=\"text-warning\"><i class=\"fa-regular fa-triangle-exclamation fa-xs\"></i> deleted agent</span>",
+            "deleted_agent": "<span class=\"text-warning\"><i class=\"fa fa-triangle-exclamation fa-xs\"></i> deleted agent</span>",
             "btn": {
                 "ask": {
                     "label": "Ask"

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -80,14 +80,6 @@ module.exports = {
                 to: 'js/lib/bootstrap/bootstrap.min.css'
             },
             {
-                from: 'node_modules/font-awesome/css',
-                to: 'font/font-awesome/4.3.0/css'
-            },
-            {
-                from: 'node_modules/font-awesome/fonts',
-                to: 'font/font-awesome/4.3.0/fonts'
-            },
-            {
                 from: 'src/css',
                 to: 'css'
             },


### PR DESCRIPTION
- FontAwesome icons are scaled globally (also added a preview in ux-test2)
- FontAwesome icons use only the fa class (and not fa-regular or alternatives like fa-thin) and the font weight is determined by the --fa-style variable.
- Removed various hacks for individual icons
- Removed FontAwesome 4 from package list
  - There was one icon in export view using it
  - Note that this npm module brought the classes pull-right and pull-left, which now need to be defined explicitly now
- Copy button directive and Open in SPARQL directive are now styled like all similar icon buttons inside the directive
- Open in SPARQL directive uses a composite FontAwesome icon to recreate the {...} icon from our font and match the rest of the FontAwesome icons around it

Other fixes:
- Added max-width to .assistant-message in TTYG to prevent long native queries from spilling to the right in explains
- Added font-variant-ligatures: none to `<pre>` in TTYG explain to prevent queries showing fancy ligatures for some character combinations