### PR TITLE
fix(GDB-10638) Add baseUrl and mount api directory

### DIFF
--- a/packages/shared-components/docker-compose.yaml
+++ b/packages/shared-components/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
       - "3333:3333"
     volumes:
       - .:/app
+      - ../api:/api
     command: npm run start
 
   cypress:

--- a/packages/shared-components/tsconfig.json
+++ b/packages/shared-components/tsconfig.json
@@ -10,6 +10,7 @@
       "dom",
       "es2017"
     ],
+    "baseUrl": "./",
     "paths": {
       "@ontotext/workbench-api": ["../api/dist/ontotext-workbench-api.d.ts"]
     },


### PR DESCRIPTION
## WHAT
- Added baseUrl to the tsconfig.json file in the shared-components package.
- Mounted the api directory to the shared_components service in docker-compose.yaml.

## WHY
baseUrl in tsconfig.json:
- Required for proper resolution of module paths defined in the paths configuration, particularly for the @ontotext/workbench-api alias

Mounting the api directory:
- Enables the shared_components service to access the api directory on the host machine

## HOW
- Updated tsconfig.json: Added "baseUrl": "./" under compilerOptions to support path alias resolution.
- Updated docker-compose.yaml: Added ../api:/api as a volume for the shared_components service to expose the api directory inside the container


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
