### PR TITLE
Fixes warning messages in browser console

### DIFF
--- a/packages/root-config/src/index.ejs
+++ b/packages/root-config/src/index.ejs
@@ -28,7 +28,6 @@
                     base-uri 'self';">
     <meta name="importmap-type" content="systemjs-importmap"/>
 
-    <link rel="preload" href="/single-spa.min.js" as="script">
     <script src="plugin-registry.js?v=<%= buildVersion %>"></script>
     <script src="plugins.js?v=<%= buildVersion %>"></script>
      <script src="/resources/import-map-overrides.js"></script>

--- a/packages/shared-components/stencil.config.ts
+++ b/packages/shared-components/stencil.config.ts
@@ -32,4 +32,17 @@ export const config: Config = {
   plugins: [
     sass(),
   ],
+  rollupPlugins: {
+    before: [
+      {
+        name: 'external-single-spa',
+        resolveId(source) {
+          if (source === 'single-spa') {
+            return { id: source, external: true };
+          }
+          return null;
+        },
+      },
+    ],
+  },
 };


### PR DESCRIPTION
## What
The browser console displays the following warning messages:
- ```The resource http://localhost:9000/single-spa.min.js was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.```
- ```single-spa minified message``` See https://single-spa.js.org/error/?code=41

## Why
- An unnecessary <link> tag preloads single-spa.min.js in the index.html, but the resource does not exist on the server after building.
- The shared-components module includes a single-spa dependency, which is loaded when the shared components are initialized in the browser. However, single-spa is already provided by the host application, leading to redundancy.

## How
- Removed the unnecessary <link> tag for preloading single-spa.min.js.
- Updated the Stencil configuration to mark single-spa as an external resource. This ensures the browser uses the already loaded instance of single-spa, as recommended by the Stencil error documentation.

## Screenshots
![image](https://github.com/user-attachments/assets/54da0b94-025d-42c0-bd04-0d9a455db796)

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
