### PR TITLE
GDB-11315 implement license notification

### DIFF
--- a/packages/api/src/models/common/subscription-list.ts
+++ b/packages/api/src/models/common/subscription-list.ts
@@ -1,0 +1,34 @@
+import { ModelList } from './model-list';
+import { Subscription } from './subscription';
+
+/**
+ * Represents a list of subscriptions that can be managed collectively.
+ * Extends the {@link ModelList} class, specialized for {@link Subscription} type.
+ */
+export class SubscriptionList extends ModelList<Subscription> {
+  /**
+   * Creates a new instance of SubscriptionList.
+   * @param subscriptions - An optional array of Subscription functions to initialize the list.
+   */
+  constructor(subscriptions?: Subscription[]) {
+    super(subscriptions);
+  }
+  
+  /**
+   * Adds a new subscription to the list.
+   * @param subscription - The Subscription function to be added to the list.
+   */
+  add(subscription: Subscription): void {
+    this.items.push(subscription);
+  }
+  
+  /**
+   * Calls all subscription functions in the list and then clears the list. Calling a subscription
+   * function unsubscribes the subscription. This effectively unsubscribes all subscriptions
+   * and removes them from the list.
+   */
+  unsubscribeAll(): void {
+    this.items.forEach(subscription => subscription());
+    this.items = [];
+  }
+}

--- a/packages/api/src/models/common/subscription.ts
+++ b/packages/api/src/models/common/subscription.ts
@@ -1,0 +1,1 @@
+export type Subscription = () => void;

--- a/packages/api/src/models/license/capability-list.ts
+++ b/packages/api/src/models/license/capability-list.ts
@@ -1,0 +1,18 @@
+import { Capability } from './capability';
+import { ModelList } from '../common/model-list';
+
+/**
+ * Represents a list of capabilities in the license model.
+ * Extends the ModelList class, specialized for Capability connectors.
+ */
+export class CapabilityList extends ModelList<Capability> {
+  /**
+   * Creates a new instance of CapabilityList.
+   *
+   * @param capabilities - An array of Capability connectors to initialize the list.
+   *                       If not provided, an empty list will be created.
+   */
+  constructor(capabilities: Capability[]) {
+    super(capabilities);
+  }
+}

--- a/packages/api/src/models/license/capability.ts
+++ b/packages/api/src/models/license/capability.ts
@@ -1,0 +1,11 @@
+/**
+ * Graph DB connector capabilities
+ */
+export enum Capability {
+  LUCENE_CONNECTOR = 'Lucene connector',
+  SOLR_CONNECTOR = 'Solr connector',
+  ELASTICSEARCH_CONNECTOR = 'Elasticsearch connector',
+  OPENSEARCH_CONNECTOR = 'OpenSearch connector',
+  KAFKA_CONNECTOR = 'Kafka connector',
+  CLUSTER = 'Cluster',
+}

--- a/packages/api/src/models/license/index.ts
+++ b/packages/api/src/models/license/index.ts
@@ -1,0 +1,3 @@
+export { License } from './license';
+export { Capability } from './capability';
+export { CapabilityList } from './capability-list';

--- a/packages/api/src/models/license/license.ts
+++ b/packages/api/src/models/license/license.ts
@@ -1,0 +1,48 @@
+import { Model } from '../common/model';
+import { CapabilityList } from './capability-list';
+import { CapabilityListMapper } from '../../services/license/mappers/capability-list.mapper';
+import { MapperProvider } from '../../providers';
+
+/**
+ * Represents a Graph DB license.
+ *
+ * Inherits copy functionality from {@link Model} and contains various properties of a GraphDB license.
+ */
+export class License extends Model<License> {
+  // Epoch
+  expiryDate?: number;
+  // Epoch
+  latestPublicationDate?: number;
+  licensee?: string;
+  maxCpuCores?: number;
+  product?: string;
+  productType?: string;
+  licenseCapabilities?: CapabilityList;
+  version?: string;
+  installationId?: string;
+  valid?: boolean;
+  typeOfUse?: string;
+  message?: string;
+
+  /**
+   * Creates a new License instance.
+   *
+   * @param data - Partial data to initialize the License object. This can include any of the properties
+   * defined in the License class. Default values are applied for some properties if not provided.
+   */
+  constructor(data: Partial<License>) {
+    super();
+    this.expiryDate = data.expiryDate;
+    this.latestPublicationDate = data.latestPublicationDate;
+    this.licensee = data.licensee || '';
+    this.maxCpuCores = data.maxCpuCores;
+    this.product = data.product || '';
+    this.productType = data.productType || '';
+    this.licenseCapabilities = MapperProvider.get(CapabilityListMapper).mapToModel(data.licenseCapabilities);
+    this.version = data.version || '';
+    this.installationId = data.installationId || '';
+    this.valid = data.valid;
+    this.typeOfUse = data.typeOfUse || '';
+    this.message = data.message || '';
+  }
+}

--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -5,6 +5,7 @@ export * from './models/repositories';
 export * from './models/repository-location';
 export * from './models/events';
 export * from './models/security';
+export * from './models/license';
 export * from './models/common';
 
 // Export providers for external usages.
@@ -16,6 +17,7 @@ export * from './services/repository';
 export * from './services/repository-location';
 export {AuthenticationService} from './services/security/authentication.service';
 export {EventEmitter} from './emitters/event.emitter';
+export * from './services/license';
 
 // Export utils for external usages.
 export * from './services/utils';

--- a/packages/api/src/services/license/index.ts
+++ b/packages/api/src/services/license/index.ts
@@ -1,0 +1,2 @@
+export { LicenseService } from './license.service';
+export { LicenseContextService } from './license-context.service';

