### PR TITLE
GDB-11319 - Add functionality to permission banner

### DIFF
--- a/packages/api/src/models/events/event-name.ts
+++ b/packages/api/src/models/events/event-name.ts
@@ -1,0 +1,10 @@
+/**
+ * A constant object that defines event names used throughout the {@link EventService}.
+ *
+ * This object acts as a central repository for all predefined event names, ensuring consistency
+ * when emitting and subscribing to events in the {@link EventService}.
+ *
+ */
+export const EventName = {
+  NAVIGATION_END: 'navigationEnd'
+};

--- a/packages/api/src/models/events/event-observer.ts
+++ b/packages/api/src/models/events/event-observer.ts
@@ -1,0 +1,18 @@
+/**
+ * Represents an observer for events, encapsulating a callback to handle event notifications.
+ *
+ * @template T - The type of the event payload.
+ */
+export class EventObserver<T> {
+
+  /**
+   * A callback function to notify the observer of an event.
+   *
+   * @param eventPayload - The payload of the event to notify the observer about.
+   */
+  notify: (eventPayload: T) => void;
+
+  constructor(callback: (payload: T) => void) {
+    this.notify = callback;
+  }
+}

--- a/packages/api/src/models/events/index.ts
+++ b/packages/api/src/models/events/index.ts
@@ -1,1 +1,4 @@
 export * from './event';
+export * from './event-name';
+export * from './navigation/navigation-end';
+export * from './navigation/navigation-end-payload';

--- a/packages/api/src/models/events/navigation/navigation-end-payload.ts
+++ b/packages/api/src/models/events/navigation/navigation-end-payload.ts
@@ -1,0 +1,19 @@
+/**
+ * Represents the payload for a navigation end event.
+ */
+export class NavigationEndPayload {
+
+  /**
+   * The URL from which the navigation originated.
+   *
+   * @type {string | undefined}
+   */
+  oldUrl: string | undefined;
+
+  /**
+   * The URL to which the navigation ended.
+   *
+   * @type {string | undefined}
+   */
+  newUrl: string | undefined;
+}

--- a/packages/api/src/models/events/navigation/navigation-end.ts
+++ b/packages/api/src/models/events/navigation/navigation-end.ts
@@ -1,0 +1,14 @@
+import {Event} from '../event';
+import {NavigationEndPayload} from './navigation-end-payload';
+import {EventName} from '../event-name';
+
+/**
+ * Represents a "navigationEnd" event.
+ *
+ * This event is triggered when navigation ends and contains information about the previous and current URLs.
+ */
+export class NavigationEnd extends Event<NavigationEndPayload> {
+  constructor(oldUrl: string, newUrl: string) {
+    super(EventName.NAVIGATION_END, {oldUrl, newUrl});
+  }
+}

--- a/packages/api/src/models/security/index.ts
+++ b/packages/api/src/models/security/index.ts
@@ -1,1 +1,2 @@
 export * from './authentication-type';
+export * from './restricted-pages';

--- a/packages/api/src/models/security/restricted-pages.ts
+++ b/packages/api/src/models/security/restricted-pages.ts
@@ -1,0 +1,18 @@
+import {Model} from '../common';
+
+/**
+ * Holds information about restricted pages for the logged-in user.
+ */
+export class RestrictedPages extends Model<RestrictedPages>{
+
+  private pages: Record<string, boolean> = {};
+
+  isRestricted(pageUrl: string): boolean {
+    return this.pages[pageUrl];
+  }
+
+  setPageRestriction(pageUrl: string, isRestricted = true): RestrictedPages {
+    this.pages[pageUrl] = isRestricted;
+    return this;
+  }
+}

--- a/packages/api/src/models/security/test/restricted-pages.spec.ts
+++ b/packages/api/src/models/security/test/restricted-pages.spec.ts
@@ -1,0 +1,20 @@
+import {RestrictedPages} from '../restricted-pages';
+
+describe('Restricted pages model', () => {
+  test('isRestricted should return true if page is restricted', () => {
+    const newPermissions = new RestrictedPages();
+    newPermissions.setPageRestriction('/restricted-page');
+    expect(newPermissions.isRestricted('/restricted-page')).toBeTruthy();
+  });
+
+  test('isRestricted should return false if page is unrestricted', () => {
+    const newPermissions = new RestrictedPages();
+    newPermissions.setPageRestriction('/restricted-page', false);
+    expect(newPermissions.isRestricted('/restricted-page')).toBeFalsy();
+  });
+
+  test('isRestricted should return false if there are not restricted page information', () => {
+    const newPermissions = new RestrictedPages();
+    expect(newPermissions.isRestricted('/restricted-page')).toBeFalsy();
+  });
+});

--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -24,6 +24,8 @@ export {EventEmitter} from './emitters/event.emitter';
 export * from './services/license';
 export * from './services/product-info';
 export * from './services/storage';
