### PR TITLE
GDB-11291 - Fix href in Imports page in external contexts

### DIFF
--- a/src/js/angular/import/templates/fileSizeLimitInfo.html
+++ b/src/js/angular/import/templates/fileSizeLimitInfo.html
@@ -2,5 +2,5 @@
     {{'import.help.on_file_size_limit.file_import_options_info_1' | translate}}
     <a href ng-click="openTab('server')" class="server-files-tab-link">{{'import.help.on_file_size_limit.server_files_link' | translate}}</a>
     {{'import.help.on_file_size_limit.file_import_options_info_2' | translate}}
-    <a href="/webapi" class="api-link">{{'import.help.on_file_size_limit.api_link' | translate}}</a>
+    <a href="webapi" class="api-link">{{'import.help.on_file_size_limit.api_link' | translate}}</a>
 </div>


### PR DESCRIPTION
## What
When the user clicks on the link **GraphDB REST API** in the Imports page, the `REST API` page will open correctly even in an external context.

## Why
The link resolved wrong.

## How
I corrected the link.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