--- a/packages/api/src/services/license/license-context.service.ts
+++ b/packages/api/src/services/license/license-context.service.ts
@@ -1,0 +1,30 @@
+import { License } from '../../models/license';
+import { ValueChangeCallback } from '../../models/context/value-change-callback';
+import { ContextService } from '../context/context.service';
+
+/**
+ * Service for managing license context in the application.
+ * Extends the base ContextService to provide license-specific functionality.
+ */
+export class LicenseContextService extends ContextService {
+  private static readonly GRAPHDB_LICENSE = 'graphDbLicense';
+
+  /**
+   * Updates the license information in the context.
+   * @param license - The new License object to be set in the context.
+   */
+  updateLicense(license: License): void {
+    this.updateContextProperty(LicenseContextService.GRAPHDB_LICENSE, license);
+  }
+
+  /**
+   * Subscribes to changes in the license context
+   * .
+   * @param callbackFn - A callback function that will be called when the license changes.
+   * The callback receives the updated License object or undefined as its parameter.
+   * @returns A function that, when called, will unsubscribe from the license changes.
+   */
+  onLicenseChanged(callbackFn: ValueChangeCallback<License | undefined>): () => void {
+    return this.subscribe(LicenseContextService.GRAPHDB_LICENSE, callbackFn);
+  }
+}

--- a/packages/api/src/services/license/license-rest.service.ts
+++ b/packages/api/src/services/license/license-rest.service.ts
@@ -1,0 +1,21 @@
+import { License } from '../../models/license';
+import { HttpService } from '../http/http.service';
+
+/**
+ * Service class for handling REST API calls related to license operations.
+ * Extends the HttpService to utilize its HTTP request capabilities.
+ */
+export class LicenseRestService extends HttpService {
+
+  /**
+   * Retrieves the current license information from the GraphDB settings.
+   * 
+   * This method sends a GET request to the '/rest/graphdb-settings/license' endpoint
+   * to fetch the license details.
+   * 
+   * @returns A Promise that resolves to a License object containing the current license information.
+   */
+  getLicense(): Promise<License> {
+    return this.get<License>('/rest/graphdb-settings/license');
+  }
+}

--- a/packages/api/src/services/license/license.service.ts
+++ b/packages/api/src/services/license/license.service.ts
@@ -1,0 +1,26 @@
+import { LicenseRestService } from './license-rest.service';
+import { ServiceProvider } from '../../providers';
+import { License } from '../../models/license';
+import { LicenseMapper } from './mappers/license-mapper';
+import { Service } from '../../providers/service/service';
+
+/**
+ * Service class for handling license-related operations.
+ */
+export class LicenseService implements Service {
+  private readonly licenseRestService: LicenseRestService = ServiceProvider.get(LicenseRestService);
+  private readonly licenseMapper: LicenseMapper = ServiceProvider.get(LicenseMapper);
+
+  /**
+   * Retrieves the current license information.
+   *
+   * This function fetches the current license data from the license REST service
+   * and maps the response to a License model object.
+   *
+   * @returns {Promise<License>} A Promise that resolves to a License object representing the current license.
+   */
+  getLicense(): Promise<License> {
+    return this.licenseRestService.getLicense()
+      .then(response => this.licenseMapper.mapToModel(response));
+  }
+}

--- a/packages/api/src/services/license/mappers/capability-list.mapper.ts
+++ b/packages/api/src/services/license/mappers/capability-list.mapper.ts
@@ -1,0 +1,19 @@
+import { CapabilityList } from '../../../models/license';
+import { Mapper } from '../../../providers/mapper/mapper';
+import { Capability } from '../../../models/license';
+
+/**
+ * Mapper class for converting an array of Capability objects to a CapabilityList model.
+ * Extends the base Mapper class with CapabilityList as the target model type.
+ */
+export class CapabilityListMapper extends Mapper<CapabilityList> {
+  /**
+   * Maps an array of Capability objects to a CapabilityList model.
+   * 
+   * @param data - An array of Capability objects to be mapped.
+   * @returns A new CapabilityList instance containing the provided Capability objects.
+   */
+  mapToModel(data: Capability[]): CapabilityList {
+    return new CapabilityList(data);
+  }
+}

--- a/packages/api/src/services/license/mappers/license-mapper.spec.ts
+++ b/packages/api/src/services/license/mappers/license-mapper.spec.ts
@@ -1,0 +1,49 @@
+import { LicenseMapper } from './license-mapper';
+import { Capability, License } from '../../../models/license';
+import { CapabilityList } from '../../../models/license';
+
+describe('LicenseMapper', () => {
+  let licenseMapper: LicenseMapper;
+
+  beforeEach(() => {
+    licenseMapper = new LicenseMapper();
+  });
+
+  test('should map all properties from JSON input data in the created License instance', () => {
+    // Given: A sample JSON input data object with various properties
+    const inputData: object = {
+      expiryDate: 1734077569000,
+      latestPublicationDate: 1734077569000,
+      licensee: 'Example Company',
+      maxCpuCores: 4,
+      product: 'GraphDB',
+      productType: 'Enterprise',
+      licenseCapabilities: [Capability.CLUSTER],
+      version: '1.0',
+      installationId: 'inst-123',
+      valid: true,
+      typeOfUse: 'Production',
+      message: 'Valid license'
+    };
+
+    // When: The input data is mapped to a License instance
+    const result = licenseMapper.mapToModel(inputData);
+    const expectedLicenseCapabilityList = new CapabilityList([Capability.CLUSTER]);
+
+    // Then: The result should be an instance of License
+    expect(result).toBeInstanceOf(License);
+
+    // Then: The licenseCapabilities property should match the expected CapabilityList
+    expect(result.licenseCapabilities).toEqual(expectedLicenseCapabilityList);
+    // Then: The licenseCapabilities property should be an instance of CapabilityList
+    expect(result.licenseCapabilities).toBeInstanceOf(CapabilityList);
+
+    // Then: All other properties from the input data should be preserved
+    Object.keys(inputData).forEach(key => {
+      // Exclude licenseCapabilities, as it is handled separately
+      if (key !== 'licenseCapabilities') {
+        expect(result[key as keyof License]).toEqual(inputData[key as keyof object]);
+      }
+    });
+  });
+});

