### PR TITLE
GDB-10834 updated yasgui component version containing a fix for prefix auto insert in queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-yasgui-web-component": "1.3.19",
+                "ontotext-yasgui-web-component": "1.3.20",
                 "shepherd.js": "^11.2.0"
             },
             "devDependencies": {
@@ -9093,9 +9093,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.19",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.19.tgz",
-            "integrity": "sha512-HJfx1zw9l/1XTULMUPN5G/E1x8LD5FcIR2ypYZVmwR56B/QozNGK0aiTlNF60sQmFFSHInYOkFRkk8Z1EZxG9Q==",
+            "version": "1.3.20",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.20.tgz",
+            "integrity": "sha512-9s5ljm48voTQY+QLm8k3lW7/kSBJfJtOvCWqXWgb+TVZdZGCrAqaANh3Mj85ozq8haoAyTR9jSuvYxFcDDGp+A==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-yasgui-web-component": "1.3.19",
+        "ontotext-yasgui-web-component": "1.3.20",
         "shepherd.js": "^11.2.0"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Fix automatic prefix insertion in queries. It used to happen in certain scenarios, but in others it required some unwanted preconditions.

## Why
Our sesame-prefixes autocomplete plugin for codemirror appeared to be broken/incomplete in handling scenarios where the prefixes had to be inserted in the query. Such scenarios were the cases where the short uri prefix was immediately preceded by some punctuation character like a brace, caret, slash, etc.

## How
Extended the condition that checks whether the prefix should be inserted in the query or not.