### PR TITLE
(cherry-pick) GDB-11404 - Ensure Local Store theme name (or default) is applied when settings aren't saved

### DIFF
--- a/src/js/angular/security/controllers/user-settings.controller.js
+++ b/src/js/angular/security/controllers/user-settings.controller.js
@@ -247,6 +247,7 @@ function UserSettingsController($scope, toastr, $window, $timeout, $jwtAuth, $ro
     $scope.$on('$destroy', function () {
         const workbenchSettings = WorkbenchSettingsStorageService.getWorkbenchSettings();
         ThemeService.toggleThemeMode(workbenchSettings.mode);
+        ThemeService.applyTheme(workbenchSettings.theme);
         $timeout.cancel(waitBeforeRedirectBack);
     });
 


### PR DESCRIPTION
## What
When the user switches between the `Default theme` and `Ontotext original theme` in the settings, the selected theme will be applied as before, however if the changes aren't saved or can't be saved, the theme will be restored.

## Why
Previously, once toggled, the theme would be applied and would remain even if the settings weren't saved.

## How
I restore the theme `on destroy`, using the `Local store` values.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests


(cherry picked from commit eb6865d3fac30caa5020ebcc3af76e25b13fc296)