### PR TITLE
GDB-11387 Pass the password property with the expected name to the UpdateUserPayload model

### DIFF
--- a/src/js/angular/security/controllers/user-settings.controller.js
+++ b/src/js/angular/security/controllers/user-settings.controller.js
@@ -138,7 +138,7 @@ function UserSettingsController($scope, toastr, $window, $timeout, $jwtAuth, $ro
         $scope.loader = true;
         const payload = new UpdateUserPayload({
             username: $scope.user.username,
-            pass: ($scope.noPassword) ? '' : $scope.user.password || undefined,
+            password: ($scope.noPassword) ? '' : $scope.user.password || undefined,
             appSettings: $scope.user.appSettings
         });
         SecurityService.updateUserData(payload)


### PR DESCRIPTION
## What
Pass the password property with the expected name to the UpdateUserPayload model.

## Why
A logged-in user can't edit his own password.

## How
Fixed the password property name passed to the user model so that it can be mapped correctly.  

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