--- a/packages/api/src/services/license/mappers/license-mapper.ts
+++ b/packages/api/src/services/license/mappers/license-mapper.ts
@@ -1,0 +1,18 @@
+import { Mapper } from '../../../providers/mapper/mapper';
+import { License } from '../../../models/license';
+
+/**
+ * Mapper for Graph DB license object. Maps the API JSON response to {@link License}
+ */
+export class LicenseMapper extends Mapper<License> {
+
+  /**
+   * Map to {@link License} object
+   *
+   * @param {Partial<License>} data - The raw representation of the license object
+   * @returns {License} - A new License instance
+   */
+  mapToModel(data: Partial<License>): License {
+    return new License(data);
+  }
+}

--- a/packages/api/src/services/license/test/license-context.service.spec.ts
+++ b/packages/api/src/services/license/test/license-context.service.spec.ts
@@ -1,0 +1,39 @@
+import { LicenseContextService } from '../license-context.service';
+import { License } from '../../../models/license';
+
+describe('LicenseContextService', () => {
+  let licenseContextService: LicenseContextService;
+
+  beforeEach(() => {
+    licenseContextService = new LicenseContextService();
+  });
+
+  test('updateLicense should update the license in the context and notify subscribers', () => {
+    // Given a new license object
+    const newLicense: License = { licensee: 'Test Company', expiryDate: 1672531200000 } as License;
+    const mockCallback = jest.fn();
+    licenseContextService.onLicenseChanged(mockCallback);
+  
+    // When updating the license
+    licenseContextService.updateLicense(newLicense);
+  
+    // Then the context should be updated and subscribers notified
+    expect(mockCallback).toHaveBeenLastCalledWith(newLicense);
+  });
+
+  test('should stop receiving updates, after unsubscribe', () => {
+    // Given a new license object
+    const newLicense: License = { licensee: 'Test Company', expiryDate: 1672531200000 } as License;
+    const mockCallback = jest.fn();
+    const unsubscribe = licenseContextService.onLicenseChanged(mockCallback);
+    // Clear the callback call when the callback function is registered.
+    mockCallback.mockClear();
+
+    // When unsubscribed
+    unsubscribe();
+
+    // Then the context should not receive updates
+    licenseContextService.updateLicense(newLicense);
+    expect(mockCallback).not.toBeCalled();
+  });
+});

--- a/packages/api/src/services/license/test/license.service.spec.ts
+++ b/packages/api/src/services/license/test/license.service.spec.ts
@@ -1,0 +1,41 @@
+import { LicenseService } from '../license.service';
+import { License } from '../../../models/license';
+import { TestUtil } from '../../utils/test/test-util';
+import { ResponseMock } from '../../http/test/response-mock';
+
+describe('LicenseService', () => {
+  let licenseService: LicenseService;
+
+  beforeEach(() => {
+    licenseService = new LicenseService();
+  });
+
+  test('should retrieve the license, mapped to a License object', async () => {
+    // Given, I have a mocked license
+    const mockLicense = { licensee: 'Test Company', expiryDate: 1672531200000 } as License;
+    TestUtil.mockResponse(new ResponseMock('/rest/graphdb-settings/license').setResponse(mockLicense));
+
+    // When I call the getLicense method
+    const result = await licenseService.getLicense();
+
+    const expectedLicense = {
+      licensee: 'Test Company',
+      expiryDate: 1672531200000,
+      product: '',
+      productType: '',
+      version: '',
+      installationId: '',
+      valid: undefined,
+      typeOfUse: '',
+      message: '',
+      latestPublicationDate: undefined,
+      maxCpuCores: undefined,
+      licenseCapabilities: {
+        items: []
+      },
+    };
+
+    // Then, I should get a License object, with default property values
+    expect(result).toEqual(expectedLicense);
+  });
+});

