### PR TITLE
GDB-10937: Automatically Update Validation in Create/Edit Agent Dialog

### DIFF
--- a/src/js/angular/models/ttyg/agent-form.js
+++ b/src/js/angular/models/ttyg/agent-form.js
@@ -260,6 +260,10 @@ export class ExtractionMethodsFormModel {
     getRetrievalExtractionMethod() {
         return this.getExtractionMethod(ExtractionMethod.RETRIEVAL);
     }
+
+    getFTSSearchExtractionMethod() {
+        return this.getExtractionMethod(ExtractionMethod.FTS_SEARCH);
+    }
 }
 
 export class ExtractionMethodFormModel {

--- a/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -134,6 +134,7 @@
 
                         <div
                             ng-if="extractionMethod.expanded && extractionMethod.method === extractionMethods.FTS_SEARCH"
+                            ng-class="{'has-error': agentSettingsForm.$error.FTSDisabled}"
                             class="extraction-method-options">
                             <button class="btn btn-link btn-sm pull-right"
                                     ng-click="checkIfFTSEnabled()"
@@ -167,6 +168,7 @@
 
                         <div
                             ng-if="extractionMethod.expanded && extractionMethod.method === extractionMethods.SIMILARITY"
+                            ng-class="{'has-error': agentSettingsForm.$error.missingIndex}"
                             class="extraction-method-options">
                             <button class="btn btn-link btn-sm pull-right"
                                     ng-click="updateSimilaritySearchPanel()"

--- a/test-cypress/integration/ttyg/create-agent.spec.js
+++ b/test-cypress/integration/ttyg/create-agent.spec.js
@@ -517,14 +517,26 @@ describe('TTYG create new agent', () => {
         TtygAgentSettingsModalSteps.getSystemInstructionsWarning().should('not.exist');
     });
 
-    it('should reset validation error when similarity search/ChatGPT connector are disabled', () => {
+    it('should reset validation error when FTS, similarity search or ChatGPT connector are disabled', () => {
         // When I open agent settings dialog and make all steps so the create button became enabled.
         TTYGStubs.stubChatsListGetNoResults();
         TTYGStubs.stubAgentListGet('/ttyg/agent/get-agent-list-0.json');
+        SimilarityIndexStubs.stubGetSimilarityIndexes('/similarity/get-similarity-indexes-0.json');
         TTYGViewSteps.visit();
         cy.wait('@get-all-repositories');
         TTYGViewSteps.createFirstAgent();
+        TtygAgentSettingsModalSteps.enableSparqlExtractionMethod();
+        TtygAgentSettingsModalSteps.selectSparqlMethodOntologyGraph();
+        TtygAgentSettingsModalSteps.getSaveAgentButton().should('be.enabled');
+
+        // When enable FTS extraction method and selected repository has not fts search enabled.
         TtygAgentSettingsModalSteps.enableFtsExtractionMethod();
+        // Then I expect the create button be disabled.
+        TtygAgentSettingsModalSteps.getSaveAgentButton().should('be.disabled');
+
+        // When I disable FTS extraction method
+        TtygAgentSettingsModalSteps.disableFtsExtractionMethod();
+        // Then I expect the save button be enabled because is deselected
         TtygAgentSettingsModalSteps.getSaveAgentButton().should('be.enabled');
 
         // When enable the similarity index method


### PR DESCRIPTION
* GDB-10937: Automatically Update Validation in Create/Edit Agent Dialog

## What
The validation for the create/edit agent dialog is refreshed when the dialog’s tab becomes active.

## Why
When users open the create/edit agent dialog and select the "FTS," "Similarity," or "ChatGPT" execution method, a help message appears if the required settings are not yet configured in GraphDB. This message provides a link to the appropriate view in the workbench. After users navigate to that view and complete the necessary setup, they can return to the dialog tab, where the validation will update automatically to reflect these changes, eliminating the need for additional manual refresh actions.

## How
An event listener was added to detect when the user reactivates the tab containing the open create/edit agent dialog. When this event occurs, the dialog’s validation is automatically refreshed to incorporate any changes the user made.

## Additional work
Added validation to the Full-text Search (FTS) query method.

(cherry picked from commit 93a0f660b8815415c3003c502c9086636abdc955)