### PR TITLE
GDB-11319 - Create denied permission alert banner

### DIFF
--- a/packages/legacy-workbench/src/template.html
+++ b/packages/legacy-workbench/src/template.html
@@ -144,18 +144,17 @@
     </li>
 </ul>
 <div ng-cloak class="page-content">
-    <div class="container-fluid main-container" ng-if="!hasPermission()">
-        <p class="alert alert-danger">
-            {{'no.access.permission.to.functionality.error' | translate}}
-            <br>
-            {{'change.menu.or.user.warning' | translate}}
-        </p>
+  <div class="container-fluid main-container" ng-if="!hasPermission()">
+    <p class="alert alert-danger">
+      {{'no.access.permission.to.functionality.error' | translate}}
+      <br>
+      {{'change.menu.or.user.warning' | translate}}
+    </p>
+  </div>
+
+    <div class="container-fluid main-container" ng-show="hasPermission()" ng-view role="main"
+         ng-class="(menuCollapsed || checkMenu()) ? 'expanded':''">
     </div>
-
-        <div class="container-fluid main-container" ng-show="hasPermission()" ng-view role="main"
-             ng-class="(menuCollapsed || checkMenu()) ? 'expanded':''">
-
-        </div>
 
     <footer ng-show="showFooter" class="footer">
         <div class="container-fluid main-container">

--- a/packages/root-config/src/styles/onto-stylesheet.css
+++ b/packages/root-config/src/styles/onto-stylesheet.css
@@ -20,6 +20,17 @@
     font-size: 1rem;
 }
 
+.onto-alert {
+  border-radius: 0;
+  border: 1px solid transparent;
+  position: relative;
+  padding: 1em;
+}
+
+.onto-alert-danger {
+  background-color: #a4142433;
+}
+
 
 /*-------------------------------------------------------------
 	KeyFrames

--- a/packages/shared-components/cypress/e2e/permission-banner/permission-banner.cy.js
+++ b/packages/shared-components/cypress/e2e/permission-banner/permission-banner.cy.js
@@ -1,0 +1,23 @@
+import {PermissionBannerSteps} from "../../steps/permission-banner/permission-banner-steps";
+
+describe('onto-permission-banner', () => {
+  beforeEach(() => {
+    // Given I visit the page where the component is rendered
+    PermissionBannerSteps.visit()
+  });
+
+  it('should render the component with the correct structure', () => {
+    // Then I expect the component exists
+    PermissionBannerSteps.getPermissionBanner().should('exist');
+    PermissionBannerSteps.getMainContainer().should('exist');
+
+    // And the alert message structure should be correct
+    PermissionBannerSteps.getAlertText()
+      .within(() => {
+        PermissionBannerSteps.getTranslationLabelElement()
+          .should('contain.text', ':host{display:inline}Please choose another menu item or login as a different user.');
+        PermissionBannerSteps.getTranslationLabelElement()
+          .should('contain.text', 'Please choose another menu item or login as a different user.');
+      });
+  });
+});

--- a/packages/shared-components/cypress/steps/permission-banner/permission-banner-steps.js
+++ b/packages/shared-components/cypress/steps/permission-banner/permission-banner-steps.js
@@ -1,0 +1,23 @@
+import {BaseSteps} from "../base-steps";
+
+export class PermissionBannerSteps extends BaseSteps{
+  static visit() {
+    super.visit('permission-banner');
+  }
+
+  static getPermissionBanner() {
+    return cy.get('.permission-banner');
+  }
+
+  static getMainContainer() {
+    return this.getPermissionBanner().find('.permission-banner-content');
+  }
+
+  static getAlertText() {
+    return this.getPermissionBanner().find('.label-container');
+  }
+
+  static getTranslationLabelElement() {
+    return cy.root().find('translate-label').shadow().eq(1);
+  }
+}

--- a/packages/shared-components/src/assets/i18n/en.json
+++ b/packages/shared-components/src/assets/i18n/en.json
@@ -103,5 +103,9 @@
     "label": {
       "all_rights_reserved": "All rights reserved."
     }
+  },
+  "permission_banner": {
+    "no_access_error": "You have no permission to access this functionality with your current credentials.",
+    "change_menu_or_user_warning": "Please choose another menu item or login as a different user."
   }
 }

--- a/packages/shared-components/src/assets/i18n/fr.json
+++ b/packages/shared-components/src/assets/i18n/fr.json
@@ -106,5 +106,9 @@
     "label": {
       "all_rights_reserved": "Tous droits réservés."
     }
+  },
+  "permission_banner": {
+    "no_access_error": "Vous n'avez pas la permission d'accéder à cette fonctionnalité avec vos informations d'identification actuelles.",
+    "change_menu_or_user_warning": "Veuillez choisir un autre élément du menu ou vous connecter comme un autre utilisateur."
   }
 }

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -103,6 +103,8 @@ export namespace Components {
          */
         "selectedMenu": string;
     }