--- a/packages/root-config/src/ontotext-root-config.js
+++ b/packages/root-config/src/ontotext-root-config.js
@@ -13,8 +13,10 @@ import {
 import microfrontendLayout from './microfrontend-layout.html';
 import './styles/bootstrap.min.css';
 import 'font-awesome/css/font-awesome.min.css';
+import './styles/onto-stylesheet.css';
 // import "./styles/bootstrap-graphdb-theme.css";
 import { defineCustomElements } from '../../shared-components/loader';
+import { ServiceProvider, LicenseService, LicenseContextService, TranslationService } from '@ontotext/workbench-api';
 
 addErrorHandler((err) => {
   console.error(err);
@@ -65,6 +67,18 @@ layoutEngine.activate();
 
 defineCustomElements();
 
+const loadLicense = () => {
+  const licenseContext = ServiceProvider.get(LicenseContextService);
+  ServiceProvider.get(LicenseService).getLicense().then(license => {
+    licenseContext.updateLicense(license);
+  }).catch(() => {
+    licenseContext.updateLicense({
+      message: TranslationService.translate('license_alert.no_license_set'),
+      valid: false
+    });
+  });
+};
+
 // This is a workaround to initialize the navbar when the root-config is loaded and the navbar is not yet initialized.
 const waitForNavbarElement = () => {
   return new Promise((resolve, reject) => {
@@ -93,6 +107,7 @@ const registerSingleSpaFirstMountListener = () => {
     window.singleSpaFirstMountListenerRegistered = true;
     window.addEventListener('single-spa:first-mount', () => {
       initializeNavbar();
+      loadLicense();
     });
   }
 };

--- a/packages/root-config/src/styles/onto-stylesheet.css
+++ b/packages/root-config/src/styles/onto-stylesheet.css
@@ -1,0 +1,41 @@
+/* Global stylesheet */
+
+/*-------------------------------------------------------------
+	Classes
+-------------------------------------------------------------*/
+.onto-button {
+    display: inline-block;
+    font-weight: 400;
+    line-height: 1.25;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    cursor: pointer;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    border: 1px solid transparent;
+    padding: .5rem 1rem;
+    font-size: 1rem;
+}
+
+
+/*-------------------------------------------------------------
+	KeyFrames
+-------------------------------------------------------------*/
+
+@keyframes fade-button {
+    from {
+        background-color: #EBEBEB;
+        border-color: #EBEBEB;
+    }
+    50% {
+        background-color: var(--fade-color);
+        border-color: var(--fade-color);
+    }
+    to {
+        background-color: #EBEBEB;
+        border-color: #EBEBEB;
+    }
+}

--- a/packages/shared-components/cypress/e2e/header/header.cy.js
+++ b/packages/shared-components/cypress/e2e/header/header.cy.js
@@ -1,4 +1,5 @@
 import {HeaderSteps} from "../../steps/header/header-steps";
+import {TooltipSteps} from "../../steps/tooltip-steps";
 
 describe('Header', () => {
   it('Should render header and various tools inside', () => {
@@ -12,5 +13,44 @@ describe('Header', () => {
     HeaderSteps.getRepositorySelector().should('be.visible');
     // And I should see the search component
     HeaderSteps.getSearch().should('be.visible');
+  });
+
+  describe('OntoLicenseAlert', () => {
+    it('Should be visible when license is invalid', () => {
+      // Given, I visit the header page
+      HeaderSteps.visit();
+
+      // When, I have an invalid license
+      HeaderSteps.setLicenseValid(false);
+
+      // Then, the license alert should be visible
+      HeaderSteps.getLicenseAlert().should('be.visible');
+
+      // When, I hover over the notification
+      HeaderSteps.getLicenseAlert().trigger('mouseover');
+
+      // Then, I should see a tooltip
+      TooltipSteps.getTooltip().should('be.visible');
+
+      // And the tooltip should contain the expected message
+      TooltipSteps.getTooltipContent().should('have.text', 'Invalid license');
+
+      // When, I move the mouse away
+      HeaderSteps.getLicenseAlert().trigger('mouseout');
+
+      // Then the tooltip should disappear
+      TooltipSteps.getTooltip().should('not.exist');
+    });
+
+    it('Should be hidden when license is valid', () => {
+      // Given, I visit the header page
+      HeaderSteps.visit();
+
+      // When, I have a valid license
+      HeaderSteps.setLicenseValid(true);
+
+      // Then, the license alert should be hidden
+      HeaderSteps.getLicenseAlert().should('not.exist');
+    });
   });
 });

--- a/packages/shared-components/cypress/e2e/license-alert/license-alert.cy.js
+++ b/packages/shared-components/cypress/e2e/license-alert/license-alert.cy.js
@@ -1,0 +1,14 @@
+import {LicenseAlertSteps} from "../../steps/license-alert/license-alert-steps";
+
+describe('LicenseAlert', () => {
+  it('Should redirect to /license, when clicked', () => {
+    // Given, I visited the license-alert page
+    LicenseAlertSteps.visit();
+
+    // When, I click on the license alert
+    LicenseAlertSteps.getLicenseAlert().should('be.visible').click();
+
+    // Then, I should be redirected to /license
+    LicenseAlertSteps.getRedirectUrl().should('have.text', 'redirect to /license');
+  });
+});

--- a/packages/shared-components/cypress/steps/base-steps.js
+++ b/packages/shared-components/cypress/steps/base-steps.js
@@ -6,4 +6,8 @@ export class BaseSteps {
   static clickOutsideElement() {
     cy.get('body').click(0,0);
   }
+
+  static getRedirectUrl() {
+    return cy.get('#redirect-url');
+  }
 }

--- a/packages/shared-components/cypress/steps/header/header-steps.js
+++ b/packages/shared-components/cypress/steps/header/header-steps.js
@@ -20,4 +20,13 @@ export class HeaderSteps extends BaseSteps {
   static getSearch() {
     return HeaderSteps.getHeader().find('.search-component');
   }
+
+  static getLicenseAlert() {
+    return HeaderSteps.getHeader().find('.onto-license-alert');
+  }
+
+  static setLicenseValid(valid) {
+    const license = valid ? '#valid-license' : '#invalid-license';
+    cy.get(license).click();
+  }
 }

--- a/packages/shared-components/cypress/steps/license-alert/license-alert-steps.js
+++ b/packages/shared-components/cypress/steps/license-alert/license-alert-steps.js
@@ -1,0 +1,12 @@
+import {BaseSteps} from "../base-steps";
+
+export class LicenseAlertSteps extends BaseSteps {
+
+  static visit() {
+    super.visit('license-alert');
+  }
+
+  static getLicenseAlert() {
+    return cy.get('.onto-license-alert');
+  }
+}

--- a/packages/shared-components/cypress/steps/tooltip-steps.js
+++ b/packages/shared-components/cypress/steps/tooltip-steps.js
@@ -26,6 +26,10 @@ export class TooltipSteps extends BaseSteps {
     return TooltipSteps.getTooltip().find('.body');
   }
 
+  static getTooltipContent() {
+    return TooltipSteps.getTooltip().find('.tippy-content');
+  }
+
   static getElementWithBottomTooltip() {
     return cy.get('.tooltip-bottom');
   }

--- a/packages/shared-components/src/assets/i18n/en.json
+++ b/packages/shared-components/src/assets/i18n/en.json
@@ -94,5 +94,9 @@
         "expansion_ratio": "Expansion ratio (total/explicit)"
       }
     }
+  },
+  "license_alert": {
+    "label": "No valid license",
+    "no_license_set": "No license was set."
   }
 }

--- a/packages/shared-components/src/assets/i18n/fr.json
+++ b/packages/shared-components/src/assets/i18n/fr.json
@@ -97,5 +97,9 @@
         "expansion_ratio": "Taux d'expansion (total/explicite)"
       }
     }
+  },
+  "license_alert": {
+    "label": "Aucune licence valide",
+    "no_license_set": "Aucune licence n'a été définie."
   }
 }

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -5,13 +5,13 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { Awaitable } from "../../api/dist/ontotext-workbench-api.d";
+import { Awaitable, License } from "../../api/dist/ontotext-workbench-api.d";
 import { DropdownItem } from "./models/dropdown/dropdown-item";
 import { DropdownItemAlignment } from "./models/dropdown/dropdown-item-alignment";
 import { ExternalMenuModel } from "./components/onto-navbar/external-menu-model";
 import { NavbarToggledEvent } from "./components/onto-navbar/navbar-toggled-event";
 import { TranslationParameter } from "./models/translation/translation-parameter";
