### PR TITLE
GDB-11251 - Close repo info popover on click outside, so content can be copied

### DIFF
--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -600,6 +600,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
     window.addEventListener('storage', localStoreChangeHandler);
 
     $scope.$on('$destroy', () => {
+        document.removeEventListener('click', closeActiveRepoPopoverEventHandler);
         window.removeEventListener('storage', localStoreChangeHandler);
         deregisterMenuWatcher();
         if ($scope.checkMenu) {
@@ -638,6 +639,12 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         $scope.popoverRepo = repository;
     };
 
+    // When the dropdown list is open, the popover of the already selected repo should disappear on mouseover on any of the listed options
+    $scope.handlePopovers = function (repository) {
+        $scope.setPopoverRepo(repository);
+        $scope.closeActiveRepoPopover();
+    };
+
     $scope.isRepoActive = function (repository) {
         return $repositories.isRepoActive(repository);
     };
@@ -651,6 +658,29 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
             });
         }
     };
+
+    $scope.isActiveRepoPopoverOpen = false;
+
+    $scope.openActiveRepoPopover = function () {
+        if ($scope.getActiveRepository()) {
+            $scope.isActiveRepoPopoverOpen = true;
+        }
+    };
+
+    $scope.closeActiveRepoPopover = function () {
+       $scope.isActiveRepoPopoverOpen = false;
+    };
+
+    const closeActiveRepoPopoverEventHandler = function(event) {
+        const popoverElement = document.querySelector('.popover');
+        if ($scope.isActiveRepoPopoverOpen && popoverElement && !popoverElement.contains(event.target)) {
+            $timeout(function () {
+                $scope.isActiveRepoPopoverOpen = false;
+            }, 0);
+        }
+    };
+
+    document.addEventListener('click', closeActiveRepoPopoverEventHandler);
 
     $scope.getDegradedReason = function () {
         return $repositories.getDegradedReason();

--- a/src/template.html
+++ b/src/template.html
@@ -42,9 +42,16 @@
     <!-- Current repository and repository selection dropdown -->
     <div id="repositorySelectDropdown" class="btn-group" role="group" ng-show="!embedded">
         <button id="btnReposGroup" type="button" class="btn btn-secondary dropdown-toggle"
+                ng-mouseover="setPopoverRepo(getActiveRepositoryObject())"
+                popover-trigger="none"
+                popover-is-open="isActiveRepoPopoverOpen"
+                popover-popup-delay="500"
+                ng-mouseenter="openActiveRepoPopover()"
+                popover-placement="left-bottom"
+                uib-popover-template="popoverTemplate"
+                popover-title="{{'security.repository.title' | translate}} {{getActiveRepositoryObject().id}}"
                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" guide-selector="repositoriesGroupButton">
-            <span ng-mouseover="setPopoverRepo(getActiveRepositoryObject())" popover-popup-delay="1000" popover-trigger="mouseenter" popover-placement="left-bottom"
-                  uib-popover-template="popoverTemplate" popover-title="{{'security.repository.title' | translate}} {{getActiveRepositoryObject().id}}" ng-if="getActiveRepository()"
+            <span ng-if="getActiveRepository()"
                   guide-selector="repository-{{getActiveRepositoryObject().id}}-button"
                   class="active-repository">
                 <em ng-class="'icon-repo-' + getActiveRepositoryObject().type"></em>
@@ -56,7 +63,7 @@
         <ul class="dropdown-menu dropdown-menu-right pre-scrollable" aria-labelledby="dropdownMenuButton">
             <li ng-repeat="repository in getReadableRepositories() | orderBy: ['location', 'id']"
                 ng-if="!isRepoActive(repository)"
-                ng-mouseover="setPopoverRepo(repository)" popover-popup-delay="500"
+                ng-mouseover="handlePopovers(repository)" popover-popup-delay="500"
                 popover-trigger="mouseenter" popover-placement="left"
                 uib-popover-template="popoverTemplate" popover-title="{{'security.repository.title' | translate}} {{repository.id}}">
                 <a class="dropdown-item" ng-click="setRepository(repository)" guide-selector="repository-{{repository.id}}-button">


### PR DESCRIPTION
## What
The user will be able to copy the information in the repository popover, because it will not disappear on `mouseleave`. Instead it will disappear on click outside.

## Why
The functionality is an improvement suggested by users. There was no way to copy this information before.

## How
I moved the popover to another element, in order to allow it to close on click outside.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [ ] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
