### PR TITLE
GDB-11282 save selected language in local storage

### DIFF
--- a/packages/api/eslint.config.js
+++ b/packages/api/eslint.config.js
@@ -22,7 +22,8 @@ module.exports = tseslint.config(
             '@typescript-eslint/no-unused-vars': ['error'],
             'no-undef': 'off',
             '@typescript-eslint/no-empty-interface': 'off',
-            '@typescript-eslint/no-empty-object-type': 'off'
+            '@typescript-eslint/no-empty-object-type': 'off',
+            '@typescript-eslint/consistent-type-definitions': 'off',
         }
     }
 );

--- a/packages/api/src/models/common/test/model-list.spec.ts
+++ b/packages/api/src/models/common/test/model-list.spec.ts
@@ -1,0 +1,74 @@
+import { ModelList } from '../model-list';
+
+describe('ModelList', () => {
+  let modelList: TestModelList;
+
+  beforeEach(() => {
+    modelList = new TestModelList([
+      new TestModel(1, 'Item 1'),
+      new TestModel(2, 'Item 2'),
+      new TestModel(3, 'Item 3'),
+    ]);
+  });
+
+  test('getItems should return all items', () => {
+    const items = modelList.getItems();
+
+    expect(items).toHaveLength(3);
+    expect(items[0].name).toBe('Item 1');
+  });
+
+  test('sort should sort items by id', () => {
+    modelList.sort((a, b) => b.id - a.id);
+
+    const items = modelList.getItems();
+
+    expect(items[0].id).toBe(3);
+    expect(items[2].id).toBe(1);
+  });
+
+  test('filter should filter items by name', () => {
+    const filteredItems = modelList.filter(item => item.name === 'Item 2');
+
+    expect(filteredItems).toHaveLength(1);
+    expect(filteredItems[0].name).toBe('Item 2');
+  });
+
+  test('find should find an item by id', () => {
+    const item = modelList.find(item => item.id === 2);
+
+    expect(item).toBeDefined();
+    expect(item?.name).toBe('Item 2');
+  });
+
+  test('isEmpty should return true if no items', () => {
+    const emptyList = new TestModelList();
+
+    expect(emptyList.isEmpty()).toBe(true);
+  });
+
+  test('isEmpty should return false if there are items', () => {
+    expect(modelList.isEmpty()).toBe(false);
+  });
+
+  test('createIdFilter should filter out items with specified ids', () => {
+    const idFilter = modelList.getIdFilter([1, 3]);
+    const filteredItems = modelList.filter(idFilter);
+    expect(filteredItems).toHaveLength(1);
+    expect(filteredItems[0].id).toBe(2);
+  });
+});
+
+class TestModel {
+  constructor(public id: number, public name: string) {}
+}
+
+class TestModelList extends ModelList<TestModel> {
+  constructor(items: TestModel[] = []) {
+    super(items);
+  }
+
+  public getIdFilter(ids: number[]): (item: TestModel) => boolean {
+    return this.createIdFilter(ids);
+  }
+}

--- a/packages/api/src/models/common/test/model.spec.ts
+++ b/packages/api/src/models/common/test/model.spec.ts
@@ -1,0 +1,35 @@
+import { Model } from '../model';
+
+describe('Model', () => {
+  test('copy should create a deep copy of the model instance', () => {
+    const original = new TestModel({ key: 'value' });
+    const copy = original.copy();
+
+    expect(copy).toEqual(original);
+    expect(copy).not.toBe(original);
+    expect(copy.data).not.toBe(original.data);
+  });
+
+  test('copy should create a deep copy with nested objects', () => {
+    const original = new TestModel({ nested: { key: 'value' } });
+    const copy = original.copy();
+
+    expect(copy.data.nested).toEqual(original.data.nested);
+    expect(copy.data.nested).not.toBe(original.data.nested);
+  });
+
+  test('copy should create a deep copy with arrays', () => {
+    const original = new TestModel({ array: [1, 2, 3] });
+    const copy = original.copy();
+
+    expect(copy.data.array).toEqual(original.data.array);
+    expect(copy.data.array).not.toBe(original.data.array);
+  });
+});
+
+class TestModel extends Model<TestModel> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(public data: any) {
+    super();
+  }
+}

--- a/packages/api/src/models/common/test/subscription-list.spec.ts
+++ b/packages/api/src/models/common/test/subscription-list.spec.ts
@@ -1,0 +1,30 @@
+import {SubscriptionList} from '../subscription-list';
+
+describe('SubscriptionList', () => {
+  let subscriptionList: SubscriptionList;
+  let mockSubscription1: jest.Mock;
+  let mockSubscription2: jest.Mock;
+
+  beforeEach(() => {
+    mockSubscription1 = jest.fn();
+    mockSubscription2 = jest.fn();
+    subscriptionList = new SubscriptionList([mockSubscription1, mockSubscription2]);
+  });
+
+  test('should initialize with given subscriptions', () => {
+    expect(subscriptionList.getItems()).toEqual([mockSubscription1, mockSubscription2]);
+  });
+
+  test('add should add a new subscription to the list', () => {
+    const newSubscription = jest.fn();
+    subscriptionList.add(newSubscription);
+    expect(subscriptionList.getItems()).toContain(newSubscription);
+  });
+
+  test('unsubscribeAll should call all subscription functions and clear the list', () => {
+    subscriptionList.unsubscribeAll();
+    expect(mockSubscription1).toHaveBeenCalled();
+    expect(mockSubscription2).toHaveBeenCalled();
+    expect(subscriptionList.getItems()).toEqual([]);
+  });
+});

