### PR TITLE
GDB-10693 - Disable local repo restart in cluster

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1755,6 +1755,7 @@
     "delete.repo.warning.msg": "<p>Are you sure you want to delete the repository <strong>{{repositoryId}}</strong>?</p><p><span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>All data in the repository will be lost.</p>",
     "confirm.restart.repo": "Confirm restart",
     "confirm.restart.repo.warning.msg": "<p>Are you sure you want to restart the repository <strong>{{repositoryId}}</strong>?</p><p><span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>The repository will be shut down immediately and all running queries and updates will be cancelled.</p>",
+    "restart.repo.in.cluster.tooltip": "Restarting a repository is not supported in a cluster environment. To apply configuration changes, restart all cluster nodes.",
     "location.cannot.be.empty.error": "Location cannot be empty",
     "required.field": "This field is required",
     "created.repo.success.msg": "The repository {{repoId}} has been created.",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1755,6 +1755,7 @@
     "delete.repo.warning.msg": "<p>Vous êtes sûr de vouloir supprimer le dépôt <strong>{{repositoryId}}</strong>?</p><p><span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>Toutes les données du dépôt seront perdues.</p>",
     "confirm.restart.repo": "Confirmer le redémarrage",
     "confirm.restart.repo.warning.msg": "<p>Vous êtes sûr de vouloir redémarrer le dépôt <strong>{{repositoryId}}</strong>?</p><p><span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>Le dépôt sera arrêté immédiatement et toutes les requêtes et mises à jour en cours seront annulées.</p>",
+    "restart.repo.in.cluster.tooltip": "Le redémarrage d'un dépôt n'est pas pris en charge dans un environnement de cluster. Pour appliquer les modifications de configuration, redémarrez tous les nœuds du cluster.",
     "location.cannot.be.empty.error": "L'emplacement ne peut pas être vide",
     "required.field": "Ce champ est requis",
     "created.repo.success.msg": "Le dépôt {{repoId}} a été créé.",

