### PR TITLE
GDB-10571 Implement workbench footer component

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 end_of_line = lf
 charset = utf-8
@@ -12,9 +12,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
-
-[*.yml]
-indent_size = 2
 
 [*.txt]
 insert_final_newline = false

--- a/packages/api/src/models/common/index.ts
+++ b/packages/api/src/models/common/index.ts
@@ -2,3 +2,4 @@ export * from './awaitable';
 export * from './copyable';
 export * from './model';
 export * from './model-list';
+export * from './subscription-list';

--- a/packages/api/src/models/product-info/index.ts
+++ b/packages/api/src/models/product-info/index.ts
@@ -1,0 +1,1 @@
+export * from './product-info';

--- a/packages/api/src/models/product-info/product-info.ts
+++ b/packages/api/src/models/product-info/product-info.ts
@@ -1,0 +1,17 @@
+export class ProductInfo {
+  workbench: string;
+  productType: string;
+  productVersion: string;
+  sesame: string;
+  connectors: string;
+
+  constructor(data: Partial<ProductInfo & { Workbench: string }>) {
+    // The 'Workbench' property comes with an upper-case 'W' from the backend
+    // Map it to lower-case for consistency
+    this.workbench = data.Workbench || '';
+    this.productType = data.productType || '';
+    this.productVersion = data.productVersion || '';
+    this.sesame = data.sesame || '';
+    this.connectors = data.connectors || '';
+  }
+}

--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -7,6 +7,7 @@ export * from './models/events';
 export * from './models/security';
 export * from './models/license';
 export * from './models/common';
+export * from './models/product-info';
 
 // Export providers for external usages.
 export * from './providers';
@@ -18,6 +19,7 @@ export * from './services/repository-location';
 export {AuthenticationService} from './services/security/authentication.service';
 export {EventEmitter} from './emitters/event.emitter';
 export * from './services/license';
+export * from './services/product-info';
 
 // Export utils for external usages.
 export * from './services/utils';

