### PR TITLE
GDB-11131: Fixes max width for explanation messages (#1653)

### DIFF
--- a/src/css/ttyg/chat-item-details.css
+++ b/src/css/ttyg/chat-item-details.css
@@ -1,10 +1,12 @@
 :root {
     --border: 1px solid #C2C1C2;
+    --assistan-icon-weight: 2.5rem;
+    --assistant-container-gap: 1rem;
 }
 
 .chat-detail .assistant {
     display: flex;
-    gap: 1rem;
+    gap: var(--assistant-container-gap);
 }
 
 .chat-detail .assistant-message {
@@ -12,6 +14,7 @@
     flex-direction: column;
     gap: 1rem;
     flex-grow: 1;
+    width: calc(100% - var(--assistan-icon-weight) - var(--assistant-container-gap));
 }
 
 .chat-detail .assistant-message .answer {
@@ -25,8 +28,8 @@
 }
 
 .chat-detail .assistant-icon {
-    width: 2.5rem;
-    height: 2.5rem;
+    width: var(--assistan-icon-weight);
+    height: var(--assistan-icon-weight);
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/js/angular/rest/ttyg.rest.service.fake.backend.js
+++ b/src/js/angular/rest/ttyg.rest.service.fake.backend.js
@@ -222,6 +222,18 @@ export class TtygRestServiceFakeBackend {
                         query: "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nPREFIX skos: <http://www.w3.org/2004/02/skos/core#>\nPREFIX onto: <http://www.ontotext.com/>\nSELECT ?label ?iri {\n    ?label onto:fts ('''Luke~ Skywalker~''' '*') .\n    ?iri rdfs:label|skos:prefLabel ?label .\n}",
                         queryType: "sparql",
                         errorOutput: null
+                    }, {
+                        name: "sparql_query",
+                        rawQuery: "SELECT ?name ?height WHERE { ?character voc:name ?name ; voc:height ?height . FILTER (?name = 'Luke Skywalker' || ?name = 'Leia Organa') }",
+                        query: "SELECT ?name ?height WHERE { ?character voc:name ?name ; voc:height ?height . FILTER (?name = 'Luke Skywalker' || ?name = 'Leia Organa') }",
+                        queryType: "sparql",
+                        errorOutput: "Error: java.lang.IllegalArgumentException: The following IRIs are not used in the data stored in GraphDB: https://swapi.co/vocabulary/name"
+                    }, {
+                        name: "sparql_query",
+                        rawQuery: "SELECT ?character ?height WHERE { ?character voc:height ?height . FILTER (?character = <https://swapi.co/resource/human/1> || ?character = <https://swapi.co/resource/human/5>) }",
+                        query: "SELEdCT ?character ?height WHERE { ?character voc:height ?height . FILTER (?character = <https://swapi.co/resource/human/1> || ?character = <https://swapi.co/resource/human/5>) }",
+                        queryType: "sparql",
+                        errorOutput: null
                     }
                 ]
             }});


### PR DESCRIPTION
## What
Addresses an issue where the chat panel sometimes displays a horizontal scroll.

## Why
Typically, the backend returns formatted assistant queries, which the markdown library displays correctly with line breaks and tabs. Occasionally, however, the backend returns a single, continuous string without line breaks or tabs, causing excessively long lines that expand the container width and introduce horizontal scrolling.

## How
Set a maximum width on the container displaying explanation messages, which forces the browser to wrap long query strings correctly.

(cherry picked from commit 1e13ca46c291dfefc850cd07dba69dadf311bde7)