### PR TITLE
(cherry-pick) GDB-11397 - Re-position the dropdown repo list popovers

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -64,7 +64,7 @@
             <li ng-repeat="repository in getReadableRepositories() | orderBy: ['location', 'id']"
                 ng-if="!isRepoActive(repository)"
                 ng-mouseover="handlePopovers(repository)" popover-popup-delay="500"
-                popover-trigger="mouseenter" popover-placement="left"
+                popover-trigger="mouseenter" popover-placement="left-bottom"
                 uib-popover-template="popoverTemplate" popover-title="{{'security.repository.title' | translate}} {{repository.id}}">
                 <a class="dropdown-item" ng-click="setRepository(repository)" guide-selector="repository-{{repository.id}}-button">
                     <em ng-class="'icon-repo-' + repository.type" class="icon-1-5x"></em>


### PR DESCRIPTION
## What
The popovers in the dropdown list for repository selection will not appear cut off by the top of the browser.

## Why
The top repositories would have a partially visible popover, because they appeared too high up and would get cut off at the end of the page.

## How
I changed the popover position to better fit the amount of rows in the popover template. This should make it less likely that it is cut off.

## Testing
N/A

## Screenshots
Before (as reported in the Jira bug):
![image](https://github.com/user-attachments/assets/1d897962-16b5-4744-9cf0-26882b766e21)

After:
![image](https://github.com/user-attachments/assets/eed5fddd-19bd-46ad-9575-cea2ae32b8a8)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