--- a/src/js/angular/repositories/controllers.js
+++ b/src/js/angular/repositories/controllers.js
@@ -175,8 +175,9 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
     }
 
     function getAndSetClusterStatus() {
-        ClusterRestService.getNodeStatus().then((response) => {
-            $scope.isInCluster = response.data.nodeState;
+        ClusterRestService.getNodeStatus().then(() => {
+            // If the endpoint returns a success response, that means we have a cluster
+            $scope.isInCluster = true;
         }).catch((error) => {
             if (error.status === 404) {
                 $scope.isInCluster = false;
@@ -421,7 +422,6 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
         // Update repositories state
         $repositories.initQuick();
         getLocations();
-        getAndSetClusterStatus();
     }, 5000);
 
     $scope.$on('$destroy', function () {

--- a/src/pages/repositories.html
+++ b/src/pages/repositories.html
@@ -120,8 +120,11 @@
                                                     <em class="icon-download"></em>
                                             </a>
                                             <button class="btn btn-link p-0 restart-repository-btn" type="button"
-                                                    gdb-tooltip="{{'restart.repo.label' | translate}} {{repository.id}}"
+                                                    gdb-tooltip="{{isInCluster
+                                                    ? ('restart.repo.in.cluster.tooltip' | translate)
+                                                    : ('restart.repo.label' | translate) + ' ' + repository.id}}"
                                                     tooltip-placement="top"
+                                                    ng-disabled="isInCluster"
                                                     ng-click="restartRepository(repository)">
                                                     <span class="icon-reload"></span>
                                             </button>

--- a/src/pages/repository.html
+++ b/src/pages/repository.html
@@ -403,12 +403,14 @@
                     <div ng-if="repositoryInfo.type !== 'ontop'" class="pt-1"></div>
                     <div class="form-group row" ng-if="repositoryInfo.type !== 'ontop' && editRepoPage">
                         <div class="checkbox col-xs-12">
-                            <label gdb-tooltip="{{'restart.repo.check.tooltip' | translate}}">
+                            <label gdb-tooltip="{{isRepoInCluster && !repositoryInfo.location
+                            ? ('restart.repo.in.cluster.tooltip' | translate)
+                            : ('restart.repo.check.tooltip' | translate)}}">
                                 <input id="restartRepo" name="restartRepo"
                                        type="checkbox"
                                        ng-model="repositoryInfo.restartRequested"
                                        ng-checked="repositoryInfo.restartRequested || repositoryInfo.saveId !== repositoryInfo.id"
-                                       ng-disabled="repositoryInfo.saveId !== repositoryInfo.id"/>
+                                       ng-disabled="(repositoryInfo.saveId !== repositoryInfo.id) || (isRepoInCluster && !repositoryInfo.location)"/>
                                 {{'restart.repo.label' | translate}}
                             </label>
                         </div>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -1755,6 +1755,7 @@
     "delete.repo.warning.msg": "<p>Are you sure you want to delete the repository <strong>{{repositoryId}}</strong>?</p><p><span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>All data in the repository will be lost.</p>",
     "confirm.restart.repo": "Confirm restart",
     "confirm.restart.repo.warning.msg": "<p>Are you sure you want to restart the repository <strong>{{repositoryId}}</strong>?</p><p><span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>The repository will be shut down immediately and all running queries and updates will be cancelled.</p>",
+    "restart.repo.in.cluster.tooltip": "Restarting a repository is not supported in a cluster environment. To apply configuration changes, restart all cluster nodes.",
     "location.cannot.be.empty.error": "Location cannot be empty",
     "required.field": "This field is required",
     "created.repo.success.msg": "The repository {{repoId}} has been created.",

--- a/test-cypress/fixtures/repositories/get-remote-and-local-repositories.json
+++ b/test-cypress/fixtures/repositories/get-remote-and-local-repositories.json
@@ -1,0 +1,34 @@
+{
+    "": [
+        {
+            "id": "test",
+            "title": "",
+            "uri": "http://localhost:8080/graphdb/repositories/test",
+            "externalUrl": "http://boyantonchev:9000/repositories/test",
+            "local": true,
+            "type": "graphdb",
+            "sesameType": "graphdb:SailRepository",
+            "location": "",
+            "readable": true,
+            "writable": true,
+            "unsupported": false,
+            "state": "RUNNING"
+        }
+    ],
+    "http://localhost:7201": [
+        {
+            "id": "movies",
+            "title": "",
+            "uri": "http://localhost:7202/repositories/movies",
+            "externalUrl": "http://localhost:7202/repositories/movies",
+            "local": false,
+            "type": "graphdb",
+            "sesameType": "graphdb:SailRepository",
+            "location": "http://localhost:7202",
+            "readable": true,
+            "writable": true,
+            "unsupported": false,
+            "state": "RUNNING"
+        }
+    ]
+}

--- a/test-cypress/integration/repository/repositories.spec.js
+++ b/test-cypress/integration/repository/repositories.spec.js
@@ -5,6 +5,8 @@ import {GlobalOperationsStatusesStub} from "../../stubs/global-operations-status
 import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
 import {ImportUserDataSteps} from "../../steps/import/import-user-data-steps";
 import {ImportSettingsDialogSteps} from "../../steps/import/import-settings-dialog-steps";
+import {ClusterStubs} from "../../stubs/cluster/cluster-stubs";
+import {RepositoriesStubs} from "../../stubs/repositories/repositories-stubs";
 
 describe('Repositories', () => {
 
@@ -501,6 +503,44 @@ describe('Repositories', () => {
 
         // Then I expect to see a confirmation dialog.
         ModalDialogSteps.verifyDialogBody('Changing the repository ID is a dangerous operation since it renames the repository folder and enforces repository shutdown.');
+    });
+
+    it('should not allow restart of local repository, if node is in cluster', () => {
+        // Given I create a repository
+        cy.createRepository({id: repositoryId});
+        // When I set the node in a cluster
+        GlobalOperationsStatusesStub.stubGlobalOperationsStatusesResponse(repositoryId);
+        //ClusterStubs.stubClusterNodeStatus();
+        // Then go to the edit repository page
+        RepositorySteps.visitEditPage(repositoryId);
+        // I expect the repository restart button to be disabled
+        RepositorySteps.getEditViewRestartButton().should('be.visible');
+        RepositorySteps.getEditViewRestartButton().should('be.disabled');
+    });
+
+    it('should not allow restart of local repositories, if node is in cluster', () => {
+        // Given I create a repository
+        cy.createRepository({id: repositoryId});
+        // When I set the node in a cluster
+        GlobalOperationsStatusesStub.stubGlobalOperationsStatusesResponse(repositoryId);
+        ClusterStubs.stubClusterNodeStatus();
+        // Then go to the repositories page
+        RepositorySteps.visit();
+        // I expect the repository restart button to be disabled
+        RepositorySteps.getRepositoryRestartButton(repositoryId).should('be.visible');
+        RepositorySteps.getRepositoryRestartButton(repositoryId).should('be.disabled');
+    });
+
+    it('should allow restart of remote repositories, even if node is in cluster', () => {
+        // Given I have a remote location
+        RepositoriesStubs.stubRepositories(0, '/repositories/get-remote-and-local-repositories.json');
+        RepositoriesStubs.stubLocations();
+        // When I set the node in a cluster
+        ClusterStubs.stubClusterNodeStatus();
+        // Then go to the repositories page
+        RepositorySteps.visit();
+        // Then I expect the remote repository's restart button to be enabled
+        RepositorySteps.getRestartRemoteRepoButton(0).should('be.enabled');
     });
 
     function interceptRulesetFileUpload() {

--- a/test-cypress/integration/repository/repositories.spec.js
+++ b/test-cypress/integration/repository/repositories.spec.js
@@ -505,20 +505,19 @@ describe('Repositories', () => {
         ModalDialogSteps.verifyDialogBody('Changing the repository ID is a dangerous operation since it renames the repository folder and enforces repository shutdown.');
     });
 
-    it('should not allow restart of local repository, if node is in cluster', () => {
+    it('should NOT allow restart of LOCAL repository from EDIT PAGE, if node is in cluster', () => {
         // Given I create a repository
         cy.createRepository({id: repositoryId});
         // When I set the node in a cluster
         GlobalOperationsStatusesStub.stubGlobalOperationsStatusesResponse(repositoryId);
-        //ClusterStubs.stubClusterNodeStatus();
-        // Then go to the edit repository page
+        // Then go to the local repository's edit page
         RepositorySteps.visitEditPage(repositoryId);
-        // I expect the repository restart button to be disabled
+        // I expect the repository restart checkbox button to be disabled
         RepositorySteps.getEditViewRestartButton().should('be.visible');
         RepositorySteps.getEditViewRestartButton().should('be.disabled');
     });
 
-    it('should not allow restart of local repositories, if node is in cluster', () => {
+    it('should NOT allow restart of LOCAL repositories from REPOSITORIES PAGE, if node is in cluster', () => {
         // Given I create a repository
         cy.createRepository({id: repositoryId});
         // When I set the node in a cluster
@@ -526,12 +525,12 @@ describe('Repositories', () => {
         ClusterStubs.stubClusterNodeStatus();
         // Then go to the repositories page
         RepositorySteps.visit();
-        // I expect the repository restart button to be disabled
+        // I expect the local repository's restart button to be disabled
         RepositorySteps.getRepositoryRestartButton(repositoryId).should('be.visible');
         RepositorySteps.getRepositoryRestartButton(repositoryId).should('be.disabled');
     });
 
-    it('should allow restart of remote repositories, even if node is in cluster', () => {
+    it('should ALLOW restart of REMOTE repositories from REPOSITORIES PAGE, if node is in cluster', () => {
         // Given I have a remote location
         RepositoriesStubs.stubRepositories(0, '/repositories/get-remote-and-local-repositories.json');
         RepositoriesStubs.stubLocations();

--- a/test-cypress/steps/repository-steps.js
+++ b/test-cypress/steps/repository-steps.js
@@ -85,6 +85,16 @@ export class RepositorySteps {
         RepositorySteps.clickRepositoryIcon(repositoryId, '.repository-actions .restart-repository-btn');
     }
 
+    static getEditViewRestartButton() {
+        return cy.get('#restartRepo');
+    }
+
+    static getRepositoryRestartButton(repositoryId) {
+        return RepositorySteps.getRepositoryFromList(repositoryId)
+            .should('be.visible')
+            .find('.repository-actions .restart-repository-btn');
+    }
+
     static createRepository() {
         RepositorySteps.getCreateRepositoryButton().click();
     }
@@ -263,6 +273,10 @@ export class RepositorySteps {
 
     static editSparqlInstance(row) {
         RepositorySteps.getEditSparqlInstanceBtn(row).click();
+    }
+
+    static getRestartRemoteRepoButton(row) {
+        return this.getRemoteGraphDBTable().eq(row).find('.repository-actions .restart-repository-btn');
     }
 
     static getRemoteGraphDBTable() {


### PR DESCRIPTION
## What
When the node is in a cluster, restarting the Local repositories from the Repositories view and the Edit Repository view will not be allowed.

## Why
The action is forbidden in the back-end and performing a restart on a Local repo, while in a cluster, causes problems for the GraphDB. 

## How
I added checks to see if the node is in a cluster and if the edited repo is a remote location or not.

## Testing
Tests added.

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