--- a/packages/api/src/services/license/license-context.service.ts
+++ b/packages/api/src/services/license/license-context.service.ts
@@ -19,7 +19,7 @@ export class LicenseContextService extends ContextService {
 
   /**
    * Subscribes to changes in the license context
-   * .
+   *
    * @param callbackFn - A callback function that will be called when the license changes.
    * The callback receives the updated License object or undefined as its parameter.
    * @returns A function that, when called, will unsubscribe from the license changes.

--- a/packages/api/src/services/license/license-rest.service.ts
+++ b/packages/api/src/services/license/license-rest.service.ts
@@ -6,13 +6,12 @@ import { HttpService } from '../http/http.service';
  * Extends the HttpService to utilize its HTTP request capabilities.
  */
 export class LicenseRestService extends HttpService {
-
   /**
    * Retrieves the current license information from the GraphDB settings.
-   * 
+   *
    * This method sends a GET request to the '/rest/graphdb-settings/license' endpoint
    * to fetch the license details.
-   * 
+   *
    * @returns A Promise that resolves to a License object containing the current license information.
    */
   getLicense(): Promise<License> {

--- a/packages/api/src/services/license/test/license-context.service.spec.ts
+++ b/packages/api/src/services/license/test/license-context.service.spec.ts
@@ -10,20 +10,20 @@ describe('LicenseContextService', () => {
 
   test('updateLicense should update the license in the context and notify subscribers', () => {
     // Given a new license object
-    const newLicense: License = { licensee: 'Test Company', expiryDate: 1672531200000 } as License;
+    const newLicense: License = {licensee: 'Test Company', expiryDate: 1672531200000} as License;
     const mockCallback = jest.fn();
     licenseContextService.onLicenseChanged(mockCallback);
-  
+
     // When updating the license
     licenseContextService.updateLicense(newLicense);
-  
+
     // Then the context should be updated and subscribers notified
     expect(mockCallback).toHaveBeenLastCalledWith(newLicense);
   });
 
   test('should stop receiving updates, after unsubscribe', () => {
     // Given a new license object
-    const newLicense: License = { licensee: 'Test Company', expiryDate: 1672531200000 } as License;
+    const newLicense: License = {licensee: 'Test Company', expiryDate: 1672531200000} as License;
     const mockCallback = jest.fn();
     const unsubscribe = licenseContextService.onLicenseChanged(mockCallback);
     // Clear the callback call when the callback function is registered.
@@ -34,6 +34,6 @@ describe('LicenseContextService', () => {
 
     // Then the context should not receive updates
     licenseContextService.updateLicense(newLicense);
-    expect(mockCallback).not.toBeCalled();
+    expect(mockCallback).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/services/product-info/index.ts
+++ b/packages/api/src/services/product-info/index.ts
@@ -1,0 +1,2 @@
+export * from './product-info-context.service';
+export * from './product-info.service';

--- a/packages/api/src/services/product-info/mappers/product-info.mapper.spec.ts
+++ b/packages/api/src/services/product-info/mappers/product-info.mapper.spec.ts
@@ -1,0 +1,46 @@
+import { ProductInfoMapper } from './product-info.mapper';
+import { ProductInfo } from '../../../models/product-info';
+
+describe('ProductInfoMapper', () => {
+  let mapper: ProductInfoMapper;
+
+  beforeEach(() => {
+    mapper = new ProductInfoMapper();
+  });
+
+  it('should map a complete product info object correctly', () => {
+    const input = {
+      Workbench: '1.0.0',
+      productType: 'GraphDB',
+      productVersion: '9.10.1',
+      sesame: '3.6.0',
+      connectors: '5.0.0'
+    };
+
+    const result = mapper.mapToModel(input);
+
+    expect(result).toBeInstanceOf(ProductInfo);
+    expect(result.workbench).toBe('1.0.0');
+    expect(result.productType).toBe('GraphDB');
+    expect(result.productVersion).toBe('9.10.1');
+    expect(result.sesame).toBe('3.6.0');
+    expect(result.connectors).toBe('5.0.0');
+  });
+
+  it('should handle missing optional fields', () => {
+    const input = {
+      Workbench: '1.0.0',
+      productType: 'GraphDB',
+      productVersion: '9.10.1'
+    };
+
+    const result = mapper.mapToModel(input);
+
+    expect(result).toBeInstanceOf(ProductInfo);
+    expect(result.workbench).toEqual('1.0.0');
+    expect(result.productType).toEqual('GraphDB');
+    expect(result.productVersion).toEqual('9.10.1');
+    expect(result.sesame).toEqual('');
+    expect(result.connectors).toEqual('');
+  });
+});

--- a/packages/api/src/services/product-info/mappers/product-info.mapper.ts
+++ b/packages/api/src/services/product-info/mappers/product-info.mapper.ts
@@ -1,0 +1,24 @@
+import { ProductInfo } from '../../../models/product-info';
+import { Mapper } from '../../../providers/mapper/mapper';
+
+/**
+ * Mapper class for ProductInfo objects.
+ *
+ * This class extends the generic Mapper class, specializing in mapping
+ * partial ProductInfo data to complete ProductInfo models.
+ */
+export class ProductInfoMapper extends Mapper<ProductInfo> {
+  /**
+   * Maps partial ProductInfo data to a complete ProductInfo model.
+   *
+   * This method takes partial ProductInfo data and creates a new ProductInfo
+   * instance, ensuring that all necessary properties are properly initialized.
+   *
+   * @param data - Partial data of ProductInfo. This can include any subset of
+   *               ProductInfo properties.
+   * @returns A new instance of ProductInfo populated with the provided data.
+   */
+  mapToModel(data: Partial<ProductInfo>): ProductInfo {
+    return new ProductInfo(data);
+  }
+}

--- a/packages/api/src/services/product-info/product-info-context.service.ts
+++ b/packages/api/src/services/product-info/product-info-context.service.ts
@@ -1,0 +1,30 @@
+import { ContextService } from '../context/context.service';
+import { ProductInfo } from '../../models/product-info';
+import { ValueChangeCallback } from '../../models/context/value-change-callback';
+
+/**
+ * Service for managing product information context.
+ */
+export class ProductInfoContextService extends ContextService {
+  private static readonly PRODUCT_INFO = 'productInfo';
+
+  /**
+   * Updates the product information in the context.
+   *
+   * @param productInfo - The new ProductInfo object to be set in the context.
+   */
+  updateProductInfo(productInfo: ProductInfo): void {
+    this.updateContextProperty(ProductInfoContextService.PRODUCT_INFO, productInfo);
+  }
+
+  /**
+   * Subscribes to changes in the product information context.
+   *
+   * @param callbackFn - A callback function that will be called when the product information changes.
+   * The callback receives the updated ProductInfo object or undefined as its parameter.
+   * @returns A function that, when called, will unsubscribe from the product information changes.
+   */
+  onProductInfoChanged(callbackFn: ValueChangeCallback<ProductInfo | undefined>): () => void {
+    return this.subscribe(ProductInfoContextService.PRODUCT_INFO, callbackFn);
+  }
+}

--- a/packages/api/src/services/product-info/product-info-rest.service.ts
+++ b/packages/api/src/services/product-info/product-info-rest.service.ts
@@ -1,0 +1,22 @@
+import { ProductInfo } from '../../models/product-info';
+import { HttpService } from '../http/http.service';
+
+/**
+ * Service for product information REST calls.
+ */
+export class ProductInfoRestService extends HttpService {
+  private readonly VERSION_URL = '/rest/info/version';
+
+  /**
+   * Retrieves the local version information of the product.
+   *
+   * This method sends a GET request to the 'rest/info/version' endpoint with a <code>local=1</code> query parameter
+   * to fetch the local version details of the product. The value of the <code>local</code> query parameter
+   * does not matter. The presence of it will result in the server returning the local version details.
+   *
+   * @returns A Promise that resolves to a ProductInfo object containing the local version information.
+   */
+  getProductInfoLocal(): Promise<ProductInfo> {
+    return this.get<ProductInfo>(`${this.VERSION_URL}?local=1`);
+  }
+}

--- a/packages/api/src/services/product-info/product-info.service.ts
+++ b/packages/api/src/services/product-info/product-info.service.ts
@@ -1,0 +1,27 @@
+import { Service } from '../../providers/service/service';
+import { ServiceProvider } from '../../providers';
+import { ProductInfo } from '../../models/product-info';
+import { ProductInfoMapper } from './mappers/product-info.mapper';
+import { ProductInfoRestService } from './product-info-rest.service';
+
+/**
+ * Service responsible for retrieving and managing product information.
+ */
+export class ProductInfoService implements Service {
+  private readonly productInfoMapper: ProductInfoMapper = ServiceProvider.get(ProductInfoMapper);
+  private readonly productInfoService: ProductInfoRestService = ServiceProvider.get(ProductInfoRestService);
+
+  /**
+   * Retrieves the local version information of the product.
+   *
+   * This function fetches the local version data from the license REST service
+   * and maps the response to a ProductInfo model object.
+   *
+   * @returns {Promise<ProductInfo>} A Promise that resolves to a ProductInfo object
+   * containing the local version information of the product.
+   */
+  getProductInfoLocal(): Promise<ProductInfo> {
+    return this.productInfoService.getProductInfoLocal()
+      .then(response => this.productInfoMapper.mapToModel(response));
+  }
+}

--- a/packages/api/src/services/product-info/test/product-info-context.service.spec.ts
+++ b/packages/api/src/services/product-info/test/product-info-context.service.spec.ts
@@ -1,0 +1,39 @@
+import { ProductInfo } from '../../../models/product-info';
+import { ProductInfoContextService } from '../product-info-context.service';
+
+describe('ProductInfoContextService', () => {
+  let productInfoContextService: ProductInfoContextService;
+
+  beforeEach(() => {
+    productInfoContextService = new ProductInfoContextService();
+  });
+
+  test('updateProductInfo should update the productInfo in the context and notify subscribers', () => {
+    // Given a new productInfo object
+    const newProductInfo: ProductInfo = {workbench: '2.8.0', productVersion: '1.0.0'} as ProductInfo;
+    const mockCallback = jest.fn();
+    productInfoContextService.onProductInfoChanged(mockCallback);
+
+    // When updating the productInfo
+    productInfoContextService.updateProductInfo(newProductInfo);
+
+    // Then the context should be updated and subscribers notified
+    expect(mockCallback).toHaveBeenLastCalledWith(newProductInfo);
+  });
+
+  test('should stop receiving updates, after unsubscribe', () => {
+    // Given a new productInfo object
+    const newProductInfo: ProductInfo = {workbench: '2.8.0', productVersion: '1.0.0'} as ProductInfo;
+    const mockCallback = jest.fn();
+    const unsubscribe = productInfoContextService.onProductInfoChanged(mockCallback);
+    // Clear the callback call when the callback function is registered.
+    mockCallback.mockClear();
+
+    // When unsubscribed
+    unsubscribe();
+
+    // Then the context should not receive updates
+    productInfoContextService.updateProductInfo(newProductInfo);
+    expect(mockCallback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/product-info/test/product-info.service.spec.ts
+++ b/packages/api/src/services/product-info/test/product-info.service.spec.ts
@@ -1,0 +1,33 @@
+import { ProductInfo } from '../../../models/product-info';
+import { TestUtil } from '../../utils/test/test-util';
+import { ResponseMock } from '../../http/test/response-mock';
+import { ProductInfoService } from '../product-info.service';
+
+describe('ProductInfoService', () => {
+  let productInfoService: ProductInfoService;
+
+  beforeEach(() => {
+    productInfoService = new ProductInfoService();
+  });
+
+  test('should retrieve the local version information of the product', async () => {
+    // Given, I have a mocked local version information
+    // Note: the Workbench property in the response has an uppercase 'W'
+    const mockProductInfo = {Workbench: '2.8.0', productVersion: '1.0.0' } as ProductInfo & { Workbench: string };
+    TestUtil.mockResponse(new ResponseMock('/rest/info/version?local=1').setResponse(mockProductInfo));
+
+    // When I call the getVersionLocal method
+    const result = await productInfoService.getProductInfoLocal();
+
+    const expectedProductInfo = {
+      workbench: '2.8.0',
+      productType: '',
+      productVersion: '1.0.0',
+      sesame: '',
+      connectors: '',
+    };
+
+    // Then, I should get a ProductInfo object, with default property values
+    expect(result).toEqual(expectedProductInfo);
+  });
+});

--- a/packages/root-config/src/ontotext-root-config.js
+++ b/packages/root-config/src/ontotext-root-config.js
@@ -16,7 +16,14 @@ import 'font-awesome/css/font-awesome.min.css';
 import './styles/onto-stylesheet.css';
 // import "./styles/bootstrap-graphdb-theme.css";
 import { defineCustomElements } from '../../shared-components/loader';
-import { ServiceProvider, LicenseService, LicenseContextService, TranslationService } from '@ontotext/workbench-api';
+import {
+  ServiceProvider,
+  LicenseService,
+  LicenseContextService,
+  TranslationService,
+  ProductInfoService,
+  ProductInfoContextService
+} from '@ontotext/workbench-api';
 
 addErrorHandler((err) => {
   console.error(err);
@@ -79,6 +86,13 @@ const loadLicense = () => {
   });
 };
 
+const loadProductInfoLocal = () => {
+  ServiceProvider.get(ProductInfoService).getProductInfoLocal()
+    .then(productInfo => {
+      ServiceProvider.get(ProductInfoContextService).updateProductInfo(productInfo);
+    }).catch(error => console.error('Could not load local product info', error));
+};
+
 // This is a workaround to initialize the navbar when the root-config is loaded and the navbar is not yet initialized.
 const waitForNavbarElement = () => {
   return new Promise((resolve, reject) => {
@@ -108,6 +122,7 @@ const registerSingleSpaFirstMountListener = () => {
     window.addEventListener('single-spa:first-mount', () => {
       initializeNavbar();
       loadLicense();
+      loadProductInfoLocal();
     });
   }
 };

--- a/packages/shared-components/cypress/e2e/footer/footer.cy.js
+++ b/packages/shared-components/cypress/e2e/footer/footer.cy.js
@@ -2,7 +2,35 @@ import {FooterSteps} from "../../steps/footer/footer-steps";
 
 describe('Footer', () => {
   it('Should render footer', () => {
+    // Given I visit the footer page
     FooterSteps.visit();
+
+    // Then I expect the footer to be visible
     FooterSteps.getFooter().should('be.visible');
+
+    // When, I load product information
+    FooterSteps.loadProductInfo();
+
+    // Then, I expect the product information to be loaded and visible in the footer
+    const currentYear = new Date().getFullYear();
+    const expectedFooterContent = `GraphDB 11.0-SNAPSHOT • RDF4J 4.3.15 • Connectors 16.2.13-RC2 • Workbench 2.8.0 • © 2002–${currentYear} Ontotext AD. All rights reserved.`;
+    FooterSteps.getFooter()
+      .invoke('text')
+      .should('contain', expectedFooterContent);
+
+    // And the GraphDB link should be present and valid
+    FooterSteps.getGraphDBLink()
+      .should('have.text', 'GraphDB')
+      .should('have.attr', 'href', 'http://graphdb.ontotext.com');
+
+    // And the RDF4J link to be present and valid
+    FooterSteps.getSesameLink()
+      .should('contain.text', 'RDF4J')
+      .should('have.attr', 'href', 'http://rdf4j.org');
+
+    // And the Ontotext AD link to be present and valid
+    FooterSteps.getOntotextAdLink()
+      .should('have.text', 'Ontotext AD')
+      .should('have.attr', 'href', 'http://ontotext.com');
   });
 });

--- a/packages/shared-components/cypress/steps/footer/footer-steps.js
+++ b/packages/shared-components/cypress/steps/footer/footer-steps.js
@@ -8,4 +8,20 @@ export class FooterSteps extends BaseSteps {
   static getFooter() {
     return cy.get('.footer-component');
   }
+
+  static getGraphDBLink() {
+    return FooterSteps.getFooter().contains('a', 'GraphDB').first();
+  }
+
+  static getSesameLink() {
+    return FooterSteps.getFooter().contains('a', 'RDF4J').first();
+  }
+
+  static getOntotextAdLink() {
+    return FooterSteps.getFooter().contains('a', 'Ontotext AD').first();
+  }
+
+  static loadProductInfo() {
+    return cy.get('#load-product-info').click();
+  }
 }

--- a/packages/shared-components/src/assets/i18n/en.json
+++ b/packages/shared-components/src/assets/i18n/en.json
@@ -98,5 +98,10 @@
   "license_alert": {
     "label": "No valid license",
     "no_license_set": "No license was set."
+  },
+  "footer": {
+    "label": {
+      "all_rights_reserved": "All rights reserved."
+    }
   }
 }

--- a/packages/shared-components/src/assets/i18n/fr.json
+++ b/packages/shared-components/src/assets/i18n/fr.json
@@ -101,5 +101,10 @@
   "license_alert": {
     "label": "Aucune licence valide",
     "no_license_set": "Aucune licence n'a été définie."
+  },
+  "footer": {
+    "label": {
+      "all_rights_reserved": "Tous droits réservés."
+    }
   }
 }

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -5,13 +5,13 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { Awaitable, License } from "../../api/dist/ontotext-workbench-api.d";
+import { Awaitable, License, ProductInfo } from "../../api/dist/ontotext-workbench-api.d";
 import { DropdownItem } from "./models/dropdown/dropdown-item";
 import { DropdownItemAlignment } from "./models/dropdown/dropdown-item-alignment";
 import { ExternalMenuModel } from "./components/onto-navbar/external-menu-model";
 import { NavbarToggledEvent } from "./components/onto-navbar/navbar-toggled-event";
 import { TranslationParameter } from "./models/translation/translation-parameter";
-export { Awaitable, License } from "../../api/dist/ontotext-workbench-api.d";
+export { Awaitable, License, ProductInfo } from "../../api/dist/ontotext-workbench-api.d";
 export { DropdownItem } from "./models/dropdown/dropdown-item";
 export { DropdownItemAlignment } from "./models/dropdown/dropdown-item-alignment";
 export { ExternalMenuModel } from "./components/onto-navbar/external-menu-model";
@@ -61,6 +61,11 @@ export namespace Components {
          */
         "tooltipTheme": string;
     }
+    /**
+     * OntoFooter component for rendering the footer of the application.
+     * This component displays information about GraphDB, RDF4J, Connectors, and Workbench versions,
+     * as well as copyright information.
+     */
     interface OntoFooter {
     }
     /**
@@ -110,6 +115,12 @@ export namespace Components {
           * @returns A Promise that resolves when the license update is complete.
          */
         "updateLicense": (license: License) => Promise<void>;
+        /**
+          * Updates the product information in the context.  This method uses the ProductInfoContextService to update the product information and returns a resolved Promise once the operation is complete.
+          * @param productInfo - The new ProductInfo object to be set.
+          * @returns A Promise that resolves when the product information update is complete.
+         */
+        "updateProductInfo": (productInfo: ProductInfo) => Promise<void>;
     }
     interface OntoTooltip {
     }
@@ -165,6 +176,11 @@ declare global {
         prototype: HTMLOntoDropdownElement;
         new (): HTMLOntoDropdownElement;
     };
+    /**
+     * OntoFooter component for rendering the footer of the application.
+     * This component displays information about GraphDB, RDF4J, Connectors, and Workbench versions,
+     * as well as copyright information.
+     */
     interface HTMLOntoFooterElement extends Components.OntoFooter, HTMLStencilElement {
     }
     var HTMLOntoFooterElement: {
@@ -316,6 +332,11 @@ declare namespace LocalJSX {
          */
         "tooltipTheme"?: string;
     }
+    /**
+     * OntoFooter component for rendering the footer of the application.
+     * This component displays information about GraphDB, RDF4J, Connectors, and Workbench versions,
+     * as well as copyright information.
+     */
     interface OntoFooter {
     }
     /**
@@ -410,6 +431,11 @@ declare module "@stencil/core" {
              * internationalization.
              */
             "onto-dropdown": LocalJSX.OntoDropdown & JSXBase.HTMLAttributes<HTMLOntoDropdownElement>;
+            /**
+             * OntoFooter component for rendering the footer of the application.
+             * This component displays information about GraphDB, RDF4J, Connectors, and Workbench versions,
+             * as well as copyright information.
+             */
             "onto-footer": LocalJSX.OntoFooter & JSXBase.HTMLAttributes<HTMLOntoFooterElement>;
             /**
              * OntoHeader component for rendering the header of the application.

--- a/packages/shared-components/src/components/onto-footer/onto-footer.tsx
+++ b/packages/shared-components/src/components/onto-footer/onto-footer.tsx
@@ -1,23 +1,57 @@
-import { Component, Host, h } from '@stencil/core';
+import { Component, Host, h, State } from '@stencil/core';
+import { ProductInfo, ServiceProvider, SubscriptionList, ProductInfoContextService } from '@ontotext/workbench-api';
+import { TranslationService } from '../../services/translation.service';
 
+/**
+ * OntoFooter component for rendering the footer of the application.
+ * This component displays information about GraphDB, RDF4J, Connectors, and Workbench versions,
+ * as well as copyright information.
+ */
 @Component({
   tag: 'onto-footer',
   styleUrl: 'onto-footer.scss',
   shadow: false,
 })
 export class OntoFooter {
+  /** State variable to store product information */
+  @State() private productInfo: ProductInfo;
+
+  /** List of subscriptions to manage component lifecycle */
+  private readonly subscriptions: SubscriptionList = new SubscriptionList();
+
+  /** Current year for copyright display */
+  private readonly currentYear = new Date().getFullYear();
+
+  /**
+   * Sets up a subscription to product info changes.
+   */
+  componentWillLoad(): void {
+    this.subscriptions.add(ServiceProvider.get(ProductInfoContextService)
+      .onProductInfoChanged(productInfo => {
+        this.productInfo = productInfo;
+      }));
+  }
+
   render() {
     return (
       <Host>
         <div class="footer-component">
-          <a href="http://graphdb.ontotext.com" target="_blank" rel="noopener noreferrer">GraphDB</a> 10.7.0
-          &bull; <a
-          href="http://rdf4j.org" target="_blank" rel="noopener noreferrer">RDF4J</a> 4.3.10 &bull; Connectors
-          16.2.8 &bull; Workbench 2.7.0 &bull; &copy;
-          2002&ndash;2024 <a href="http://ontotext.com" target="_blank" rel="noopener noreferrer">Ontotext
-          AD</a>. All rights reserved.
+          <a href="http://graphdb.ontotext.com" target="_blank"
+             rel="noopener noreferrer">GraphDB</a>&nbsp;{this.productInfo?.productVersion} &bull;&nbsp;<a
+          href="http://rdf4j.org" target="_blank" rel="noopener noreferrer">RDF4J&nbsp;</a
+          >{this.productInfo?.sesame} &bull; Connectors {this.productInfo?.connectors} &bull; Workbench {this.productInfo?.workbench} &bull; &copy;
+          2002&ndash;{this.currentYear}&nbsp;<a href="http://ontotext.com" target="_blank" rel="noopener noreferrer">Ontotext
+          AD</a>. {TranslationService.translate('footer.label.all_rights_reserved')}
         </div>
       </Host>
     );
+  }
+
+  /**
+   * Lifecycle method called when the component is about to be removed from the DOM.
+   * Unsubscribes from all subscriptions to prevent memory leaks.
+   */
+  disconnectedCallback(): void {
+    this.subscriptions.unsubscribeAll();
   }
 }

--- a/packages/shared-components/src/components/onto-footer/readme.md
+++ b/packages/shared-components/src/components/onto-footer/readme.md
@@ -5,6 +5,12 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+OntoFooter component for rendering the footer of the application.
+This component displays information about GraphDB, RDF4J, Connectors, and Workbench versions,
+as well as copyright information.
+
 ## Dependencies
 
 ### Used by

--- a/packages/shared-components/src/components/onto-header/onto-header.tsx
+++ b/packages/shared-components/src/components/onto-header/onto-header.tsx
@@ -1,6 +1,5 @@
 import { Component, Host, h, State } from '@stencil/core';
-import { ServiceProvider, LicenseContextService, License } from '@ontotext/workbench-api'
-import { SubscriptionList } from '../../../../api/src/models/common/subscription-list';
+import { ServiceProvider, LicenseContextService, License, SubscriptionList } from '@ontotext/workbench-api'
 
 /**
  * OntoHeader component for rendering the header of the application.

--- a/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
+++ b/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
@@ -1,5 +1,11 @@
 import { Component, Method } from '@stencil/core';
-import { License, LicenseContextService, ServiceProvider } from '@ontotext/workbench-api';
+import {
+  License,
+  LicenseContextService,
+  ProductInfo,
+  ProductInfoContextService,
+  ServiceProvider
+} from '@ontotext/workbench-api';
 
 /**
  * A component for managing test context in the application. Used only for testing
@@ -21,6 +27,21 @@ export class OntoTestContext {
   @Method()
   updateLicense(license: License): Promise<void> {
     ServiceProvider.get(LicenseContextService).updateLicense(license);
+    return Promise.resolve();
+  }
+
+    /**
+   * Updates the product information in the context.
+   *
+   * This method uses the ProductInfoContextService to update the product information
+   * and returns a resolved Promise once the operation is complete.
+   *
+   * @param productInfo - The new ProductInfo object to be set.
+   * @returns A Promise that resolves when the product information update is complete.
+   */
+  @Method()
+  updateProductInfo(productInfo: ProductInfo): Promise<void> {
+    ServiceProvider.get(ProductInfoContextService).updateProductInfo(productInfo);
     return Promise.resolve();
   }
 }

--- a/packages/shared-components/src/components/onto-test-context/readme.md
+++ b/packages/shared-components/src/components/onto-test-context/readme.md
@@ -30,6 +30,25 @@ Type: `Promise<void>`
 
 A Promise that resolves when the license update is complete.
 
+### `updateProductInfo(productInfo: ProductInfo) => Promise<void>`
+
+Updates the product information in the context.
+
+This method uses the ProductInfoContextService to update the product information
+and returns a resolved Promise once the operation is complete.
+
+#### Parameters
+
+| Name          | Type          | Description                             |
+| ------------- | ------------- | --------------------------------------- |
+| `productInfo` | `ProductInfo` | - The new ProductInfo object to be set. |
+
+#### Returns
+
+Type: `Promise<void>`
+
+A Promise that resolves when the product information update is complete.
+
 
 ----------------------------------------------
 

--- a/packages/shared-components/src/pages/footer/index.html
+++ b/packages/shared-components/src/pages/footer/index.html
@@ -16,10 +16,12 @@
   <script type="module" src="/build/shared-components.esm.js"></script>
   <script nomodule src="/build/shared-components.js"></script>
   <script src="./main.js" defer></script>
+  <script src="../js/main.js" defer></script>
   <link rel="stylesheet" href="../css/bootstrap.min.css">
   <link rel="stylesheet" href="../css/font-awesome.min.css">
 </head>
 <body>
+<button id="load-product-info" onclick="loadProductInfo()">Load product info</button>
 <onto-footer></onto-footer>
 </body>
 </html>

--- a/packages/shared-components/src/pages/js/main.js
+++ b/packages/shared-components/src/pages/js/main.js
@@ -15,3 +15,12 @@ window.singleSpa = {
 const updateLicense = (license) => {
   testContext.updateLicense(license);
 }
+
+const loadProductInfo = () => {
+  testContext.updateProductInfo({
+    workbench: '2.8.0',
+    sesame: '4.3.15',
+    connectors: '16.2.13-RC2',
+    productVersion: '11.0-SNAPSHOT'
+  });
+};


### PR DESCRIPTION
## What
Implemented dynamic data loading for footer component

## Why
To populate the versions, mentioned in the footer dynamically.

## How
Added a request to `/rest/info/version?local=1` upon `single-spa:first-mount`. If the request is successful, we update the license context with the product info. The `onto-footer` component now gets the data from the context and visualises it, once it is available.

## Testing
Jest unit tests and cypress component tests

## Screenshots
![image](https://github.com/user-attachments/assets/39d51332-84c8-47f0-9c25-253b5419d849)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
