### PR TITLE
GDB-11204 - Position Info Popover, so user can hover and click the link inside

### DIFF
--- a/src/css/sparql-editor.css
+++ b/src/css/sparql-editor.css
@@ -1,6 +1,9 @@
-.sparql-editor-view #sparql-query-update-title-label {
+.sparql-editor-view #title-container {
     position: relative;
     margin-bottom: -35px;
+}
+
+.sparql-editor-view #sparql-query-update-title-label {
     z-index: 1;
 }
 

--- a/src/pages/sparql-editor.html
+++ b/src/pages/sparql-editor.html
@@ -1,8 +1,8 @@
 <link href="css/sparql-editor.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 
 <div class="sparql-editor-view">
-    <h1 id="sparql-query-update-title-label">
-        <span>{{title}}</span>
+    <h1 id="title-container">
+        <span id="sparql-query-update-title-label">{{title}}</span>
         <page-info-tooltip></page-info-tooltip>
     </h1>
 


### PR DESCRIPTION
## What
In the SPARQL editor page, the user will be able to see the entire `info popover` after hovering the icon next to the title and will be able to click the link to the documentation.

## Why
The positioning of the elements in the DOM meant that the `active tab` was visible above the popover and triggered the `mouseleave` event, even though the user could see the mouse was over the popover. The result was that the popover disappeared before the user had a chance to click the link to the documentation. 

## How
I created the correct `stacking context` by moving the `z-index`.

## Testing
No tests for CSS changes

## Screenshots
**The long text in the Editor does not render on top of the popover, allowing the link to be reached.**

![image](https://github.com/user-attachments/assets/ccd7dcca-2ec5-464e-853d-a0dbabf610fc)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
