### PR TITLE
GDB-11227: Missing Icons for Cluster Legend

### DIFF
--- a/src/css/bootstrap-graphdb-theme.css
+++ b/src/css/bootstrap-graphdb-theme.css
@@ -68,7 +68,6 @@
 [class^="icon-"], [class*=" icon-"], .icon-any, .fa-d3 {
     speak: none;
     font-style: normal;
-    font-weight: normal;
     font-variant: normal;
     text-transform: none;
     line-height: 1;
@@ -79,14 +78,18 @@
     -moz-osx-font-smoothing: grayscale;
 }
 
-[class^="icon-"], [class*=" icon-"], .icon-any, .fa-d3 {
+[class^="icon-"], [class*=" icon-"], .icon-any, .fa-d3:not(.fa-solid) {
+    font-weight: normal;
+}
+
+[class^="icon-"], [class*=" icon-"], .icon-any {
     /* use !important to prevent issues with browser extensions that change fonts */
     font-family: 'icomoon', sans-serif !important;
 }
 
 .fa-d3 {
     /* use !important to prevent issues with browser extensions that change fonts */
-    font-family: 'FontAwesome', sans-serif !important;
+    font-family: 'Font Awesome 6 Pro', sans-serif !important;
 }
 
 .icon-arrow-up-off:before {

--- a/src/js/angular/models/clustermanagement/cluster-management-constants.js
+++ b/src/js/angular/models/clustermanagement/cluster-management-constants.js
@@ -80,19 +80,19 @@ const CLUSTER_MANAGEMENT_CONSTANTS = (function () {
                 icon: '\uf017'
             }, {
                 labelKey: 'recovery_state.building_snapshot',
-                classes: 'fa-d3',
+                classes: 'fa-d3 fa-solid',
                 icon: '\uf187'
             }, {
                 labelKey: 'recovery_state.sending_snapshot',
-                classes: 'fa-d3',
+                classes: 'fa-d3 fa-solid',
                 icon: '\uf0ee'
             }, {
                 labelKey: 'recovery_state.receiving_snapshot',
-                classes: 'fa-d3',
+                classes: 'fa-d3 fa-solid',
                 icon: '\uf0ed'
             }, {
                 labelKey: 'recovery_state.applying_snapshot',
-                classes: 'fa-d3',
+                classes: 'fa-d3 fa-solid',
                 icon: '\uf050'
             }
         ];

--- a/src/vendor.js
+++ b/src/vendor.js
@@ -4,6 +4,7 @@ import 'lib/awesome_me/css/fontawesome.min.css';
 import 'lib/awesome_me/css/regular.min.css';
 import 'lib/awesome_me/css/sharp-regular.min.css';
 import 'lib/awesome_me/css/custom-icons.min.css';
+import 'lib/awesome_me/css/solid.min.css';
 import './css/lib/animate/animate.css';
 import 'shepherd.js/dist/css/shepherd.css';
 import './css/shepherd-custom.css';


### PR DESCRIPTION
## What
Icons are missing from the cluster legend in the "Cluster Management" view.

## Why
We recently started using a new pro version of Font Awesome, which introduces a new font-family name: "Font Awesome 6 Pro". Initially, both the new and old versions of Font Awesome were included, so the icons were displayed correctly. However, a recent commit removed the old Font Awesome version, breaking the icon visualization. The difference between the two versions lies in the font-family name, likely for backward compatibility. The old font-family name was "FontAwesome", while the new one is "Font Awesome 6 Pro".

## How
- Updated the font-family name to the new version.
- Fixed solid icons by including the solid CSS file in the vendor bundle.

## Screenshots
![image](https://github.com/user-attachments/assets/acc4415a-f4f1-436e-9bd5-4ba23e5192dc)

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] MR name
- [X] MR Description
