### PR TITLE
(cherry-pick) GDB-11286 - Ensure theme mode changes in My Settings are only applied on Save

### DIFF
--- a/src/js/angular/utils/workbench-settings-storage-service.js
+++ b/src/js/angular/utils/workbench-settings-storage-service.js
@@ -20,7 +20,7 @@ function WorkbenchSettingsStorageService(localStorageAdapter, LSKeys) {
     const getWorkbenchSettings = () => {
         let settings = localStorageAdapter.get(LSKeys.WORKBENCH_SETTINGS);
         if (!settings) {
-            settings = defaultSettings;
+            settings = _.clone(defaultSettings);
         }
         return settings;
     };


### PR DESCRIPTION
## What
Whenever the user changes the theme mode (Light or Dark) in the Settings page, the mode will not be applied if the changes are not saved.

## Why
There were several cases when toggling the mode changed the theme even when the setting were not saved. Exiting the page or clicking cancel after changing the mode option would apply the selected option if the `local store` did not have a saved value.

## How
The reason for this bug is that whenever the `local store` does not have the settings saved, it returns the default settings. That object is mutated every time the user changes the theme mode.
I clone the default settings before they are returned. This way only the clone is changed before saving to the `local store`.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests

(cherry picked from commit 4650315f86618f97c00d69002949fa1ecb4aa56d)
