### PR TITLE
GDB-11398 - Style popover and repo icon like in the legacy WB

### DIFF
--- a/packages/shared-components/src/components/onto-dropdown/onto-dropdown.scss
+++ b/packages/shared-components/src/components/onto-dropdown/onto-dropdown.scss
@@ -34,6 +34,7 @@
   &.open {
     background-color: var(--onto-dropdown-button-icon-color);
     color: #FFFFFF;
+    height: 2rem;
 
     .button-icon {
       color: var(--onto-dropdown-button-open-icon-color);
@@ -43,15 +44,17 @@
   .onto-dropdown-button {
     font-size: 1rem;
     font-weight: 400;
-    padding: 0.5em 1rem;
-    line-height: 1.25;
+    padding: 0.4em 1rem;
+    line-height: 1.5;
     border: 1px solid transparent;
     outline: none;
+    width: fit-content;
+    height: fit-content;
     color: var(--onto-dropdown-color);
     background-color: var(--onto-dropdown-button-background-color);
 
     .button-icon {
-      font-size: 1.5rem;
+      font-size: 1.4em;
       padding-right: 0.2em;
     }
   }
@@ -63,6 +66,7 @@
     z-index: 1000;
     overflow-y: auto;
     max-height: 340px;
+    min-width: 100%;
   }
 
   .onto-dropdown-menu-item {
@@ -102,12 +106,14 @@
     left: auto;
   }
 
-  @media (max-width: 768px) {
-    .onto-dropdown-button:after {
-      padding-left: 0 !important;
+  @media (max-width: 1440px) {
+    .onto-dropdown-button, .onto-dropdown.open {
+      font-size: 0.9rem;
+      min-height: 2rem;
     }
-    .button-name {
-      display: none;
+
+    .selector-button, .button-name {
+      font-size: 0.9rem;
     }
   }
 }

--- a/packages/shared-components/src/components/onto-header/onto-header.scss
+++ b/packages/shared-components/src/components/onto-header/onto-header.scss
@@ -9,7 +9,7 @@
 .header-component {
   display: flex;
   justify-content: flex-end;
-  align-items: center;
+  align-items: stretch;
   gap: 0.25em;
   padding: 0 2rem .5em 0;
   font-size: 1.1em;

--- a/packages/shared-components/src/components/onto-language-selector/onto-language-selector.scss
+++ b/packages/shared-components/src/components/onto-language-selector/onto-language-selector.scss
@@ -8,8 +8,10 @@ onto-language-selector {
   .onto-dropdown {
     height: 100%;
 
-    .onto-dropdown-button {
-      height: 100%;
+    &.open {
+      .onto-dropdown-button {
+        height: fit-content;
+      }
     }
 
     &.closed {
@@ -22,5 +24,15 @@ onto-language-selector {
         background-color: #d4d4d4;
       }
     }
+  }
+}
+
+@media (max-width: 1440px) {
+  .onto-dropdown-button {
+    font-size: 0.9rem;
+  }
+
+  .selector-button, .button-name, .onto-dropdown-menu-item > * {
+    font-size: 0.9rem;
   }
 }

--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.scss
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.scss
@@ -28,13 +28,14 @@
     gap: 0.4em;
 
     .item-icon {
-      font-size: 1.5em;
+      font-size: 1.4em;
     }
 
     .item-label {
-      display: flex;
-      flex-direction: column;
-      align-items: start;
+      line-height: 0.75em;
+      display: inline-block;
+      vertical-align: middle;
+      text-align: left;
 
       .repository-id {
         line-height: .75em;
@@ -43,7 +44,7 @@
       .repository-location {
         font-weight: 300;
         font-size: .75em;
-        margin-top: .3em;
+        margin-top: .4em;
         display: inline-block;
         max-width: 120px;
         text-overflow: ellipsis;
@@ -59,12 +60,15 @@
   .tippy-content {
     padding: 0;
     color: #373a3c;
+    border: 1px solid rgba(0, 0, 0, .125);
+    box-shadow: 1px 3px 6px rgba(0, 0, 0, 0.2);
 
     .repository-tooltip-title {
-      font-size: 1rem;
+      font-size: 0.875rem;
       font-weight: 400;
       padding: 8px 14px;
       background-color: #f7f7f7;
+      border-bottom: #EBEBEB 1px solid;
 
       .value {
         word-wrap: break-word;
@@ -72,7 +76,7 @@
     }
 
     .repository-tooltip-content {
-      padding: 8px 14px;
+      padding: 1.5rem 0.5rem;
       display: flex;
       flex-direction: column;
       gap: 0.8em;


### PR DESCRIPTION
## What
The changes address some of the differences in the repository popover and icon styles in the repo selector. 

## Why
There were some styling differences when comparing with the legacy Workbench.

## How
I edited the tooltip theme and button icon size.

## Testing
N/A

## Screenshots
Legacy WB:
![Screenshot from 2025-01-14 15-43-34](https://github.com/user-attachments/assets/2a0172b6-d796-49d3-9891-9930e1db6122)

Current update:
![Screenshot from 2025-01-14 16-01-15](https://github.com/user-attachments/assets/9258d01f-dd9f-479d-a071-0873b692501e)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
