### PR TITLE
GDB-11295 - Add missing TTYG documentation link

### DIFF
--- a/src/js/angular/ttyg/templates/no-agents-view.html
+++ b/src/js/angular/ttyg/templates/no-agents-view.html
@@ -16,7 +16,7 @@
         </div>
 
         <div class="alert alert-warning mt-3">
-            <div ng-bind-html="'ttyg.agent.messages.help_config' | translate | trustAsHtml"></div>
+            <div ng-bind-html="'ttyg.agent.messages.help_config' | translate: {talkToGraphDocumentationLink: talkToGraphDocumentationLink} | trustAsHtml"></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## What
When clicking the link in the bottom panel of the TTYG page, the user will be taken to the correct page in the documentation.

## Why
The link did not work before.

## How
I added the missing parameter from the directive for the interpolation to work.

## Testing
N/A

## Screenshots
Link visible in screenshot:
![Screenshot from 2024-12-05 12-38-26](https://github.com/user-attachments/assets/ed7aeb3d-9f67-45e2-a2ff-49535a5f1863)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
