### PR TITLE
GDB-11148: Cluster creation popup, advanced options label is black onblack in dark mode

### DIFF
--- a/src/css/clustermanagement.css
+++ b/src/css/clustermanagement.css
@@ -145,6 +145,7 @@ text.id-host, .node-info-fo {
 }
 
 .text-btn {
+    color: #000000;
     background: none;
     border: none;
     margin: 0;

--- a/src/css/repositories.css
+++ b/src/css/repositories.css
@@ -341,6 +341,7 @@ span.label {
 }
 
 .text-btn {
+    color: #000000;
     background: none;
     border: none;
     margin: 0;


### PR DESCRIPTION
## What
   The text button labels are not visible in dark mode because they appear black on a black background.

## Why
   The color styles for text buttons are not explicitly set and depend on the user's browser's default settings. In some cases, this results in the text color being set to black, making it invisible against the black background.

## How
   Set an explicit color for text buttons to ensure visibility across all themes, including dark mode.

## Screenshots
![image](https://github.com/user-attachments/assets/892c2e28-6738-4eab-b794-d0a29625574b)


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] MR name
- [X] MR Description
