### PR TITLE
Cherry-pick GDB-11134 fix error handling in namespace view (#1661)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,7 +26,7 @@
         "key-spacing": "off"
     },
     "parserOptions": {
-        "ecmaVersion": 2016,
+        "ecmaVersion": 2017,
         "sourceType": "module",
         "ecmaFeatures": {
             "impliedStrict": true

--- a/test-cypress/steps/setup/namespace-steps.js
+++ b/test-cypress/steps/setup/namespace-steps.js
@@ -1,0 +1,211 @@
+export class NamespaceSteps {
+    static visit() {
+        cy.visit('/namespaces');
+    }
+
+    static getNamespacesView() {
+        return cy.get('#wb-namespaces');
+    }
+
+    // ------ Generic ------
+
+    static waitUntilPageIsLoaded() {
+        // Workbench loading screen should not be visible
+        cy.get('.ot-splash').should('not.be.visible');
+
+        // No active loader
+        cy.get('.ot-loader').should('not.be.visible');
+
+        this.getAddNamespaceForm().should('be.visible');
+    }
+
+    static getNoNamespacesAlert() {
+        return this.getNamespacesView().find('.no-namespaces-alert');
+    }
+
+    static getNoNamespacesMatchAlert() {
+        return this.getNamespacesView().find('.no-namespaces-match-alert');
+    }
+
+    // ------ Add namespaces ------
+
+    static getAddNamespaceForm() {
+        return this.getNamespacesView().find('.add-namespace-form');
+    }
+
+    static getNamespacePrefixField() {
+        return this.getAddNamespaceForm().find('#wb-namespaces-prefix');
+    }
+
+    static typeNamespacePrefix(prefix) {
+        this.getNamespacePrefixField().type(prefix);
+    }
+
+    static getNamespaceValueField() {
+        return this.getAddNamespaceForm().find('#wb-namespaces-namespace');
+    }
+
+    static typeNamespaceURI(uri) {
+        this.getNamespaceValueField().type(uri);
+    }
+
+    static getAddNamespaceButton() {
+        return this.getAddNamespaceForm().find('#wb-namespaces-addNamespace');
+    }
+
+    static addNamespace() {
+        this.getAddNamespaceButton().click();
+    }
+
+    // ------ Namespaces per page ------
+
+    static getNamespacesPerPageMenu() {
+        return cy.get('.namespaces-per-page-menu');
+    }
+
+    // ------ Namespaces results header ------
+
+    static getNamespacesResultHeader() {
+        return cy.get('.namespaces-result-header');
+    }
+
+    static getNamespacesFilterField() {
+        return this.getNamespacesResultHeader().find('.namespaces-filter');
+    }
+
+    static getNamespacesHeaderPagination() {
+        return this.getNamespacesResultHeader().find('.namespaces-header-pagination .pagination');
+    }
+
+    static getNamespacesHeaderPaginationInfo() {
+        return this.getNamespacesResultHeader().find('.showing-info-namespaces');
+    }
+
+    // ------ Namespaces results ------
+
+    static getNamespacesTable() {
+        return cy.get('#wb-namespaces-namespaceInNamespaces');
+    }
+
+    static getSelectAllNamespacesCheckbox() {
+        return this.getNamespacesTable().find('.select-all-namespaces');
+    }
+
+    static getDeleteNamespacesButton() {
+        return this.getNamespacesTable().get('[data-cy="delete-several-prefixes"]');
+    }
+
+    static getNamespaces() {
+        return this.getNamespacesTable().find('.namespace');
+    }
+
+    static getNamespacePrefix(index) {
+        return this.getNamespaces().eq(index).find('.namespace-prefix').invoke('text');
+    }
+
+    static getNamespaceValue(index) {
+        return this.getNamespaces().eq(index).find('.namespaceURI').invoke('text');
+    }
+
+    static getRefreshedTableNamespaces() {
+        cy.get('[data-cy="namespaces-per-page-menu"]').click()
+            .get('[data-cy="all-label"]').click();
+    }
+
+    static getNamespace(prefix) {
+        return this.getNamespacesTable().find('.namespace')
+            .should('be.visible')
+            .find('.namespace-prefix')
+            .should('be.visible')
+            .contains(prefix)
+            .should('be.visible')
+            .parentsUntil('tbody')
+            .last();
+    }
+
+    static getSelectNamespaceCheckbox(prefix) {
+        return this.getNamespace(prefix)
+            .should('be.visible')
+            .find('.select-namespace');
+    }
+
+    static selectNamespace(prefix) {
+        this.getSelectNamespaceCheckbox(prefix).click();
+    }
+
+    static getEditNamespaceButton(prefix) {
+        return this.getNamespace(prefix)
+            .should('be.visible')
+            .find('.edit-namespace-btn');
+    }
+
+    static editNamespaceByIndex(index) {
+        this.getNamespaces().eq(index).find('.edit-namespace-btn').click();
+    }
+
+    static getInlineNamespacePrefix(index) {
+        return this.getNamespaces().eq(index).find('.namespace-prefix').siblings('.editable-text').find('input');
+    }
+
+    static typeInlineNamespacePrefix(index, prefix) {
+        this.getInlineNamespacePrefix(index).clear().type(prefix);
+    }
+
+    static getInlineNamespaceValue(index) {
+        return this.getNamespaces().eq(index).find('.namespaceURI').siblings('.editable-url').find('input');
+    }
+
+    static typeInlineNamespaceValue(index, namespace) {
+        this.getInlineNamespaceValue(index).clear().type(namespace);
+    }
+
+    static getSaveInlineNamespaceButton(index) {
+        return this.getNamespaces().eq(index).find('button[type="submit"]');
+    }
+
+    static saveInlineNamespace(index) {
+        this.getSaveInlineNamespaceButton(index).click();
+    }
+
+    // TODO: Not used yet
+    static editNamespace(prefix) {
+        this.getEditNamespaceButton(prefix).click();
+    }
+
+    static getDeleteNamespaceButton(prefix) {
+        return this.getNamespace(prefix)
+            .should('be.visible')
+            .get(`[data-cy="delete-pref_${prefix}"]`)
+            .should('be.visible');
+    }
+
+    static deleteNamespace(prefix) {
+        this.getDeleteNamespaceButton(prefix).should('be.visible').click();
+    }
+
+    // ------ Namespaces pagination ------
+
+    static getNamespacesPagination() {
+        return this.getNamespacesView().find('.namespaces-pagination .pagination');
+    }
+
+    static getDefaultNamespacesLength(namespacesObject) {
+        return Object.keys(namespacesObject).length;
+    }
+
+    static getPagingCount(namespacesObject) {
+        const count = this.getDefaultNamespacesLength(namespacesObject);
+        if (count <= 10) {
+            return 1;
+        }
+        if (count <= 20) {
+            return 2;
+        }
+        if (count <= 50) {
+            return 3;
+        }
+        if (count <= 100) {
+            return 4;
+        } else return 5;
+    }
+}

--- a/test-cypress/stubs/namespace-stubs.js
+++ b/test-cypress/stubs/namespace-stubs.js
@@ -7,4 +7,9 @@ export class NamespaceStubs {
     static stubNameSpaceResponse(repositoryId, fixture, withDelay = 0) {
         cy.intercept(`/repositories/${repositoryId}/namespaces`, {fixture, delay: withDelay}).as(`${repositoryId}-stub-namespaces`);
     }
+
+    static stubErrorOnNamespaceUpdate(repositoryId) {
+        cy.intercept('PUT', `/repositories/${repositoryId}/namespaces/*`,
+            {statusCode: 500, body: 'Internal Server Error'}).as(`stub-namespace-update-error`);
+    }
 }


### PR DESCRIPTION
## What
Fixing the error handling in the namespaces view.

## Why
Error handling in the namespace view is practically missing which makes the UI to behave in unexpected ways. For example, when user tries to edit a namespace, but the server returns some error, the UI updated, although it mustn't.

## How
* Implemented error handling for create and edit namespace operation.
* Did some minor refactoring and removed some duplications.
* Implemented tests.

Updated jsdoc

(cherry picked from commit 15bc755564ea651e5036c515134f17e5a8322b0b)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] MR name
- [x] MR Description
- [x] Tests