+    interface OntoPermissionBanner {
+    }
     interface OntoRepositorySelector {
     }
     /**
@@ -233,6 +235,12 @@ declare global {
         prototype: HTMLOntoNavbarElement;
         new (): HTMLOntoNavbarElement;
     };
+    interface HTMLOntoPermissionBannerElement extends Components.OntoPermissionBanner, HTMLStencilElement {
+    }
+    var HTMLOntoPermissionBannerElement: {
+        prototype: HTMLOntoPermissionBannerElement;
+        new (): HTMLOntoPermissionBannerElement;
+    };
     interface HTMLOntoRepositorySelectorElement extends Components.OntoRepositorySelector, HTMLStencilElement {
     }
     var HTMLOntoRepositorySelectorElement: {
@@ -278,6 +286,7 @@ declare global {
         "onto-layout": HTMLOntoLayoutElement;
         "onto-license-alert": HTMLOntoLicenseAlertElement;
         "onto-navbar": HTMLOntoNavbarElement;
+        "onto-permission-banner": HTMLOntoPermissionBannerElement;
         "onto-repository-selector": HTMLOntoRepositorySelectorElement;
         "onto-test-context": HTMLOntoTestContextElement;
         "onto-tooltip": HTMLOntoTooltipElement;
@@ -378,6 +387,8 @@ declare namespace LocalJSX {
          */
         "selectedMenu"?: string;
     }
+    interface OntoPermissionBanner {
+    }
     interface OntoRepositorySelector {
     }
     /**
@@ -415,6 +426,7 @@ declare namespace LocalJSX {
         "onto-layout": OntoLayout;
         "onto-license-alert": OntoLicenseAlert;
         "onto-navbar": OntoNavbar;
+        "onto-permission-banner": OntoPermissionBanner;
         "onto-repository-selector": OntoRepositorySelector;
         "onto-test-context": OntoTestContext;
         "onto-tooltip": OntoTooltip;
@@ -447,6 +459,7 @@ declare module "@stencil/core" {
             "onto-layout": LocalJSX.OntoLayout & JSXBase.HTMLAttributes<HTMLOntoLayoutElement>;
             "onto-license-alert": LocalJSX.OntoLicenseAlert & JSXBase.HTMLAttributes<HTMLOntoLicenseAlertElement>;
             "onto-navbar": LocalJSX.OntoNavbar & JSXBase.HTMLAttributes<HTMLOntoNavbarElement>;
+            "onto-permission-banner": LocalJSX.OntoPermissionBanner & JSXBase.HTMLAttributes<HTMLOntoPermissionBannerElement>;
             "onto-repository-selector": LocalJSX.OntoRepositorySelector & JSXBase.HTMLAttributes<HTMLOntoRepositorySelectorElement>;
             /**
              * A component for managing test context in the application. Used only for testing

--- a/packages/shared-components/src/components/onto-layout/onto-layout.scss
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.scss
@@ -33,6 +33,10 @@
     margin-left: 0;
   }
 
+  .default-slot-wrapper {
+    display: none;
+  }
+
   footer {
     grid-area: footer;
   }

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -26,6 +26,7 @@ export class OntoLayout {
   @Element() hostElement: HTMLOntoLayoutElement;
 
   @State() isLowResolution = false;
+  @State() hasPermission = true; // TODO get from local store
 
   /**
    * Event listener for the navbar toggled event. The layout needs to respond properly when the navbar is toggled in
@@ -86,6 +87,10 @@ export class OntoLayout {
   render() {
     return (
       <Host class="wb-layout">
+        {/* Default slot is explicitly defined to be able to hide the main content in the user permission check */}
+        <div class="default-slot-wrapper">
+          <slot name="default"></slot>
+        </div>
         <header class="wb-header">
           <onto-header></onto-header>
         </header>
