### PR TITLE
GDB-11282 save selected repository in local storage

### DIFF
--- a/packages/api/src/models/storage/storage-data.ts
+++ b/packages/api/src/models/storage/storage-data.ts
@@ -28,7 +28,7 @@ export class StorageData {
    * @param defaultValue The default value to return if the value is null.
    * @returns The value as a string or the default value if the value is null.
    */
-  getValueOrDefault(defaultValue: string): string {
+  getValueOrDefault(defaultValue: string): string | undefined {
     return this.value || defaultValue;
   }
 

--- a/packages/api/src/services/repository/index.ts
+++ b/packages/api/src/services/repository/index.ts
@@ -1,2 +1,4 @@
 export * from './repository.service';
 export * from './repository-context.service';
+export * from './repository-rest.service';
+export * from './repository-storage.service';

--- a/packages/api/src/services/repository/repository-context.service.ts
+++ b/packages/api/src/services/repository/repository-context.service.ts
@@ -2,32 +2,61 @@ import {ContextService} from '../context';
 import {Repository, RepositoryList} from '../../models/repositories';
 import {ValueChangeCallback} from '../../models/context/value-change-callback';
 import {DeriveContextServiceContract} from '../../models/context/update-context-method';
+import {ServiceProvider} from '../../providers';
+import {RepositoryStorageService} from './repository-storage.service';
 
 type RepositoryContextFields = {
-  readonly SELECTED_REPOSITORY: string;
+  readonly SELECTED_REPOSITORY_ID: string;
   readonly REPOSITORY_LIST: string;
+  readonly REPOSITORY_LOCATION: string;
 }
 
 type RepositoryContextFieldParams = {
-  readonly SELECTED_REPOSITORY: Repository;
+  readonly SELECTED_REPOSITORY_ID: string;
   readonly REPOSITORY_LIST: RepositoryList;
+  readonly REPOSITORY_LOCATION: string;
 };
 
 /**
  * The RepositoryContextService class manages the application's repository context.
  */
 export class RepositoryContextService extends ContextService<RepositoryContextFields> implements DeriveContextServiceContract<RepositoryContextFields, RepositoryContextFieldParams> {
-
   readonly SELECTED_REPOSITORY = 'selectedRepository';
+  readonly SELECTED_REPOSITORY_ID = 'selectedRepositoryId';
   readonly REPOSITORY_LIST = 'repositoryList';
+  readonly REPOSITORY_LOCATION = 'repositoryLocation';
+
+  /**
+   * Updates the selected repository ID in the context and persist it in the local storage using the storage service.
+   *
+   * @param selectedRepositoryId - The new repository ID.
+   */
+  updateSelectedRepositoryId(selectedRepositoryId: string): void {
+    const storageService = ServiceProvider.get(RepositoryStorageService);
+    storageService.set(this.SELECTED_REPOSITORY_ID, selectedRepositoryId);
+    this.updateContextProperty(this.SELECTED_REPOSITORY_ID, selectedRepositoryId);
+  }
+
+  /**
+   * Registers the <code>callbackFunction</code> to be called whenever the selected repository ID changes.
+   *
+   * @param callbackFunction - The function to call when the selected repository ID changes.
+   * @returns A function to unsubscribe from updates.
+   */
+  onSelectedRepositoryIdChanged(callbackFunction: ValueChangeCallback<string | undefined>): () => void {
+    return this.subscribe(this.SELECTED_REPOSITORY_ID, callbackFunction);
+  }
 
   /**
    * Updates the selected repository and notifies subscribers about the change.
    *
-   * @param repository - The new repository to set as selected.
+   * @param selectedRepository - The new repository to set as selected.
    */
-  updateSelectedRepository(repository: Repository | undefined): void {
-    this.updateContextProperty(this.SELECTED_REPOSITORY, repository);
+  updateSelectedRepository(selectedRepository: Repository | undefined): void {
+    if (selectedRepository) {
+      this.updateSelectedRepositoryId(selectedRepository.id);
+    }
+    this.updateContextProperty(this.SELECTED_REPOSITORY, selectedRepository);
   }
 
   /**
@@ -38,6 +67,25 @@ export class RepositoryContextService extends ContextService<RepositoryContextFi
    */
   onSelectedRepositoryChanged(callbackFunction: ValueChangeCallback<Repository | undefined>): () => void {
     return this.subscribe(this.SELECTED_REPOSITORY, callbackFunction);
+  }
+
+  /**
+   * Updates the repository location in the context.
+   *
+   * @param repositoryLocation - The new repository location.
+   */
+  updateRepositoryLocation(repositoryLocation: string): void {
+    return this.updateContextProperty(this.REPOSITORY_LOCATION, repositoryLocation);
+  }
+
+  /**
+   * Registers the <code>callbackFunction</code> to be called whenever the repository location changes.
+   *
+   * @param callbackFunction - The function to call when the repository location changes.
+   * @returns A function to unsubscribe from updates.
+   */
+  onRepositoryLocationChanged(callbackFunction: ValueChangeCallback<string | undefined>): () => void {
+    return this.subscribe(this.REPOSITORY_LOCATION, callbackFunction);
   }
 
   /**
@@ -56,7 +104,7 @@ export class RepositoryContextService extends ContextService<RepositoryContextFi
    * @param callbackFunction - The function to call when the repository list changes.
    * @returns A function to unsubscribe from updates.
    */
-  onRepositoriesChanged(callbackFunction: ValueChangeCallback<RepositoryList | undefined>): () => void {
+  onRepositoryListChanged(callbackFunction: ValueChangeCallback<RepositoryList | undefined>): () => void {
     return this.subscribe(this.REPOSITORY_LIST, callbackFunction);
   }
 }

--- a/packages/api/src/services/repository/repository-storage.service.ts
+++ b/packages/api/src/services/repository/repository-storage.service.ts
@@ -1,0 +1,12 @@
+import {LocalStorageService} from '../storage';
+
+/**
+ * Service that handles the repository related properties in the local storage.
+ */
+export class RepositoryStorageService extends LocalStorageService {
+  readonly NAMESPACE = 'repository';
+
+  set(key: string, value: string) {
+    this.storeValue(key, value);
+  }
+}

--- a/packages/api/src/services/repository/test/repository-context.service.spec.ts
+++ b/packages/api/src/services/repository/test/repository-context.service.spec.ts
@@ -45,7 +45,7 @@ describe('RepositoryContextService', () => {
     const newRepositories = new RepositoryList([createRepositoryInstance('repo-one')]);
 
     // When I register a callback function for repository changes,
-    repositoryContextService.onRepositoriesChanged(onRepositoriesChangedCallbackFunction);
+    repositoryContextService.onRepositoryListChanged(onRepositoriesChangedCallbackFunction);
     // and the repositories are updated,
     repositoryContextService.updateRepositoryList(newRepositories);
 
@@ -53,6 +53,37 @@ describe('RepositoryContextService', () => {
     expect(onRepositoriesChangedCallbackFunction).toHaveBeenLastCalledWith(newRepositories);
     // but the repositories should be a different instance.
     expect(onRepositoriesChangedCallbackFunction.mock.lastCall[0]).not.toBe(newRepositories);
+  });
+
+  test('Should call the callback function when the selected repository ID changes.', () => {
+    const onSelectedRepositoryIdChangedCallbackFunction = jest.fn();
+    const newRepositoryId = 'repo-one-id';
+
+    repositoryContextService.onSelectedRepositoryIdChanged(onSelectedRepositoryIdChangedCallbackFunction);
+    repositoryContextService.updateSelectedRepositoryId(newRepositoryId);
+
+    expect(onSelectedRepositoryIdChangedCallbackFunction).toHaveBeenLastCalledWith(newRepositoryId);
+  });
+
+  test('Should update the selected repository and repository ID if provided.', () => {
+    const updateContextPropertySpy = jest.spyOn(repositoryContextService, 'updateContextProperty');
+    const updatedRepository = new Repository({
+      id: 'repo-id'
+    });
+
+    repositoryContextService.updateSelectedRepository(updatedRepository);
+
+    expect(updateContextPropertySpy).toHaveBeenCalledWith(repositoryContextService.SELECTED_REPOSITORY_ID, 'repo-id');
+    expect(updateContextPropertySpy).toHaveBeenCalledWith(repositoryContextService.SELECTED_REPOSITORY, updatedRepository);
+  });
+
+  test('Should not update the selected repository ID if repository instance is not provided.', () => {
+    const updateContextPropertySpy = jest.spyOn(repositoryContextService, 'updateContextProperty');
+
+    repositoryContextService.updateSelectedRepository(undefined);
+
+    expect(updateContextPropertySpy).not.toHaveBeenCalledWith(repositoryContextService.SELECTED_REPOSITORY_ID, undefined);
+    expect(updateContextPropertySpy).toHaveBeenCalledWith(repositoryContextService.SELECTED_REPOSITORY, undefined);
   });
 
   function createRepositoryInstance(id: string, location = 'http://example.com:7300') {

--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -28,6 +28,7 @@ import 'angularjs-slider/dist/rzslider.min';
 import {debounce} from "lodash";
 import {DocumentationUrlResolver} from "./utils/documentation-url-resolver";
 import {NamespacesListModel} from "./models/namespaces/namespaces-list";
+import {RepositoryContextService, ServiceProvider} from "@ontotext/workbench-api";
 
 angular
     .module('graphdb.workbench.se.controllers', [
@@ -140,7 +141,7 @@ function homeCtrl($scope,
         $scope.isAutocompleteEnabled = autocompleteEnabled;
     };
 
-    subscriptions.push(WorkbenchContextService.onSelectedRepositoryIdUpdated(onSelectedRepositoryIdUpdated));
+    subscriptions.push(ServiceProvider.get(RepositoryContextService).onSelectedRepositoryIdChanged(onSelectedRepositoryIdUpdated));
     subscriptions.push(WorkbenchContextService.onAutocompleteEnabledUpdated(onAutocompleteEnabledUpdated));
 
     $scope.$on('$destroy', () => subscriptions.forEach((subscription) => subscription()));
@@ -567,6 +568,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
      * @type {undefined | boolean}
      */
     let isAuthenticated = undefined;
+
     const localStoreChangeHandler = (localStoreEvent) => {
         if (AuthTokenService.AUTH_STORAGE_NAME === localStoreEvent.key) {
             const newAuthenticationState = $jwtAuth.isAuthenticated();
@@ -582,23 +584,10 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
                     reloadPageOutsideAngularScope();
                 }
             }
+        } else if ('ls.' + LSKeys.AUTOCOMPLETE_ENABLED === localStoreEvent.key) {
+          WorkbenchContextService.setAutocompleteEnabled(localStoreEvent.newValue === 'true');
         }
     };
-
-    /**
-     * Add a listener for the browser's local store change event. This event will be fired in all tabs of the current domain
-     * EXPECT FOR THE ONE where the local store changed.
-     */
-    window.addEventListener('storage', localStoreChangeHandler);
-
-    $scope.$on('$destroy', () => {
-        document.removeEventListener('click', closeActiveRepoPopoverEventHandler);
-        window.removeEventListener('storage', localStoreChangeHandler);
-        deregisterMenuWatcher();
-        if ($scope.checkMenu) {
-            $timeout.cancel($scope.checkMenu);
-        }
-    });
 
     $scope.isAdmin = function () {
         return $scope.hasRole(UserRole.ROLE_ADMIN);
@@ -1038,20 +1027,39 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         }
     };
     $rootScope.$on("repositoryIsSet", onRepositoriesChanged);
-    window.addEventListener('storage', (event) => {
-        if ('ls.' + LSKeys.AUTOCOMPLETE_ENABLED === event.key) {
-            WorkbenchContextService.setAutocompleteEnabled(event.newValue === 'true');
-        } else if ('ls.' + LSKeys.REPOSITORY_ID === event.key) {
-            onRepositoriesChanged();
-        }
-    });
+
+    /**
+     * Add a listener for the browser's local store change event. This event will be fired in all tabs of the current domain
+     * EXPECT FOR THE ONE where the local store changed.
+     */
+    window.addEventListener('storage', localStoreChangeHandler);
+
+    // Selected repository ID change event is fired when the user changes the repository from the dropdown or by
+    // selecting a repository from the repository list page. This triggers the event in the current tab and also stores
+    // the new repository ID in the local storage. Local storage change event is handled by a central handler
+    // LocalStorageSubscriptionHandlerService in the api module which triggers the change for the respective context
+    // properties.
+    const onSelectedRepositoryIdChangedSubscription = ServiceProvider.get(RepositoryContextService)
+      .onSelectedRepositoryIdChanged((repositoryId) => {
+        onRepositoriesChanged();
+      });
 
     $scope.downloadGuidesFile = (resourcePath, resourceFile) => {
-        GuidesService.downloadGuidesFile(resourcePath, resourceFile)
-            .catch((error) => {
-                toastr.error($translate.instant('guide.step_plugin.download-guide-resource.download.message.failure', {resourceFile}));
-            });
+      GuidesService.downloadGuidesFile(resourcePath, resourceFile)
+        .catch((error) => {
+          toastr.error($translate.instant('guide.step_plugin.download-guide-resource.download.message.failure', {resourceFile}));
+        });
     };
+
+    $scope.$on('$destroy', () => {
+      onSelectedRepositoryIdChangedSubscription();
+      document.removeEventListener('click', closeActiveRepoPopoverEventHandler);
+      window.removeEventListener('storage', localStoreChangeHandler);
+      deregisterMenuWatcher();
+      if ($scope.checkMenu) {
+        $timeout.cancel($scope.checkMenu);
+      }
+    });
 }
 
 repositorySizeCtrl.$inject = ['$scope', '$http', 'RepositoriesRestService'];

--- a/packages/legacy-workbench/src/js/angular/core/interceptors/authentication.interceptor.js
+++ b/packages/legacy-workbench/src/js/angular/core/interceptors/authentication.interceptor.js
@@ -1,4 +1,5 @@
 import 'angular/core/services';
+import {RepositoryStorageService, RepositoryContextService, ServiceProvider} from "@ontotext/workbench-api";
 
 angular.module('graphdb.framework.core.interceptors.authentication', [
     'ngCookies'
@@ -31,8 +32,10 @@ angular.module('graphdb.framework.core.interceptors.authentication', [
                     }
 
                     if (!headers['X-GraphDB-Repository']) {
-                        const repositoryId = LocalStorageAdapter.get(LSKeys.REPOSITORY_ID);
-                        const repositoryLocation = LocalStorageAdapter.get(LSKeys.REPOSITORY_LOCATION);
+                        const repositoryStorageService = ServiceProvider.get(RepositoryStorageService);
+                        const repositoryContextService = ServiceProvider.get(RepositoryContextService);
+                        const repositoryId = repositoryStorageService.get(repositoryContextService.SELECTED_REPOSITORY_ID).getValue();
+                        const repositoryLocation = repositoryStorageService.get(repositoryContextService.REPOSITORY_LOCATION).getValue();
 
                         headers['X-GraphDB-Repository'] = repositoryId ? repositoryId : undefined;
                         headers['X-GraphDB-Repository-Location'] = repositoryLocation ? repositoryLocation : undefined;

--- a/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
@@ -2,6 +2,7 @@ import 'angular/core/services';
 import 'angular/core/services/openid-auth.service.js';
 import 'angular/rest/security.rest.service';
 import {UserRole} from 'angular/utils/user-utils';
+import {RepositoryStorageService, RepositoryContextService, ServiceProvider} from "@ontotext/workbench-api";
 
 angular.module('graphdb.framework.core.services.jwtauth', [
     'toastr',
@@ -288,16 +289,19 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                     $rootScope.deniedPermissions = {};
                     this.securityInitialized = true;
 
+                    const repositoryStorageService = ServiceProvider.get(RepositoryStorageService);
+                    const repositoryContextService = ServiceProvider.get(RepositoryContextService);
+
                     const selectedRepo = {
-                        id: LocalStorageAdapter.get(LSKeys.REPOSITORY_ID) || '',
-                        location: LocalStorageAdapter.get(LSKeys.REPOSITORY_LOCATION) || ''
+                        id: repositoryStorageService.get(repositoryContextService.SELECTED_REPOSITORY_ID).getValueOrDefault(''),
+                        location: repositoryStorageService.get(repositoryContextService.REPOSITORY_LOCATION).getValueOrDefault('')
                     };
 
                     if (!jwtAuth.canReadRepo(selectedRepo)) {
                         // if the current repo is unreadable by the currently logged-in user (or free access user)
                         // we unset the repository
-                        LocalStorageAdapter.remove(LSKeys.REPOSITORY_ID);
-                        LocalStorageAdapter.remove(LSKeys.REPOSITORY_LOCATION);
+                        repositoryStorageService.remove(repositoryContextService.SELECTED_REPOSITORY_ID);
+                        repositoryStorageService.remove(repositoryContextService.REPOSITORY_LOCATION);
                         // reset denied permissions (different repo, different rights)
                         $rootScope.deniedPermissions = {};
                     }

--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-config.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-config.controller.js
@@ -10,6 +10,7 @@ import {
 import {GraphsConfig, StartMode} from "../../models/graphs/graphs-config";
 import {mapGraphConfigSamplesToGraphConfigs} from "../../rest/mappers/graphs-config-mapper";
 import {NamespacesListModel} from "../../models/namespaces/namespaces-list";
+import {RepositoryContextService, ServiceProvider} from "@ontotext/workbench-api";
 
 angular
     .module('graphdb.framework.graphexplore.controllers.graphviz.config', [
@@ -634,7 +635,7 @@ function GraphConfigCtrl(
     // =========================
 
     const subscriptions = [];
-    subscriptions.push(WorkbenchContextService.onSelectedRepositoryIdUpdated(onSelectedRepositoryIdUpdated));
+    subscriptions.push(ServiceProvider.get(RepositoryContextService).onSelectedRepositoryIdChanged(onSelectedRepositoryIdUpdated));
     subscriptions.push(WorkbenchContextService.onAutocompleteEnabledUpdated(onAutocompleteEnabledUpdated));
     subscriptions.push($scope.$on('$locationChangeStart', locationChangedHandler));
     subscriptions.push($scope.$on('$destroy', unsubscribeListeners));

--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -8,6 +8,7 @@ import 'angular/utils/local-storage-adapter';
 import {NUMBER_PATTERN} from "../../repositories/repository.constants";
 import {removeSpecialChars} from "../../utils/string-utils";
 import {NamespacesListModel} from "../../models/namespaces/namespaces-list";
+import {RepositoryContextService, ServiceProvider} from "@ontotext/workbench-api";
 
 const modules = [
     'ui.scroll.jqlite',
@@ -352,7 +353,7 @@ function GraphsVisualizationsCtrl(
     }));
 
     subscriptions.push(WorkbenchContextService.onAutocompleteEnabledUpdated(onAutocompleteEnabledUpdated));
-    subscriptions.push(WorkbenchContextService.onSelectedRepositoryIdUpdated(onSelectedRepositoryIdUpdated));
+    subscriptions.push(ServiceProvider.get(RepositoryContextService).onSelectedRepositoryIdChanged(onSelectedRepositoryIdUpdated));
 
     subscriptions.push($scope.$on('repositoryIsSet', function (event, args) {
         // New repo set from dropdown, clear init state

--- a/packages/legacy-workbench/src/js/angular/similarity/controllers/similarity-list.controller.js
+++ b/packages/legacy-workbench/src/js/angular/similarity/controllers/similarity-list.controller.js
@@ -9,6 +9,7 @@ import {mapIndexesResponseToSimilarityIndex} from "../../rest/mappers/similarity
 import {SimilaritySearch} from "../../models/similarity/similarity-search";
 import {RenderingMode} from "../../models/ontotext-yasgui/rendering-mode";
 import {NamespacesListModel} from "../../models/namespaces/namespaces-list";
+import {RepositoryContextService, ServiceProvider} from "@ontotext/workbench-api";
 
 const modules = ['graphdb.core.services.workbench-context', 'graphdb.framework.core.services.rdf4j.repositories'];
 angular
@@ -364,7 +365,7 @@ function SimilarityCtrl(
     };
 
     subscriptions.push(WorkbenchContextService.onAutocompleteEnabledUpdated(onAutocompleteEnabledUpdated));
-    subscriptions.push(WorkbenchContextService.onSelectedRepositoryIdUpdated(onSelectedRepositoryIdUpdated));
+    subscriptions.push(ServiceProvider.get(RepositoryContextService).onSelectedRepositoryIdChanged(onSelectedRepositoryIdUpdated));
 
     const searchTypeChangeHandler = () => {
         $scope.empty = true;

--- a/packages/legacy-workbench/src/pages/repositories.html
+++ b/packages/legacy-workbench/src/pages/repositories.html
@@ -13,7 +13,6 @@
     <div class="ot-loader ot-main-loader" onto-loader size="50" ng-show="loader"></div>
     <!-- Local GraphDB instance -->
     <div ng-if="getLocalLocation(true, RemoteLocationType.GRAPH_DB).length && hasActiveLocation()" class="mb-1">
-
         <table id="wb-locations-locationInGetLocations" class="table" aria-describedby="Locations repository table">
             <tbody>
             <tr class="location"

--- a/packages/shared-components/cypress/e2e/repository-selector/repository-selector.cy.js
+++ b/packages/shared-components/cypress/e2e/repository-selector/repository-selector.cy.js
@@ -5,6 +5,7 @@ describe("Repository Selector", () => {
   it('Should select repository', () => {
     // When I visit a page with repository selector in it.
     RepositorySelectorSteps.visit();
+    RepositorySelectorSteps.triggerRepositoriesLoading();
     // Then I expect to see only toggle selector button with default label, because the repository is not selected,
     RepositorySelectorSteps.getRepositorySelectorToggleButton()
       .should('be.visible')

--- a/packages/shared-components/cypress/steps/header/repository-selector-steps.js
+++ b/packages/shared-components/cypress/steps/header/repository-selector-steps.js
@@ -6,6 +6,10 @@ export class RepositorySelectorSteps extends BaseSteps {
     super.visit('repository-selector');
   }
 
+  static triggerRepositoriesLoading() {
+    cy.get('#loadRepositories').click();
+  }
+
   static getRepositorySelector() {
     return cy.get('.onto-repository-selector');
   }

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -112,6 +112,10 @@ export namespace Components {
      */
     interface OntoTestContext {
         /**
+          * Loads the repositories in the application.
+         */
+        "loadRepositories": () => Promise<void>;
+        /**
           * Updates the license information in the context.  This method uses the LicenseContextService to update the license and returns a resolved Promise once the operation is complete.
           * @param license - The new License object to be set.
           * @returns A Promise that resolves when the license update is complete.

--- a/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
+++ b/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
@@ -3,7 +3,7 @@ import {
   License,
   LicenseContextService,
   ProductInfo,
-  ProductInfoContextService,
+  ProductInfoContextService, RepositoryContextService, RepositoryService,
   ServiceProvider
 } from '@ontotext/workbench-api';
 
@@ -42,6 +42,17 @@ export class OntoTestContext {
   @Method()
   updateProductInfo(productInfo: ProductInfo): Promise<void> {
     ServiceProvider.get(ProductInfoContextService).updateProductInfo(productInfo);
+    return Promise.resolve();
+  }
+
+  /**
+   * Loads the repositories in the application.
+   */
+  @Method()
+  loadRepositories(): Promise<void> {
+    ServiceProvider.get(RepositoryService).getRepositories().then((repositories) => {
+      ServiceProvider.get(RepositoryContextService).updateRepositoryList(repositories);
+    });
     return Promise.resolve();
   }
 }

--- a/packages/shared-components/src/components/onto-test-context/readme.md
+++ b/packages/shared-components/src/components/onto-test-context/readme.md
@@ -11,6 +11,16 @@ A component for managing test context in the application. Used only for testing
 
 ## Methods
 
+### `loadRepositories() => Promise<void>`
+
+Loads the repositories in the application.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `updateLicense(license: License) => Promise<void>`
 
 Updates the license information in the context.

--- a/packages/shared-components/src/pages/js/main.js
+++ b/packages/shared-components/src/pages/js/main.js
@@ -24,3 +24,7 @@ const loadProductInfo = () => {
     productVersion: '11.0-SNAPSHOT'
   });
 };
+
+const loadRepositories = () => {
+  testContext.loadRepositories();
+}

--- a/packages/shared-components/src/pages/repository-selector/index.html
+++ b/packages/shared-components/src/pages/repository-selector/index.html
@@ -16,6 +16,7 @@
   <script type="module" src="/build/shared-components.esm.js"></script>
   <script nomodule src="/build/shared-components.js"></script>
   <script src="./main.js" defer></script>
+  <script src="../js/main.js" defer></script>
   <link rel="stylesheet" href="../css/bootstrap.min.css">
   <link rel="stylesheet" href="../css/font-awesome.min.css">
 
@@ -28,6 +29,8 @@
 <body>
 
 <div class="page-content">
+  <button id="loadRepositories" onclick="loadRepositories()">Load repositories</button>
+  <hr/>
   <onto-repository-selector></onto-repository-selector>
   <onto-tooltip></onto-tooltip>
 </div>

--- a/packages/workbench/src/app/graphql/graphql.component.ts
+++ b/packages/workbench/src/app/graphql/graphql.component.ts
@@ -12,7 +12,7 @@ import {AuthenticationService, RepositoryContextService, ServiceProvider, Reposi
 export class GraphqlComponent {
   constructor() {
     console.log('GraphqlComponent login', ServiceProvider.get(AuthenticationService).login());
-    ServiceProvider.get(RepositoryContextService).onRepositoriesChanged((repositoryList: RepositoryList | undefined) => {
+    ServiceProvider.get(RepositoryContextService).onRepositoryListChanged((repositoryList: RepositoryList | undefined) => {
       console.log('GraphqlComponent repositories', repositoryList?.getItems());
     });
   }


### PR DESCRIPTION
## What
Refactored the repository selector component and extended repository context service to allow loading repositories from the context and synchronizing the selected repository through the local storage. Additionaly, updated the legacy-workbench to use the new context and storage services from the api module.

## Why
It is expected that repositories are loaded during application bootstrap and also the selected repository to be persisted in local storage so that application opened in multiple tabs to be synchronized automatically.

## How
* Extended repository context service and implemented repository storage service in the api module.
* Updated root-config to fetch repositories from backend and store the in the repository context service.
* Refactored repository selector shared component to fetch repository list from the repostory context service instead directly fetching them from the backend. Also, the component gets the current selected repository ID from the local storage via the new service. Additionally, when selected repository is changed through the menu, then the component updates the context, which also updates the value in the local storage.
* Updated legacy-workbench implementation to use the new services.

## Testing
* Extended tests suites.

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
