### PR TITLE
GDB-11134 fix error handling in JDBC view

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
     "extends": [
         "eslint:recommended",
-        "google"
+        "google",
+        "plugin:cypress/recommended"
     ],
     "rules": {
         "no-console": "error",
@@ -34,8 +35,12 @@
     "env": {
         "es6": true,
         "browser": true,
-        "amd": true
+        "amd": true,
+        "cypress/globals": true
     },
+    "plugins": [
+        "cypress"
+    ],
     "globals": {
         "angular": true,
         "$": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
                 "ejs-loader": "^0.5.0",
                 "eslint": "^5.16.0",
                 "eslint-config-google": "^0.13.0",
+                "eslint-plugin-cypress": "^4.1.0",
                 "expose-loader": "^0.7.5",
                 "extract-loader": "^5.1.0",
                 "file-loader": "^4.3.0",
@@ -4935,6 +4936,30 @@
             },
             "peerDependencies": {
                 "eslint": ">=5.16.0"
+            }
+        },
+        "node_modules/eslint-plugin-cypress": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-4.1.0.tgz",
+            "integrity": "sha512-JhqkMY02mw74USwK9OFhectx3YSj6Co1NgWBxlGdKvlqiAp9vdEuQqt33DKGQFvvGS/NWtduuhWXWNnU29xDSg==",
+            "dev": true,
+            "dependencies": {
+                "globals": "^15.11.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=9"
+            }
+        },
+        "node_modules/eslint-plugin-cypress/node_modules/globals": {
+            "version": "15.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-15.12.0.tgz",
+            "integrity": "sha512-1+gLErljJFhbOVyaetcwJiJ4+eLe45S2E7P5UiZ9xGfeq3ATQf5DOv9G7MH3gGbKQLkzmNh2DxfZwLdw+j6oTQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "ejs-loader": "^0.5.0",
         "eslint": "^5.16.0",
         "eslint-config-google": "^0.13.0",
+        "eslint-plugin-cypress": "^4.1.0",
         "expose-loader": "^0.7.5",
         "extract-loader": "^5.1.0",
         "file-loader": "^4.3.0",

--- a/src/js/angular/jdbc/controllers.js
+++ b/src/js/angular/jdbc/controllers.js
@@ -346,7 +346,7 @@ function JdbcCreateCtrl(
             query: jdbcConfigurationInfo.query,
             columns: jdbcConfigurationInfo.columns
         };
-        JdbcRestService.updateJdbcConfiguration(configuration)
+        return JdbcRestService.updateJdbcConfiguration(configuration)
             .then(() => {
                 $scope.isDirty = false;
                 $scope.jdbcConfigurationInfo.isNewConfiguration = false;

--- a/test-cypress/integration/setup/jdbc/jdbc-create.spec.js
+++ b/test-cypress/integration/setup/jdbc/jdbc-create.spec.js
@@ -1,12 +1,12 @@
-import {JdbcSteps} from "../../steps/setup/jdbc-steps";
-import {JdbcCreateSteps} from "../../steps/setup/jdbc-create-steps";
-import {ToasterSteps} from "../../steps/toaster-steps";
-import {YasrSteps} from "../../steps/yasgui/yasr-steps";
-import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../steps/modal-dialog-steps";
-import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
-import {MainMenuSteps} from "../../steps/main-menu-steps";
-import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";
-import {YasguiLoader} from "../../steps/yasgui/yasgui-loader";
+import {JdbcSteps} from "../../../steps/setup/jdbc-steps";
+import {JdbcCreateSteps} from "../../../steps/setup/jdbc-create-steps";
+import {ToasterSteps} from "../../../steps/toaster-steps";
+import {YasrSteps} from "../../../steps/yasgui/yasr-steps";
+import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../../steps/modal-dialog-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {RepositorySelectorSteps} from "../../../steps/repository-selector-steps";
+import {YasguiLoader} from "../../../steps/yasgui/yasgui-loader";
 
 const FILE_TO_IMPORT = '200-row-allianz.ttl';
 const DEFAULT_QUERY = 'PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n' +
@@ -229,7 +229,6 @@ describe('JDBC configuration', () => {
         // Then I expect the new page is loaded.
         JdbcSteps.verifyUrl();
     });
-
 
     it('should display confirm message when configuration name is changed', () => {
         // When I open the create JDBC configuration page,

--- a/test-cypress/integration/setup/jdbc/jdbc.spec.js
+++ b/test-cypress/integration/setup/jdbc/jdbc.spec.js
@@ -1,22 +1,19 @@
-import {JdbcSteps} from "../../steps/setup/jdbc-steps";
-import {JdbcCreateSteps} from "../../steps/setup/jdbc-create-steps";
-import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
-import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
+import {JdbcSteps} from "../../../steps/setup/jdbc-steps";
+import {JdbcCreateSteps} from "../../../steps/setup/jdbc-create-steps";
+import {ModalDialogSteps} from "../../../steps/modal-dialog-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {JdbcStubs} from "../../../stubs/jdbc/jdbc-stubs";
+import {ApplicationSteps} from "../../../steps/application-steps";
 
 const FILE_TO_IMPORT = '200-row-allianz.ttl';
-const EDIT_QUERY = "PREFIX ex:<http://example.com/#>\n" +
-    "PREFIX base:<http://example/base/>\n" +
-    "PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>\n" +
-    "PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" +
-    "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n" +
-    "\n" +
-    "select ?id ?fraud_score ?customer_loyalty where { \n" +
-    "\t?id rdf:type ex:Customer;\n" +
-    "      \tex:fraudScore ?fraud_score;\n" +
-    "       \tex:customerLoyalty ?customer_loyalty_id.\n" +
-    "    ?customer_loyalty_id rdfs:label ?customer_loyalty.\n" +
-    "    # !filter\n" +
-    "}  ";
+
+// The closing brace is intentionally omitted because when cypress types in the query, the editor will automatically add it.
+const EDIT_QUERY = `
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    SELECT ?id ?label {
+        ?id rdfs:label ?label
+        #!filter
+`;
 
 describe('JDBC configuration', () => {
 
@@ -34,7 +31,7 @@ describe('JDBC configuration', () => {
         cy.deleteRepository(repositoryId);
     });
 
-    it('Should not create a new JDBC configuration click on cancel button', () => {
+    it('Should be able to cancel JDBC configuration creation', () => {
         // When I am on JDBC configurations page and click on create a new table configuration button.
         JdbcSteps.clickOnCreateJdbcConfigurationButton();
 
@@ -82,7 +79,8 @@ describe('JDBC configuration', () => {
         // When I click on edit button,
         JdbcSteps.clickOnEditButton();
         // change the query,
-        YasqeSteps.pasteQuery(EDIT_QUERY);
+        YasqeSteps.clearEditor();
+        YasqeSteps.writeInEditor(EDIT_QUERY);
         // and click on save button.
         JdbcCreateSteps.clickOnSave();
 
@@ -113,13 +111,6 @@ describe('JDBC configuration', () => {
         JdbcSteps.clickOnDeleteButton();
 
         // Then I expect to be asked to confirm the deletion,
-        // and click on cancel dialog button.
-        ModalDialogSteps.clickOnCancelButton();
-
-        // When I click on delete button.
-        JdbcSteps.clickOnDeleteButton();
-
-        // Then I expect to be asked to confirm the deletion,
         // and when click on confirm dialog button.
         ModalDialogSteps.clickOnConfirmButton();
 
@@ -127,4 +118,43 @@ describe('JDBC configuration', () => {
         JdbcSteps.getJDBCConfigurations().should('contain', 'No tables are defined');
     });
 
+    it('Should show error notification on server error during jdbc configuration creation', () => {
+        // Given that the server will return an error on saving the JDBC configuration
+        JdbcStubs.stubJdbcCreateError();
+        // And I have configured a new JDBC configuration
+        JdbcSteps.clickOnCreateJdbcConfigurationButton();
+        JdbcCreateSteps.verifyUrl();
+        JdbcCreateSteps.typeTableName('JdbcTest');
+        JdbcCreateSteps.openColumnTypesTab();
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 2);
+        // When I click on save button.
+        JdbcCreateSteps.clickOnSave();
+        // Then I expect to see a notification with the error message.
+        ApplicationSteps.getErrorNotifications().should('contain', 'Could not save SQL table configuration');
+        // And the configuration to not be created.
+        cy.url().should('include', '/jdbc/configuration/create');
+        JdbcCreateSteps.getSaveButton().should('be.visible').and('be.enabled');
+    });
+
+    it('Should show error notification on server error during jdbc configuration creation', () => {
+        // Given that the server will return an error on saving the JDBC configuration
+        JdbcStubs.stubJdbcUpdateError();
+        // And I have configured and saved a new JDBC configuration
+        JdbcSteps.clickOnCreateJdbcConfigurationButton();
+        JdbcCreateSteps.verifyUrl();
+        JdbcCreateSteps.typeTableName('JdbcTest2');
+        JdbcCreateSteps.openColumnTypesTab();
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 2);
+        JdbcCreateSteps.clickOnSave();
+        JdbcSteps.verifyUrl();
+        JdbcSteps.getJDBCConfigurationResults().should('have.length', 1);
+        // When I edit the configuration
+        JdbcSteps.clickOnEditButton();
+        YasqeSteps.clearEditor();
+        YasqeSteps.writeInEditor(EDIT_QUERY);
+        // And click on save button.
+        JdbcCreateSteps.clickOnSave();
+        // Then I expect to see a notification with the error message.
+        ApplicationSteps.getErrorNotifications().should('contain', 'Could not save SQL table configuration');
+    });
 });

--- a/test-cypress/stubs/jdbc/jdbc-stubs.js
+++ b/test-cypress/stubs/jdbc/jdbc-stubs.js
@@ -1,0 +1,19 @@
+export class JdbcStubs {
+    static stubJdbcCreateError() {
+        cy.intercept('POST', '/rest/sql-views/tables/', {
+            statusCode: 500,
+            response: {
+                error: 'Internal Server Error'
+            }
+        }).as('create-jdbc-configuration-error');
+    }
+
+    static stubJdbcUpdateError() {
+        cy.intercept('PUT', '/rest/sql-views/tables/**', {
+            statusCode: 500,
+            response: {
+                error: 'Internal Server Error'
+            }
+        }).as('update-jdbc-configuration-error');
+    }
+}


### PR DESCRIPTION
* GDB-11134 fix error handling in JDBC view

## What
Fix error handling in JDBC view.

## Why
The promise from the update request for the JDBC config was not returned by the method used in the controller which made the handler to misbehave.

## How
Changed the update method to return the promise so that the handler to be able to react on the success and errors.

* Moved specs for the JDBC view in separate folder

* Installed cypress plugin for ESLint to help with the analysis and get rid of the warnings in the test specs for undefined cypress stuff.

* Refactored and fixed jdbc tests and added tests to cover the scenarios with server errors during save and update.

(cherry picked from commit cd4bfbf576c49a7ad80dcae0e27588ca18328309)

## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] MR name
- [ ] MR Description
- [ ] Tests
