### PR TITLE
GDB-11282 introduce local storage service

### DIFF
--- a/packages/api/src/models/storage/index.ts
+++ b/packages/api/src/models/storage/index.ts
@@ -1,0 +1,2 @@
+export * from './storage-data';
+export * from './storage-key';

--- a/packages/api/src/models/storage/storage-data.ts
+++ b/packages/api/src/models/storage/storage-data.ts
@@ -1,0 +1,37 @@
+/**
+ * Represents a wrapper of the data obtained from the storage with methods to convert it to different formats.
+ */
+export class StorageData {
+  /**
+   * The value obtained from the storage.
+   */
+  value: string | null;
+
+  /**
+   * Creates a new instance of the StorageData class.
+   * @param value The value obtained from the storage.
+   */
+  constructor(value: string | null) {
+    this.value = value;
+  }
+
+  getValue(): string | null {
+    return this.value;
+  }
+
+  /**
+   * Returns the value as a JSON object or null if the value is not a valid JSON. Conversion is done using JSON.parse.
+   */
+  getAsJson(): unknown {
+    if (this.value === null) {
+      return null;
+    }
+    try {
+      return JSON.parse(this.value);
+    } catch (error) {
+      console.error('Error parsing JSON', error);
+      return null;
+    }
+  }
+}
+

--- a/packages/api/src/models/storage/storage-key.ts
+++ b/packages/api/src/models/storage/storage-key.ts
@@ -1,0 +1,18 @@
+/**
+ * A utility class for generating storage keys by prefixing them with a namespace.
+ */
+export class StorageKey {
+  static readonly namespace: string = 'ontotext.gdb.';
+
+  /**
+   * Prefixes the given key with the namespace.
+   * @param key The key to prefix.
+   * @returns The prefixed key.
+   */
+  static prefix(key: string): string {
+    if (!key) {
+      throw new Error('Key must be a non-empty string');
+    }
+    return StorageKey.namespace + key;
+  }
+}

--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -8,6 +8,7 @@ export * from './models/security';
 export * from './models/license';
 export * from './models/common';
 export * from './models/product-info';
+export * from './models/storage';
 
 // Export providers for external usages.
 export * from './providers';
@@ -20,6 +21,7 @@ export {AuthenticationService} from './services/security/authentication.service'
 export {EventEmitter} from './emitters/event.emitter';
 export * from './services/license';
 export * from './services/product-info';
+export * from './services/storage';
 
 // Export utils for external usages.
 export * from './services/utils';

--- a/packages/api/src/services/storage/index.ts
+++ b/packages/api/src/services/storage/index.ts
@@ -1,0 +1,2 @@
+export * from './persistence';
+export * from './local-storage.service';

--- a/packages/api/src/services/storage/local-storage.service.ts
+++ b/packages/api/src/services/storage/local-storage.service.ts
@@ -1,0 +1,69 @@
+import {StorageData} from '../../models/storage';
+import {Persistence} from './persistence';
+import {StorageKey} from '../../models/storage';
+
+/**
+ * Persistence implementation backed by the localStorage API.
+ * In most cases, this class should not be used directly but extended by a service that provides additional specific
+ * functionality and keys.
+ */
+export abstract class LocalStorageService implements Persistence {
+  /**
+   * Returns the key to use for the localStorage.
+   * Each concrete implementation should implement this method to return a key prefixed with some domain related
+   * namespace. For example, the language storage service could return 'i18n.'.
+   * @param key The key to be prefixed with the local namespace.
+   */
+  abstract getLocalKey(key: string): string;
+
+  /**
+   * Sets the value for the given key in the localStorage.
+   * Each implementation must implement this method to store the value in the localStorage by invoking the
+   * LocalStorageService.storeValue method and eventually doing some additional work if needed, for example, notifying
+   * other services about the change.
+   * @param key The key to set the value for. Every key must be prefixed with {@link StorageKey.namespace}.
+   * @param value The value to set.
+   */
+  abstract set(key: string, value: string): void;
+
+  /**
+   * Getter for the localStorage implementation.
+   */
+  getStorage(): Storage {
+    return localStorage;
+  }
+
+  /**
+   * Returns the value of the given key from the localStorage.
+   * @param key The key to get the value for. Every key must be prefixed with {@link StorageKey.namespace}.
+   */
+  get(key: string): StorageData {
+    const value = this.getStorage().getItem(this.getPrefixedKey(this.getLocalKey(key)));
+    return new StorageData(value);
+  }
+
+  /**
+   * Stores the value for the given key in the localStorage.
+   * @param key The key to set the value for. Every key must be prefixed with {@link StorageKey.namespace}.
+   * @param value The value to set.
+   */
+  storeValue(key: string, value: string): void {
+    const prefixedKey = this.getPrefixedKey(key);
+    this.getStorage().setItem(prefixedKey, value);
+  }
+
+  /**
+   * Removes the value for the given key from the localStorage.
+   * @param key The key to remove the value for. Every key must be prefixed with {@link StorageKey.namespace}.
+   */
+  remove(key: string): void {
+    this.getStorage().removeItem(this.getPrefixedKey(this.getLocalKey(key)));
+  }
+
+  private getPrefixedKey(key: string): string {
+    if (!key.startsWith(StorageKey.namespace)) {
+      return StorageKey.prefix(key);
+    }
+    return key;
+  }
+}