+export * from './services/security';
+export * from './services/event-service';
 
 // Export utils for external usages.
 export * from './services/utils';

--- a/packages/api/src/services/event-service/event.service.ts
+++ b/packages/api/src/services/event-service/event.service.ts
@@ -1,0 +1,76 @@
+import {Event} from '../../models/events';
+import {Service} from '../../providers/service/service';
+import {ObjectUtil} from '../utils';
+import {EventObserver} from '../../models/events/event-observer';
+
+/**
+ * A service that manages event subscriptions and emissions.
+ *
+ * Allows components or modules to subscribe to specific events and be notified when those events are emitted.
+ */
+export class EventService implements Service {
+
+  /**
+   * A map of event names to their corresponding list of subscribers.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private eventSubscribers: Map<string, EventObserver<any>[]> = new Map<string, EventObserver<any>[]>();
+
+  /**
+   * Emits an event to all subscribers of the specified event type.
+   *
+   * @template T - The type of the event payload.
+   * @param event - The event to emit, containing its name and payload.
+   */
+  emit<T extends {} | undefined>(event: Event<T>): void {
+    const subscribers = this.eventSubscribers.get(event.NAME);
+    if (subscribers) {
+      subscribers.forEach((subscriber) => {
+        subscriber.notify(ObjectUtil.deepCopy(event.payload));
+      });
+    }
+  }
+
+  /**
+   * Subscribes to a specific event with a callback function.
+   *
+   * @template T - The type of the event payload.
+   * @param eventName - The name of the event to subscribe to.
+   * @param callback - A callback function to handle the event notifications.
+   *
+   * @returns A function to unsubscribe from the event.
+   */
+  subscribe<T extends {} | undefined>(eventName: string, callback: (payload: T) => void): () => void {
+    const observer = new EventObserver<T>(callback);
+    const eventSubscribers = this.eventSubscribers.get(eventName);
+
+    if (eventSubscribers) {
+      eventSubscribers.push(observer);
+    } else {
+      this.eventSubscribers.set(eventName, [observer]);
+    }
+    return () => this.unsubscribe(eventName, observer);
+  }
+
+  /**
+   * Unsubscribes an observer from a specific event type.
+   *
+   * @template T - The type of the event payload.
+   * @param eventName - The name of the event to unsubscribe from.
+   * @param observer - The observer to remove from the subscribers list.
+   *
+   * @private
+   */
+  private unsubscribe<T extends {} | undefined>(eventName: string, observer: EventObserver<T>): void {
+    const eventSubscribers = this.eventSubscribers.get(eventName);
+    if (eventSubscribers) {
+      const index = eventSubscribers.indexOf(observer);
+      if (index !== -1) {
+        eventSubscribers.splice(index, 1);
+      }
+      if (eventSubscribers.length === 0) {
+        this.eventSubscribers.delete(eventName);
+      }
+    }
+  }
+}

--- a/packages/api/src/services/event-service/index.ts
+++ b/packages/api/src/services/event-service/index.ts
@@ -1,0 +1,1 @@
+export * from './event.service';

