### PR TITLE
GDB-11179 issue with times in tooltip

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -436,7 +436,7 @@
                 "form": {
                     "agent_name": {
                         "label": "Agent name",
-                        "placeholder": "Enter user friendly name",
+                        "placeholder": "Enter а user friendly name",
                         "tooltip": "A descriptive name that helps you identify this agent."
                     },
                     "repository": {

--- a/src/js/angular/ttyg/directives/chat-item-detail.directive.js
+++ b/src/js/angular/ttyg/directives/chat-item-detail.directive.js
@@ -101,7 +101,7 @@ function ChatItemDetailComponent(toastr, $translate, TTYGContextService, TTYGSer
              * Triggers an asking how the answer was generated.
              */
             $scope.onAskHowAnswerWasDerived = () => {
-                $scope.onAskHowDeliveredAnswer({chatItem: $scope.chatItemDetail});
+                $scope.onAskHowDeliveredAnswer();
             };
 
             /**

--- a/src/js/angular/ttyg/directives/chat-panel.directive.js
+++ b/src/js/angular/ttyg/directives/chat-panel.directive.js
@@ -104,6 +104,7 @@ function ChatPanelComponent(toastr, $translate, TTYGContextService) {
             $scope.regenerateQuestion = (chatItem) => {
                 const regenerateChatItem = getEmptyChatItem();
                 regenerateChatItem.setQuestionMessage(chatItem.getQuestionMessage());
+                regenerateChatItem.question.timestamp = Date.now();
                 $scope.askingChatItem = regenerateChatItem;
                 askQuestion(regenerateChatItem);
                 scrollToBottom();
@@ -124,6 +125,7 @@ function ChatPanelComponent(toastr, $translate, TTYGContextService) {
             $scope.onAskHowDeliveredAnswer = () => {
                 const askHowDerivedAnswerChatItem = getEmptyChatItem();
                 askHowDerivedAnswerChatItem.setQuestionMessage($translate.instant('ttyg.chat_panel.btn.derive_answer.label'));
+                askHowDerivedAnswerChatItem.question.timestamp = Date.now();
                 $scope.askingChatItem = cloneDeep(askHowDerivedAnswerChatItem);
                 askQuestion(askHowDerivedAnswerChatItem);
                 scrollToBottom();

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -436,7 +436,7 @@
                 "form": {
                     "agent_name": {
                         "label": "Agent name",
-                        "placeholder": "Enter user friendly name",
+                        "placeholder": "Enter a user friendly name",
                         "tooltip": "A descriptive name that helps you identify this agent."
                     },
                     "repository": {


### PR DESCRIPTION
## What
When the "Regenerate" or "How did you derive this answer?" buttons are clicked, the tooltip showing the time for questions and answers is incorrect.

## Why
Upon asking a question, the chat messages list in the UI is updated so the question becomes visible immediately after the user clicks the "Ask" button. Therefore, the question time needs to be set on the chatItem passed to the askQuestion function. This behavior already works for regular questions, but in the "Regenerate" and "How did you derive this answer?" scenarios, the time was not set before askQuestion was called.

## How
The question time is now set before calling the askQuestion function when the "Regenerate" or "How did you derive this answer?" buttons are clicked.

### Additional work
 Update the label of the agent name placeholder


## Testing


## Screenshots
### Before
![image](https://github.com/user-attachments/assets/c42a0a6d-95c8-4a7c-bd73-d9274de8557f)

![image](https://github.com/user-attachments/assets/1c9cc518-06be-4deb-b46a-1abe75b15ae4)

### After
![image](https://github.com/user-attachments/assets/8167e2b8-4826-44ec-9e20-af243acf44cd)

![image](https://github.com/user-attachments/assets/15e0f60e-8f62-4648-bef6-c78d68f0a53d)



## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] MR name
- [x] MR Description
- [ ] Tests