--- a/packages/api/src/models/context/test/value-context.spec.ts
+++ b/packages/api/src/models/context/test/value-context.spec.ts
@@ -1,0 +1,62 @@
+import { ValueContext } from '../value-context';
+import { ObjectUtil } from '../../../services/utils';
+import {Copyable} from '../../common';
+
+describe('ValueContext', () => {
+  let valueContext: ValueContext<number>;
+  let callback: jest.Mock;
+
+  beforeEach(() => {
+    valueContext = new ValueContext<number>();
+    callback = jest.fn();
+  });
+
+  it('should set and get value correctly', () => {
+    valueContext.setValue(42);
+    expect(valueContext.getValue()).toBe(42);
+  });
+
+  it('setValue should not update value if it is the same', () => {
+    jest.spyOn(ObjectUtil, 'deepEqual').mockReturnValue(true);
+    valueContext.setValue(42);
+    valueContext.setValue(42);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('subscribe should update value and notify subscribers if value changes', () => {
+    jest.spyOn(ObjectUtil, 'deepEqual').mockReturnValue(false);
+    valueContext.subscribe(callback);
+    valueContext.setValue(42);
+    expect(callback).toHaveBeenCalledWith(42);
+  });
+
+  it('setValue should return a deep copy of the value if it is an object', () => {
+    const obj = { a: 1 };
+    jest.spyOn(ObjectUtil, 'deepCopy').mockReturnValue({ a: 1 });
+    valueContext.setValue(obj as unknown as number);
+    expect(valueContext.getValue()).toEqual({ a: 1 });
+  });
+
+  it('should unsubscribe callback correctly', () => {
+    const unsubscribe = valueContext.subscribe(callback);
+    unsubscribe();
+    valueContext.setValue(42);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should return a deep copy of the value if it has a copy method', () => {
+    class CopyableValue implements Copyable<CopyableValue> {
+      constructor(public a: number) {}
+      copy(): CopyableValue {
+        return new CopyableValue(this.a);
+      }
+    }
+
+    const copyableValue = new CopyableValue(1);
+    valueContext.setValue(copyableValue as unknown as number);
+    const result = valueContext.getValue() as unknown as CopyableValue;
+    expect(result).toEqual(copyableValue);
+    // Ensure it's a copy, not the same instance
+    expect(result).not.toBe(copyableValue);
+  });
+});

--- a/packages/api/src/models/context/update-context-method.ts
+++ b/packages/api/src/models/context/update-context-method.ts
@@ -1,0 +1,23 @@
+/**
+ * Utility type to convert SNAKE_CASE to PascalCase.
+ */
+type SnakeToPascalCase<S extends string> =
+  S extends `${infer Head}_${infer Tail}`
+    ? `${Capitalize<Lowercase<Head>>}${SnakeToPascalCase<Tail>}`
+    : Capitalize<Lowercase<S>>;
+
+/**
+ * A contract that defines the fields and methods of a context service.
+ */
+export type DeriveContextServiceContract<TFields extends Record<string, unknown>, TParams extends Partial<Record<keyof TFields, unknown>> = TFields> =
+  TFields & UpdateContextMethods<TFields, TParams>;
+
+/**
+ * Generates update methods based on fields.
+ * Each field will have an update method with the name update{FieldName} and a single parameter of the field type.
+ */
+export type UpdateContextMethods<T, TParams extends Partial<Record<keyof T, unknown>> = T> = {
+  [K in keyof T as K extends string
+    ? `update${SnakeToPascalCase<K>}`
+    : never]: (value: TParams[K]) => void;
+};

--- a/packages/api/src/models/context/value-context.ts
+++ b/packages/api/src/models/context/value-context.ts
@@ -1,6 +1,6 @@
 import {ObjectUtil} from '../../services/utils';
 import {ValueChangeCallback} from './value-change-callback';
-import {Copyable} from '../common/copyable';
+import {Copyable} from '../common';
 
 /**
  * ValueContext is a generic class for managing a value of type T. It provides functionality to set and retrieve the value,
@@ -53,7 +53,6 @@ export class ValueContext<T> {
    */
   subscribe(callbackFunction: ValueChangeCallback<T | undefined>): () => void {
     this.callbackFunctions.push(callbackFunction);
-
     return () => {
       this.callbackFunctions = this.callbackFunctions.filter(fn => fn !== callbackFunction);
     };

--- a/packages/api/src/models/repositories/repository-list.ts
+++ b/packages/api/src/models/repositories/repository-list.ts
@@ -1,5 +1,5 @@
 import {Repository} from './repository';
-import {ModelList} from '../common/model-list';
+import {ModelList} from '../common';
 
 const REPOSITORY_LOCATION_ID_COMPARATOR = (r1: Repository, r2: Repository) => {
   // Compare locations.

--- a/packages/api/src/models/repositories/test/repository-list.spec.ts
+++ b/packages/api/src/models/repositories/test/repository-list.spec.ts
@@ -1,0 +1,87 @@
+import {Repository} from '../repository';
+import {RepositoryList} from '../repository-list';
+
+describe('RepositoryList', () => {
+  let repositories: Repository[];
+  let repositoryList: RepositoryList;
+
+  beforeEach(() => {
+    repositories = [
+      {
+        id: '1', location: 'A',
+        title: '',
+        type: undefined,
+        sesameType: undefined,
+        uri: '',
+        externalUrl: '',
+        state: undefined,
+        local: undefined,
+        readable: undefined,
+        writable: undefined,
+        unsupported: undefined,
+        copy: function (): Repository {
+          throw new Error('Function not implemented.');
+        }
+      },
+      {
+        id: '2', location: 'B',
+        title: '',
+        type: undefined,
+        sesameType: undefined,
+        uri: '',
+        externalUrl: '',
+        state: undefined,
+        local: undefined,
+        readable: undefined,
+        writable: undefined,
+        unsupported: undefined,
+        copy: function (): Repository {
+          throw new Error('Function not implemented.');
+        }
+      },
+      {
+        id: '3', location: 'A',
+        title: '',
+        type: undefined,
+        sesameType: undefined,
+        uri: '',
+        externalUrl: '',
+        state: undefined,
+        local: undefined,
+        readable: undefined,
+        writable: undefined,
+        unsupported: undefined,
+        copy: function (): Repository {
+          throw new Error('Function not implemented.');
+        }
+      },
+    ];
+    repositoryList = new RepositoryList(repositories);
+  });
+
+  test('should find a repository by ID and location', () => {
+    const repository = repositoryList.findRepository('1', 'A');
+    expect(repository?.id).toBe('1');
+  });
+
+  test('should return undefined if repository is not found', () => {
+    const repository = repositoryList.findRepository('4', 'C');
+    expect(repository).toBeUndefined();
+  });
+
+  test('should sort repositories by location and ID', () => {
+    repositoryList.sortByLocationAndId();
+    expect(repositoryList.getItems()).toEqual([
+      expect.objectContaining({ id: '1', location: 'A' }),
+      expect.objectContaining({ id: '3', location: 'A' }),
+      expect.objectContaining({ id: '2', location: 'B' }),
+    ]);
+  });
+
+  test('should filter repositories by excluding specified IDs', () => {
+    const filteredRepositories = repositoryList.filterByIds(['1', '3']);
+    expect(filteredRepositories).toEqual([
+      expect.objectContaining({ id: '2', location: 'B' }),
+    ]);
+  });
+});

--- a/packages/api/src/models/storage/storage-data.ts
+++ b/packages/api/src/models/storage/storage-data.ts
@@ -15,12 +15,26 @@ export class StorageData {
     this.value = value;
   }
 
+  /**
+   * Returns the value as a string or null if the value is null.
+   * @returns The value as a string or null if the value is null.
+   */
   getValue(): string | null {
     return this.value;
   }
 
   /**
+   * Returns the value as a string or the default value if the value is null.
+   * @param defaultValue The default value to return if the value is null.
+   * @returns The value as a string or the default value if the value is null.
+   */
+  getValueOrDefault(defaultValue: string): string {
+    return this.value || defaultValue;
+  }
+
+  /**
    * Returns the value as a JSON object or null if the value is not a valid JSON. Conversion is done using JSON.parse.
+   * @returns The value as a JSON object or null if the value is not a valid JSON.
    */
   getAsJson(): unknown {
     if (this.value === null) {

--- a/packages/api/src/models/storage/storage-key.ts
+++ b/packages/api/src/models/storage/storage-key.ts
@@ -1,18 +1,6 @@
 /**
- * A utility class for generating storage keys by prefixing them with a namespace.
+ * A utility class holding the storage keys used by the application.
  */
 export class StorageKey {
-  static readonly namespace: string = 'ontotext.gdb.';
-
-  /**
-   * Prefixes the given key with the namespace.
-   * @param key The key to prefix.
-   * @returns The prefixed key.
-   */
-  static prefix(key: string): string {
-    if (!key) {
-      throw new Error('Key must be a non-empty string');
-    }
-    return StorageKey.namespace + key;
-  }
+  static readonly GLOBAL_NAMESPACE: string = 'ontotext.gdb';
 }

--- a/packages/api/src/models/storage/test/storage-data.spec.ts
+++ b/packages/api/src/models/storage/test/storage-data.spec.ts
@@ -1,0 +1,43 @@
+import { StorageData } from '../storage-data';
+
+describe('StorageData', () => {
+  test('getValue should return the value', () => {
+    const storageData = new StorageData('testValue');
+    expect(storageData.getValue()).toBe('testValue');
+  });
+
+  test('getValue should return null if the value is null', () => {
+    const storageData = new StorageData(null);
+    expect(storageData.getValue()).toBeNull();
+  });
+
+  test('getValueOrDefault should return the value if it is not null', () => {
+    const storageData = new StorageData('testValue');
+    expect(storageData.getValueOrDefault('defaultValue')).toBe('testValue');
+  });
+
+  test('getValueOrDefault should return the default value if the value is null', () => {
+    const storageData = new StorageData(null);
+    expect(storageData.getValueOrDefault('defaultValue')).toBe('defaultValue');
+  });
+
+  test('getAsJson should return the value as a JSON object', () => {
+    const jsonValue = { key: 'value' };
+    const storageData = new StorageData(JSON.stringify(jsonValue));
+    expect(storageData.getAsJson()).toStrictEqual(jsonValue);
+  });
+
+  test('getAsJson should return null if the value is not a valid JSON', () => {
+    const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => {
+      // Do nothing
+    });
+    const storageData = new StorageData('invalidJson');
+    expect(storageData.getAsJson()).toBeNull();
+    consoleErrorMock.mockRestore();
+  });
+
+  test('getAsJson should return null if the value is null', () => {
+    const storageData = new StorageData(null);
+    expect(storageData.getAsJson()).toBeNull();
+  });
+});

--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -14,6 +14,7 @@ export * from './models/storage';
 export * from './providers';
 
 // Export services for external usages.
+export * from './services/context';
 export * from './services/language';
 export * from './services/repository';
 export * from './services/repository-location';

--- a/packages/api/src/providers/service/service.provider.ts
+++ b/packages/api/src/providers/service/service.provider.ts
@@ -1,23 +1,41 @@
 import {Service} from './service';
 
 /**
- * Service provider for all {@link Service} instances.
- * This provider caches all workbench services created on demand, ensuring that all micro frontends share a single instance of each service.
+ * Service provider for all {@link Service} instances. Services in the API are singletons, meaning that there is only
+ * one instance of each service in the application. This provider caches all workbench services created on demand,
+ * ensuring that all micro frontends share a single instance of each service.
  */
 export class ServiceProvider {
-
   /**
      * The static modifier ensures the map is the same for all ServiceProviders. Each micro-frontend will have its
      * own instance of {@see ServiceFactoryService}, but the map with instances will be shared.
-     *
-     * @private
      */
   private static readonly SERVICE_INSTANCES = new Map<string, Service>;
 
-  public static get<T extends Service>(type: new(service: Service) => T): T {
+  /**
+   * Returns the instance of the given service type. If the service has not been created yet, it will be created and
+   * cached.
+   * @param type The service type to retrieve.
+   * @returns The instance of the service.
+   * @template T The type of the service to retrieve.
+   */
+  // eslint-disable-next-line @typescript-eslint/prefer-function-type
+  public static get<T extends Service>(type: { new (): T }): T {
     if (!ServiceProvider.SERVICE_INSTANCES.has(type.name)) {
-      ServiceProvider.SERVICE_INSTANCES.set(type.name, new type(this));
+      const instance = new type();
+      ServiceProvider.SERVICE_INSTANCES.set(type.name, instance);
     }
     return this.SERVICE_INSTANCES.get(type.name) as T;
+  }
+
+  /**
+   * Returns all instances of the given service type.
+   * @param superType The super type of the services to retrieve.
+   * @returns All instances of the given service type.
+   * @template T The super type of the services to retrieve.
+   */
+  public static getAllBySuperType<T>(superType: abstract new(service: T) => T): T[] {
+    return Array.from(ServiceProvider.SERVICE_INSTANCES.values())
+      .filter((service) => service instanceof superType) as T[];
   }
 }

--- a/packages/api/src/services/context/context.service.ts
+++ b/packages/api/src/services/context/context.service.ts
@@ -5,15 +5,16 @@ import {Service} from '../../providers/service/service';
 /**
  * Abstract service that manages the context for various properties and allows for value retrieval, updates
  * and subscriptions to value changes.
+ * The service is generic and requires a type parameter that defines the fields that the service can handle.
+ * The fields are defined as properties of the service class and are used to access the context values.
  */
-export abstract class ContextService implements Service {
-
+export abstract class ContextService<TFields extends Record<string, unknown>> implements Service {
   /**
    * A map that stores the context for each property, keyed by property name.
    * The context holds the value and the list of subscribers (callback functions).
    */
   // eslint-disable-next-line @typescript-eslint/consistent-generic-constructors, @typescript-eslint/no-explicit-any
-  private context: Map<string, ValueContext<any>> = new Map();
+  protected context: Map<string, ValueContext<any>> = new Map();
 
   /**
    * Updates the value of a specific property.
@@ -23,7 +24,7 @@ export abstract class ContextService implements Service {
    *
    * @template T The type of the value to be set.
    */
-  protected updateContextProperty<T>(propertyName: string, value: T): void {
+  updateContextProperty<T>(propertyName: string, value: T): void {
     this.getOrCreateValueContext(propertyName).setValue(value);
   }
 
@@ -78,5 +79,22 @@ export abstract class ContextService implements Service {
       this.context.set(propertyName, valueContext);
     }
     return valueContext;
+  }
+
+  /**
+   * Finds out if particular implementation of the ContextService contains a field with the given name. This can be used
+   * to determine if the service can handle a specific field.
+   * This method uses the keys of the TFields type to check if the field exists because all fields that the service can
+   * handle are defined in the TFields type.
+   * @param fieldName The name of the field to check.
+   */
+  canHandle(fieldName: string): boolean {
+    // Iterate over all keys of TFields
+    for (const key in this as unknown as TFields) {
+      if ((this as never)[key] === fieldName) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/packages/api/src/services/context/index.ts
+++ b/packages/api/src/services/context/index.ts
@@ -1,0 +1,1 @@
+export * from './context.service';

--- a/packages/api/src/services/context/test/context.servce.spec.ts
+++ b/packages/api/src/services/context/test/context.servce.spec.ts
@@ -1,19 +1,5 @@
 import {ContextService} from '../context.service';
-
-// Expose protected methods for testing
-class TestContextService extends ContextService {
-  public updateProperty<T>(propertyName: string, value: T): void {
-    this.updateContextProperty(propertyName, value);
-  }
-
-  public getProperty<T>(propertyName: string): T | undefined {
-    return this.getContextPropertyValue(propertyName);
-  }
-
-  public subscribeToProperty<T>(propertyName: string, callback: (value?: T) => void): () => void {
-    return this.subscribe(propertyName, callback);
-  }
-}
+import {DeriveContextServiceContract} from '../../../models/context/update-context-method';
 
 describe('ContextService', () => {
   let contextService: TestContextService;
@@ -113,4 +99,38 @@ describe('ContextService', () => {
     expect(secondCallBackFunction.mock.lastCall[0]).not.toBe(valueOfTestProperty);
     expect(firstCallBackFunction.mock.lastCall[0]).not.toBe(secondCallBackFunction.mock.lastCall[0]);
   });
+
+  it('canHandle should return false if the field name is not handled', () => {
+    const result = contextService.canHandle('nonExistentField');
+    expect(result).toBe(false);
+  });
 });
+
+type TestContextFields = {
+  readonly TEST_PROPERTY: 'testProperty';
+}
+
+type TestContextFieldParams = {
+  readonly TEST_PROPERTY: string;
+}
+
+// Expose protected methods for testing
+class TestContextService extends ContextService<TestContextFields> implements DeriveContextServiceContract<TestContextFields, TestContextFieldParams> {
+  readonly TEST_PROPERTY = 'testProperty';
+
+  updateTestProperty(value: string): void {
+    this.updateContextProperty(this.TEST_PROPERTY, value);
+  }
+
+  public updateProperty<T>(propertyName: string, value: T): void {
+    this.updateContextProperty(propertyName, value);
+  }
+
+  public getProperty<T>(propertyName: string): T | undefined {
+    return this.getContextPropertyValue(propertyName);
+  }
+
+  public subscribeToProperty<T>(propertyName: string, callback: (value?: T) => void): () => void {
+    return this.subscribe(propertyName, callback);
+  }
+}

--- a/packages/api/src/services/language/index.ts
+++ b/packages/api/src/services/language/index.ts
@@ -1,2 +1,3 @@
 export * from './language.service';
 export * from './language-context.service';
+export * from './language-storage.service';

--- a/packages/api/src/services/language/language-context.service.ts
+++ b/packages/api/src/services/language/language-context.service.ts
@@ -1,12 +1,19 @@
-import {ContextService} from '../context/context.service';
+import {ContextService} from '../context';
 import {ValueChangeCallback} from '../../models/context/value-change-callback';
+import {ServiceProvider} from '../../providers';
+import {LanguageStorageService} from './language-storage.service';
+import {LanguageService} from './language.service';
+import {DeriveContextServiceContract} from '../../models/context/update-context-method';
+
+type LanguageContextFields = {
+  readonly SELECTED_LANGUAGE: string;
+}
 
 /**
  * The LanguageService class manages the application's language context.
  */
-export class LanguageContextService extends ContextService {
-
-  private static readonly SELECTED_LANGUAGE = 'selectedLanguage';
+export class LanguageContextService extends ContextService<LanguageContextFields> implements DeriveContextServiceContract<LanguageContextFields> {
+  readonly SELECTED_LANGUAGE = 'selectedLanguage';
 
   /**
    * Changes the selected language of the application. This method updates the selected language and notifies
@@ -15,8 +22,10 @@ export class LanguageContextService extends ContextService {
    * @param {string} locale - The new language code to set (e.g., 'en', 'fr', 'de').
    */
   updateSelectedLanguage(locale: string | undefined): void {
-    // TODO save it to local store.
-    this.updateContextProperty(LanguageContextService.SELECTED_LANGUAGE, locale);
+    const selectedLanguage = locale || LanguageService.DEFAULT_LANGUAGE;
+    const storageService = ServiceProvider.get(LanguageStorageService);
+    storageService.set(this.SELECTED_LANGUAGE, selectedLanguage);
+    this.updateContextProperty(this.SELECTED_LANGUAGE, locale);
   }
 
   /**
@@ -27,6 +36,6 @@ export class LanguageContextService extends ContextService {
    * @returns A function to unsubscribe from updates.
    */
   onSelectedLanguageChanged(callbackFunction: ValueChangeCallback<string | undefined>): () => void {
-    return this.subscribe(LanguageContextService.SELECTED_LANGUAGE, callbackFunction);
+    return this.subscribe(this.SELECTED_LANGUAGE, callbackFunction);
   }
 }

--- a/packages/api/src/services/language/language-storage.service.ts
+++ b/packages/api/src/services/language/language-storage.service.ts
@@ -1,0 +1,12 @@
+import {LocalStorageService} from '../storage';
+
+/**
+ * Service that handles the language related properties in the local storage.
+ */
+export class LanguageStorageService extends LocalStorageService {
+  readonly NAMESPACE = 'i18n';
+
+  set(key: string, value: string) {
+    this.storeValue(key, value);
+  }
+}

--- a/packages/api/src/services/language/test/language-context.service.spec.ts
+++ b/packages/api/src/services/language/test/language-context.service.spec.ts
@@ -1,13 +1,45 @@
 import {LanguageContextService} from '../language-context.service';
+import {LanguageStorageService} from '../language-storage.service';
+import {ServiceProvider} from '../../../providers';
+import {LanguageService} from '../language.service';
 
 describe('LanguageContextService', () => {
   let languageContextService: LanguageContextService;
+  let languageStorageServiceMock: jest.Mocked<LanguageStorageService>;
 
   beforeEach(() => {
     languageContextService = new LanguageContextService();
+    languageStorageServiceMock = {
+      set: jest.fn(),
+    } as unknown as jest.Mocked<LanguageStorageService>;
+
+    jest.spyOn(ServiceProvider, 'get').mockReturnValue(languageStorageServiceMock);
   });
 
-  test('Should call the "onSelectLanguageCallbackFunction" when the language changes.', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('updateSelectedLanguage should update selected language and notify subscribers', () => {
+    const locale = 'fr';
+    const updateContextPropertySpy = jest.spyOn(languageContextService, 'updateContextProperty');
+
+    languageContextService.updateSelectedLanguage(locale);
+
+    expect(languageStorageServiceMock.set).toHaveBeenCalledWith(languageContextService.SELECTED_LANGUAGE, locale);
+    expect(updateContextPropertySpy).toHaveBeenCalledWith(languageContextService.SELECTED_LANGUAGE, locale);
+  });
+
+  test('updateSelectedLanguage should use default language if locale is undefined', () => {
+    const updateContextPropertySpy = jest.spyOn(languageContextService, 'updateContextProperty');
+
+    languageContextService.updateSelectedLanguage(undefined);
+
+    expect(languageStorageServiceMock.set).toHaveBeenCalledWith(languageContextService.SELECTED_LANGUAGE, LanguageService.DEFAULT_LANGUAGE);
+    expect(updateContextPropertySpy).toHaveBeenCalledWith(languageContextService.SELECTED_LANGUAGE, undefined);
+  });
+
+  test('should call the "onSelectLanguageCallbackFunction" when the language changes.', () => {
     const onSelectLanguageCallbackFunction = jest.fn();
     const newLanguage = 'en';
 

--- a/packages/api/src/services/language/test/language-storage.service.spec.ts
+++ b/packages/api/src/services/language/test/language-storage.service.spec.ts
@@ -1,0 +1,20 @@
+import {LanguageStorageService} from '../language-storage.service';
+import {LocalStorageService} from '../../storage';
+
+describe('LanguageStorageService', () => {
+  let service: LanguageStorageService;
+
+  beforeEach(() => {
+    service = new LanguageStorageService();
+  });
+
+  it('set should store the value in local storage with the correct key', () => {
+    const key = 'testKey';
+    const value = 'testValue';
+    const storeValueSpy = jest.spyOn(LocalStorageService.prototype, 'storeValue');
+
+    service.set(key, value);
+
+    expect(storeValueSpy).toHaveBeenCalledWith(key, value);
+  });
+});

--- a/packages/api/src/services/license/license-context.service.ts
+++ b/packages/api/src/services/license/license-context.service.ts
@@ -1,20 +1,29 @@
-import { License } from '../../models/license';
-import { ValueChangeCallback } from '../../models/context/value-change-callback';
-import { ContextService } from '../context/context.service';
+import {License} from '../../models/license';
+import {ValueChangeCallback} from '../../models/context/value-change-callback';
+import {ContextService} from '../context';
+import {DeriveContextServiceContract} from '../../models/context/update-context-method';
+
+type LicenseContextFields = {
+  readonly GRAPHDB_LICENSE: string;
+}
+
+type LicenseContextFieldParams = {
+  readonly GRAPHDB_LICENSE: License;
+};
 
 /**
  * Service for managing license context in the application.
  * Extends the base ContextService to provide license-specific functionality.
  */
-export class LicenseContextService extends ContextService {
-  private static readonly GRAPHDB_LICENSE = 'graphDbLicense';
+export class LicenseContextService extends ContextService<LicenseContextFields> implements DeriveContextServiceContract<LicenseContextFields, LicenseContextFieldParams> {
+  readonly GRAPHDB_LICENSE = 'graphDbLicense';
 
   /**
    * Updates the license information in the context.
    * @param license - The new License object to be set in the context.
    */
-  updateLicense(license: License): void {
-    this.updateContextProperty(LicenseContextService.GRAPHDB_LICENSE, license);
+  updateGraphdbLicense(license: License | undefined): void {
+    this.updateContextProperty(this.GRAPHDB_LICENSE, license);
   }
 
   /**
@@ -25,6 +34,6 @@ export class LicenseContextService extends ContextService {
    * @returns A function that, when called, will unsubscribe from the license changes.
    */
   onLicenseChanged(callbackFn: ValueChangeCallback<License | undefined>): () => void {
-    return this.subscribe(LicenseContextService.GRAPHDB_LICENSE, callbackFn);
+    return this.subscribe(this.GRAPHDB_LICENSE, callbackFn);
   }
 }

--- a/packages/api/src/services/license/test/license-context.service.spec.ts
+++ b/packages/api/src/services/license/test/license-context.service.spec.ts
@@ -15,7 +15,7 @@ describe('LicenseContextService', () => {
     licenseContextService.onLicenseChanged(mockCallback);
 
     // When updating the license
-    licenseContextService.updateLicense(newLicense);
+    licenseContextService.updateGraphdbLicense(newLicense);
 
     // Then the context should be updated and subscribers notified
     expect(mockCallback).toHaveBeenLastCalledWith(newLicense);
@@ -33,7 +33,7 @@ describe('LicenseContextService', () => {
     unsubscribe();
 
     // Then the context should not receive updates
-    licenseContextService.updateLicense(newLicense);
+    licenseContextService.updateGraphdbLicense(newLicense);
     expect(mockCallback).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/services/product-info/product-info-context.service.ts
+++ b/packages/api/src/services/product-info/product-info-context.service.ts
@@ -1,12 +1,21 @@
-import { ContextService } from '../context/context.service';
+import { ContextService } from '../context';
 import { ProductInfo } from '../../models/product-info';
 import { ValueChangeCallback } from '../../models/context/value-change-callback';
+import {DeriveContextServiceContract} from '../../models/context/update-context-method';
+
+type ProductInfoContextFields = {
+  readonly PRODUCT_INFO: string;
+};
+
+type ProductInfoContextFieldParams = {
+  readonly PRODUCT_INFO: ProductInfo;
+};
 
 /**
  * Service for managing product information context.
  */
-export class ProductInfoContextService extends ContextService {
-  private static readonly PRODUCT_INFO = 'productInfo';
+export class ProductInfoContextService extends ContextService<ProductInfoContextFields> implements DeriveContextServiceContract<ProductInfoContextFields, ProductInfoContextFieldParams> {
+  readonly PRODUCT_INFO = 'productInfo';
 
   /**
    * Updates the product information in the context.
@@ -14,7 +23,7 @@ export class ProductInfoContextService extends ContextService {
    * @param productInfo - The new ProductInfo object to be set in the context.
    */
   updateProductInfo(productInfo: ProductInfo): void {
-    this.updateContextProperty(ProductInfoContextService.PRODUCT_INFO, productInfo);
+    this.updateContextProperty(this.PRODUCT_INFO, productInfo);
   }
 
   /**
@@ -25,6 +34,6 @@ export class ProductInfoContextService extends ContextService {
    * @returns A function that, when called, will unsubscribe from the product information changes.
    */
   onProductInfoChanged(callbackFn: ValueChangeCallback<ProductInfo | undefined>): () => void {
-    return this.subscribe(ProductInfoContextService.PRODUCT_INFO, callbackFn);
+    return this.subscribe(this.PRODUCT_INFO, callbackFn);
   }
 }

--- a/packages/api/src/services/repository-location/repository-location-context.service.ts
+++ b/packages/api/src/services/repository-location/repository-location-context.service.ts
@@ -1,21 +1,30 @@
-import {ContextService} from '../context/context.service';
+import {ContextService} from '../context';
 import {ValueChangeCallback} from '../../models/context/value-change-callback';
 import {RepositoryLocation} from '../../models/repository-location';
+import {DeriveContextServiceContract} from '../../models/context/update-context-method';
+
+type RepositoryLocationContextFields = {
+  readonly ACTIVE_REPOSITORY_LOCATION: string;
+}
+
+type RepositoryLocationContextFieldParams = {
+  readonly ACTIVE_REPOSITORY_LOCATION: RepositoryLocation;
+};
 
 /**
  * The RepositoryLocationContextService class manages the application's repository location context.
  */
-export class RepositoryLocationContextService extends ContextService {
+export class RepositoryLocationContextService extends ContextService<RepositoryLocationContextFields> implements DeriveContextServiceContract<RepositoryLocationContextFields, RepositoryLocationContextFieldParams> {
 
-  private static readonly ACTIVE_REPOSITORY_LOCATION = 'activeRepositoryLocation';
+  readonly ACTIVE_REPOSITORY_LOCATION = 'activeRepositoryLocation';
 
   /**
    * Updates the active repository location and notifies subscribers about the change.
    *
    * @param repositoryLocation - The repository location to set as active.
    */
-  updateActiveLocation(repositoryLocation: RepositoryLocation): void {
-    this.updateContextProperty(RepositoryLocationContextService.ACTIVE_REPOSITORY_LOCATION, repositoryLocation);
+  updateActiveRepositoryLocation(repositoryLocation: RepositoryLocation): void {
+    this.updateContextProperty(this.ACTIVE_REPOSITORY_LOCATION, repositoryLocation);
   }
 
   /**
@@ -25,6 +34,6 @@ export class RepositoryLocationContextService extends ContextService {
    * @returns A function to unsubscribe from notifications.
    */
   onActiveLocationChanged(callbackFunction: ValueChangeCallback<RepositoryLocation | undefined>): () => void {
-    return this.subscribe(RepositoryLocationContextService.ACTIVE_REPOSITORY_LOCATION, callbackFunction);
+    return this.subscribe(this.ACTIVE_REPOSITORY_LOCATION, callbackFunction);
   }
 }

--- a/packages/api/src/services/repository-location/test/repository-location-context.service.spec.ts
+++ b/packages/api/src/services/repository-location/test/repository-location-context.service.spec.ts
@@ -15,7 +15,7 @@ describe('RepositoryLocationContextService', () => {
     // When I register a callback function for active location changes,
     repositoryLocationContextService.onActiveLocationChanged(onActiveLocationChangedCallbackFunction);
     // and the active repository location is updated,
-    repositoryLocationContextService.updateActiveLocation(newRepositoryLocation);
+    repositoryLocationContextService.updateActiveRepositoryLocation(newRepositoryLocation);
 
     // Then I expect the callback function to be called with the passed repository location.
     expect(onActiveLocationChangedCallbackFunction).toHaveBeenLastCalledWith(newRepositoryLocation);

--- a/packages/api/src/services/repository/repository-context.service.ts
+++ b/packages/api/src/services/repository/repository-context.service.ts
@@ -1,14 +1,25 @@
-import {ContextService} from '../context/context.service';
+import {ContextService} from '../context';
 import {Repository, RepositoryList} from '../../models/repositories';
 import {ValueChangeCallback} from '../../models/context/value-change-callback';
+import {DeriveContextServiceContract} from '../../models/context/update-context-method';
+
+type RepositoryContextFields = {
+  readonly SELECTED_REPOSITORY: string;
+  readonly REPOSITORY_LIST: string;
+}
+
+type RepositoryContextFieldParams = {
+  readonly SELECTED_REPOSITORY: Repository;
+  readonly REPOSITORY_LIST: RepositoryList;
+};
 
 /**
  * The RepositoryContextService class manages the application's repository context.
  */
-export class RepositoryContextService extends ContextService {
+export class RepositoryContextService extends ContextService<RepositoryContextFields> implements DeriveContextServiceContract<RepositoryContextFields, RepositoryContextFieldParams> {
 
-  private static readonly UPDATE_SELECTED_REPOSITORY = 'selectedRepository';
-  private static readonly UPDATE_REPOSITORY_LIST = 'repositoryList';
+  readonly SELECTED_REPOSITORY = 'selectedRepository';
+  readonly REPOSITORY_LIST = 'repositoryList';
 
   /**
    * Updates the selected repository and notifies subscribers about the change.
@@ -16,7 +27,7 @@ export class RepositoryContextService extends ContextService {
    * @param repository - The new repository to set as selected.
    */
   updateSelectedRepository(repository: Repository | undefined): void {
-    this.updateContextProperty(RepositoryContextService.UPDATE_SELECTED_REPOSITORY, repository);
+    this.updateContextProperty(this.SELECTED_REPOSITORY, repository);
   }
 
   /**
@@ -26,16 +37,16 @@ export class RepositoryContextService extends ContextService {
    * @returns A function to unsubscribe from updates.
    */
   onSelectedRepositoryChanged(callbackFunction: ValueChangeCallback<Repository | undefined>): () => void {
-    return this.subscribe(RepositoryContextService.UPDATE_SELECTED_REPOSITORY, callbackFunction);
+    return this.subscribe(this.SELECTED_REPOSITORY, callbackFunction);
   }
 
   /**
-   * Updates the lsit with repositories and notifies subscribers about the change.
+   * Updates the list with repositories and notifies subscribers about the change.
    *
    * @param repositories - The new list with repositories.
    */
-  updateRepositories(repositories: RepositoryList): void {
-    return this.updateContextProperty(RepositoryContextService.UPDATE_REPOSITORY_LIST, repositories);
+  updateRepositoryList(repositories: RepositoryList): void {
+    return this.updateContextProperty(this.REPOSITORY_LIST, repositories);
   }
 
   /**
@@ -46,6 +57,6 @@ export class RepositoryContextService extends ContextService {
    * @returns A function to unsubscribe from updates.
    */
   onRepositoriesChanged(callbackFunction: ValueChangeCallback<RepositoryList | undefined>): () => void {
-    return this.subscribe(RepositoryContextService.UPDATE_REPOSITORY_LIST, callbackFunction);
+    return this.subscribe(this.REPOSITORY_LIST, callbackFunction);
   }
 }

--- a/packages/api/src/services/repository/test/repository-context.service.spec.ts
+++ b/packages/api/src/services/repository/test/repository-context.service.spec.ts
@@ -47,7 +47,7 @@ describe('RepositoryContextService', () => {
     // When I register a callback function for repository changes,
     repositoryContextService.onRepositoriesChanged(onRepositoriesChangedCallbackFunction);
     // and the repositories are updated,
-    repositoryContextService.updateRepositories(newRepositories);
+    repositoryContextService.updateRepositoryList(newRepositories);
 
     // Then I expect the callback function to be called with the passed repositories,
     expect(onRepositoriesChangedCallbackFunction).toHaveBeenLastCalledWith(newRepositories);

--- a/packages/api/src/services/storage/index.ts
+++ b/packages/api/src/services/storage/index.ts
@@ -1,2 +1,3 @@
 export * from './persistence';
 export * from './local-storage.service';
+export * from './local-storage-subscription-handler.service';

--- a/packages/api/src/services/storage/local-storage-subscription-handler.service.ts
+++ b/packages/api/src/services/storage/local-storage-subscription-handler.service.ts
@@ -1,0 +1,56 @@
+import {Service} from '../../providers/service/service';
+import {StorageKey} from '../../models/storage';
+import {ServiceProvider} from '../../providers';
+import {ContextService} from '../context';
+
+/**
+ * Service that handles the storage change events and triggers the appropriate context property change handlers.
+ */
+export class LocalStorageSubscriptionHandlerService implements Service {
+
+  /**
+   * Handles the storage change event and triggers the appropriate context property change handlers.
+   * @param event The storage change event.
+   */
+  handleStorageChange(event: StorageEvent): void {
+    // Keys used to map properties in the local storage are in format 'storage.namespace.propertyName'.
+    // The 'storage.' prefix is removed to get the namespace and property name.
+    const withoutGlobalPrefix = event.key?.substring(StorageKey.GLOBAL_NAMESPACE.length + 1);
+    let namespace = '';
+    let contextPropertyKey = '';
+    if (withoutGlobalPrefix) {
+      // The namespace is the part of the key before the first '.'.
+      namespace = withoutGlobalPrefix.substring(0, withoutGlobalPrefix.indexOf('.'));
+      // The context property key is the part of the key after the first '.'.
+      contextPropertyKey = withoutGlobalPrefix.substring(namespace.length + 1);
+    }
+
+    const handler = this.resolveHandler(namespace, contextPropertyKey);
+    if (handler) {
+      handler.updateContextProperty(contextPropertyKey, event.newValue);
+    }
+  }
+
+  /**
+   * Resolves the context property change handler for the given namespace and property name.
+   * @param namespace The namespace of the context property change handler.
+   * @param propertyName The property name of the context property change handler.
+   */
+  private resolveHandler(namespace: string, propertyName: string): ContextService<Record<string, unknown>> | undefined {
+    if (!namespace) {
+      // eslint-disable-next-line no-console
+      console.warn('Namespace is required to resolve a context property change handler.');
+      return;
+    }
+    const handler = ServiceProvider.getAllBySuperType(ContextService)
+      .find((service) => {
+        return service.canHandle(propertyName);
+      });
+    if (!handler) {
+      // eslint-disable-next-line no-console
+      console.warn(`No context property change handler found for namespace: ${namespace} and property: ${propertyName}`);
+      return;
+    }
+    return handler as ContextService<Record<string, unknown>>;
+  }
+}

--- a/packages/api/src/services/storage/local-storage.service.ts
+++ b/packages/api/src/services/storage/local-storage.service.ts
@@ -9,19 +9,17 @@ import {StorageKey} from '../../models/storage';
  */
 export abstract class LocalStorageService implements Persistence {
   /**
-   * Returns the key to use for the localStorage.
-   * Each concrete implementation should implement this method to return a key prefixed with some domain related
-   * namespace. For example, the language storage service could return 'i18n.'.
-   * @param key The key to be prefixed with the local namespace.
+   * The namespace is used to scope keys for the persistent properties by component or view. Each persistence service
+   * should define a namespace to be used for the keys in the localStorage.
    */
-  abstract getLocalKey(key: string): string;
+  abstract get NAMESPACE(): string;
 
   /**
    * Sets the value for the given key in the localStorage.
    * Each implementation must implement this method to store the value in the localStorage by invoking the
    * LocalStorageService.storeValue method and eventually doing some additional work if needed, for example, notifying
    * other services about the change.
-   * @param key The key to set the value for. Every key must be prefixed with {@link StorageKey.namespace}.
+   * @param key The key to set the value for. Every key must be prefixed with {@link StorageKey.GLOBAL_NAMESPACE}.
    * @param value The value to set.
    */
   abstract set(key: string, value: string): void;
@@ -35,35 +33,45 @@ export abstract class LocalStorageService implements Persistence {
 
   /**
    * Returns the value of the given key from the localStorage.
-   * @param key The key to get the value for. Every key must be prefixed with {@link StorageKey.namespace}.
+   * @param key The key to get the value for. Every key must be prefixed with {@link StorageKey.GLOBAL_NAMESPACE}.
    */
   get(key: string): StorageData {
-    const value = this.getStorage().getItem(this.getPrefixedKey(this.getLocalKey(key)));
+    const value = this.getStorage().getItem(this.getPrefixedKey(key));
     return new StorageData(value);
   }
 
   /**
    * Stores the value for the given key in the localStorage.
-   * @param key The key to set the value for. Every key must be prefixed with {@link StorageKey.namespace}.
+   * @param key The key to set the value for. Every key must be prefixed with {@link StorageKey.GLOBAL_NAMESPACE}.
    * @param value The value to set.
    */
   storeValue(key: string, value: string): void {
-    const prefixedKey = this.getPrefixedKey(key);
-    this.getStorage().setItem(prefixedKey, value);
+    this.getStorage().setItem(this.getPrefixedKey(key), value);
   }
 
   /**
    * Removes the value for the given key from the localStorage.
-   * @param key The key to remove the value for. Every key must be prefixed with {@link StorageKey.namespace}.
+   * @param key The key to remove the value for. Every key must be prefixed with {@link StorageKey.GLOBAL_NAMESPACE}.
    */
   remove(key: string): void {
-    this.getStorage().removeItem(this.getPrefixedKey(this.getLocalKey(key)));
+    this.getStorage().removeItem(this.getPrefixedKey(key));
   }
 
   private getPrefixedKey(key: string): string {
-    if (!key.startsWith(StorageKey.namespace)) {
-      return StorageKey.prefix(key);
+    const globalLocalPrefix = `${StorageKey.GLOBAL_NAMESPACE}.${this.NAMESPACE}.`;
+    const localPrefix = `${this.NAMESPACE}.`;
+
+    // If the key is already prefixed with the global and local namespaces, return as is
+    if (key.startsWith(globalLocalPrefix)) {
+      return key;
     }
-    return key;
+
+    // If the key is prefixed with the local namespace only, add the global namespace
+    if (key.startsWith(localPrefix)) {
+      return `${StorageKey.GLOBAL_NAMESPACE}.${key}`;
+    }
+
+    // If the key is unprefixed, add both global and local namespaces
+    return `${globalLocalPrefix}${key}`;
   }
 }

--- a/packages/api/src/services/storage/test/local-storage-subscription-handler.service.spec.ts
+++ b/packages/api/src/services/storage/test/local-storage-subscription-handler.service.spec.ts
@@ -1,0 +1,85 @@
+import {ContextService} from '../../context';
+import {LocalStorageSubscriptionHandlerService} from '../local-storage-subscription-handler.service';
+import {ServiceProvider} from '../../../providers';
+import {StorageKey} from '../../../models/storage';
+import {DeriveContextServiceContract} from '../../../models/context/update-context-method';
+
+describe('LocalStorageSubscriptionHandlerService', () => {
+  let service: LocalStorageSubscriptionHandlerService;
+  let mockContextService: ContextService<Record<string, unknown>>;
+
+  beforeEach(() => {
+    service = new LocalStorageSubscriptionHandlerService();
+    // Register the mock context service in the service provider
+    mockContextService = ServiceProvider.get(TestContextService);
+    jest.spyOn(mockContextService, 'updateContextProperty');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('handleStorageChange should handle storage change event and trigger context property change handler', () => {
+    const event = {
+      key: `${StorageKey.GLOBAL_NAMESPACE}.namespace.testProperty`,
+      newValue: 'newValue'
+    } as StorageEvent;
+
+    service.handleStorageChange(event);
+
+    expect(mockContextService.updateContextProperty).toHaveBeenCalledWith('testProperty', 'newValue');
+  });
+
+  test('should warn if namespace is missing in storage change event key', () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const event = {
+      key: `${StorageKey.GLOBAL_NAMESPACE}.propertyName`,
+      newValue: 'newValue'
+    } as StorageEvent;
+
+    service.handleStorageChange(event);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith('Namespace is required to resolve a context property change handler.');
+  });
+
+  test('should warn if no context property change handler is found', () => {
+    jest.spyOn(ServiceProvider, 'getAllBySuperType').mockReturnValue([]);
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const event = {
+      key: `${StorageKey.GLOBAL_NAMESPACE}.namespace.propertyName`,
+      newValue: 'newValue'
+    } as StorageEvent;
+
+    service.handleStorageChange(event);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith('No context property change handler found for namespace: namespace and property: propertyName');
+  });
+
+  test('should not trigger handler if event key is null', () => {
+    const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation(() => {
+      // Do nothing
+    });
+    const event = {
+      key: null,
+      newValue: 'newValue'
+    } as StorageEvent;
+
+    service.handleStorageChange(event);
+
+    expect(mockContextService.updateContextProperty).not.toHaveBeenCalled();
+
+    consoleWarnMock.mockRestore();
+  });
+});
+
+type TestContextFields = {
+  readonly TEST_PROPERTY: string;
+}
+
+class TestContextService extends ContextService<TestContextFields> implements DeriveContextServiceContract<TestContextFields> {
+  readonly TEST_PROPERTY = 'testProperty';
+
+  updateTestProperty(value: string): void {
+    this.updateContextProperty(this.TEST_PROPERTY, value);
+  }
+}

--- a/packages/api/src/services/storage/test/local-storage.service.spec.ts
+++ b/packages/api/src/services/storage/test/local-storage.service.spec.ts
@@ -20,6 +20,26 @@ describe('LocalStorageService', () => {
     expect(storageService.getStorage().getItem(prefixedKey)).toBe(value);
   });
 
+  test('set should store a string value with a locally prefixed key', () => {
+    const storageService = new TestStorageService();
+    const key = 'domain.testKey';
+    const value = 'testValue';
+
+    storageService.set(key, value);
+
+    expect(storageService.getStorage().getItem(prefixedKey)).toBe(value);
+  });
+
+  test('set should store a string value with a globally and locally prefixed key', () => {
+    const storageService = new TestStorageService();
+    const key = 'ontotext.gdb.domain.testKey';
+    const value = 'testValue';
+
+    storageService.set(key, value);
+
+    expect(storageService.getStorage().getItem(prefixedKey)).toBe(value);
+  });
+
   test('get should retrieve a string value by an automatically prefixed key', () => {
     const storageService = new TestStorageService();
     const key = 'testKey';
@@ -70,12 +90,10 @@ describe('LocalStorageService', () => {
 });
 
 class TestStorageService extends LocalStorageService {
-  getLocalKey(key: string): string {
-    return 'domain.' + key;
-  }
+  readonly NAMESPACE = 'domain';
 
   set(key: string, value: string) {
-    this.storeValue(this.getLocalKey(key), value);
+    this.storeValue(key, value);
   }
 
   getStorage(): Storage {

--- a/packages/shared-components/src/components/onto-language-selector/onto-language-selector.tsx
+++ b/packages/shared-components/src/components/onto-language-selector/onto-language-selector.tsx
@@ -1,6 +1,11 @@
 import {Component, Host, h, State, Prop} from '@stencil/core';
 import {DropdownItem} from '../../models/dropdown/dropdown-item';
-import {ServiceProvider, LanguageService, LanguageContextService} from "@ontotext/workbench-api";
+import {
+  ServiceProvider,
+  LanguageService,
+  LanguageContextService,
+  LanguageStorageService
+} from "@ontotext/workbench-api";
 import {DropdownItemAlignment} from '../../models/dropdown/dropdown-item-alignment';
 
 @Component({
@@ -12,7 +17,7 @@ export class OntoLanguageSelector {
   private languageService: LanguageService;
   private languageContextService: LanguageContextService;
   private items: DropdownItem<string>[] = [];
-  private readonly onLanguageChangeSubscription: () => void;
+  private onLanguageChangeSubscription: () => void;
 
   /**
    * Specifies the dropdown items' alignment. If not provided, the items and the dropdown button will be aligned to the left.
@@ -28,8 +33,8 @@ export class OntoLanguageSelector {
   constructor() {
     this.languageService = ServiceProvider.get(LanguageService);
     this.languageContextService = ServiceProvider.get(LanguageContextService);
-    // TODO read it from local store and pass it as first value
-    this.changeLanguage(LanguageService.DEFAULT_LANGUAGE);
+    const selectedLanguage = ServiceProvider.get(LanguageStorageService).get(this.languageContextService.SELECTED_LANGUAGE);
+    this.changeLanguage(selectedLanguage?.getValueOrDefault(LanguageService.DEFAULT_LANGUAGE));
     this.onLanguageChangeSubscription = this.languageContextService.onSelectedLanguageChanged((newLanguage) => this.changeLanguage(newLanguage));
     this.items = this.getLanguageDropdownOptions();
   }

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -2,6 +2,7 @@ import {Component, Host, h, Listen, Element, State} from '@stencil/core';
 import {NavbarToggledEvent} from "../onto-navbar/navbar-toggled-event";
 import {debounce} from "../../utils/function-utils";
 import {WINDOW_WIDTH_FOR_COLLAPSED_NAVBAR} from "../../models/constants";
+import {ServiceProvider, LocalStorageSubscriptionHandlerService} from "@ontotext/workbench-api";
 
 @Component({
   tag: 'onto-layout',
@@ -59,6 +60,11 @@ export class OntoLayout {
     }
   }
 
+  private handleStorageChange(event: StorageEvent) {
+    const service = ServiceProvider.get(LocalStorageSubscriptionHandlerService);
+    service.handleStorageChange(event);
+  }
+
   // ========================
   // Lifecycle methods
   // ========================
@@ -70,6 +76,11 @@ export class OntoLayout {
   componentWillLoad() {
     let route = window.location.pathname;
     this.currentRoute  = route.replace('/', '').split('/')[0];
+    window.addEventListener("storage", this.handleStorageChange);
+  }
+
+  disconnectedCallback() {
+    window.removeEventListener("storage", this.handleStorageChange);
   }
 
   render() {

--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
@@ -88,7 +88,7 @@ export class OntoRepositorySelector {
   private loadRepositories(): void {
     this.repositoryService.getRepositories()
       .then((repositories) => {
-        this.repositoryContextService.updateRepositories(repositories);
+        this.repositoryContextService.updateRepositoryList(repositories);
         const repositoryId = undefined;
         const location = undefined;
         const repository = repositories.findRepository(repositoryId, location);

--- a/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
+++ b/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
@@ -26,7 +26,7 @@ export class OntoTestContext {
    */
   @Method()
   updateLicense(license: License): Promise<void> {
-    ServiceProvider.get(LicenseContextService).updateLicense(license);
+    ServiceProvider.get(LicenseContextService).updateGraphdbLicense(license);
     return Promise.resolve();
   }
 


### PR DESCRIPTION
## What
* Implemented a generic local storage handler that is capable of to update data in context services automatically.
* Integrated the language selector functionality to store and obtain selected language in the context service and have it synchronized via the localstorage.
* Extended and added many new tests.

## Why
* The selected language needs to be synchronized between multiple opened browser tabs.
* A generic solution for handling of srorage change is good for decreasing the code duplication, coupling and better typesafety.

## How
* Implemented LocalStorageSubscriptionHandlerService which is called by the onto-layout component where a subscription for the localStorage `store` event is implemented. The handler parses the key under which given property in the local storage is persisted and resolves which context service is responsible for that property if any and then invokes its update`PropertyName` method.
* Extended the language selector and related services to store and synchronize with a `selectedLanguage` property in the local storage.

## Testing
* Implemented tests for the new functionality.
* Extended existing tests.
* Implemented many new tests for functionality which wasn't covered with tests until now.
* Fixed some issues with a couple of tests.

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