--- a/packages/api/src/services/event-service/test/event.service.spec.ts
+++ b/packages/api/src/services/event-service/test/event.service.spec.ts
@@ -1,0 +1,85 @@
+import {EventService} from '../event.service';
+import {Event} from '../../../models/events';
+import {EventName, NavigationEnd} from '../../../models/events';
+
+const TEST_EVENT_NAME = 'testEventName';
+
+describe('EventService', () => {
+  let eventService: EventService;
+
+  beforeEach(() => {
+    eventService = new EventService();
+  });
+
+  it('emit should notify observers of a given event', () => {
+
+    const oldUrl = '/import';
+    const newUrl = '/graphql';
+
+    // Given: there are registered callback functions for the navigation end event.
+    const callBackFunction = jest.fn();
+    const callBackFunctionTwo = jest.fn();
+    eventService.subscribe(EventName.NAVIGATION_END, callBackFunction);
+    eventService.subscribe(EventName.NAVIGATION_END, callBackFunctionTwo);
+
+    // When: the navigation end event is emitted.
+    eventService.emit(new NavigationEnd(oldUrl, newUrl));
+
+    // Then: I expect the registered callback functions to be called.
+    expect(callBackFunction).toHaveBeenLastCalledWith({oldUrl, newUrl});
+    expect(callBackFunctionTwo).toHaveBeenLastCalledWith({oldUrl, newUrl});
+  });
+
+  it('emit should notify observers of a given event if emitted value is undefined', () => {
+
+    // Given: there is a registered callback function for an event.
+    const callBackFunction = jest.fn();
+    eventService.subscribe(TEST_EVENT_NAME, callBackFunction);
+
+    // When: the event is emitted with undefined value.
+    eventService.emit(new TestEvent(undefined));
+
+    // Then: I expect the registered callback function to be called.
+    expect(callBackFunction).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it('emit shouldn\'t notify observers if they are registered for another event', () => {
+
+    // Given: there is a registered callback function for the navigation end event.
+    const callBackFunction = jest.fn();
+    eventService.subscribe(EventName.NAVIGATION_END, callBackFunction);
+
+    // When: an event different of the navigation end event is emitted.
+    eventService.emit(new TestEvent(undefined));
+
+    // I expect the registered callback function not to be called
+    expect(callBackFunction).toHaveBeenCalledTimes(0);
+  });
+
+  it('emit shouldn\'t notify observers that are unsubscribed', () => {
+
+    // Given there is a registered callback function for an event.
+    const callBackFunction = jest.fn();
+    const callBackFunctionTwo = jest.fn();
+    eventService.subscribe(TEST_EVENT_NAME, callBackFunction);
+    const unsubscribe = eventService.subscribe(TEST_EVENT_NAME, callBackFunctionTwo);
+
+    // When the event is emitted,
+    eventService.emit(new TestEvent(undefined));
+    // and unregister one of the functions (for example, the second one).
+    unsubscribe();
+    // and second event is emitted
+    eventService.emit(new TestEvent('test'));
+
+    // Then I expect the first registered callback function to be called twice.
+    expect(callBackFunction).toHaveBeenCalledTimes(2);
+    // and the second one to be called only one
+    expect(callBackFunctionTwo).toHaveBeenCalledTimes(1);
+  });
+});
+
+class TestEvent extends Event<string> {
+  constructor(payload: string | undefined) {
+    super(TEST_EVENT_NAME, payload);
+  }
+}

--- a/packages/api/src/services/security/index.ts
+++ b/packages/api/src/services/security/index.ts
@@ -1,0 +1,1 @@
+export * from './security-context.service';

--- a/packages/api/src/services/security/security-context.service.ts
+++ b/packages/api/src/services/security/security-context.service.ts
@@ -1,0 +1,47 @@
+import {ContextService} from '../context';
+import {ValueChangeCallback} from '../../models/context/value-change-callback';
+import {DeriveContextServiceContract} from '../../models/context/update-context-method';
+import {RestrictedPages} from '../../models/security';
+
+type SecurityContextFields = {
+  readonly RESTRICTED_PAGES: string
+}
+
+type SecurityContextFieldParams = {
+  readonly RESTRICTED_PAGES: RestrictedPages;
+}
+
+/**
+ * The SecurityContextService class manages the various fields in the security context.
+ */
+export class SecurityContextService extends ContextService<SecurityContextFields> implements DeriveContextServiceContract<SecurityContextFields, SecurityContextFieldParams> {
+  readonly RESTRICTED_PAGES = 'restrictedPages';
+
+  /**
+   * Retrieves the restricted pages for the user.
+   *
+   * @return a map with restricted pages.
+   */
+  getRestrictedPages(): RestrictedPages | undefined {
+    return this.getContextPropertyValue(this.RESTRICTED_PAGES) || new RestrictedPages();
+  }
+
+  /**
+   * Updates the restricted pages and notifies subscribers about the change.
+   *
+   * @param restrictedPages - an object with restricted pages.
+   */
+  updateRestrictedPages(restrictedPages: RestrictedPages): void {
+    this.updateContextProperty(this.RESTRICTED_PAGES, restrictedPages);
+  }
+
+  /**
+   * Registers the <code>callbackFunction</code> to be called whenever the restricted pages are changed.
+   *
+   * @param callbackFunction - The function to call when the restricted pages are changed.
+   * @returns A function to unsubscribe from updates.
+   */
+  onRestrictedPagesChanged(callbackFunction: ValueChangeCallback<RestrictedPages | undefined>): () => void {
+    return this.subscribe(this.RESTRICTED_PAGES, callbackFunction);
+  }
+}

--- a/packages/api/src/services/security/test/security-context.service.spec.ts
+++ b/packages/api/src/services/security/test/security-context.service.spec.ts
@@ -1,0 +1,50 @@
+import {SecurityContextService} from '../security-context.service';
+import {RestrictedPages} from '../../../models/security/restricted-pages';
+
+describe('SecurityContextService', () => {
+  let securityContextService: SecurityContextService;
+
+  beforeEach(() => {
+    securityContextService = new SecurityContextService();
+  });
+
+  test('Should call onRestrictedPagesChanged callback with correct denied routes', () => {
+    const onPermissionChangedCallBackFunction = jest.fn();
+    const newPermissions = new RestrictedPages();
+    newPermissions.setPageRestriction('/testPage');
+
+    // Given I register a callback function for permission changes
+    securityContextService.onRestrictedPagesChanged(onPermissionChangedCallBackFunction);
+    // When I update the permissions
+    securityContextService.updateRestrictedPages(newPermissions);
+    // Then I expect the callback function to be called with the passed object of routes
+    expect(onPermissionChangedCallBackFunction).toHaveBeenLastCalledWith(newPermissions);
+    // And the contained routes should be correct
+    expect(onPermissionChangedCallBackFunction.mock.lastCall[0]).toEqual(newPermissions);
+  });
+
+  test('Should not call callback, if unsubscribed', () => {
+    const onPermissionChangedCallBackFunction = jest.fn();
+
+    // Given I have registered a callback
+    const unsubscribeFunction = securityContextService.onRestrictedPagesChanged(onPermissionChangedCallBackFunction);
+    // When I clear the first callback call when the callback function is registered
+    onPermissionChangedCallBackFunction.mockClear();
+    // And I unsubscribe the function from the permission change event,
+    unsubscribeFunction();
+    // And the permissions are updated
+    securityContextService.updateRestrictedPages(new RestrictedPages());
+    // Then I expect the callback function to not be called.
+    expect(onPermissionChangedCallBackFunction).toHaveBeenCalledTimes(0);
+  });
+
+  test('getRestrictedPages should return a copy of restricted pages.', () => {
+    const restrictedPages = new RestrictedPages();
+    restrictedPages.setPageRestriction('/testPage');
+
+    securityContextService.updateRestrictedPages(restrictedPages);
+    const restrictedPagesFromContext = securityContextService.getRestrictedPages();
+    expect(restrictedPagesFromContext).toEqual(restrictedPages);
+    expect(restrictedPagesFromContext).not.toBe(restrictedPages);
+  });
+});

--- a/packages/api/src/services/user-permission/user-permission-storage.service.ts
+++ b/packages/api/src/services/user-permission/user-permission-storage.service.ts
@@ -1,0 +1,9 @@
+import {LocalStorageService} from '../storage';
+
+export class UserPermissionStorageService extends LocalStorageService {
+  readonly NAMESPACE = 'auth';
+
+  set(key: string, value: string): void {
+    this.storeValue(key, value);
+  }
+}

--- a/packages/legacy-workbench/src/template.html
+++ b/packages/legacy-workbench/src/template.html
@@ -144,14 +144,6 @@
     </li>
 </ul>
 <div ng-cloak class="page-content">
-  <div class="container-fluid main-container" ng-if="!hasPermission()">
-    <p class="alert alert-danger">
-      {{'no.access.permission.to.functionality.error' | translate}}
-      <br>
-      {{'change.menu.or.user.warning' | translate}}
-    </p>
-  </div>
-
     <div class="container-fluid main-container" ng-show="hasPermission()" ng-view role="main"
          ng-class="(menuCollapsed || checkMenu()) ? 'expanded':''">
     </div>

--- a/packages/root-config/src/ontotext-root-config.js
+++ b/packages/root-config/src/ontotext-root-config.js
@@ -17,6 +17,11 @@ import './styles/onto-stylesheet.css';
 // import "./styles/bootstrap-graphdb-theme.css";
 import {defineCustomElements} from '../../shared-components/loader';
 import {bootstrapPromises} from './bootstrap/bootstrap';
+import {
+  ServiceProvider,
+  EventService,
+  NavigationEnd
+} from '@ontotext/workbench-api';
 
 addErrorHandler((err) => {
   console.error(err);
@@ -101,7 +106,14 @@ const registerSingleSpaFirstMountListener = () => {
   }
 };
 
-registerSingleSpaFirstMountListener();
+const registerSingleSpaRouterListener = () => {
+  if (!window.singleSingleSpaRouterListenerRegistered) {
+    window.singleSingleSpaRouterListenerRegistered = true;
+    window.addEventListener('single-spa:routing-event', (evt) => {
+      ServiceProvider.get(EventService).emit(new NavigationEnd(evt.detail.oldUrl, evt.detail.newUrl));
+    });
+  }
+};
 
 const bootstrapApplication = () => {
   Promise.all(bootstrapPromises.map((bootstrapFn) => bootstrapFn()))
@@ -115,6 +127,8 @@ const bootstrapApplication = () => {
     });
 };
 
+registerSingleSpaFirstMountListener();
+registerSingleSpaRouterListener();
 bootstrapApplication();
 
 // window.addEventListener("single-spa:routing-event", (evt) => {

--- a/packages/shared-components/cypress/e2e/permission-banner/restricted-pages.cy.js
+++ b/packages/shared-components/cypress/e2e/permission-banner/restricted-pages.cy.js
@@ -1,0 +1,61 @@
+import {RestrictedPagesSteps} from "../../steps/restricted-pages/restricted-pages-steps";
+import {PermissionBannerSteps} from "../../steps/permission-banner/permission-banner-steps";
+
+describe("Restricted pages", () => {
+    it('Should restrict the page when current page permissions changed', () => {
+        // When: visit SPA where have restricted pages
+        RestrictedPagesSteps.visit();
+        // Then: I expect the home page be loaded
+        RestrictedPagesSteps.getPageContentElement().contains('Welcome to the Home Page');
+        // and permission banner is not visible.
+        PermissionBannerSteps.getPermissionBanner().should('not.exist');
+
+        // When: I make current page restricted
+        RestrictedPagesSteps.makeHomePageRestricted();
+        // Then: I expect to see the permission banner
+        PermissionBannerSteps.getPermissionBanner().should('exist').and('be.visible');
+        // and page content not be visible
+        RestrictedPagesSteps.getPageContentElement().should('not.be.visible');
+
+        // When: I make page unrestricted
+        RestrictedPagesSteps.makeCurrentPageUnrestricted();
+        // Then: I expect to the permission banner not exist
+        PermissionBannerSteps.getPermissionBanner().should('not.exist');
+        // and page content to be visible again
+        RestrictedPagesSteps.getPageContentElement().should('be.visible');
+        RestrictedPagesSteps.getPageContentElement().contains('Welcome to the Home Page');
+
+        // Given: current page is restricted
+        RestrictedPagesSteps.makeHomePageRestricted();
+        // and permission banner exist
+        PermissionBannerSteps.getPermissionBanner().should('exist').and('be.visible');
+        // When: the permission pages map is empty
+        RestrictedPagesSteps.makeRestrictedPagesMapEmpty();
+        // Then: I expect to the permission banner not exist
+        PermissionBannerSteps.getPermissionBanner().should('not.exist');
+
+        // Given: current page is restricted
+        RestrictedPagesSteps.makeHomePageRestricted();
+        // and permission banner exist
+        PermissionBannerSteps.getPermissionBanner().should('exist').and('be.visible');
+        // When: the permission pages map is empty
+        RestrictedPagesSteps.makeRestrictedPagesMapUndefined();
+        // Then: I expect to the permission banner not exist
+        PermissionBannerSteps.getPermissionBanner().should('not.exist');
+    });
+
+    it('Should the banner permission appear when navigate to view that is restricted', () => {
+        // Given: visit SPA where have restricted pages
+        RestrictedPagesSteps.visit();
+
+        // When: I navigate to a restricted page
+        RestrictedPagesSteps.navigateToRestrictedPage();
+        // Then: I expect to see the permission banner
+        PermissionBannerSteps.getPermissionBanner().should('exist').and('be.visible');
+
+        // When: I navigate to an unrestricted page
+        RestrictedPagesSteps.navigateToUnrestrictedPage();
+        // Then: I expect the permission banner not exist.
+        PermissionBannerSteps.getPermissionBanner().should('not.exist');
+    });
+});

--- a/packages/shared-components/cypress/steps/restricted-pages/restricted-pages-steps.js
+++ b/packages/shared-components/cypress/steps/restricted-pages/restricted-pages-steps.js
@@ -1,0 +1,35 @@
+import {BaseSteps} from "../base-steps";
+
+export class RestrictedPagesSteps extends BaseSteps {
+    static visit() {
+        cy.visit('/pages/restricted-pages');
+    }
+
+    static getPageContentElement() {
+        return cy.get('#app');
+    }
+
+    static makeHomePageRestricted() {
+        cy.get('#make-current-page-restricted').click();
+    }
+
+    static makeCurrentPageUnrestricted() {
+        cy.get('#make-current-page-unrestricted').click();
+    }
+
+    static makeRestrictedPagesMapEmpty() {
+        cy.get('#make-restriction-pages-map-empty').click();
+    }
+
+    static makeRestrictedPagesMapUndefined() {
+        cy.get('#make-restriction-pages-map-undefined').click();
+    }
+
+    static navigateToRestrictedPage() {
+        cy.get('#restricted-page-link').click();
+    }
+
+    static navigateToUnrestrictedPage() {
+        cy.get('#unrestricted-page-link').click();
+    }
+}

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -118,6 +118,12 @@ export namespace Components {
          */
         "changeLanguage": (language: string) => Promise<void>;
         /**
+          * Emits {@see NavigationEnd} event with <code>oldUrl</code> and <code>newUrl</code>.
+          * @param oldUrl - the value will be used as old url in the event payload.
+          * @param newUrl - the value will be used as new url in the event payload.
+         */
+        "emitNavigateEndEvent": (oldUrl: string, newUrl: string) => Promise<void>;
+        /**
           * Loads the repositories in the application.
          */
         "loadRepositories": () => Promise<void>;
@@ -133,6 +139,11 @@ export namespace Components {
           * @returns A Promise that resolves when the product information update is complete.
          */
         "updateProductInfo": (productInfo: ProductInfo) => Promise<void>;
+        /**
+          * Updates the {@see SecurityContextService} map with <code>restrictedPages</code>.
+          * @param restrictedPages - the map with restricted pages to be set in context service as new value.
+         */
+        "updateRestrictedPage": (restrictedPages: Record<string, boolean>) => Promise<void>;
     }
     interface OntoTooltip {
     }

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -2,7 +2,14 @@ import {Component, Host, h, Listen, Element, State} from '@stencil/core';
 import {NavbarToggledEvent} from "../onto-navbar/navbar-toggled-event";
 import {debounce} from "../../utils/function-utils";
 import {WINDOW_WIDTH_FOR_COLLAPSED_NAVBAR} from "../../models/constants";
-import {ServiceProvider, LocalStorageSubscriptionHandlerService} from "@ontotext/workbench-api";
+import {
+  ServiceProvider,
+  LocalStorageSubscriptionHandlerService,
+  SecurityContextService,
+  RestrictedPages,
+  EventService,
+  EventName, SubscriptionList
+} from "@ontotext/workbench-api";
 
 @Component({
   tag: 'onto-layout',
@@ -11,7 +18,11 @@ import {ServiceProvider, LocalStorageSubscriptionHandlerService} from "@ontotext
 })
 export class OntoLayout {
   private windowResizeObserver: (...args: any) => void;
-
+  private securityContextService = ServiceProvider.get(SecurityContextService);
+  /**
+   * List of subscriptions to manage component lifecycle
+   * */
+  private readonly subscriptions: SubscriptionList = new SubscriptionList();
   private isNavbarCollapsed = false;
 
   /**
@@ -26,7 +37,7 @@ export class OntoLayout {
   @Element() hostElement: HTMLOntoLayoutElement;
 
   @State() isLowResolution = false;
-  @State() hasPermission = true; // TODO get from local store
+  @State() hasPermission: boolean = true;
 
   /**
    * Event listener for the navbar toggled event. The layout needs to respond properly when the navbar is toggled in
@@ -66,6 +77,21 @@ export class OntoLayout {
     service.handleStorageChange(event);
   }
 
+  private setPermission(permissions: RestrictedPages) {
+    if (permissions) {
+      const path = location.pathname;
+      this.hasPermission = !permissions.isRestricted(path);
+    } else {
+      // If the permissions are undefined, the user can access the url
+      this.hasPermission = true;
+    }
+
+    const mainContent = document.querySelector('.wb-layout main') as HTMLElement;
+    if (mainContent) {
+      mainContent.style.display = this.hasPermission ? 'block' : 'none';
+    }
+  }
+
   // ========================
   // Lifecycle methods
   // ========================
@@ -80,8 +106,20 @@ export class OntoLayout {
     window.addEventListener("storage", this.handleStorageChange);
   }
 
+  connectedCallback() {
+    // Subscribing here, because after a disconnectedCallback the connectedCallback is called, instead of componentDidLoad or constructor
+    this.subscriptions.add(this.securityContextService.onRestrictedPagesChanged((restrictedPages) => this.setPermission(restrictedPages)));
+    this.subscriptions.add(ServiceProvider.get(EventService).subscribe(EventName.NAVIGATION_END, () => this.setPermission(this.securityContextService.getRestrictedPages())));
+    this.setPermission(this.securityContextService.getRestrictedPages());
+  }
+
+  /**
+   * Lifecycle method called when the component is about to be removed from the DOM.
+   * Unsubscribes from all subscriptions to prevent memory leaks.
+   */
   disconnectedCallback() {
     window.removeEventListener("storage", this.handleStorageChange);
+    this.subscriptions.unsubscribeAll();
   }
 
   render() {
@@ -99,11 +137,12 @@ export class OntoLayout {
           <onto-navbar navbar-collapsed={this.isLowResolution} selected-menu={this.currentRoute}></onto-navbar>
         </nav>
 
-        {
-          this.hasPermission ?
-            <slot name="main"></slot> :
+        {this.hasPermission ? (
+          <div class='main-slot-wrapper'>
+            <slot name="main"></slot></div>
+            ) : (
             <onto-permission-banner></onto-permission-banner>
-        }
+            )}
         <footer class="wb-footer">
           <onto-footer></onto-footer>
         </footer>

--- a/packages/shared-components/src/components/onto-navbar/onto-navbar.scss
+++ b/packages/shared-components/src/components/onto-navbar/onto-navbar.scss
@@ -5,7 +5,6 @@
 .navbar-component {
   width: 15rem;
   position: fixed;
-  top: 0;
   font-weight: 400;
   z-index: 1010;
   margin: 0;

--- a/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
+++ b/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
@@ -1,10 +1,11 @@
 import { Component, Method } from '@stencil/core';
 import {
+  EventService,
   LanguageContextService,
   License,
-  LicenseContextService,
+  LicenseContextService, NavigationEnd,
   ProductInfo,
-  ProductInfoContextService, RepositoryContextService, RepositoryService,
+  ProductInfoContextService, RepositoryContextService, RepositoryService, RestrictedPages, SecurityContextService,
   ServiceProvider
 } from '@ontotext/workbench-api';
 import en from '../../assets/i18n/en.json';
@@ -78,6 +79,36 @@ export class OntoTestContext {
   @Method()
   changeLanguage(language: string): Promise<void> {
     ServiceProvider.get(LanguageContextService).updateLanguageBundle(this.bundles[language]);
+    return Promise.resolve();
+  }
+
+  /**
+   * Emits {@see NavigationEnd} event with <code>oldUrl</code> and <code>newUrl</code>.
+   * @param oldUrl - the value will be used as old url in the event payload.
+   * @param newUrl - the value will be used as new url in the event payload.
+   */
+  @Method()
+  emitNavigateEndEvent(oldUrl: string, newUrl: string): Promise<void> {
+    ServiceProvider.get(EventService).emit(new NavigationEnd(oldUrl, newUrl));
+    return Promise.resolve();
+  }
+
+  /**
+   * Updates the {@see SecurityContextService} map with <code>restrictedPages</code>.
+   * @param restrictedPages - the map with restricted pages to be set in context service as new value.
+   */
+  @Method()
+  updateRestrictedPage(restrictedPages: Record<string, boolean>): Promise<void> {
+    const restriction = new RestrictedPages();
+    if (!restrictedPages) {
+      ServiceProvider.get(SecurityContextService).updateRestrictedPages(undefined);
+      return;
+    }
+
+    Object.entries(restrictedPages).forEach(([key, value]) => {
+      restriction.setPageRestriction(key, value);
+    });
+    ServiceProvider.get(SecurityContextService).updateRestrictedPages(restriction);
     return Promise.resolve();
   }
 

--- a/packages/shared-components/src/components/onto-test-context/readme.md
+++ b/packages/shared-components/src/components/onto-test-context/readme.md
@@ -31,6 +31,23 @@ Type: `Promise<void>`
 
 A Promise that resolves when the language update is complete.
 
+### `emitNavigateEndEvent(oldUrl: string, newUrl: string) => Promise<void>`
+
+Emits {@see NavigationEnd} event with <code>oldUrl</code> and <code>newUrl</code>.
+
+#### Parameters
+
+| Name     | Type     | Description                                               |
+| -------- | -------- | --------------------------------------------------------- |
+| `oldUrl` | `string` | - the value will be used as old url in the event payload. |
+| `newUrl` | `string` | - the value will be used as new url in the event payload. |
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `loadRepositories() => Promise<void>`
 
 Loads the repositories in the application.
@@ -78,6 +95,22 @@ and returns a resolved Promise once the operation is complete.
 Type: `Promise<void>`
 
 A Promise that resolves when the product information update is complete.
+
+### `updateRestrictedPage(restrictedPages: Record<string, boolean>) => Promise<void>`
+
+Updates the {@see SecurityContextService} map with <code>restrictedPages</code>.
+
+#### Parameters
+
+| Name              | Type                        | Description                                                                |
+| ----------------- | --------------------------- | -------------------------------------------------------------------------- |
+| `restrictedPages` | `{ [x: string]: boolean; }` | - the map with restricted pages to be set in context service as new value. |
+
+#### Returns
+
+Type: `Promise<void>`
+
+
 
 
 ----------------------------------------------

--- a/packages/shared-components/src/index.html
+++ b/packages/shared-components/src/index.html
@@ -21,6 +21,7 @@
       <li><a href="/pages/repository-selector/index.html">Repository Selector</a></li>
       <li><a href="/pages/license-alert/index.html">license alert</a></li>
       <li><a href="/pages/permission-banner/index.html">Permission banner</a></li>
+      <li><a href="/pages/restricted-pages">Restricted pages</a></li>
     </ul>
   </body>
 </html>

--- a/packages/shared-components/src/pages/js/main.js
+++ b/packages/shared-components/src/pages/js/main.js
@@ -1,4 +1,4 @@
-let testContext = document.createElement('onto-test-context');
+const testContext = document.createElement('onto-test-context');
 document.body.appendChild(testContext);
 testContext.changeLanguage('en');
 

--- a/packages/shared-components/src/pages/restricted-pages/index.html
+++ b/packages/shared-components/src/pages/restricted-pages/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"/>
+    <title>Restricted pages</title>
+
+    <script type="importmap">
+        {
+          "imports": {
+            "@ontotext/workbench-api": "/resources/ontotext-workbench-api.js"
+          }
+        }
+    </script>
+
+    <script type="module" src="/build/shared-components.esm.js"></script>
+    <script nomodule src="/build/shared-components.js"></script>
+    <script src="./js/main.js" defer></script>
+    <script src="./restricted-pages/main.js" defer></script>
+    <link rel="stylesheet" href="./css/bootstrap.min.css">
+    <link rel="stylesheet" href="./css/font-awesome.min.css">
+    <style>
+        nav a {
+            margin-left: 20px;
+        }
+    </style>
+</head>
+<body>
+<nav>
+    <a href="/pages/restricted-pages" class="nav-link" data-link>Home</a>
+    <a id="restricted-page-link" href="/pages/restricted-pages/restricted-page" class="nav-link" data-link>Restricted page</a>
+    <a id="unrestricted-page-link" href="/pages/restricted-pages/unrestricted-page" class="nav-link" data-link>Unrestricted page</a>
+</nav>
+<div>
+    <button id="make-current-page-restricted" onclick="makeCurrentPageRestricted()">Make current page restricted</button>
+    <button id="make-current-page-unrestricted" onclick="makeCurrentPageUnrestricted()">Make current page unrestricted</button>
+    <button id="make-restriction-pages-map-empty" onclick="makeRestrictedPagesMapEmpty()">Make restricted pages map empty</button>
+    <button id="make-restriction-pages-map-undefined" onclick="makeRestrictedPagesMapUndefined()">Make restricted pages map undefined</button>
+</div>
+<div style="margin: 100px">
+    <onto-layout id="onto-layout">
+        <main id="app" slot="main">
+
+        </main>
+    </onto-layout>
+</div>
+</body>
+</html>

--- a/packages/shared-components/src/pages/restricted-pages/main.js
+++ b/packages/shared-components/src/pages/restricted-pages/main.js
@@ -1,0 +1,65 @@
+let bannerElement = document.querySelector("onto-permission-banner");
+
+const setDefaultRestrictedPages = () => testContext.updateRestrictedPage({
+    '/pages/restricted-pages/restricted-page': true});
+
+const makeCurrentPageRestricted = () => {
+    testContext.updateRestrictedPage({
+            '/pages/restricted-pages': true,
+            '/pages/restricted-pages/restricted-page': true
+        }
+    );
+};
+
+const makeCurrentPageUnrestricted = () => {
+    testContext.updateRestrictedPage({
+        '/pages/restricted-pages': false,
+        '/pages/restricted-pages/restricted-page': true});
+};
+
+const makeRestrictedPagesMapUndefined = () => {
+    testContext.updateRestrictedPage(undefined);
+};
+
+const makeRestrictedPagesMapEmpty = () => {
+    testContext.updateRestrictedPage({});
+};
+
+const routes = {
+    '/pages/restricted-pages': '<h1>Welcome to the Home Page</h1>',
+    '/pages/restricted-pages/restricted-page': '<h1>Restricted page</h1><p>This is a restricted page and should not be visible.</p>',
+    '/pages/restricted-pages/unrestricted-page': '<h1>Unrestricted page</h1><p>This is a unrestricted page and should be visible.</p>',
+};
+
+// Function to handle navigation
+function navigateTo(url) {
+    setDefaultRestrictedPages();
+    // Update the URL without reloading
+    const oldUrl = window.location.pathname;
+    history.pushState(null, null, url);
+    const newUrl = window.location.pathname;
+    testContext.emitNavigateEndEvent(oldUrl, newUrl);
+    renderPage();
+}
+
+// Function to render the content based on the current route
+function renderPage() {
+    const app = document.getElementById('onto-layout');
+    const currentRoute = window.location.pathname;
+    if (app) {
+        app.innerHTML = ` <main id="app" slot="main">${routes[currentRoute]}</main>`;
+    }
+}
+
+// Handle link clicks
+document.body.addEventListener('click', (event) => {
+    if (event.target.matches('[data-link]')) {
+        // Prevent full-page reload
+        event.preventDefault();
+        navigateTo(event.target.href);
+    }
+});
+
+// Initial render
+setDefaultRestrictedPages();
+renderPage();


### PR DESCRIPTION
## What
- The user denied permission banner will appear when the page is unauthorized;
- The onto-navbar remains aligned to the top of the page regardless of the margin-top set on the onto-layout. For instance, if onto-layout has margin-top: 100px, the navbar will still stay fixed at the top of the page.
![image](https://github.com/user-attachments/assets/09d23e69-c959-4560-b444-7649678ea999)


## Why
- The banner was added as a component, but the functionality was not;
- This behavior occurs because there is a top: 0 declaration on the onto-navbar container.

## How
- I added a context service, which communicates between the new and old WB. The onto-layout also listens for route changes, in order to know that the flag for the banner should be re-calculated. The UserPermissionStorageService remains from a previous implementation of the solution, but is not used here otherwise;
- Remove the top: 0 CSS declaration.

## Testing
Tests added.

## Screenshots
![image](https://github.com/user-attachments/assets/703bb064-79ed-46a2-9b57-45c90278ff5c)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
