### PR TITLE
GDB-11134 fix error handling in my settings view

### DIFF
--- a/src/js/angular/core/services/security.service.js
+++ b/src/js/angular/core/services/security.service.js
@@ -1,0 +1,25 @@
+import 'angular/rest/ttyg.rest.service';
+
+const modules = ['graphdb.framework.rest.security.service'];
+
+angular
+    .module('graphdb.framework.core.services.security-service', modules)
+    .factory('SecurityService', SecurityService);
+
+SecurityService.$inject = ['SecurityRestService'];
+
+function SecurityService(SecurityRestService) {
+
+    /**
+     * Updates user data in the backend using the SecurityRestService.
+     * @param {UpdateUserPayload} payload The payload to update the user data.
+     * @return {Promise<*>}
+     */
+    const updateUserData = (payload) => {
+        return SecurityRestService.updateUserData(payload);
+    };
+
+    return {
+        updateUserData
+    };
+}

--- a/src/js/angular/models/security/security.js
+++ b/src/js/angular/models/security/security.js
@@ -1,0 +1,31 @@
+export class UpdateUserPayload {
+    constructor(data) {
+        this._username = data.username;
+        this._password = data.password;
+        this._appSettings = data.appSettings;
+    }
+
+    get username() {
+        return this._username;
+    }
+
+    set username(value) {
+        this._username = value;
+    }
+
+    get password() {
+        return this._password;
+    }
+
+    set password(value) {
+        this._password = value;
+    }
+
+    get appSettings() {
+        return this._appSettings;
+    }
+
+    set appSettings(value) {
+        this._appSettings = value;
+    }
+}

--- a/src/js/angular/rest/security.rest.service.js
+++ b/src/js/angular/rest/security.rest.service.js
@@ -68,12 +68,17 @@ function SecurityRestService($http) {
         });
     }
 
