### PR TITLE
Cherry-pick GDB-11171 - show ellipsis on long chat names and show full name on hover, with the help of a new directive.

### DIFF
--- a/src/css/ttyg/chat-list.css
+++ b/src/css/ttyg/chat-list.css
@@ -61,7 +61,7 @@
     width: 90%;
 }
 
-.chat-list-component .chat-item .chat-name .inline-editable-text {
+.chat-list-component .chat-item .chat-name .inline-editable-text .editable-text-element {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/js/angular/core/directives/inline-editable-text/templates/inline-editable-text.template.html
+++ b/src/js/angular/core/directives/inline-editable-text/templates/inline-editable-text.template.html
@@ -1,6 +1,6 @@
 <div class="inline-editable-text">
-    <div ng-if="!isEditing"
-          ng-click="onSelect()">
+    <div ng-if="!isEditing" class="editable-text-element"
+         ng-click="onSelect()">
         {{ source[fieldName] || '&nbsp;'}}
     </div>
 

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -3,6 +3,7 @@ import 'angular/ttyg/directives/chat-panel.directive';
 import 'angular/ttyg/directives/agent-list.directive';
 import 'angular/ttyg/directives/agent-select-menu.directive';
 import 'angular/ttyg/directives/no-agents-view.directive';
+import 'angular/ttyg/directives/show-tooltip-on-overflow.directive';
 import 'angular/ttyg/controllers/agent-settings-modal.controller';
 import 'angular/core/services/ttyg.service';
 import 'angular/ttyg/services/ttyg-context.service';
@@ -31,6 +32,7 @@ const modules = [
     'graphdb.framework.ttyg.directives.agent-list',
     'graphdb.framework.ttyg.directives.agent-select-menu',
     'graphdb.framework.ttyg.directives.no-agents-view',
+    'graphdb.framework.ttyg.directives.show-tooltip-on-overflow',
     'graphdb.framework.ttyg.controllers.agent-settings-modal'
 ];
 

--- a/src/js/angular/ttyg/directives/show-tooltip-on-overflow.directive.js
+++ b/src/js/angular/ttyg/directives/show-tooltip-on-overflow.directive.js
@@ -1,0 +1,25 @@
+const modules = [];
+
+angular
+    .module('graphdb.framework.ttyg.directives.show-tooltip-on-overflow', modules)
+    .directive('showTooltipOnOverflow', ShowTooltipOnOverflow);
+
+function ShowTooltipOnOverflow() {
+    return {
+        link: function(scope, element) {
+            function updateTooltip() {
+                const innerTextElement = element[0].querySelector('.editable-text-element');
+                if (!innerTextElement) return;
+
+                if (innerTextElement.scrollWidth > innerTextElement.clientWidth) {
+                    element.attr('title', scope.chat.name);
+                } else {
+                    element.removeAttr('title');
+                }
+            }
+
+            // Needed in order to have values for scrollWidth and clientWidth
+            setTimeout(updateTooltip, 0);
+        }
+    };
+}

--- a/src/js/angular/ttyg/templates/chat-list.html
+++ b/src/js/angular/ttyg/templates/chat-list.html
@@ -16,7 +16,9 @@
                                 on-save="onRenameChat(newText, source)"
                                 on-cancel="onCancelChatRenaming()"
                                 on-dblclick="onSelectChatForRenaming(chat)"
-                                on-click="onSelectChat(source)">
+                                on-click="onSelectChat(source)"
+                                title="{{chat.name}}"
+                                show-tooltip-on-overflow>
                             </inline-editable-text>
                         </div>
                         <div ng-if="chat.id && (!renamedChat || chat.id !== renamedChat.id)" class="btn-group">


### PR DESCRIPTION
## What
Long chat names will be truncated with an ellipsis. The user can see the longer name on hover.

## Why
The names were not truncated, due to an incorrect selector.

## How
I added the correct selector and a directive, which works on hover to add the long name as a tooltip.

(cherry picked from commit cca49af52da291948c25ab2566d756090e50e283)

## Screenshots
![image](https://github.com/user-attachments/assets/d8ed9883-9bb5-465b-bde3-c94a092b44e7)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] MR name
- [x] MR Description