@@ -94,8 +99,11 @@ export class OntoLayout {
           <onto-navbar navbar-collapsed={this.isLowResolution} selected-menu={this.currentRoute}></onto-navbar>
         </nav>
 
-        <slot name="main"></slot>
-
+        {
+          this.hasPermission ?
+            <slot name="main"></slot> :
+            <onto-permission-banner></onto-permission-banner>
+        }
         <footer class="wb-footer">
           <onto-footer></onto-footer>
         </footer>

--- a/packages/shared-components/src/components/onto-layout/readme.md
+++ b/packages/shared-components/src/components/onto-layout/readme.md
@@ -11,6 +11,7 @@
 
 - [onto-header](../onto-header)
 - [onto-navbar](../onto-navbar)
+- [onto-permission-banner](../onto-permission-banner)
 - [onto-footer](../onto-footer)
 - [onto-tooltip](../onto-tooltip)
 
@@ -19,6 +20,7 @@
 graph TD;
   onto-layout --> onto-header
   onto-layout --> onto-navbar
+  onto-layout --> onto-permission-banner
   onto-layout --> onto-footer
   onto-layout --> onto-tooltip
   onto-header --> onto-license-alert
@@ -28,6 +30,7 @@ graph TD;
   onto-repository-selector --> onto-dropdown
   onto-language-selector --> onto-dropdown
   onto-navbar --> translate-label
+  onto-permission-banner --> translate-label
   style onto-layout fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/shared-components/src/components/onto-permission-banner/onto-permission-banner.scss
+++ b/packages/shared-components/src/components/onto-permission-banner/onto-permission-banner.scss
@@ -1,0 +1,28 @@
+:host {
+  display: block;
+}
+
+.permission-banner {
+  margin: 0 1rem;
+}
+
+.permission-banner-content {
+  display: flex;
+  align-items: center;
+  margin: 1rem;
+  padding: 0 2rem 3rem 2rem;
+}
+
+.label-container {
+  display: flex;
+  flex-direction: column;
+  margin-left: 1rem;
+}
+
+.icon-warning::before {
+  font-family: 'icomoon', sans-serif;
+  content: '\e920';
+  display: block;
+  font-size: 1.5em;
+  pointer-events: none;
+}

--- a/packages/shared-components/src/components/onto-permission-banner/onto-permission-banner.tsx
+++ b/packages/shared-components/src/components/onto-permission-banner/onto-permission-banner.tsx
@@ -1,0 +1,22 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'onto-permission-banner',
+  styleUrl: 'onto-permission-banner.scss',
+  shadow: false,
+})
+export class OntoPermissionBanner {
+  render() {
+    return (
+      <Host class="permission-banner">
+        <p class="permission-banner-content onto-alert onto-alert-danger">
+          <div class="icon-warning"></div>
+          <div class="label-container">
+            <translate-label labelKey={'permission_banner.no_access_error'}></translate-label>
+            <translate-label labelKey={'permission_banner.change_menu_or_user_warning'}></translate-label>
+          </div>
+        </p>
+      </Host>
+    );
+  }
+}

--- a/packages/shared-components/src/components/onto-permission-banner/readme.md
+++ b/packages/shared-components/src/components/onto-permission-banner/readme.md
@@ -1,0 +1,28 @@
+# onto-permission-banner
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Dependencies
+
+### Used by
+
+ - [onto-layout](../onto-layout)
+
+### Depends on
+
+- [translate-label](../translate-label)
+
+### Graph
+```mermaid
+graph TD;
+  onto-permission-banner --> translate-label
+  onto-layout --> onto-permission-banner
+  style onto-permission-banner fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/shared-components/src/components/translate-label/readme.md
+++ b/packages/shared-components/src/components/translate-label/readme.md
@@ -30,12 +30,14 @@ Example of usage:
 
  - [onto-license-alert](../onto-license-alert)
  - [onto-navbar](../onto-navbar)
+ - [onto-permission-banner](../onto-permission-banner)
 
 ### Graph
 ```mermaid
 graph TD;
   onto-license-alert --> translate-label
   onto-navbar --> translate-label
+  onto-permission-banner --> translate-label
   style translate-label fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/shared-components/src/index.html
+++ b/packages/shared-components/src/index.html
@@ -20,6 +20,7 @@
       <li><a href="/pages/language-selector/index.html">Language Selector</a></li>
       <li><a href="/pages/repository-selector/index.html">Repository Selector</a></li>
       <li><a href="/pages/license-alert/index.html">license alert</a></li>
+      <li><a href="/pages/permission-banner/index.html">Permission banner</a></li>
     </ul>
   </body>
 </html>

--- a/packages/shared-components/src/pages/permission-banner/index.html
+++ b/packages/shared-components/src/pages/permission-banner/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+  <title>Stencil Component Starter</title>
+
+  <script type="importmap">
+    {
+      "imports": {
+        "@ontotext/workbench-api": "/resources/ontotext-workbench-api.js"
+      }
+    }
+  </script>
+
+  <script type="module" src="/build/shared-components.esm.js"></script>
+  <script nomodule src="/build/shared-components.js"></script>
+  <script src="./main.js" defer></script>
+  <link rel="stylesheet" href="../css/bootstrap.min.css">
+  <link rel="stylesheet" href="../css/font-awesome.min.css">
+</head>
+<body>
+  <onto-permission-banner></onto-permission-banner>
+</body>
+</html>

--- a/packages/shared-components/src/pages/permission-banner/main.js
+++ b/packages/shared-components/src/pages/permission-banner/main.js
@@ -1,0 +1,1 @@
+let bannerElement = document.querySelector("onto-permission-banner");


### PR DESCRIPTION
## What
The "permission denied" banner has been created in the new WB. Functionality to be added with another MR.

## Why
This was one of the elements due to be migrated.

## How
I created a new shared component with the banner and styled it like the one in the legacy WB.

## Testing
Test added.

## Screenshots
![Screenshot from 2025-01-09 12-24-46](https://github.com/user-attachments/assets/860a2913-321c-4e35-a130-bfaac20ad16d)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