+    /**
+     * Updates the user data in the backend.
+     * @param {UpdateUserPayload} data - The user data to be updated.
+     * @return {Promise<*>}
+     */
     function updateUserData(data) {
         return $http({
             method: 'PATCH',
             url: `${SECURITY_USER_ENDPOINT}/${fixedEncodeURIComponent(data.username)}`,
             data: {
-                password: data.pass,
+                password: data.password,
                 appSettings: data.appSettings
             }
         });

--- a/src/js/angular/security/app.js
+++ b/src/js/angular/security/app.js
@@ -1,6 +1,7 @@
 import 'angular/core/services';
 import 'angular/core/directives';
 import 'angular/security/controllers';
+import 'angular/security/controllers/user-settings.controller';
 import 'angular/core/services/jwt-auth.service';
 import 'ng-tags-input/build/ng-tags-input.min';
 
@@ -9,6 +10,7 @@ const modules = [
     'ui.bootstrap',
     'ngRoute',
     'graphdb.framework.security.controllers',
+    'graphdb.framework.security.controllers.user-settings',
     'graphdb.framework.core.interceptors.unauthorized',
     'graphdb.framework.core.interceptors.authentication',
     'graphdb.framework.core.services.jwtauth'

--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -4,7 +4,6 @@ import 'angular/core/services/openid-auth.service';
 import 'angular/rest/security.rest.service';
 import {UserRole, UserType} from 'angular/utils/user-utils';
 import 'angular/aclmanagement/directives/custom-role-prefix.directive';
-import {CookiePolicyModalController} from "../core/directives/cookie-policy/cookie-policy-modal-controller";
 import {READ_REPO, READ_REPO_PREFIX, SYSTEM_REPO, WRITE_REPO, WRITE_REPO_PREFIX} from "./services/constants";
 import {createUniqueKey, parseAuthorities} from "./services/authorities-util";
 
@@ -21,8 +20,8 @@ const modules = [
 
 const securityModule = angular.module('graphdb.framework.security.controllers', modules);
 
-securityModule.controller('LoginCtrl', ['$scope', '$http', 'toastr', '$jwtAuth', '$openIDAuth', '$location', '$rootScope', '$translate',
-    function ($scope, $http, toastr, $jwtAuth, $openIDAuth, $location, $rootScope, $translate) {
+securityModule.controller('LoginCtrl', ['$scope', '$http', 'toastr', '$jwtAuth', '$openIDAuth', '$location', '$rootScope', '$translate', 'TrackingService',
+    function ($scope, $http, toastr, $jwtAuth, $openIDAuth, $location, $rootScope, $translate, TrackingService) {
         $scope.username = '';
         $scope.password = '';
 

--- a/src/js/angular/security/controllers/user-settings.controller.js
+++ b/src/js/angular/security/controllers/user-settings.controller.js
@@ -1,0 +1,215 @@
+import 'angular/core/services/similarity.service';
+import 'angular/core/services/connectors.service';
+import 'angular/core/services/ttyg.service';
+import 'angular/rest/repositories.rest.service';
+import {READ_REPO, WRITE_REPO} from "../services/constants";
+import {UserType} from 'angular/utils/user-utils';
+import {parseAuthorities} from "../services/authorities-util";
+
+angular
+    .module('graphdb.framework.security.controllers.user-settings', [])
+    .controller('UserSettingsController', UserSettingsController);
+
+UserSettingsController.$inject = [
+    '$scope',
+    'toastr',
+    '$window',
+    '$timeout',
+    '$jwtAuth',
+    '$rootScope',
+    '$controller',
+    'SecurityRestService',
+    'ModalService',
+    '$translate',
+    'ThemeService',
+    'WorkbenchSettingsStorageService',
+    '$q',
+    '$uibModal',
+    '$licenseService'
+];
+
+function UserSettingsController($scope, toastr, $window, $timeout, $jwtAuth, $rootScope, $controller, SecurityRestService, ModalService, $translate, ThemeService, WorkbenchSettingsStorageService, $q, $uibModal, $licenseService) {
+    angular.extend(this, $controller('CommonUserCtrl', {$scope: $scope, passwordPlaceholder: 'security.new.password'}));
+
+    $scope.themes = ThemeService.getThemes();
+    $scope.mode = 'settings';
+    $scope.showWorkbenchSettings = true;
+    /** @type {WorkbenchSettingsModel} */
+    $scope.workbenchSettings = WorkbenchSettingsStorageService.getWorkbenchSettings();
+    $scope.selectedThemeMode = $scope.workbenchSettings.mode;
+    $scope.saveButtonText = $translate.instant('common.save.btn');
+    $scope.pageTitle = $translate.instant('view.settings.title');
+    $scope.passwordPlaceholder = $translate.instant('security.new.password');
+    $scope.grantedAuthorities = {
+        [READ_REPO]: {},
+        [WRITE_REPO]: {}
+    };
+    $scope.loader = false;
+    /** @type {ThemeModel} */
+    $scope.selectedTheme = ThemeService.getTheme();
+
+    $scope.hasEditRestrictions = function () {
+        return true;
+    };
+
+    $scope.isUser = function () {
+        return $scope.userType === UserType.USER;
+    };
+
+    $scope.goBack = function () {
+        const timer = $timeout(function () {
+            $window.history.back();
+        }, 100);
+        $scope.$on('$destroy', function () {
+            $timeout.cancel(timer);
+        });
+    };
+
+    // Wrapped in a scope function for ease of testing
+    $scope.getPrincipal = function () {
+        return $jwtAuth.getPrincipal()
+            .then((principal) => {
+                $scope.currentUserData = _.cloneDeep(principal);
+            });
+    };
+
+    $scope.getPrincipal().then(() => {
+        $scope.redirectAdmin();
+        initUserData($scope);
+    });
+
+    $scope.updateCurrentUserData = function () {
+        // Using $q.when to proper set values in view
+        $q.when($jwtAuth.getPrincipal())
+            .then((principal) => _.assign(principal, $scope.userData));
+    };
+
+    //call it as a function so I can make test on it
+    $scope.redirectAdmin = function () {
+        if (!$scope.currentUserData) {
+            $rootScope.redirectToLogin();
+        }
+    };
+
+    const initUserData = function (scope) {
+        // Copy needed so that Cancel would work correctly, need to call updateCurrentUserData on OK
+        scope.userData = _.cloneDeep(scope.currentUserData);
+        scope.user = {username: scope.userData.username};
+        scope.user.password = '';
+        scope.user.confirmpassword = '';
+        scope.user.external = scope.userData.external;
+        scope.user.appSettings = scope.userData.appSettings;
+        // For backward compatibility
+        if (scope.user.appSettings['DEFAULT_VIS_GRAPH_SCHEMA'] === undefined) {
+            scope.user.appSettings['DEFAULT_VIS_GRAPH_SCHEMA'] = true;
+        }
+
+        const pa = parseAuthorities(scope.userData.authorities);
+        $scope.userType = pa.userType;
+        $scope.grantedAuthorities = pa.grantedAuthorities;
+        $scope.customRoles = pa.customRoles;
+    };
+
+    $scope.submit = function () {
+        if ($scope.noPassword && $scope.userType === UserType.ADMIN) {
+            ModalService.openSimpleModal({
+                title: $translate.instant('security.save.admin.settings'),
+                message: $translate.instant('security.admin.pass.unset'),
+                warning: true
+            }).result.then(function () {
+                $scope.updateUser();
+            });
+        } else {
+            $scope.updateUser();
+        }
+    };
+
+    $scope.updateUserHttp = function () {
+        $scope.loader = true;
+        SecurityRestService.updateUserData({
+            username: $scope.user.username,
+            pass: ($scope.noPassword) ? '' : $scope.user.password || undefined,
+            appSettings: $scope.user.appSettings
+        }).success(function () {
+            $scope.updateCurrentUserData();
+            toastr.success($translate.instant('security.user.updated', {name: $scope.user.username}));
+            const timer = $timeout(function () {
+                $scope.loader = false;
+                $window.history.back();
+            }, 2000);
+            WorkbenchSettingsStorageService.saveWorkbenchSettings($scope.workbenchSettings);
+            $scope.$on('$destroy', function () {
+                $timeout.cancel(timer);
+            });
+        }).error(function (data) {
+            const msg = getError(data);
+            $scope.loader = false;
+            toastr.error(msg, $translate.instant('common.error'));
+        });
+    };
+
+    $scope.updateUser = function () {
+        if (!$scope.validateForm()) {
+            return false;
+        }
+        ThemeService.toggleThemeMode($scope.selectedThemeMode);
+        $scope.updateUserHttp();
+    };
+
+    $scope.validateForm = function () {
+        return $scope.validatePassword();
+    };
+
+    $scope.setThemeMode = function () {
+        $scope.selectedThemeMode = $scope.workbenchSettings.mode;
+    };
+
+    /**
+     * @param {{name: string, label: string}} theme
+     */
+    $scope.setTheme = (theme) => {
+        $scope.selectedTheme = theme;
+        $scope.workbenchSettings.theme = theme.name;
+        ThemeService.applyTheme(theme.name);
+    };
+
+    const checkLicenseStatus = () => {
+        $licenseService.checkLicenseStatus().then(() => {
+            $scope.showCookiePolicyLink = $licenseService.isTrackingAllowed();
+        }).catch((error) => {
+            const msg = getError(error.data, error.status);
+            toastr.error(msg, $translate.instant('common.error'));
+        });
+    };
+
+    $scope.showCookiePolicy = () => {
+        $uibModal.open({
+            templateUrl: 'js/angular/core/templates/cookie-policy/cookie-policy.html',
+            controller: ['$scope', function ($scope) {
+                $scope.close = () => {
+                    $scope.$close();
+                };
+            }],
+            backdrop: 'static',
+            windowClass: 'cookie-policy-modal',
+            keyboard: false
+        });
+    };
+
+    $scope.$on('$destroy', function () {
+        const workbenchSettings = WorkbenchSettingsStorageService.getWorkbenchSettings();
+        ThemeService.toggleThemeMode(workbenchSettings.mode);
+    });
+
+    const initView = () => {
+        if (!$scope.workbenchSettings) {
+            $scope.workbenchSettings = {
+                theme: 'light'
+            };
+        }
+        $scope.setThemeMode();
+        checkLicenseStatus();
+    };
+
+    initView();
+}

--- a/src/js/angular/security/controllers/user-settings.controller.js
+++ b/src/js/angular/security/controllers/user-settings.controller.js
@@ -73,7 +73,7 @@ function UserSettingsController($scope, toastr, $window, $timeout, $jwtAuth, $ro
      */
     $scope.noPassword = false;
     /**
-     * If the cookie policy banner should be visible or not.
+     * If the button that opens the cookie policy modal should be visible or not.
      * @type {boolean}
      */
     $scope.showCookiePolicyLink = false;
@@ -99,18 +99,14 @@ function UserSettingsController($scope, toastr, $window, $timeout, $jwtAuth, $ro
         });
     };
 
-    // Wrapped in a scope function for ease of testing
     $scope.getPrincipal = function () {
         return $jwtAuth.getPrincipal()
             .then((principal) => {
                 $scope.currentUserData = _.cloneDeep(principal);
+                $scope.redirectAdmin();
+                initUserData($scope);
             });
     };
-
-    $scope.getPrincipal().then(() => {
-        $scope.redirectAdmin();
-        initUserData($scope);
-    });
 
     $scope.updateCurrentUserData = function () {
         // Using $q.when to proper set values in view
@@ -264,6 +260,7 @@ function UserSettingsController($scope, toastr, $window, $timeout, $jwtAuth, $ro
                 theme: 'light'
             };
         }
+        $scope.getPrincipal();
         $scope.setThemeMode();
         showCookiePolicyLink();
     };

--- a/src/js/angular/security/plugin.js
+++ b/src/js/angular/security/plugin.js
@@ -38,7 +38,7 @@ PluginRegistry.add('route', [
         'module': 'graphdb.framework.security',
         'path': 'security/app',
         'chunk': 'security',
-        'controller': 'ChangeUserPasswordSettingsCtrl',
+        'controller': 'UserSettingsController',
         'templateUrl': 'js/angular/security/templates/user.html',
         'title': 'view.settings.title',
         'documentationUrl': 'customizing-workbench-behavior.html#user-settings'

--- a/src/js/angular/security/services/authorities-util.js
+++ b/src/js/angular/security/services/authorities-util.js
@@ -1,0 +1,52 @@
+import {UserRole, UserType, UserUtils} from "../../utils/user-utils";
+import {READ_REPO, WRITE_REPO} from "./constants";
+
+export const parseAuthorities = (authorities) => {
+    let userType = UserType.USER;
+    const grantedAuthorities = {
+        [READ_REPO]: {},
+        [WRITE_REPO]: {}
+    };
+    const repositories = {};
+    const customRoles = [];
+    for (let i = 0; i < authorities.length; i++) {
+        const role = authorities[i];
+        if (role === UserRole.ROLE_ADMIN) {
+            userType = UserType.ADMIN;
+        } else if (role === UserRole.ROLE_REPO_MANAGER) {
+            if (userType !== UserType.ADMIN) {
+                userType = UserType.REPO_MANAGER;
+            }
+        } else if (role === UserRole.ROLE_USER) {
+            userType = UserType.USER;
+        } else if (role.indexOf('READ_REPO_') === 0 || role.indexOf('WRITE_REPO_') === 0) {
+            const index = role.indexOf('_', role.indexOf('_') + 1);
+            const op = role.substr(0, index);
+            const repo = role.substr(index + 1);
+            grantedAuthorities[op][repo] = true;
+            repositories[repo] = repositories[repo] || {};
+            if (op === READ_REPO) {
+                repositories[repo].read = true;
+            } else if (op === WRITE_REPO) {
+                repositories[repo].write = true;
+            }
+        } else if (role.indexOf('CUSTOM_') === 0) {
+            customRoles.push(role.substr('CUSTOM_'.length));
+        }
+    }
+
+    return {
+        userType: userType,
+        userTypeDescription: UserUtils.getUserRoleName(userType),
+        grantedAuthorities: grantedAuthorities,
+        repositories: repositories,
+        customRoles: customRoles
+    };
+};
+
+export const createUniqueKey = function (repository) {
+    if (repository.location) {
+        return `${repository.id}@${repository.location}`;
+    }
+    return repository.id;
+};

--- a/src/js/angular/security/services/constants.js
+++ b/src/js/angular/security/services/constants.js
@@ -1,0 +1,5 @@
+export const SYSTEM_REPO = 'SYSTEM';
+export const READ_REPO = 'READ_REPO';
+export const READ_REPO_PREFIX = 'READ_REPO_';
+export const WRITE_REPO = 'WRITE_REPO';
+export const WRITE_REPO_PREFIX = 'WRITE_REPO_';


### PR DESCRIPTION
## What
Fix the error handling in my settings view so that the UI state to be properly saved or retained when server error occurs during save or update operation.

## Why
This broken error handling harms the user experience in the view.

## How
* Moved switching the theme in the success handler after user's data have been updated to prevent the inconsistency in the UI state when a server error occurs and the user update operation fails.
* Extracted the ChangeUserPasswordSettingsCtrl as UserSettingsController in separate controller file. Extracted constants and utilities in separate files.
* Also reorganized and cleaned the code in the new UserSettingsController a bit for better readability and maintainability.

## Testing


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] MR name
- [x] MR Description
- [ ] Tests
