### PR TITLE
fix(GDB-11271) Restrict delete tag button visibility to admin users in cluster configuration

### DIFF
--- a/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
+++ b/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
@@ -81,7 +81,8 @@
                         </td>
                         <td class="actions-cell">
                             <div class="actions">
-                                <button ng-click="deleteTag(tag[0])"
+                                <button ng-if="isAdmin"
+                                        ng-click="deleteTag(tag[0])"
                                         ng-disabled="addingTag"
                                         class="btn btn-link delete-tag-btn secondary"
                                         gdb-tooltip="{{ 'cluster_management.cluster_configuration_multi_region.delete_tag_tooltip' | translate }}"


### PR DESCRIPTION
## WHAT:
Add `ng-if="isAdmin"` condition to the delete tag button in the multi-region cluster configuration template to restrict its visibility to admin users.

## WHY:
The delete button was visible to basic users, who are not allowed to delete tags. Clicking the button resulted in a "forbidden" toast and banner, which blocked the cluster view until a page refresh.

## HOW:
Added a `ng-if="isAdmin"` directive to the delete tag button in the HTML template. This ensures the button is only rendered for admin users, preventing basic users from interacting with it.


## Testing


## Screenshots
Admin user
![image](https://github.com/user-attachments/assets/931cfeb6-3e76-4f70-bc26-2d327fbe0918)

Regular user
![image](https://github.com/user-attachments/assets/50d63fee-2fb2-487f-825c-e299b1b1a8bc)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
