### PR TITLE
cherry-pick(GDB-11271) Restrict delete tag button visibility to admin users in cluster configuration

### DIFF
--- a/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
+++ b/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
@@ -81,7 +81,8 @@
                         </td>
                         <td class="actions-cell">
                             <div class="actions">
-                                <button ng-click="deleteTag(tag[0])"
+                                <button ng-if="isAdmin"
+                                        ng-click="deleteTag(tag[0])"
                                         ng-disabled="addingTag"
                                         class="btn btn-link delete-tag-btn secondary"
                                         gdb-tooltip="{{ 'cluster_management.cluster_configuration_multi_region.delete_tag_tooltip' | translate }}"


### PR DESCRIPTION
## WHAT:
Add `ng-if="isAdmin"` condition to the delete tag button in the multi-region cluster configuration template to restrict its visibility to admin users.

## WHY:
The delete button was visible to basic users, who are not allowed to delete tags. Clicking the button resulted in a "forbidden" toast and banner, which blocked the cluster view until a page refresh.

## HOW:
Added a `ng-if="isAdmin"` directive to the delete tag button in the HTML template. This ensures the button is only rendered for admin users, preventing basic users from interacting with it.

(cherry picked from commit 181c4e1f2b9418686af275c95cef3073ac24cd3b)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