--- a/packages/api/src/services/storage/persistence.ts
+++ b/packages/api/src/services/storage/persistence.ts
@@ -1,0 +1,29 @@
+import {StorageData} from '../../models/storage';
+import {Service} from '../../providers/service/service';
+
+export interface Persistence extends Service {
+  /**
+   * Getter for the actual storage implementation, for example localStorage or sessionStorage.
+   * The implementation must be compatible with the {@link Storage} interface.
+   */
+  getStorage(): Storage;
+
+  /**
+   * Returns the value of the given key from the storage.
+   * @param key The key to get the value for.
+   */
+  get(key: string): StorageData;
+
+  /**
+   * Sets the value for the given key in the storage.
+   * @param key The key to set the value for.
+   * @param value The value to set.
+   */
+  set(key: string, value: string): void;
+
+  /**
+   * Removes the value for the given key from the storage.
+   * @param key The key to remove the value for.
+   */
+  remove(key: string): void;
+}

--- a/packages/api/src/services/storage/test/local-storage.service.spec.ts
+++ b/packages/api/src/services/storage/test/local-storage.service.spec.ts
@@ -1,0 +1,112 @@
+import { LocalStorageService } from '../local-storage.service';
+
+describe('LocalStorageService', () => {
+
+  const prefixedKey = 'ontotext.gdb.domain.testKey';
+
+  beforeEach(() => {
+    const storageMock = new StorageMock();
+    jest.spyOn(TestStorageService.prototype, 'getStorage')
+      .mockImplementation(() => storageMock);
+  });
+
+  test('set should store a string value automatically prefixing the key', () => {
+    const storageService = new TestStorageService();
+    const key = 'testKey';
+    const value = 'testValue';
+
+    storageService.set(key, value);
+
+    expect(storageService.getStorage().getItem(prefixedKey)).toBe(value);
+  });
+
+  test('get should retrieve a string value by an automatically prefixed key', () => {
+    const storageService = new TestStorageService();
+    const key = 'testKey';
+    const value = 'testValue';
+
+    storageService.set(key, value);
+    const storedValue = storageService.get(key).getValue();
+
+    expect(storedValue).toBe(value);
+  });
+
+  test('get should retrieve a JSON value as a string', () => {
+    const storageService = new TestStorageService();
+    const key = 'testKey';
+    const value = { value: 'testValue' };
+
+    storageService.set(key, JSON.stringify(value));
+    const storedValue = storageService.get(key).getValue();
+
+    expect(storedValue).toBe('{"value":"testValue"}');
+  });
+
+  test('get should retrieve a JSON object value', () => {
+    const storageService = new TestStorageService();
+    const key = 'testKey';
+    const value = { value: 'testValue' };
+
+    storageService.set(key, JSON.stringify(value));
+    const storedValue = storageService.get(key).getAsJson();
+
+    expect(storedValue).toStrictEqual({'value':'testValue'});
+  });
+
+  test('remove should remove a value', () => {
+    const storageService = new TestStorageService();
+    const key = 'testKey';
+    const value = 'testValue';
+
+    storageService.set(key, value);
+    // check if it's there
+    expect(storageService.getStorage().getItem(prefixedKey)).toBe(value);
+
+    storageService.remove(key);
+    const storedValue = storageService.get(key).getValue();
+
+    expect(storedValue).toBeNull();
+  });
+});
+
+class TestStorageService extends LocalStorageService {
+  getLocalKey(key: string): string {
+    return 'domain.' + key;
+  }
+
+  set(key: string, value: string) {
+    this.storeValue(this.getLocalKey(key), value);
+  }
+
+  getStorage(): Storage {
+    return localStorage;
+  }
+}
+
+class StorageMock  implements Storage {
+  private storage: Record<string, string> = {};
+
+  get length(): number {
+    return Object.keys(this.storage).length;
+  }
+
+  clear(): void {
+    this.storage = {};
+  }
+
+  getItem(key: string): string | null {
+    return this.storage[key] || null;
+  }
+
+  key(index: number): string | null {
+    return Object.keys(this.storage)[index] || null;
+  }
+
+  removeItem(key: string): void {
+    delete this.storage[key];
+  }
+
+  setItem(key: string, value: string): void {
+    this.storage[key] = value;
+  }
+}


### PR DESCRIPTION
## What
Introduce a local storage service that will be used to persist data in the browser.

## Why
Some features in the workbench require data to be persisted locally in the browser.

## How
* Implemented a Persistence interface that must be implemented by every storage service. The Persistence name was chosen to avoid confusion with the native Storage interface.
* Implemented a LocalStorageService backed by the localStorage API.
* Implemented a StorageData wrapper model which provides convenient methods for access and convert the stored value.

## Testing
Implemented tests for the service and storage data wrapper.

## Screenshots
NA

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
