### PR TITLE
Ensure `toggleSecurity` consistently returns a promise and remove redundant timer in `controllers.js`

### DIFF
--- a/src/js/angular/core/services/jwt-auth.service.js
+++ b/src/js/angular/core/services/jwt-auth.service.js
@@ -236,7 +236,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
 
             this.toggleSecurity = function (enabled) {
                 if (enabled !== this.securityEnabled) {
-                    SecurityRestService.toggleSecurity(enabled).then(function () {
+                    return SecurityRestService.toggleSecurity(enabled).then(function () {
                         toastr.success($translate.instant('jwt.auth.security.status', {status: ($translate.instant(enabled ? 'enabled.status' : 'disabled.status'))}));
                         AuthTokenService.clearAuthToken();
                         that.initSecurity();
@@ -245,6 +245,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                         toastr.error(err.data, $translate.instant('common.error'));
                     });
                 }
+                return Promise.resolve();
             };
 
             this.toggleFreeAccess = function (enabled, authorities, appSettings, updateFreeAccess) {

--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -213,15 +213,12 @@ securityCtrl.controller('UsersCtrl', ['$scope', '$uibModal', 'toastr', '$window'
         });
 
         $scope.toggleSecurity = function () {
-            $jwtAuth.toggleSecurity(!$jwtAuth.isSecurityEnabled());
-            if ($jwtAuth.isSecurityEnabled()) {
-                const timer = $timeout(function () {
-                    $window.location.reload();
-                }, 500);
-                $scope.$on('$destroy', function () {
-                    $timeout.cancel(timer);
+            $jwtAuth.toggleSecurity(!$jwtAuth.isSecurityEnabled())
+                .then(() => {
+                    if ($jwtAuth.isSecurityEnabled()) {
+                        $window.location.reload();
+                    }
                 });
-            }
         };
 
         $scope.toggleFreeAccess = function (updateFreeAccess) {


### PR DESCRIPTION
## WHAT:
- Modified `toggleSecurity` in `jwt-auth.service.js` to always return a promise
- Removed the `$timeout` timer and `$scope.$on('$destroy', ...)` logic in `controllers.js` that previously managed the timing of `$window.location.reload()`.

## WHY:
- Previously, a `$timeout` was used to delay `$window.location.reload()` in `controllers.js` because the state change initiated by `$jwtAuth.toggleSecurity(...)` is asynchronous. This timer was a workaround to ensure the security toggle had time to take effect
- This workaround was unreliable, as the timer might not perfectly align with the completion of the asynchronous operation, leading to inconsistencies such the user remains logged in
- By ensuring that `toggleSecurity` always returns a promise, we can now use `.then(...)` in `controllers.js` to wait for the toggle operation to complete before reloading the page

## HOW:
- Updated `toggleSecurity` to return `Promise.resolve()` if no state change is needed
- Replaced the `$timeout` and `$scope.$on('$destroy', ...)` logic in `controllers.js` with a `.then(...)` chain