-export { Awaitable } from "../../api/dist/ontotext-workbench-api.d";
+export { Awaitable, License } from "../../api/dist/ontotext-workbench-api.d";
 export { DropdownItem } from "./models/dropdown/dropdown-item";
 export { DropdownItemAlignment } from "./models/dropdown/dropdown-item-alignment";
 export { ExternalMenuModel } from "./components/onto-navbar/external-menu-model";
@@ -63,6 +63,11 @@ export namespace Components {
     }
     interface OntoFooter {
     }
+    /**
+     * OntoHeader component for rendering the header of the application.
+     * This component includes a search component, license alert (if applicable),
+     * repository selector, and language selector.
+     */
     interface OntoHeader {
     }
     interface OntoLanguageSelector {
@@ -72,6 +77,12 @@ export namespace Components {
         "dropdownAlignment": DropdownItemAlignment;
     }
     interface OntoLayout {
+    }
+    interface OntoLicenseAlert {
+        /**
+          * The current license information
+         */
+        "license": License;
     }
     interface OntoNavbar {
         /**
@@ -88,6 +99,17 @@ export namespace Components {
         "selectedMenu": string;
     }
     interface OntoRepositorySelector {
+    }
+    /**
+     * A component for managing test context in the application. Used only for testing
+     */
+    interface OntoTestContext {
+        /**
+          * Updates the license information in the context.  This method uses the LicenseContextService to update the license and returns a resolved Promise once the operation is complete.
+          * @param license - The new License object to be set.
+          * @returns A Promise that resolves when the license update is complete.
+         */
+        "updateLicense": (license: License) => Promise<void>;
     }
     interface OntoTooltip {
     }
@@ -149,6 +171,11 @@ declare global {
         prototype: HTMLOntoFooterElement;
         new (): HTMLOntoFooterElement;
     };
+    /**
+     * OntoHeader component for rendering the header of the application.
+     * This component includes a search component, license alert (if applicable),
+     * repository selector, and language selector.
+     */
     interface HTMLOntoHeaderElement extends Components.OntoHeader, HTMLStencilElement {
     }
     var HTMLOntoHeaderElement: {
@@ -166,6 +193,12 @@ declare global {
     var HTMLOntoLayoutElement: {
         prototype: HTMLOntoLayoutElement;
         new (): HTMLOntoLayoutElement;
+    };
+    interface HTMLOntoLicenseAlertElement extends Components.OntoLicenseAlert, HTMLStencilElement {
+    }
+    var HTMLOntoLicenseAlertElement: {
+        prototype: HTMLOntoLicenseAlertElement;
+        new (): HTMLOntoLicenseAlertElement;
     };
     interface HTMLOntoNavbarElementEventMap {
         "navbarToggled": NavbarToggledEvent;
@@ -189,6 +222,15 @@ declare global {
     var HTMLOntoRepositorySelectorElement: {
         prototype: HTMLOntoRepositorySelectorElement;
         new (): HTMLOntoRepositorySelectorElement;
+    };
+    /**
+     * A component for managing test context in the application. Used only for testing
+     */
+    interface HTMLOntoTestContextElement extends Components.OntoTestContext, HTMLStencilElement {
+    }
+    var HTMLOntoTestContextElement: {
+        prototype: HTMLOntoTestContextElement;
+        new (): HTMLOntoTestContextElement;
     };
     interface HTMLOntoTooltipElement extends Components.OntoTooltip, HTMLStencilElement {
     }
@@ -218,8 +260,10 @@ declare global {
         "onto-header": HTMLOntoHeaderElement;
         "onto-language-selector": HTMLOntoLanguageSelectorElement;
         "onto-layout": HTMLOntoLayoutElement;
+        "onto-license-alert": HTMLOntoLicenseAlertElement;
         "onto-navbar": HTMLOntoNavbarElement;
         "onto-repository-selector": HTMLOntoRepositorySelectorElement;
+        "onto-test-context": HTMLOntoTestContextElement;
         "onto-tooltip": HTMLOntoTooltipElement;
         "translate-label": HTMLTranslateLabelElement;
     }
@@ -274,6 +318,11 @@ declare namespace LocalJSX {
     }
     interface OntoFooter {
     }
+    /**
+     * OntoHeader component for rendering the header of the application.
+     * This component includes a search component, license alert (if applicable),
+     * repository selector, and language selector.
+     */
     interface OntoHeader {
     }
     interface OntoLanguageSelector {
@@ -283,6 +332,12 @@ declare namespace LocalJSX {
         "dropdownAlignment"?: DropdownItemAlignment;
     }
     interface OntoLayout {
+    }
+    interface OntoLicenseAlert {
+        /**
+          * The current license information
+         */
+        "license"?: License;
     }
     interface OntoNavbar {
         /**
@@ -303,6 +358,11 @@ declare namespace LocalJSX {
         "selectedMenu"?: string;
     }
     interface OntoRepositorySelector {
+    }
+    /**
+     * A component for managing test context in the application. Used only for testing
+     */
+    interface OntoTestContext {
     }
     interface OntoTooltip {
     }
@@ -332,8 +392,10 @@ declare namespace LocalJSX {
         "onto-header": OntoHeader;
         "onto-language-selector": OntoLanguageSelector;
         "onto-layout": OntoLayout;
+        "onto-license-alert": OntoLicenseAlert;
         "onto-navbar": OntoNavbar;
         "onto-repository-selector": OntoRepositorySelector;
+        "onto-test-context": OntoTestContext;
         "onto-tooltip": OntoTooltip;
         "translate-label": TranslateLabel;
     }
@@ -349,11 +411,21 @@ declare module "@stencil/core" {
              */
             "onto-dropdown": LocalJSX.OntoDropdown & JSXBase.HTMLAttributes<HTMLOntoDropdownElement>;
             "onto-footer": LocalJSX.OntoFooter & JSXBase.HTMLAttributes<HTMLOntoFooterElement>;
+            /**
+             * OntoHeader component for rendering the header of the application.
+             * This component includes a search component, license alert (if applicable),
+             * repository selector, and language selector.
+             */
             "onto-header": LocalJSX.OntoHeader & JSXBase.HTMLAttributes<HTMLOntoHeaderElement>;
             "onto-language-selector": LocalJSX.OntoLanguageSelector & JSXBase.HTMLAttributes<HTMLOntoLanguageSelectorElement>;
             "onto-layout": LocalJSX.OntoLayout & JSXBase.HTMLAttributes<HTMLOntoLayoutElement>;
+            "onto-license-alert": LocalJSX.OntoLicenseAlert & JSXBase.HTMLAttributes<HTMLOntoLicenseAlertElement>;
             "onto-navbar": LocalJSX.OntoNavbar & JSXBase.HTMLAttributes<HTMLOntoNavbarElement>;
             "onto-repository-selector": LocalJSX.OntoRepositorySelector & JSXBase.HTMLAttributes<HTMLOntoRepositorySelectorElement>;
+            /**
+             * A component for managing test context in the application. Used only for testing
+             */
+            "onto-test-context": LocalJSX.OntoTestContext & JSXBase.HTMLAttributes<HTMLOntoTestContextElement>;
             "onto-tooltip": LocalJSX.OntoTooltip & JSXBase.HTMLAttributes<HTMLOntoTooltipElement>;
             /**
              * The purpose of this component is to display translated literals in the DOM. A Stencil component re-renders when a prop or state changes,

--- a/packages/shared-components/src/components/onto-header/onto-header.tsx
+++ b/packages/shared-components/src/components/onto-header/onto-header.tsx
@@ -1,21 +1,54 @@
-import { Component, Host, h } from '@stencil/core';
+import { Component, Host, h, State } from '@stencil/core';
+import { ServiceProvider, LicenseContextService, License } from '@ontotext/workbench-api'
+import { SubscriptionList } from '../../../../api/src/models/common/subscription-list';
 
+/**
+ * OntoHeader component for rendering the header of the application.
+ * This component includes a search component, license alert (if applicable),
+ * repository selector, and language selector.
+ */
 @Component({
   tag: 'onto-header',
   styleUrl: 'onto-header.scss',
   shadow: false,
 })
 export class OntoHeader {
+  /** The current license information */
+  @State() private license: License;
+
+  /** Array of subscription cleanup functions */
+  private readonly subscriptions: SubscriptionList = new SubscriptionList();
+
+  /**
+   * Initializes the component and sets up license change subscription.
+   */
+  constructor() {
+    this.subscriptions.add(ServiceProvider.get(LicenseContextService)
+      .onLicenseChanged(license => {
+        this.license = license;
+      }));
+  }
 
   render() {
     return (
       <Host>
         <div class="header-component">
           <div class="search-component">&#x1F50D;</div>
+          {Boolean(this.license) && !this.license?.valid ?
+            <onto-license-alert license={this.license}></onto-license-alert> : ''
+          }
           <onto-repository-selector></onto-repository-selector>
           <onto-language-selector dropdown-alignment="right"></onto-language-selector>
         </div>
       </Host>
     );
+  }
+
+  /**
+   * Lifecycle method called when the component is about to be removed from the DOM.
+   * Cleans up all subscriptions.
+   */
+  disconnectedCallback(): void {
+    this.subscriptions.unsubscribeAll();
   }
 }

--- a/packages/shared-components/src/components/onto-header/readme.md
+++ b/packages/shared-components/src/components/onto-header/readme.md
@@ -5,6 +5,12 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+OntoHeader component for rendering the header of the application.
+This component includes a search component, license alert (if applicable),
+repository selector, and language selector.
+
 ## Dependencies
 
 ### Used by
@@ -13,14 +19,17 @@
 
 ### Depends on
 
+- [onto-license-alert](../onto-license-alert)
 - [onto-repository-selector](../onto-repository-selector)
 - [onto-language-selector](../onto-language-selector)
 
 ### Graph
 ```mermaid
 graph TD;
+  onto-header --> onto-license-alert
   onto-header --> onto-repository-selector
   onto-header --> onto-language-selector
+  onto-license-alert --> translate-label
   onto-repository-selector --> onto-dropdown
   onto-language-selector --> onto-dropdown
   onto-layout --> onto-header

--- a/packages/shared-components/src/components/onto-layout/readme.md
+++ b/packages/shared-components/src/components/onto-layout/readme.md
@@ -21,8 +21,10 @@ graph TD;
   onto-layout --> onto-navbar
   onto-layout --> onto-footer
   onto-layout --> onto-tooltip
+  onto-header --> onto-license-alert
   onto-header --> onto-repository-selector
   onto-header --> onto-language-selector
+  onto-license-alert --> translate-label
   onto-repository-selector --> onto-dropdown
   onto-language-selector --> onto-dropdown
   onto-navbar --> translate-label

--- a/packages/shared-components/src/components/onto-license-alert/onto-license-alert.scss
+++ b/packages/shared-components/src/components/onto-license-alert/onto-license-alert.scss
@@ -1,0 +1,31 @@
+:host {
+  display: block;
+}
+
+.onto-license-alert {
+  animation: fade-button 2s infinite;
+  --fade-color: var(--color-danger-medium);
+  border: 1px solid transparent !important;
+
+  &:hover {
+    text-decoration: none;
+    background-color: var(--color-danger-medium) !important;
+    border-color: var(--color-danger-medium) !important;
+
+    & span {
+      transform: scale(1.2);
+    }
+  }
+
+  & span {
+    transition: transform 0.15s ease-out;
+  }
+
+  & .icon-warning {
+    margin-right: 0.2em;
+    line-height: 0.75;
+    font-size: 1.4em;
+    display: inline-block;
+    vertical-align: middle;
+  }
+}

--- a/packages/shared-components/src/components/onto-license-alert/onto-license-alert.tsx
+++ b/packages/shared-components/src/components/onto-license-alert/onto-license-alert.tsx
@@ -1,0 +1,36 @@
+import { License } from '@ontotext/workbench-api';
+import { Component, Host, h, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'onto-license-alert',
+  styleUrl: 'onto-license-alert.scss'
+})
+/**
+ * OntoLicenseAlert component
+ *
+ * This component displays a license alert button with a tooltip.
+ * It is used to show license-related information and provide a link to the license page.
+ */
+export class OntoLicenseAlert {
+
+  /** The current license information */
+  @Prop() license: License;
+
+  render() {
+    return (
+      <Host tooltip-content={this.license?.message} tooltip-placement="bottom">
+        <a class="onto-license-alert onto-button" onClick={this.onLicenseAlertClick}>
+          <span class="icon-warning"></span>
+          <translate-label labelKey={'license_alert.label'}></translate-label>
+        </a>
+      </Host>
+    );
+  }
+
+  private onLicenseAlertClick(event: Event) {
+    event.preventDefault();
+    // Navigate to the license page without reloading.
+    // @ts-ignore
+    window.singleSpa.navigateToUrl('/license');
+  }
+}

--- a/packages/shared-components/src/components/onto-license-alert/readme.md
+++ b/packages/shared-components/src/components/onto-license-alert/readme.md
@@ -1,0 +1,35 @@
+# onto-license-alert
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property  | Attribute | Description                     | Type      | Default     |
+| --------- | --------- | ------------------------------- | --------- | ----------- |
+| `license` | --        | The current license information | `License` | `undefined` |
+
+
+## Dependencies
+
+### Used by
+
+ - [onto-header](../onto-header)
+
+### Depends on
+
+- [translate-label](../translate-label)
+
+### Graph
+```mermaid
+graph TD;
+  onto-license-alert --> translate-label
+  onto-header --> onto-license-alert
+  style onto-license-alert fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/shared-components/src/components/onto-license-alert/test/onto-license-alert.e2e.ts
+++ b/packages/shared-components/src/components/onto-license-alert/test/onto-license-alert.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('onto-license-alert', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<onto-license-alert></onto-license-alert>');
+
+    const element = await page.find('onto-license-alert');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/packages/shared-components/src/components/onto-license-alert/test/onto-license-alert.spec.tsx
+++ b/packages/shared-components/src/components/onto-license-alert/test/onto-license-alert.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { OntoLicenseAlert } from '../onto-license-alert';
+
+describe('onto-license-alert', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [OntoLicenseAlert],
+      html: `<onto-license-alert></onto-license-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <onto-license-alert>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </onto-license-alert>
+    `);
+  });
+});

--- a/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
+++ b/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
@@ -1,0 +1,26 @@
+import { Component, Method } from '@stencil/core';
+import { License, LicenseContextService, ServiceProvider } from '@ontotext/workbench-api';
+
+/**
+ * A component for managing test context in the application. Used only for testing
+ */
+@Component({
+  tag: 'onto-test-context',
+})
+export class OntoTestContext {
+
+  /**
+   * Updates the license information in the context.
+   *
+   * This method uses the LicenseContextService to update the license
+   * and returns a resolved Promise once the operation is complete.
+   *
+   * @param license - The new License object to be set.
+   * @returns A Promise that resolves when the license update is complete.
+   */
+  @Method()
+  updateLicense(license: License): Promise<void> {
+    ServiceProvider.get(LicenseContextService).updateLicense(license);
+    return Promise.resolve();
+  }
+}

--- a/packages/shared-components/src/components/onto-test-context/readme.md
+++ b/packages/shared-components/src/components/onto-test-context/readme.md
@@ -1,0 +1,36 @@
+# onto-test-context
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+A component for managing test context in the application. Used only for testing
+
+## Methods
+
+### `updateLicense(license: License) => Promise<void>`
+
+Updates the license information in the context.
+
+This method uses the LicenseContextService to update the license
+and returns a resolved Promise once the operation is complete.
+
+#### Parameters
+
+| Name      | Type      | Description                         |
+| --------- | --------- | ----------------------------------- |
+| `license` | `License` | - The new License object to be set. |
+
+#### Returns
+
+Type: `Promise<void>`
+
+A Promise that resolves when the license update is complete.
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/shared-components/src/components/translate-label/readme.md
+++ b/packages/shared-components/src/components/translate-label/readme.md
@@ -28,11 +28,13 @@ Example of usage:
 
 ### Used by
 
+ - [onto-license-alert](../onto-license-alert)
  - [onto-navbar](../onto-navbar)
 
 ### Graph
 ```mermaid
 graph TD;
+  onto-license-alert --> translate-label
   onto-navbar --> translate-label
   style translate-label fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/shared-components/src/index.html
+++ b/packages/shared-components/src/index.html
@@ -19,6 +19,7 @@
       <li><a href="/pages/tooltip/index.html">tooltip</a></li>
       <li><a href="/pages/language-selector/index.html">Language Selector</a></li>
       <li><a href="/pages/repository-selector/index.html">Repository Selector</a></li>
+      <li><a href="/pages/license-alert/index.html">license alert</a></li>
     </ul>
   </body>
 </html>

--- a/packages/shared-components/src/pages/header/main.js
+++ b/packages/shared-components/src/pages/header/main.js
@@ -1,1 +1,35 @@
-let headerElement = document.querySelector("onto-header");
+const setValidLicense = () => {
+  updateLicense({
+      "expiryDate": 1734077569000,
+      "latestPublicationDate": 1734077569000,
+      "licensee": "Example Company",
+      "maxCpuCores": 4,
+      "product": "GraphDB",
+      "productType": "Enterprise",
+      "licenseCapabilities": ["Capability.CLUSTER"],
+      "version": "1.0",
+      "installationId": "inst-123",
+      "valid": true,
+      "typeOfUse": "Production",
+      "message": "Valid license"
+    }
+  )
+}
+
+const setInvalidLicense = () => {
+  updateLicense({
+      "expiryDate": 1734077569000,
+      "latestPublicationDate": 1734077569000,
+      "licensee": "Example Company",
+      "maxCpuCores": 4,
+      "product": "GraphDB",
+      "productType": "Enterprise",
+      "licenseCapabilities": ["Capability.CLUSTER"],
+      "version": "1.0",
+      "installationId": "inst-123",
+      "valid": false,
+      "typeOfUse": "Production",
+      "message": "Invalid license"
+    }
+  )
+}

--- a/packages/shared-components/src/pages/js/main.js
+++ b/packages/shared-components/src/pages/js/main.js
@@ -1,0 +1,17 @@
+let testContext = document.createElement('onto-test-context');
+document.body.appendChild(testContext);
+
+// Mock the navigateUrl function which is exposed by the single-spa via the root-config module
+// in order to allow the menu to work without going anywhere when clicking the menu items
+window.singleSpa = {
+  navigateToUrl: function (url) {
+    const redirect = document.createElement('div');
+    redirect.id = 'redirect-url';
+    redirect.innerHTML = `redirect to ${url}`;
+    document.body.appendChild(redirect);
+  }
+};
+
+const updateLicense = (license) => {
+  testContext.updateLicense(license);
+}

--- a/packages/shared-components/src/pages/license-alert/index.html
+++ b/packages/shared-components/src/pages/license-alert/index.html
@@ -21,9 +21,6 @@
   <link rel="stylesheet" href="../css/font-awesome.min.css">
 </head>
 <body>
-<button id="valid-license" onclick="setValidLicense()">set valid license</button>
-<button id="invalid-license" onclick="setInvalidLicense()">set invalid license</button>
-<onto-header></onto-header>
-<onto-tooltip></onto-tooltip>
+<onto-license-alert></onto-license-alert>
 </body>
 </html>

--- a/packages/shared-components/src/pages/license-alert/main.js
+++ b/packages/shared-components/src/pages/license-alert/main.js
@@ -1,0 +1,5 @@
+const licenseAlert = document.querySelector('onto-license-alert');
+licenseAlert.license = {
+  message: 'No license set',
+  valid: false
+}


### PR DESCRIPTION
## What
Implement license alert component

## Why
To display a notification to the user, whenever a license is invalid

## How
- Added `license-alert-component`
- The new component is displayed in the header, when license is not valid, or an error occurred, when retrieving the license
- Added request for retrieving license info inside `ontotext-root-config.js` (to be done once globally)
- Added services, mappers and models needed for the new component
- Added `onto-stylesheet.css` for global styles

## Testing
jest unit tests

## Screenshots
![image](https://github.com/user-attachments/assets/646838a3-76b2-4ffa-8f6a-8d4f04e2ee80)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
