### PR TITLE
GDB-11134 fix error handling in similarity indexes view

### DIFF
--- a/src/css/create-similarity-index.css
+++ b/src/css/create-similarity-index.css
@@ -14,3 +14,9 @@ yasgui-component .CodeMirror {
 .keyboard-shortcuts-dialog-wrapper {
     margin-top: -21px;
 }
+
+.create-similarity-index-btn .saving-index-loader,
+.create-similarity-index-btn .save-query-btn {
+    position: relative;
+    bottom: -3px
+}

--- a/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/src/js/angular/similarity/controllers/create-index.controller.js
@@ -76,6 +76,11 @@ function CreateSimilarityIdxCtrl(
     $scope.saveOrUpdateExecuted = false;
     $scope.loadingControllerResources = false;
     $scope.helpHidden = LocalStorageAdapter.get(LSKeys.HIDE_SIMILARITY_HELP) === 1;
+    /**
+     * Flag that indicates if the index save operation is in progress.
+     * @type {boolean}
+     */
+    $scope.savingIndex = false;
 
     let isDirty = false;
     let searchQueries = undefined;
@@ -146,16 +151,21 @@ function CreateSimilarityIdxCtrl(
      */
     $scope.createSimilarityIndex = () => {
         $scope.saveOrUpdateExecuted = true;
+        $scope.savingIndex = true;
         updateQueryFromEditor($scope.similarityIndexInfo)
             .then(validateQuery)
             .then(validateQueryType)
             .then(validateSimilarityIndex)
             .then(validateSimilarityIndexNameExistence)
             .then((similarityIndexInfo) => createIndex(similarityIndexInfo.getSimilarityIndex()))
+            .then(() => goToSimilarityIndexesView())
             .catch((error) => {
                 if (!(error instanceof SimilarityIndexError)) {
                     toastr.error(getError(error), $translate.instant('similarity.could.not.get.indexes.error'));
                 }
+            })
+            .finally(() => {
+                $scope.savingIndex = false;
             });
     };
 
@@ -185,24 +195,34 @@ function CreateSimilarityIdxCtrl(
     }
 
     $scope.saveSearchQuery = function () {
-        $scope.saveOrUpdateExecuted = true;
         if (!isDirty) {
-            goToSimilarityIndexesView();
+            $location.url('similarity');
+        } else {
+            $scope.saveOrUpdateExecuted = true;
+            $scope.savingIndex = true;
+            updateQueryFromEditor($scope.similarityIndexInfo)
+                .then(validateSimilarityIndexName)
+                .then(validateQuery)
+                .then(validateQueryType)
+                .then(validateSearchQuery)
+                .then(validateAnalogicalQuery)
+                .then(saveQuery)
+                .then((isSearchQuery) => {
+                    // toastr should be triggered before the redirect because the redirect will remove the toast
+                    return Notifications.showToastMessageWithDelay(isSearchQuery ? 'similarity.changed.search.query.msg' : 'similarity.changed.analogical.query.msg');
+                })
+                .then(() => {
+                    $location.url('similarity');
+                })
+                .catch((error) => {
+                    if (!(error instanceof SimilarityIndexError)) {
+                        toastr.error(getError(error), $translate.instant('similarity.change.query.error'));
+                    }
+                })
+                .finally(() => {
+                    $scope.savingIndex = false;
+                });
         }
-        $scope.saveOrUpdateExecuted = true;
-        updateQueryFromEditor($scope.similarityIndexInfo)
-            .then(validateSimilarityIndexName)
-            .then(validateQuery)
-            .then(validateQueryType)
-            .then(validateSearchQuery)
-            .then(validateAnalogicalQuery)
-            .then(saveQuery)
-            .then(notifySaveSuccess)
-            .catch((error) => {
-                if (!(error instanceof SimilarityIndexError)) {
-                    toastr.error(getError(error), $translate.instant('similarity.change.query.error'));
-                }
-            });
     };
 
     /**
@@ -561,10 +581,6 @@ function CreateSimilarityIdxCtrl(
             similarityIndex.options = similarityIndex.options + (similarityIndex.options === '' ? '' : ' ') + '-literal_index' + ' true';
             similarityIndex.type = SimilarityIndexType.TEXT_LITERAL;
         }
-        // TODO this can be very slowly, old implementation redirect to the indexes view before execute the query
-        // ask the team if this have to be like old implementation or we can show a dialog that describes that creation of query is slow
-        // and can take a time. We can ask tha user to stay on page or live it
-        goToSimilarityIndexesView();
         isDirty = false;
         return SimilarityRestService.createIndex('POST',
             similarityIndex.name,
@@ -593,6 +609,7 @@ function CreateSimilarityIdxCtrl(
         await Notifications.showToastMessageWithDelay(isSearchQuery ? 'similarity.changed.search.query.msg' : 'similarity.changed.analogical.query.msg');
         $location.url('similarity');
     }
+
     const saveQuery = (similarityIndexInfo) => {
         const isSearchQuery = similarityIndexInfo.isSearchQueryTypeSelected();
         let data = {

--- a/src/pages/create-index.html
+++ b/src/pages/create-index.html
@@ -247,17 +247,25 @@
                            popover-trigger="mouseenter">
                             {{'common.cancel.btn' | translate}}
                         </a>
-                        <button ng-if="!isEditViewMode()" class="btn btn-lg btn-primary create-similarity-index-btn" ng-click="createSimilarityIndex()"
+                        <button ng-if="!isEditViewMode()" class="btn btn-lg btn-primary create-similarity-index-btn"
+                                ng-disabled="savingIndex"
+                                ng-click="createSimilarityIndex()"
                                 uib-popover="{{'create.index.label' | translate}}"
                                 popover-placement="top"
                                 popover-trigger="mouseenter">
-                            {{'common.create.btn' | translate}}
+                            <span>{{'common.create.btn' | translate}}</span>
+                            <span class="saving-index-loader" ng-if="savingIndex" onto-loader-fancy hide-message="true"
+                                  size="18"></span>
                         </button>
-                        <button ng-if="isEditViewMode()" class="btn btn-lg btn-primary save-query-btn" ng-click="saveSearchQuery()"
+                        <button ng-if="isEditViewMode()" class="btn btn-lg btn-primary save-query-btn"
+                                ng-disabled="savingIndex"
+                                ng-click="saveSearchQuery()"
                                 uib-popover="{{'core.edit.query' | translate}}"
                                 popover-placement="top"
                                 popover-trigger="mouseenter">
-                            {{'common.save.btn' | translate}}
+                            <span>{{'common.save.btn' | translate}}</span>
+                            <span class="saving-index-loader" ng-if="savingIndex" onto-loader-fancy hide-message="true"
+                                  size="18"></span>
                         </button>
                     </div>
                     <div class="pull-left">

--- a/test-cypress/integration/explore/similarity-index/similarity-index-create.spec.js
+++ b/test-cypress/integration/explore/similarity-index/similarity-index-create.spec.js
@@ -1,6 +1,6 @@
-import {SimilarityIndexCreateSteps} from "../../steps/explore/similarity-index-create-steps";
-import {ErrorSteps} from "../../steps/error-steps";
-import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
+import {SimilarityIndexCreateSteps} from "../../../steps/explore/similarity-index-create-steps";
+import {ErrorSteps} from "../../../steps/error-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
 
 const FILE_TO_IMPORT = 'people.zip';
 const INSERT_QUERY = 'PREFIX dc: <http://purl.org/dc/elements/1.1/>\n INSERT DATA\n{\nGRAPH <http://example> {\n<http://example/book1> dc:title "A new book" ;\ndc:creator "A.N.Other" .\n}\n}';

--- a/test-cypress/integration/explore/similarity-index/similarity-index.spec.js
+++ b/test-cypress/integration/explore/similarity-index/similarity-index.spec.js
@@ -1,8 +1,8 @@
-import {SimilarityIndexCreateSteps} from "../../steps/explore/similarity-index-create-steps";
-import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";
-import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
-import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../steps/modal-dialog-steps";
-import {SimilarityIndexesSteps} from "../../steps/explore/similarity-indexes-steps";
+import {SimilarityIndexCreateSteps} from "../../../steps/explore/similarity-index-create-steps";
+import {RepositorySelectorSteps} from "../../../steps/repository-selector-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../../steps/modal-dialog-steps";
+import {SimilarityIndexesSteps} from "../../../steps/explore/similarity-indexes-steps";
 
 const FILE_TO_IMPORT = 'people.zip';
 

--- a/test-cypress/integration/explore/similarity-index/similarity.spec.js
+++ b/test-cypress/integration/explore/similarity-index/similarity.spec.js
@@ -1,11 +1,10 @@
-import {SparqlEditorSteps} from "../../steps/sparql-editor-steps";
-import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
-import {YasrSteps} from "../../steps/yasgui/yasr-steps";
-import {SimilarityIndexCreateSteps} from "../../steps/explore/similarity-index-create-steps";
-import {SimilarityIndexesSteps} from "../../steps/explore/similarity-indexes-steps";
-import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../steps/modal-dialog-steps";
-import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";
-import {ErrorSteps} from "../../steps/error-steps";
+import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {YasrSteps} from "../../../steps/yasgui/yasr-steps";
+import {SimilarityIndexCreateSteps} from "../../../steps/explore/similarity-index-create-steps";
+import {SimilarityIndexesSteps} from "../../../steps/explore/similarity-indexes-steps";
+import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../../steps/modal-dialog-steps";
+import {ErrorSteps} from "../../../steps/error-steps";
 
 const INDEX_NAME = 'index-' + Date.now();
 const FILE_TO_IMPORT = 'people.zip';

--- a/test-cypress/steps/yasgui/yasqe-steps.js
+++ b/test-cypress/steps/yasgui/yasqe-steps.js
@@ -74,6 +74,9 @@ export class YasqeSteps {
         this.getCodeMirror().then((cm) => {
             cm.getDoc().setValue(query);
         });
+        // Type some spaces to trigger the change event and make angular aware
+        // that the value has been changed.
+        YasqeSteps.getEditor().find('textarea').type('  ', {force: true, parseSpecialCharSequences: false});
         YasqeSteps.verifyQueryTyped(query);
     }
 


### PR DESCRIPTION
## What
Fix error handling in similarity indexes view.

## Why
Error handling in the similarity indexes view is broken and leads to unpleasant experience in the user. For example, when user tries to create or edit a namespace, but the server returns some error, the UI doesn't show a notification for the error, but just navigates to other view which leads to confusion.

## How
* Refactored the save and edit action handlers and added a flag that indicates whether the operation is in progress which is also reflected in the UI with a progress indicator in the respective action button.

* Fixed navigation to index list view if no changes were found in the search query and after save operation.

* Moved similarity index specs in separate folder and fixed type in a file name

* Changed the paste query method in the steps to type some spaces in the editor after query has been pasted in order to trigger the change event and notify angular that the value has been changed. Otherwise the field will remain pristine and tests would report false positive and mask possible issues in the implementation.

(cherry picked from commit f7b6394b9e3a8794d6ece7c14b0a651ea9d6a02f)

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] MR name
- [X] MR Description
- [X] Tests
