### PR TITLE
GDB-11180 Replace hardcoded error message when creating new chat (#1688)

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -325,7 +325,6 @@
                 }
             },
             "messages": {
-                "create_failure": "Failed to create new conversation. Please try again.",
                 "rename_failure": "Failed to rename the conversation. Please try again.",
                 "delete_failure": "Failed to delete the conversation. Please try again.",
                 "export_failure": "Failed to export the conversation. Please try again."

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -325,7 +325,6 @@
                 }
             },
             "messages": {
-                "create_failure": "Échec de la création de la conversation. Veuillez réessayer.",
                 "rename_failure": "Échec du renommage de la conversation. Veuillez réessayer.",
                 "delete_failure": "Échec de la suppression de la conversation. Veuillez réessayer.",
                 "export_failure": "Échec de l'exportation de la conversation. Veuillez réessayer."

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -450,9 +450,9 @@ function TTYGViewCtrl(
                     updateChatAnswersFirstResponse(selectedChat, chatItem, chatAnswer);
                 }
             })
-            .catch(() => {
+            .catch((error) => {
                 TTYGContextService.emit(TTYGEventName.CREATE_CHAT_FAILURE);
-                toastr.error($translate.instant('ttyg.chat.messages.create_failure'));
+                toastr.error(getError(error, 0, TTYG_ERROR_MSG_LENGTH));
             });
     };
 

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -325,7 +325,6 @@
                 }
             },
             "messages": {
-                "create_failure": "Failed to create new conversation. Please try again.",
                 "rename_failure": "Failed to rename the conversation. Please try again.",
                 "delete_failure": "Failed to delete the conversation. Please try again.",
                 "export_failure": "Failed to export the conversation. Please try again."


### PR DESCRIPTION
## What
* Replace hardcoded error message with the error returned by the server when creating a new chat, because there might be many reasons for a chat creation to fail and it is not user friendly
* Increase GDB version used for tests
* Moved specs for similarity index in separate folder

## Why


## How


## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] MR name
- [ ] MR Description
- [ ] Tests

(cherry picked from commit ffe6d7ac4a94ea72e32681a7c6588ce0636cbfb3)