### PR TITLE
GDB-11114: License appears editable regardless than GraphDB configured through a file

### DIFF
--- a/src/js/angular/core/services/license.service.js
+++ b/src/js/angular/core/services/license.service.js
@@ -37,7 +37,7 @@ function licenseService($window, $document, LicenseRestService, $translate) {
         _loadingLicense = true;
         return LicenseRestService.getHardcodedLicense()
             .then((res) => {
-                _isLicenseHardcoded = (res === 'true');
+                _isLicenseHardcoded = (res.data === 'true');
                 return LicenseRestService.getLicenseInfo();
             })
             .then((res) => {

--- a/src/pages/licenseInfo.html
+++ b/src/pages/licenseInfo.html
@@ -56,10 +56,10 @@
             <p class="text-muted">{{license.typeOfUse}}</p>
             <div class="text-right">
                 <button ng-click="revertToFree()" ng-if="!isLicenseHardcoded() && !isFreeEdition() && isAdmin()"
-                        class="btn btn-secondary">
+                        class="btn btn-secondary revert-to-free-license-btn">
                     {{'revert.to.free' | translate}}
                 </button>
-                <a href="license/register" ng-if="!isLicenseHardcoded() && isAdmin()" class="btn btn-primary">
+                <a href="license/register" ng-if="!isLicenseHardcoded() && isAdmin()" class="btn btn-primary set-new-license-link">
                     {{'core.errors.set.new.license.warning.msg' | translate}}
                 </a>
             </div>
@@ -71,13 +71,11 @@
     </div>
 </div>
 
-<div class="alert alert-warning" ng-if="isLicenseHardcoded() && isAdmin() && !isFreeEdition()">
+<div class="alert alert-warning license-hardcoded-alert-message" ng-if="isLicenseHardcoded() && isAdmin() && !isFreeEdition()">
     {{'license.cannot.be.changed.from.wb.warning' | translate}}
 </div>
 
 <div class="alert alert-warning" ng-if="!isAdmin() && !isFreeEdition()">
     {{'license.admin.authority.constraint' | translate}}
 </div>
-</div>
-
 

--- a/test-cypress/integration/license/license.spec.js
+++ b/test-cypress/integration/license/license.spec.js
@@ -3,8 +3,9 @@ import {LicenseStubs} from "../../stubs/license-stubs";
 
 describe('License', () => {
    it('Should displays an informational message if the license is provided through a file (hardcoded)', () => {
-      LicenseSteps.visit();
       LicenseStubs.stubLicenseHardcoded(true);
+      LicenseStubs.stubEnterpriseLicense();
+      LicenseSteps.visit();
       LicenseSteps.getLicenseHeader().should('have.text', "GraphDB Enterprise Edition");
 
       LicenseSteps.getHardcodedAlertMessage().should('exist');
@@ -13,8 +14,9 @@ describe('License', () => {
    });
 
    it('Should not displays an informational message if the license is not provided through a file (not hardcoded)', () => {
-      LicenseSteps.visit();
       LicenseStubs.stubLicenseHardcoded(false);
+      LicenseStubs.stubEnterpriseLicense();
+      LicenseSteps.visit();
       LicenseSteps.getLicenseHeader().should('have.text', "GraphDB Enterprise Edition");
 
       LicenseSteps.getHardcodedAlertMessage().should('not.exist');

--- a/test-cypress/integration/license/license.spec.js
+++ b/test-cypress/integration/license/license.spec.js
@@ -1,0 +1,24 @@
+import {LicenseSteps} from "../../steps/license-steps";
+import {LicenseStubs} from "../../stubs/license-stubs";
+
+describe('License', () => {
+   it('Should displays an informational message if the license is provided through a file (hardcoded)', () => {
+      LicenseSteps.visit();
+      LicenseStubs.stubLicenseHardcoded(true);
+      LicenseSteps.getLicenseHeader().should('have.text', "GraphDB Enterprise Edition");
+
+      LicenseSteps.getHardcodedAlertMessage().should('exist');
+      LicenseSteps.getRevertToFreeLicenseButton().should('not.exist');
+      LicenseSteps.getSetNewLicenseElement().should('not.exist');
+   });
+
+   it('Should not displays an informational message if the license is not provided through a file (not hardcoded)', () => {
+      LicenseSteps.visit();
+      LicenseStubs.stubLicenseHardcoded(false);
+      LicenseSteps.getLicenseHeader().should('have.text', "GraphDB Enterprise Edition");
+
+      LicenseSteps.getHardcodedAlertMessage().should('not.exist');
+      LicenseSteps.getRevertToFreeLicenseButton().should('exist');
+      LicenseSteps.getSetNewLicenseElement().should('exist');
+   });
+});

--- a/test-cypress/steps/license-steps.js
+++ b/test-cypress/steps/license-steps.js
@@ -1,0 +1,25 @@
+export class LicenseSteps {
+    static visit() {
+        cy.visit('/license');
+    }
+
+    static getLicense() {
+        return cy.get('.license-container');
+    }
+
+    static getLicenseHeader() {
+        return LicenseSteps.getLicense().find('.card-header');
+    }
+
+    static getHardcodedAlertMessage() {
+        return cy.get('.license-hardcoded-alert-message');
+    }
+
+    static getRevertToFreeLicenseButton() {
+        return LicenseSteps.getLicense().find('.revert-to-free-license-btn');
+    }
+
+    static getSetNewLicenseElement() {
+        return LicenseSteps.getLicense().find('.set-new-license-link');
+    }
+}

--- a/test-cypress/stubs/license-stubs.js
+++ b/test-cypress/stubs/license-stubs.js
@@ -98,4 +98,11 @@ export class LicenseStubs {
             statusCode: 500
         });
     }
+
+    static stubLicenseHardcoded(hardcoded = false) {
+        cy.intercept('GET', '/rest/graphdb-settings/license/hardcoded', {
+            statusCode: 200,
+            body: hardcoded + ''
+        }).as('license-hardcoded');
+    }
 }


### PR DESCRIPTION
What
The buttons "Revert to Free License" and "Set New License" are visible, and the informational message, "License cannot be changed from the Workbench as it was set ..." does not appear, regardless than GraphDB has a license set via the configuration graphdb.license.file.

Why
This occurs due to an incorrect check following the server response.

How
The license configuration check has been corrected to address this issue.