### PR TITLE
Cherry-pick GDB-11196 Add Language Service Provider for Dynamic Language Configuration

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -383,3 +383,52 @@ folder. The `file-loader` is used for the purpose.
 `url-loader`.
 * The `/dist` directory is cleaned up before every build to prevent accumulating bundle files with
 different hashes in their names.
+
+# Extending Translation Capabilities with the Language Service
+
+## Overview
+
+The introduction of `$languageServiceProvider` allows for flexible, dynamic language support within the GraphDB Workbench. This enhancement enables administrators to add or configure new languages directly through the configuration file (`languages.json`), eliminating the need for code changes or redeployment.
+
+## Key Benefits
+
+1. **Development-Free Translation Management**:
+    - Administrators can now manage supported languages by simply updating `languages.json`.
+    - This configuration-based approach makes it easy to introduce or remove languages without modifying the application code.
+
+2. **Dynamic Language Settings**:
+    - The workbench adapts automatically to the languages defined in `languages.json`, allowing administrators to plug in translations as needed.
+    - Language fallbacks and defaults are handled seamlessly, improving the application’s accessibility and usability.
+
+## How It Works
+
+- **Configuration File**: The `languages.json` file, located in the `src/i18n` directory, defines the `defaultLanguage` and `availableLanguages`.
+    - Example of `languages.json`:
+      ```json
+      {
+          "defaultLanguage": "en",
+          "availableLanguages": [
+              { "key": "en", "name": "English" },
+              { "key": "fr", "name": "Français" }
+          ]
+      }
+      ```
+- **Provider Integration**: `$languageServiceProvider` reads this configuration during the application initialization and exposes methods for retrieving the default language and available languages.
+- **Application-Wide Language Access**: Components across the application can access language settings via `$languageService`, ensuring consistency in language display and fallback behavior.
+
+## How to Add a New Language
+
+1. **Edit `languages.json`**: Add a new language entry in the `availableLanguages` array with the desired language `key` and `name`.
+   ```json
+   {
+       "defaultLanguage": "en",
+       "availableLanguages": [
+           { "key": "en", "name": "English" },
+           { "key": "fr", "name": "Français" },
+           { "key": "es", "name": "Español" }
+       ]
+   }
+   
+2. **Ensure Translations Are Available** Make sure a translation file (e.g., `es.json`) exists for the new language, following the naming convention used for other languages.
+
+3. **Reload the Application** The workbench will recognize the new language without requiring additional code changes or redeployment.

--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,7 @@ import 'angular/core/directives/operations-statuses-monitor/operations-statuses-
 import 'angular/core/directives/autocomplete/autocomplete.directive';
 import 'angular/core/directives/prop-indeterminate/prop-indeterminate.directive';
 import 'angular/core/directives/page-info-tooltip.directive';
+import 'angular/core/services/language.service'
 import {defineCustomElements} from 'ontotext-yasgui-web-component/loader';
 import {convertToHumanReadable} from "./js/angular/utils/size-util";
 import {DocumentationUrlResolver} from "./js/angular/utils/documentation-url-resolver";
@@ -46,7 +47,8 @@ const modules = [
     'graphdb.framework.guides.services',
     'graphdb.framework.core.directives.operationsstatusesmonitor',
     'graphdb.framework.core.directives.autocomplete',
-    'ngCustomElement'
+    'ngCustomElement',
+    'graphdb.framework.core.services.language-service'
 ];
 
 const providers = [
@@ -58,7 +60,8 @@ const providers = [
     '$uibTooltipProvider',
     '$httpProvider',
     '$templateRequestProvider',
-    '$translateProvider'
+    '$translateProvider',
+    '$languageServiceProvider'
 ];
 
 const moduleDefinition = function (productInfo, translations) {
@@ -74,7 +77,8 @@ const moduleDefinition = function (productInfo, translations) {
                   $uibTooltipProvider,
                   $httpProvider,
                   $templateRequestProvider,
-                  $translateProvider) {
+                  $translateProvider,
+                  $languageServiceProvider) {
 
             if (translations && Object.keys(translations).length > 0) {
                 // If translations data is provided, iterate over the object and register each language key
@@ -92,7 +96,7 @@ const moduleDefinition = function (productInfo, translations) {
                     suffix: '.json?v=[AIV]{version}[/AIV]'
                 });
                 // load 'en' table on startup
-                $translateProvider.preferredLanguage('en');
+                $translateProvider.preferredLanguage($languageServiceProvider.getDefaultLanguage());
             }
             $translateProvider.useSanitizeValueStrategy('escape');
 
@@ -245,7 +249,7 @@ const moduleDefinition = function (productInfo, translations) {
 
 // Manually load language files
 function loadTranslationsBeforeWorkbenchStart() {
-    const languages = ['en', 'fr']
+    const languages = __LANGUAGES__.availableLanguages.map(lang => lang.key)
     const promises = languages.map(loadTranslations);
     const translations = {};
     Promise.all(promises)

--- a/src/i18n/languages.json
+++ b/src/i18n/languages.json
@@ -1,0 +1,7 @@
+{
+    "defaultLanguage": "en",
+    "availableLanguages": [
+        { "key": "en", "name": "English" },
+        { "key": "fr", "name": "Français" }
+    ]
+}

--- a/src/js/angular/core/directives/languageselector/language-selector.directive.js
+++ b/src/js/angular/core/directives/languageselector/language-selector.directive.js
@@ -4,8 +4,7 @@ angular
     .module('graphdb.framework.core.directives.languageselector.languageselector', [
         'graphdb.framework.utils.localstorageadapter', 'graphdb.framework.utils.event-emitter-service'
     ])
-    .directive('languageSelector', languageSelector)
-    .service('$languageService', [languageService]);
+    .directive('languageSelector', languageSelector);
 
 languageSelector.$inject = ['$translate', 'LocalStorageAdapter', 'LSKeys', '$languageService', 'EventEmitterService'];
 
@@ -18,19 +17,11 @@ function languageSelector($translate, LocalStorageAdapter, LSKeys, $languageServ
             const browserPreferredLanguages = navigator.languages;
 
             $scope.selectedLang = {};
-            $scope.languages = [
-                {
-                    key: 'en',
-                    name: 'English'
-                },
-                {
-                    key: 'fr',
-                    name: 'Français'
-            }];
+            $scope.languages = $languageService.getAvailableLanguages();
 
             // If some keys in i18n folder are not
             // translated they will be translated in English
-            $translate.fallbackLanguage('en');
+            $translate.fallbackLanguage($languageService.getDefaultLanguage());
 
             function setAndPersistLanguage(lang) {
                 $scope.selectedLang = lang;
@@ -86,22 +77,11 @@ function languageSelector($translate, LocalStorageAdapter, LSKeys, $languageServ
                 .then(function () {
                     if (!$scope.selectedLang) {
                         // or fallback to English
-                        $scope.selectedLang = $scope.languages.find((lang) => lang.key === 'en');
+                        $scope.selectedLang = $scope.languages.find((lang) => lang.key === $languageService.getDefaultLanguage());
                     }
                     $translate.use($scope.selectedLang.key);
                     $languageService.setLanguage($scope.selectedLang.key);
             });
         }
-    };
-}
-
-function languageService() {
-    this.language = 'en';
-    this.setLanguage = function (lang) {
-        this.language = lang;
-    };
-
-    this.getLanguage = function () {
-        return this.language;
     };
 }

--- a/src/js/angular/core/services/language.service.js
+++ b/src/js/angular/core/services/language.service.js
@@ -1,0 +1,40 @@
+/**
+ * @ngdoc provider
+ * @name $languageServiceProvider
+ * @module graphdb.framework.core.services.language-service
+ * @description
+ * Provider for configuring and accessing language settings in the application.
+ * This provider allows configuring default and available languages during the
+ * application configuration phase.
+ */
+angular.module('graphdb.framework.core.services.language-service', [])
+    .provider('$languageService', function () {
+        const LANGUAGES = __LANGUAGES__ || {
+            defaultLanguage: 'en',
+            availableLanguages: [{key: 'en', name: 'English'}]
+        };
+        let language = LANGUAGES.defaultLanguage;
+
+        this.getDefaultLanguage = function () {
+            return LANGUAGES.defaultLanguage;
+        };
+
+        this.$get = function () {
+            const setLanguage = (lang) => {
+                language = lang;
+            };
+
+            const getLanguage = () => language;
+            const getDefaultLanguage = () => LANGUAGES.defaultLanguage;
+            const getAvailableLanguages = () => LANGUAGES.availableLanguages;
+            const getSupportedLanguages = () => LANGUAGES.availableLanguages.map((lang) => lang.key);
+
+            return {
+                setLanguage,
+                getLanguage,
+                getDefaultLanguage,
+                getAvailableLanguages,
+                getSupportedLanguages
+            };
+        };
+    });

--- a/src/js/angular/core/services/translation.service.js
+++ b/src/js/angular/core/services/translation.service.js
@@ -3,11 +3,11 @@ const modules = [];
 angular.module('graphdb.framework.core.services.translation-service', modules)
     .service('TranslationService', TranslationService);
 
-TranslationService.$inject = ['$translate'];
+TranslationService.$inject = ['$translate', '$languageService'];
 
-function TranslationService($translate) {
+function TranslationService($translate, $languageService) {
 
-    const supportedLanguages = ['en', 'fr'];
+    const supportedLanguages = $languageService.getSupportedLanguages();
     let allTranslations;
 
     const getTranslations = () => {

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -3,6 +3,13 @@ const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 const MergeIntoSingleFilePlugin = require('webpack-merge-and-include-globally');
 const WebpackAutoInject = require('webpack-auto-inject-version');
+const webpack = require('webpack');
+const fs = require('fs');
+
+// Load the languages JSON file as a string for injection
+const languagesConfig = JSON.stringify(
+    JSON.parse(fs.readFileSync(path.resolve(__dirname, 'src/i18n/languages.json'), 'utf8'))
+);
 
 // Pass this function as a transform argument to CopyPlugin elements to replace [AIV]{version}[/AIV]
 // with the current workbench version number. This is not related to the WebpackAutoInject plugin
@@ -32,6 +39,9 @@ module.exports = {
         extensions: ['.js', '.mjs']
     },
     plugins: [
+        new webpack.DefinePlugin({
+            __LANGUAGES__: languagesConfig
+        }),
         new WebpackAutoInject({
             SILENT: true,
             components: {


### PR DESCRIPTION
## WHAT
 - Introduced a new $languageServiceProvider for managing and configuring language settings across the application.
 - Updated relevant modules and components to leverage the provider for dynamic language management.
 - Injected languages.json through Webpack’s DefinePlugin to enable flexible language configuration based on an external JSON file

 ## WHY
 To centralize language configuration in the application. This change enables dynamic adjustment of default and available languages, reducing hardcoded values and simplifying internationalization management

 ## HOW
- Created $languageServiceProvider in language.service.js with configuration options for defaultLanguage and availableLanguages.
- Integrated the provider with $translateProvider to set the preferred language dynamically.
- Updated language-selector.directive.js to use $languageService for retrieving available languages and setting the default language.
- Updated TranslationService to retrieve supported languages from $languageService, replacing the previous hardcoded array.
- Added Webpack’s DefinePlugin to inject the languages.json content as __LANGUAGES__, making it accessible in the provider.
- Defined languages.json in src/i18n/ to manage defaultLanguage and availableLanguages externally

* fix notes

---------

Co-authored-by: Svilen Velikov <51084653+svilenvelikov@users.noreply.github.com>
(cherry picked from commit 213947c59a63c3bdc4c3d0739f2bf1ec9c9cd576)

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] MR name
- [X] MR Description