### PR TITLE
GDB-11179 issue with times in tooltip

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -436,7 +436,7 @@
                 "form": {
                     "agent_name": {
                         "label": "Agent name",
-                        "placeholder": "Enter user friendly name",
+                        "placeholder": "Enter а user friendly name",
                         "tooltip": "A descriptive name that helps you identify this agent."
                     },
                     "repository": {

--- a/src/js/angular/ttyg/directives/chat-item-detail.directive.js
+++ b/src/js/angular/ttyg/directives/chat-item-detail.directive.js
@@ -101,7 +101,7 @@ function ChatItemDetailComponent(toastr, $translate, TTYGContextService, TTYGSer
              * Triggers an asking how the answer was generated.
              */
             $scope.onAskHowAnswerWasDerived = () => {
-                $scope.onAskHowDeliveredAnswer({chatItem: $scope.chatItemDetail});
+                $scope.onAskHowDeliveredAnswer();
             };
 
             /**

--- a/src/js/angular/ttyg/directives/chat-panel.directive.js
+++ b/src/js/angular/ttyg/directives/chat-panel.directive.js
@@ -104,6 +104,7 @@ function ChatPanelComponent(toastr, $translate, TTYGContextService) {
             $scope.regenerateQuestion = (chatItem) => {
                 const regenerateChatItem = getEmptyChatItem();
                 regenerateChatItem.setQuestionMessage(chatItem.getQuestionMessage());
+                regenerateChatItem.question.timestamp = Date.now();
                 $scope.askingChatItem = regenerateChatItem;
                 askQuestion(regenerateChatItem);
                 scrollToBottom();
@@ -124,6 +125,7 @@ function ChatPanelComponent(toastr, $translate, TTYGContextService) {
             $scope.onAskHowDeliveredAnswer = () => {
                 const askHowDerivedAnswerChatItem = getEmptyChatItem();
                 askHowDerivedAnswerChatItem.setQuestionMessage($translate.instant('ttyg.chat_panel.btn.derive_answer.label'));
+                askHowDerivedAnswerChatItem.question.timestamp = Date.now();
                 $scope.askingChatItem = cloneDeep(askHowDerivedAnswerChatItem);
                 askQuestion(askHowDerivedAnswerChatItem);
                 scrollToBottom();

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -436,7 +436,7 @@
                 "form": {
                     "agent_name": {
                         "label": "Agent name",
-                        "placeholder": "Enter user friendly name",
+                        "placeholder": "Enter a user friendly name",
                         "tooltip": "A descriptive name that helps you identify this agent."
                     },
                     "repository": {


### PR DESCRIPTION
## What
When the "Regenerate" or "How did you derive this answer?" buttons are clicked, the tooltip showing the time for questions and answers is incorrect.

## Why
Upon asking a question, the chat messages list in the UI is updated so the question becomes visible immediately after the user clicks the "Ask" button. Therefore, the question time needs to be set on the chatItem passed to the askQuestion function. This behavior already works for regular questions, but in the "Regenerate" and "How did you derive this answer?" scenarios, the time was not set before askQuestion was called.

## How
The question time is now set before calling the askQuestion function when the "Regenerate" or "How did you derive this answer?" buttons are clicked.

## Testing


## Screenshots
 ### Before
![image](https://github.com/user-attachments/assets/855c736a-a682-4a44-bdbd-1db855922c44)
![image](https://github.com/user-attachments/assets/0c1a7a93-ad3a-4e5f-b3f3-5f2850db5bcf)


### After
![image](https://github.com/user-attachments/assets/f53e77b9-c715-48bb-9e46-91fac599bc17)
![image](https://github.com/user-attachments/assets/a290461e-c290-4b17-a712-2ba792caa7ac)


## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] MR name
- [ ] MR Description
- [ ] Tests
