### PR TITLE
GDB-10925: Remove Unnecessary Autocomplete Check in Repository View

### DIFF
--- a/src/js/angular/aclmanagement/controllers.js
+++ b/src/js/angular/aclmanagement/controllers.js
@@ -503,6 +503,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
         subscriptions.push($scope.$on('$destroy', unsubscribeListeners));
         // Listening for event fired when browser window is going to be closed
         window.addEventListener('beforeunload', beforeUnloadHandler);
+        $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus();
     };
 
     init();

--- a/src/js/angular/core/services/autocomplete-status.service.js
+++ b/src/js/angular/core/services/autocomplete-status.service.js
@@ -15,7 +15,11 @@ function autocompleteStatusService($rootScope, AutocompleteRestService, LocalSto
     that.setAutocompleteStatus(value);
   }, true);
 
-  function refreshAutocompleteStatus() {
+  function refreshAutocompleteStatus(event, eventPayload) {
+      if (!eventPayload.newRepo) {
+          // skip emitting the event if the repository has not changed.
+          return;
+      }
       // Autocomplete is related with an active repository
       if (!$repositories.getActiveRepository() ||
             $repositories.isActiveRepoOntopType() ||

--- a/src/js/angular/similarity/controllers/similarity-list.controller.js
+++ b/src/js/angular/similarity/controllers/similarity-list.controller.js
@@ -274,6 +274,7 @@ function SimilarityCtrl(
     };
 
     const init = () => {
+        $scope.getAutocompletePromise = AutocompleteRestService.checkAutocompleteStatus();
         const activeRepository = $scope.getActiveRepository();
         if (activeRepository && $scope.activeRepository !== activeRepository) {
             $scope.canEditRepo = $scope.canWriteActiveRepo();


### PR DESCRIPTION
## What
An unnecessary periodic check for "autocomplete enabled" is triggered in the repository view. Steps to reproduce:
- Open the autocomplete view.
- Switch to the repository view.

## Why
Opening the autocomplete view initializes $autocompleteStatus service, that registers a listener for repositoryIsSet event, which triggers a check for autocomplete enabled. The service remains active after the autocomplete page is visited, until the tab is closed or refreshed. The repository view fires the repositoryIsSet event every 5 seconds, causing repeated, unnecessary checks.

## How
Added check if 'repositoryIsSet' is fired because repository is changed if yes the check is executed.

## Additional work
Fixes autocomplete in aclmanagement view