### PR TITLE
(cherry-pick) GDB-11294 - Load the default SPARQL query during Agent Edit

### DIFF
--- a/src/js/angular/ttyg/services/agents.mapper.js
+++ b/src/js/angular/ttyg/services/agents.mapper.js
@@ -59,6 +59,7 @@ const agentInstructionsFormMapper = (currentAgentModelInstructions, defaultInstr
  */
 const extractionMethodsFormMapper = (agentFormModel, operation, defaultData, data = []) => {
     const defaultExtractionMethods = defaultData.filter((defaultExtractionMethod) => !data.some((agentMethod) => agentMethod.method === defaultExtractionMethod.method));
+    const defaultSparqlMethodValues = defaultData.find((defaultExtractionMethod) => defaultExtractionMethod.method === 'sparql_search');
     const extractionMethods = [...data, ...defaultExtractionMethods];
     extractionMethods.forEach((extractionMethod) => {
         const isMethodSelected = data.some((method) => method.method === extractionMethod.method);
@@ -79,10 +80,10 @@ const extractionMethodsFormMapper = (agentFormModel, operation, defaultData, dat
             selected: shouldShowSelectedMethods && isMethodSelected,
             method: extractionMethod.method,
             sparqlOption: sparqlOption,
-            ontologyGraph: extractionMethod.ontologyGraph,
+            ontologyGraph: extractionMethod.ontologyGraph || defaultSparqlMethodValues.ontologyGraph,
             addMissingNamespaces: extractionMethod.addMissingNamespaces,
-            sparqlQuery: extractionMethod.sparqlQuery && new TextFieldModel({
-                value: extractionMethod.sparqlQuery,
+            sparqlQuery: new TextFieldModel({
+                value: extractionMethod.sparqlQuery || defaultSparqlMethodValues.sparqlQuery,
                 minLength: 1,
                 maxLength: 2380
             }),


### PR DESCRIPTION
## What
When the user edits an Agent that has `Fetch ontology from a named graph` selected, selecting `Provide a SPARQL CONSTRUCT query that fetches the ontology` will display the default SPARQL query in the text field.

## Why
Previously, switching from `Fetch ontology from a named graph` to `Provide a SPARQL CONSTRUCT query that fetches the ontology` loaded an empty text field, because for the named graph option there was no `sparqlQuery` for that extraction method when the `Agent` is loaded initially.

## How
I edited the `extraction methods form mapper` to use the `default Agent` values for the `sparqlQuery` and `ontologyGraph` fields when the current model data has an `undefined` property.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests

(cherry picked from commit 1a345c3a8b33329cbc72ea48aff605e55b763730)