### PR TITLE
GDB-11134 fix error handling in similarity indexes view

### DIFF
--- a/src/css/create-similarity-index.css
+++ b/src/css/create-similarity-index.css
@@ -14,3 +14,9 @@ yasgui-component .CodeMirror {
 .keyboard-shortcuts-dialog-wrapper {
     margin-top: -21px;
 }
+
+.create-similarity-index-btn .saving-index-loader,
+.create-similarity-index-btn .save-query-btn {
+    position: relative;
+    bottom: -3px
+}

--- a/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/src/js/angular/similarity/controllers/create-index.controller.js
@@ -195,32 +195,34 @@ function CreateSimilarityIdxCtrl(
     }
 
     $scope.saveSearchQuery = function () {
-        $scope.saveOrUpdateExecuted = true;
-        $scope.savingIndex = true;
-        updateQueryFromEditor($scope.similarityIndexInfo)
-            .then(validateSimilarityIndexName)
-            .then(validateQuery)
-            .then(validateQueryType)
-            .then(validateSearchQuery)
-            .then(validateAnalogicalQuery)
-            .then(saveQuery)
-            .then((isSearchQuery) => {
-                // toastr should be triggered before the redirect because the redirect will remove the toast
-                return Notifications.showToastMessageWithDelay(isSearchQuery ? 'similarity.changed.search.query.msg' : 'similarity.changed.analogical.query.msg');
-            })
-            .then(() => {
-                if (!isDirty) {
+        if (!isDirty) {
+            $location.url('similarity');
+        } else {
+            $scope.saveOrUpdateExecuted = true;
+            $scope.savingIndex = true;
+            updateQueryFromEditor($scope.similarityIndexInfo)
+                .then(validateSimilarityIndexName)
+                .then(validateQuery)
+                .then(validateQueryType)
+                .then(validateSearchQuery)
+                .then(validateAnalogicalQuery)
+                .then(saveQuery)
+                .then((isSearchQuery) => {
+                    // toastr should be triggered before the redirect because the redirect will remove the toast
+                    return Notifications.showToastMessageWithDelay(isSearchQuery ? 'similarity.changed.search.query.msg' : 'similarity.changed.analogical.query.msg');
+                })
+                .then(() => {
                     $location.url('similarity');
-                }
-            })
-            .catch((error) => {
-                if (!(error instanceof SimilarityIndexError)) {
-                    toastr.error(getError(error), $translate.instant('similarity.change.query.error'));
-                }
-            })
-            .finally(() => {
-                $scope.savingIndex = false;
-            });
+                })
+                .catch((error) => {
+                    if (!(error instanceof SimilarityIndexError)) {
+                        toastr.error(getError(error), $translate.instant('similarity.change.query.error'));
+                    }
+                })
+                .finally(() => {
+                    $scope.savingIndex = false;
+                });
+        }
     };
 
     /**

--- a/src/pages/create-index.html
+++ b/src/pages/create-index.html
@@ -247,17 +247,25 @@
                            popover-trigger="mouseenter">
                             {{'common.cancel.btn' | translate}}
                         </a>
-                        <button ng-if="!isEditViewMode()" class="btn btn-lg btn-primary create-similarity-index-btn" ng-click="createSimilarityIndex()"
+                        <button ng-if="!isEditViewMode()" class="btn btn-lg btn-primary create-similarity-index-btn"
+                                ng-disabled="savingIndex"
+                                ng-click="createSimilarityIndex()"
                                 uib-popover="{{'create.index.label' | translate}}"
                                 popover-placement="top"
                                 popover-trigger="mouseenter">
-                            {{'common.create.btn' | translate}}
+                            <span>{{'common.create.btn' | translate}}</span>
+                            <span class="saving-index-loader" ng-if="savingIndex" onto-loader-fancy hide-message="true"
+                                  size="18"></span>
                         </button>
-                        <button ng-if="isEditViewMode()" class="btn btn-lg btn-primary save-query-btn" ng-click="saveSearchQuery()"
+                        <button ng-if="isEditViewMode()" class="btn btn-lg btn-primary save-query-btn"
+                                ng-disabled="savingIndex"
+                                ng-click="saveSearchQuery()"
                                 uib-popover="{{'core.edit.query' | translate}}"
                                 popover-placement="top"
                                 popover-trigger="mouseenter">
-                            {{'common.save.btn' | translate}}
+                            <span>{{'common.save.btn' | translate}}</span>
+                            <span class="saving-index-loader" ng-if="savingIndex" onto-loader-fancy hide-message="true"
+                                  size="18"></span>
                         </button>
                     </div>
                     <div class="pull-left">

--- a/test-cypress/integration/explore/similarity-index/similarity-index-create.spec.js
+++ b/test-cypress/integration/explore/similarity-index/similarity-index-create.spec.js
@@ -1,6 +1,6 @@
-import {SimilarityIndexCreateSteps} from "../../steps/explore/similarity-index-create-steps";
-import {ErrorSteps} from "../../steps/error-steps";
-import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
+import {SimilarityIndexCreateSteps} from "../../../steps/explore/similarity-index-create-steps";
+import {ErrorSteps} from "../../../steps/error-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
 
 const FILE_TO_IMPORT = 'people.zip';
 const INSERT_QUERY = 'PREFIX dc: <http://purl.org/dc/elements/1.1/>\n INSERT DATA\n{\nGRAPH <http://example> {\n<http://example/book1> dc:title "A new book" ;\ndc:creator "A.N.Other" .\n}\n}';

--- a/test-cypress/integration/explore/similarity-index/similarity-index.spec.js
+++ b/test-cypress/integration/explore/similarity-index/similarity-index.spec.js
@@ -1,8 +1,8 @@
-import {SimilarityIndexCreateSteps} from "../../steps/explore/similarity-index-create-steps";
-import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";
-import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
-import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../steps/modal-dialog-steps";
-import {SimilarityIndexesSteps} from "../../steps/explore/similarity-indexes-steps";
+import {SimilarityIndexCreateSteps} from "../../../steps/explore/similarity-index-create-steps";
+import {RepositorySelectorSteps} from "../../../steps/repository-selector-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../../steps/modal-dialog-steps";
+import {SimilarityIndexesSteps} from "../../../steps/explore/similarity-indexes-steps";
 
 const FILE_TO_IMPORT = 'people.zip';
 

--- a/test-cypress/integration/explore/similarity-index/similarity.spec.js
+++ b/test-cypress/integration/explore/similarity-index/similarity.spec.js
@@ -1,11 +1,10 @@
-import {SparqlEditorSteps} from "../../steps/sparql-editor-steps";
-import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
-import {YasrSteps} from "../../steps/yasgui/yasr-steps";
-import {SimilarityIndexCreateSteps} from "../../steps/explore/similarity-index-create-steps";
-import {SimilarityIndexesSteps} from "../../steps/explore/similarity-indexes-steps";
-import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../steps/modal-dialog-steps";
-import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";
-import {ErrorSteps} from "../../steps/error-steps";
+import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {YasrSteps} from "../../../steps/yasgui/yasr-steps";
+import {SimilarityIndexCreateSteps} from "../../../steps/explore/similarity-index-create-steps";
+import {SimilarityIndexesSteps} from "../../../steps/explore/similarity-indexes-steps";
+import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../../steps/modal-dialog-steps";
+import {ErrorSteps} from "../../../steps/error-steps";
 
 const INDEX_NAME = 'index-' + Date.now();
 const FILE_TO_IMPORT = 'people.zip';

--- a/test-cypress/steps/yasgui/yasqe-steps.js
+++ b/test-cypress/steps/yasgui/yasqe-steps.js
@@ -74,6 +74,9 @@ export class YasqeSteps {
         this.getCodeMirror().then((cm) => {
             cm.getDoc().setValue(query);
         });
+        // Type some spaces to trigger the change event and make angular aware
+        // that the value has been changed.
+        YasqeSteps.getEditor().find('textarea').type('  ', {force: true, parseSpecialCharSequences: false});
         YasqeSteps.verifyQueryTyped(query);
     }
 


### PR DESCRIPTION
## What
Fix error handling in similarity indexes view.

## Why
Error handling in the similarity indexes view is broken and leads to unpleasant experience in the user. For example, when user tries to create or edit a namespace, but the server returns some error, the UI doesn't show a notification for the error, but just navigates to other view which leads to confusion.

## How
* Refactored the save and edit action handlers and added a flag that indicates whether the operation is in progress which is also reflected in the UI with a progress indicator in the respective action button.