### PR TITLE
GDB-11177 agent id should not be persisted in local storage anymore

### DIFF
--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -694,24 +694,6 @@ function TTYGViewCtrl(
      */
     const onAgentSelected = (agent) => {
         $scope.selectedAgent = agent;
-        TTYGStorageService.saveAgent(agent);
-    };
-
-    /**
-     * Loads an agent using the agent ID stored in the local storage and selects it.
-     */
-    const setCurrentAgent = () => {
-        const agentId = TTYGStorageService.getAgentId();
-        if (!agentId) {
-            return;
-        }
-        TTYGService.getAgent(agentId).then((agent) => {
-            if (agent) {
-                TTYGContextService.selectAgent(agent);
-            }
-        }).catch((error) => {
-            toastr.error(getError(error, 0, TTYG_ERROR_MSG_LENGTH));
-        });
     };
 
     /**
@@ -880,7 +862,6 @@ function TTYGViewCtrl(
             .then(() => {
                 $scope.initialized = true;
                 buildAgentsFilterModel();
-                setCurrentAgent();
                 return loadChats();
             })
             .then(setCurrentChat);

--- a/src/js/angular/ttyg/directives/chat-panel.directive.js
+++ b/src/js/angular/ttyg/directives/chat-panel.directive.js
@@ -167,6 +167,8 @@ function ChatPanelComponent(toastr, $translate, TTYGContextService) {
                 $scope.chatItem = getEmptyChatItem();
                 $scope.askingChatItem = undefined;
                 if ($scope.chat) {
+                    // TODO: Why on earth this is here? The chat changed handler is in the ttyg.view. Why doesn't it handle this
+                    // but we need to go through 2 more events to achieve the same result?
                     const lastChatItem = $scope.chat.chatHistory.getLast();
                     if (lastChatItem && lastChatItem.agentId) {
                         TTYGContextService.selectAgent(TTYGContextService.getAgent(lastChatItem.agentId));

--- a/test-cypress/integration/ttyg/create-chat.spec.js
+++ b/test-cypress/integration/ttyg/create-chat.spec.js
@@ -61,7 +61,6 @@ describe('TTYG create chat', () => {
         TTYGStubs.stubAgentGet();
         TTYGViewSteps.visit();
         cy.wait('@get-chat-list');
-        cy.wait('@get-agent');
         // Then I expect newly created chat be selected.
         TTYGViewSteps.getChatFromGroup(0, 0).should('contain', 'New chat of Han Solo is a character');
         TTYGViewSteps.getChatFromGroup(0, 0).should('have.class', 'selected');


### PR DESCRIPTION
## What
The agent id should not be persisted in the local storage anymore.

## Why
This leads to some unwanted behavior when the recently selected agent was deleted or the repository is changed where the view in certain scenarios is trying to load the agent using the saved agent id but it can't. This functionality is now replaced by the feature where the agent is derived by the most recent chat.

## How
Removed the steps for persisting and loading of agent by saved id on page load.

## Testing
Existing tests were updated.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] MR name
- [x] MR Description
- [x] Tests
