### PR TITLE
(cherry-pick) GDB-11166 - Add correct subtitle to Off-heap monitoring chart

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1093,6 +1093,7 @@
     "resource.memory.heap.label": "Heap memory usage",
     "resource.memory.heap.tooltip": "Shows the heap memory used by GraphDB. The heap memory is the main memory allocated for keeping the database running and it is also used for any memory-intensive operations when needed. Approaching the maximum heap size can slow down GraphDB",
     "resource.memory.heap.max": "Maximum heap size: ",
+    "resource.memory.non_heap.max": "Maximum off-heap size: ",
     "resource.memory.non_heap.label": "Off-heap memory usage",
     "resource.memory.non_heap.tooltip": "Shows the off-heap memory used by GraphDB. The off-heap memory is used only for certain structures and should not grow substantially with time",
     "resource.memory.committed": "Committed memory",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1093,6 +1093,7 @@
     "resource.memory.heap.label": "Utilisation de la mémoire du tas",
     "resource.memory.heap.tooltip": "Montre la mémoire du tas utilisée par GraphDB. La mémoire du tas est la mémoire principale allouée pour faire fonctionner la base de données et elle est également utilisée pour toutes les opérations gourmandes en mémoire lorsque cela est nécessaire. L'approche de la taille maximale du tas peut ralentir GraphDB",
     "resource.memory.heap.max": "Taille maximale du tas : ",
+    "resource.memory.non_heap.max": "Taille maximale hors-heap : ",
     "resource.memory.non_heap.label": "Utilisation de la mémoire hors-heap",
     "resource.memory.non_heap.tooltip": "Montre la mémoire hors-heap utilisée par GraphDB. La mémoire off-heap n'est utilisée que pour certaines structures et ne devrait pas augmenter de façon substantielle avec le temps",
     "resource.memory.committed": "La mémoire engagée",

--- a/src/js/angular/resources/chart-models/resource/non-heap-memory-chart.js
+++ b/src/js/angular/resources/chart-models/resource/non-heap-memory-chart.js
@@ -5,6 +5,16 @@ export class NonHeapMemoryChart extends HeapMemoryChart {
         super(translateService, false, false);
     }
 
+    configureSubtitle(isNonHeapChart) {
+        if (this.latestData.max > 0) {
+            const subTitleKeyValues = [{
+                label: this.translateService.instant('resource.memory.non_heap.max'),
+                value: HeapMemoryChart.formatBytesValue(this.latestData.max, null, this.selectedSeries)
+            }];
+            this.setSubTitle(subTitleKeyValues);
+        }
+    }
+
     parseData(data) {
         return data.nonHeapMemoryUsage;
     }

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -1093,6 +1093,7 @@
     "resource.memory.heap.label": "Heap memory usage",
     "resource.memory.heap.tooltip": "Shows the heap memory used by GraphDB. The heap memory is the main memory allocated for keeping the database running and it is also used for any memory-intensive operations when needed. Approaching the maximum heap size can slow down GraphDB",
     "resource.memory.heap.max": "Maximum heap size: ",
+    "resource.memory.non_heap.max": "Maximum off-heap size: ",
     "resource.memory.non_heap.label": "Off-heap memory usage",
     "resource.memory.non_heap.tooltip": "Shows the off-heap memory used by GraphDB. The off-heap memory is used only for certain structures and should not grow substantially with time",
     "resource.memory.committed": "Committed memory",


### PR DESCRIPTION
## What
The subtitle for the **Off-heap memory usage chart** will be **Maximum off-heap size**.

## Why
The label used to be the same as the **Heap memory usage chart**, which incorrect. It was instantiated and applied to both charts when the **Heap memory usage chart** was created.

## How
I added a translation method for the `NonHeapMemoryChart` class. I also added a new label in the locale files.

## Testing
N/A for labels.

## Screenshots
![image](https://github.com/user-attachments/assets/a459ac7f-87ab-42fb-8451-dcb098a484d6)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] MR name
- [x] MR Description
- [x] Tests
