### PR TITLE
GDB-11275 Implement dynamic language loading

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -695,51 +695,129 @@ folder. The `file-loader` is used for the purpose.
 * The `/dist` directory is cleaned up before every build to prevent accumulating bundle files with
 different hashes in their names.
 
-# Extending Translation Capabilities with the Language Service
+## Internationalization (i18n) Guide for the Application
 
-## Overview
+### How It Works
 
-The introduction of `$languageServiceProvider` allows for flexible, dynamic language support within the GraphDB Workbench. This enhancement enables administrators to add or configure new languages directly through the configuration file (`languages.json`), eliminating the need for code changes or redeployment.
+The system ensures that translations from different modules are merged into a single bundle per language,
+using the [merge-i18n-plugin.js](./webpack/merge-i18n-plugin.js). After they are merged, all `.json`
+files from `src/assets/i18n` directories are transferred to the webpack output directory. That includes
+[language-config.json](packages/root-config/src/assets/i18n/language-config.json), which contains the default language
+and the available languages for the application. The configuration file is read, upon starting the application inside
+[ontotext-root-config.js#getLanguageConfig](packages/root-config/src/ontotext-root-config.js). The default language
+is loaded and the app starts listening for [ontotext-root-config.js#onLanguageChange](packages/root-config/src/ontotext-root-config.js)
+events. Once a language changes, the respective bundle is loaded and emitted via [language-context.service.ts#updateLanguageBundle](packages/api/src/services/language/language-context.service.ts).
+Modules listen for bundle changes from [language-context.service.ts#onLanguageBundleChanged](packages/api/src/services/language/language-context.service.ts)
+and apply translation logic independently from each other.
 
-## Key Benefits
+### Translation File Structure
 
-1. **Development-Free Translation Management**:
-    - Administrators can now manage supported languages by simply updating `languages.json`.
-    - This configuration-based approach makes it easy to introduce or remove languages without modifying the application code.
+Every module in the application must follow the convention of placing translation files under the `src/assets/i18n` directory.
+For example:
+```code
+packages/ 
+  module1/
+    src/assets/i18n/en.json 
+    src/assets/i18n/fr.json 
+  module2/ 
+    src/assets/i18n/en.json 
+    src/assets/i18n/fr.json
+```
 
-2. **Dynamic Language Settings**:
-    - The workbench adapts automatically to the languages defined in `languages.json`, allowing administrators to plug in translations as needed.
-    - Language fallbacks and defaults are handled seamlessly, improving the application’s accessibility and usability.
+Translation files should be JSON objects where the keys are the translation identifiers, and the values are the translated strings.
+For example:
 
-## How It Works
+`src/assets/i18n/en.json`:
+```json
+{
+  "greeting": "Hello",
+  "farewell": {
+    "label": "Goodbye"
+  }
+}
+```
+src/assets/i18n/fr.json:
 
-- **Configuration File**: The `languages.json` file, located in the `src/i18n` directory, defines the `defaultLanguage` and `availableLanguages`.
-    - Example of `languages.json`:
-      ```json
-      {
-          "defaultLanguage": "en",
-          "availableLanguages": [
-              { "key": "en", "name": "English" },
-              { "key": "fr", "name": "Français" }
-          ]
-      }
-      ```
-- **Provider Integration**: `$languageServiceProvider` reads this configuration during the application initialization and exposes methods for retrieving the default language and available languages.
-- **Application-Wide Language Access**: Components across the application can access language settings via `$languageService`, ensuring consistency in language display and fallback behavior.
+```json
+{
+  "greeting": "Bonjour",
+  "farewell": {
+    "label": "Au revoir"
+  }
+}
+```
 
-## How to Add a New Language
+### Bundling Translations
+The [merge-i18n-plugin.js](./webpack/merge-i18n-plugin.js) aggregates these translation files
+across all modules and merges them into a single bundle for each language. For example:
 
-1. **Edit `languages.json`**: Add a new language entry in the `availableLanguages` array with the desired language `key` and `name`.
-   ```json
-   {
-       "defaultLanguage": "en",
-       "availableLanguages": [
-           { "key": "en", "name": "English" },
-           { "key": "fr", "name": "Français" },
-           { "key": "es", "name": "Español" }
-       ]
-   }
-   
-2. **Ensure Translations Are Available** Make sure a translation file (e.g., `es.json`) exists for the new language, following the naming convention used for other languages.
+`packages/module1/src/assets/i18n/en.json` and `packages/module2/src/assets/i18n/en.json` will be combined into a single en.json.
+The output will look like this:
+```code
+dist/${outputDirectory}/en.json
+```  
 
-3. **Reload the Application** The workbench will recognize the new language without requiring additional code changes or redeployment.
+### Conflicts
+The plugin resolves conflicts by throwing an error if multiple files define the same key for the same language.
+For example:<br>
+`module1/src/assets/i18n/en.json`
+```json
+{
+  "some-prop": "Hello",
+  "menu.logo.link.title": {
+    "label": "Goodbye"
+  }
+}
+```
+`module2/src/assets/i18n/en.json`:
+
+```json
+{
+  "another-prop": "Bonjour",
+  "menu.logo.link.title": {
+    "another-label": "Different Goodbye"
+  }
+}
+```
+
+Will result in an error, similar to this one:
+```code
+Processing file: en.json
+Error: Conflict detected for key 'menu.logo.link.title' in language 'en' in file: packages/workbench/src/assets/i18n/en.json
+```
+
+### Key Features:
+`Automatic Directory Traversal`: Scans all modules for src/assets/i18n folders.<br>
+`Conflict Detection`: Throws an error if there are duplicate keys in the same language.<br>
+`JSON Merging`: Combines all translations into one file per language.<br>
+`Asset Emission`: Writes the merged bundles to the specified output directory in the Webpack dist folder.<br>
+
+### Plugin Options
+`startDirectory`: The base directory where the plugin begins searching for modules.<br>
+`outputDirectory`: The directory inside the Webpack output folder where the merged translation bundles will be written.<br>
+
+### Example Usage in Webpack Config
+```javascript
+const { MergeI18nPlugin } = require('./plugins/MergeI18nPlugin');
+
+module.exports = {
+  // Other Webpack configurations...
+  plugins: [
+    new MergeI18nPlugin({
+      startDirectory: 'packages',
+      outputDirectory: 'onto-i18n',
+    }),
+  ],
+};
+```
+
+### How to Add new Translations
+1. Add your language in the `availableLanguages` array in [language-config.json](packages/root-config/src/assets/i18n/language-config.json).
+2. Add translation files for the new language in every `src/assets/i18n` folder, where there are translations.
+   The `key` in `availableLanguages`, should be the name of the new file translation, e.g. `${key}.json`.
+   Avoid conflicting keys in your new bundle, as it will cause an error.
+3. Build the application
+4. Check merged output: After building the application, check the `${webpack.outputFolder}/${mergeI18nPlugin.outputDirectory}`
+   (currently `dist/onto-i18n`) folder to verify that all translations are included and correctly merged.
+5. Listen for bundle changes in the new module, using [language-context.service.ts#onLanguageBundleChanged](packages/api/src/services/language/language-context.service.ts)
+6. Use the new bundle for module translation (may be different, depending on the module).

--- a/packages/api/src/models/language/available-language.ts
+++ b/packages/api/src/models/language/available-language.ts
@@ -1,0 +1,15 @@
+import { Model } from '../common';
+
+/**
+ * Represents an available language in the system.
+ */
+export class AvailableLanguage extends Model<AvailableLanguage> {
+  key: string;
+  name: string;
+
+  constructor(data: AvailableLanguage) {
+    super();
+    this.key = data.key;
+    this.name = data.name;
+  }
+}

--- a/packages/api/src/models/language/available-languages-list.ts
+++ b/packages/api/src/models/language/available-languages-list.ts
@@ -1,0 +1,25 @@
+import {AvailableLanguage} from './available-language';
+
+/**
+ * Represents a list of available languages.
+ */
+export class AvailableLanguagesList {
+  languages: AvailableLanguage[];
+
+  constructor(languages: AvailableLanguage[]) {
+    this.languages = languages;
+  }
+
+  /**
+   * Retrieves an array of language codes from the available languages.
+   *
+   * This method maps over the list of available languages and extracts
+   * the 'key' property from each language object, which represents
+   * the language code.
+   *
+   * @returns {string[]} An array of language codes (e.g., ['en', 'fr', 'de']).
+   */
+  getLanguageCodes(): string[] {
+    return this.languages?.map(language => language.key);
+  }
+}

--- a/packages/api/src/models/language/index.ts
+++ b/packages/api/src/models/language/index.ts
@@ -1,0 +1,3 @@
+export { LanguageConfig } from './language-config';
+export { AvailableLanguagesList } from './available-languages-list';
+export type { TranslationBundle } from './translation-bundle';

--- a/packages/api/src/models/language/language-config.ts
+++ b/packages/api/src/models/language/language-config.ts
@@ -1,0 +1,19 @@
+import { AvailableLanguagesList } from './available-languages-list';
+import { Model } from '../common';
+import { MapperProvider } from '../../providers';
+import { AvailableLanguagesListMapper } from '../../services/language/mappers/available-languages-list-mapper';
+
+/**
+ * Represents the configuration for language settings in the application.
+ */
+export class LanguageConfig extends Model<LanguageConfig>  {
+  defaultLanguage: string;
+
+  availableLanguages: AvailableLanguagesList;
+
+  constructor(data: LanguageConfig) {
+    super();
+    this.defaultLanguage = data.defaultLanguage;
+    this.availableLanguages = MapperProvider.get(AvailableLanguagesListMapper).mapToModel(data.availableLanguages);
+  }
+}

--- a/packages/api/src/models/language/translation-bundle.ts
+++ b/packages/api/src/models/language/translation-bundle.ts
@@ -1,0 +1,3 @@
+export type TranslationBundle = {
+  [key: string]: string | TranslationBundle;
+}

--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -9,6 +9,7 @@ export * from './models/license';
 export * from './models/common';
 export * from './models/product-info';
 export * from './models/storage';
+export * from './models/language';
 
 // Export providers for external usages.
 export * from './providers';

--- a/packages/api/src/services/language/index.ts
+++ b/packages/api/src/services/language/index.ts
@@ -1,3 +1,4 @@
 export * from './language.service';
 export * from './language-context.service';
 export * from './language-storage.service';
+export * from './language-rest.service';

--- a/packages/api/src/services/language/language-context.service.ts
+++ b/packages/api/src/services/language/language-context.service.ts
@@ -4,6 +4,7 @@ import {ServiceProvider} from '../../providers';
 import {LanguageStorageService} from './language-storage.service';
 import {LanguageService} from './language.service';
 import {DeriveContextServiceContract} from '../../models/context/update-context-method';
+import {LanguageConfig, TranslationBundle} from '../../models/language';
 
 type LanguageContextFields = {
   readonly SELECTED_LANGUAGE: string;
@@ -13,7 +14,10 @@ type LanguageContextFields = {
  * The LanguageService class manages the application's language context.
  */
 export class LanguageContextService extends ContextService<LanguageContextFields> implements DeriveContextServiceContract<LanguageContextFields> {
+  private readonly LANGUAGE_CONFIG = 'languageConfig';
   readonly SELECTED_LANGUAGE = 'selectedLanguage';
+  readonly LANGUAGE_BUNDLE = 'languageBundle';
+  readonly DEFAULT_BUNDLE = 'defaultBundle';
 
   /**
    * Changes the selected language of the application. This method updates the selected language and notifies
@@ -21,8 +25,8 @@ export class LanguageContextService extends ContextService<LanguageContextFields
    *
    * @param {string} locale - The new language code to set (e.g., 'en', 'fr', 'de').
    */
-  updateSelectedLanguage(locale: string | undefined): void {
-    const selectedLanguage = locale || LanguageService.DEFAULT_LANGUAGE;
+  updateSelectedLanguage(locale?: string): void {
+    const selectedLanguage = locale || ServiceProvider.get(LanguageService).getDefaultLanguage();
     const storageService = ServiceProvider.get(LanguageStorageService);
     storageService.set(this.SELECTED_LANGUAGE, selectedLanguage);
     this.updateContextProperty(this.SELECTED_LANGUAGE, locale);
@@ -37,5 +41,74 @@ export class LanguageContextService extends ContextService<LanguageContextFields
    */
   onSelectedLanguageChanged(callbackFunction: ValueChangeCallback<string | undefined>): () => void {
     return this.subscribe(this.SELECTED_LANGUAGE, callbackFunction);
+  }
+
+  /**
+   * Updates the language bundle in the context.
+   *
+   * This method is responsible for updating the translation bundle used for
+   * internationalization in the application. It updates the context property
+   * associated with the language bundle.
+   *
+   * @param {TranslationBundle} bundle - The new translation bundle to be set.
+   */
+  updateLanguageBundle(bundle: TranslationBundle): void {
+    this.updateContextProperty<TranslationBundle>(this.LANGUAGE_BUNDLE, bundle);
+  }
+
+  /**
+   * Registers a callback function to be called whenever the language bundle changes.
+   *
+   * @param {ValueChangeCallback<TranslationBundle | undefined>} callbackFunction - The function to call when the language bundle changes.
+   *        This function will receive the new TranslationBundle as its parameter, or undefined if the bundle is cleared.
+   */
+  onLanguageBundleChanged(callbackFunction: ValueChangeCallback<TranslationBundle | undefined>): () => void {
+    return this.subscribe(this.LANGUAGE_BUNDLE, callbackFunction);
+  }
+
+  /**
+   * Updates the default language bundle in the context.
+   *
+   * This method sets a new default translation bundle for the application.
+   * It's typically used to store a fallback bundle that can be used when
+   * the primary language bundle is not available or incomplete.
+   *
+   * @param {TranslationBundle} bundle - The new default translation bundle to be set.
+   */
+  updateDefaultBundle(bundle: TranslationBundle): void {
+    this.updateContextProperty<TranslationBundle>(this.DEFAULT_BUNDLE, bundle);
+  }
+
+  /**
+   * Retrieves the current default language bundle from the context.
+   *
+   * This method returns the default translation bundle that was previously
+   * set using the updateDefaultBundle method. If no default bundle has been
+   * set, it returns undefined.
+   *
+   * @returns {TranslationBundle | undefined} The current default translation bundle,
+   *          or undefined if no default bundle has been set.
+   */
+  getDefaultBundle(): TranslationBundle | undefined {
+    return this.getContextPropertyValue(this.DEFAULT_BUNDLE);
+  }
+
+  /**
+   * Retrieves the current language configuration from the context.
+   *
+   * @returns {LanguageConfig | undefined} The current language configuration,
+   *          or undefined if no configuration has been set.
+   */
+  getLanguageConfig(): LanguageConfig | undefined {
+    return this.getContextPropertyValue(this.LANGUAGE_CONFIG);
+  }
+
+  /**
+   * Sets a new language configuration in the context.
+   *
+   * @param {LanguageConfig} languageConfig - The new language configuration to be set.
+   */
+  setLanguageConfig(languageConfig?: LanguageConfig) {
+    this.updateContextProperty(this.LANGUAGE_CONFIG, languageConfig);
   }
 }

--- a/packages/api/src/services/language/language-rest.service.ts
+++ b/packages/api/src/services/language/language-rest.service.ts
@@ -1,0 +1,26 @@
+import { HttpService } from '../http/http.service';
+import { LanguageConfig, TranslationBundle } from '../../models/language';
+
+/**
+ * Service for handling language-related REST operations.
+ */
+export class LanguageRestService extends HttpService {
+  /**
+   * Retrieves the translation bundle for a specific language.
+   *
+   * @param languageCode - The code of the language for which to fetch translations.
+   * @returns A Promise that resolves to a TranslationBundle containing the translations for the specified language.
+   */
+  getLanguage(languageCode: string): Promise<TranslationBundle> {
+    return this.get<TranslationBundle>(`/onto-i18n/${languageCode}.json`);
+  }
+
+  /**
+   * Fetches the language configuration for the application.
+   *
+   * @returns A Promise that resolves to a {@link LanguageConfig} object containing the language configuration settings.
+   */
+  getLanguageConfiguration(): Promise<LanguageConfig> {
+    return this.get<LanguageConfig>('/onto-i18n/language-config.json');
+  }
+}

--- a/packages/api/src/services/language/language.service.ts
+++ b/packages/api/src/services/language/language.service.ts
@@ -1,20 +1,66 @@
 import {Service} from '../../providers/service/service';
+import {TranslationBundle} from '../../models/language';
+import {MapperProvider, ServiceProvider} from '../../providers';
+import {LanguageConfig} from '../../models/language';
+import {LanguageRestService} from './language-rest.service';
+import {LanguageConfigMapper} from './mappers/language-config-mapper';
+import {LanguageContextService} from './language-context.service';
 
 /**
  * The LanguageService class is responsible for fetching language-related data from the backend
  * and mapping the responses to the workbench models.
  */
 export class LanguageService implements Service {
-
-  static readonly DEFAULT_LANGUAGE = 'en';
-  // TODO load this dynamically
-  private supportedLanguages = ['en', 'fr'];
+  private readonly languageRestService: LanguageRestService = ServiceProvider.get(LanguageRestService);
+  private readonly languageContextService: LanguageContextService = ServiceProvider.get(LanguageContextService);
 
   /**
-   * Returns an array with supported languages.
+   * Retrieves an array of supported language codes.
+   *
+   * This function fetches the language configuration from the storage service
+   * and extracts the list of supported language codes. If no configuration
+   * is found, it returns a default array with 'en' and 'fr'.
+   *
    * @returns {string[]} An array of supported language codes.
    */
   getSupportedLanguages(): string[] {
-    return this.supportedLanguages;
+    const languageConfig = this.languageContextService.getLanguageConfig();
+    return languageConfig ? languageConfig.availableLanguages.getLanguageCodes() : ['en', 'fr'];
+  }
+
+  /**
+   * Retrieves the translation bundle for a specified language.
+   *
+   * @param {string} languageCode - The code of the language for which to fetch the translation bundle.
+   * @returns {Promise<TranslationBundle>} A promise that resolves to a TranslationBundle object
+   * containing the translations for the specified language.
+   */
+  getLanguage(languageCode: string): Promise<TranslationBundle> {
+    return this.languageRestService.getLanguage(languageCode);
+  }
+
+  /**
+   * Retrieves the language configuration from the server and maps it to a LanguageConfig model.
+   *
+   * @returns {Promise<LanguageConfig>} A promise that resolves to a LanguageConfig object
+   * representing the current language configuration.
+   */
+  getLanguageConfiguration(): Promise<LanguageConfig> {
+    return this.languageRestService.getLanguageConfiguration()
+      .then(config => MapperProvider.get(LanguageConfigMapper).mapToModel(config));
+  }
+
+  /**
+   * Retrieves the default language code from the stored language configuration.
+   *
+   * This function attempts to fetch the language configuration from the storage service
+   * and extract the default language code. If no configuration is found, it returns 'en'
+   * (English) as the default language.
+   *
+   * @returns {string} The default language code. Returns 'en' if no configuration is found.
+   */
+  getDefaultLanguage(): string {
+    const languageConfig = this.languageContextService.getLanguageConfig();
+    return languageConfig ? languageConfig.defaultLanguage : 'en';
   }
 }

--- a/packages/api/src/services/language/mappers/available-languages-list-mapper.ts
+++ b/packages/api/src/services/language/mappers/available-languages-list-mapper.ts
@@ -1,0 +1,18 @@
+import { AvailableLanguagesList } from '../../../models/language/available-languages-list';
+import { Mapper } from '../../../providers/mapper/mapper';
+import { AvailableLanguage } from '../../../models/language/available-language';
+
+/**
+ * Mapper class for converting an array of AvailableLanguage objects to an AvailableLanguagesList model.
+ */
+export class AvailableLanguagesListMapper extends Mapper<AvailableLanguagesList> {
+  /**
+   * Maps an array of AvailableLanguage objects to an AvailableLanguagesList model.
+   *
+   * @param data - An array of AvailableLanguage objects to be mapped.
+   * @returns A new AvailableLanguagesList instance containing the provided AvailableLanguage objects.
+   */
+  mapToModel(data: AvailableLanguage[]): AvailableLanguagesList {
+    return new AvailableLanguagesList(data);
+  }
+}

--- a/packages/api/src/services/language/mappers/language-config-mapper.ts
+++ b/packages/api/src/services/language/mappers/language-config-mapper.ts
@@ -1,0 +1,17 @@
+import { LanguageConfig } from '../../../models/language';
+import { Mapper } from '../../../providers/mapper/mapper';
+
+/**
+ * Mapper class for LanguageConfig objects.
+ */
+export class LanguageConfigMapper extends Mapper<LanguageConfig> {
+  /**
+   * Maps the input data to a new LanguageConfig model instance.
+   *
+   * @param data - The LanguageConfig data to be mapped.
+   * @returns A new LanguageConfig instance created from the input data.
+   */
+  mapToModel(data: LanguageConfig): LanguageConfig {
+    return new LanguageConfig(data);
+  }
+}

--- a/packages/api/src/services/language/mappers/test/available-languages-list-mapper.spec.ts
+++ b/packages/api/src/services/language/mappers/test/available-languages-list-mapper.spec.ts
@@ -1,0 +1,26 @@
+import { AvailableLanguagesListMapper } from '../available-languages-list-mapper';
+import { AvailableLanguagesList } from '../../../../models/language/available-languages-list';
+import { AvailableLanguage } from '../../../../models/language/available-language';
+
+describe('AvailableLanguagesListMapper', () => {
+  let mapper: AvailableLanguagesListMapper;
+
+  beforeEach(() => {
+    mapper = new AvailableLanguagesListMapper();
+  });
+  test('should correctly map a single AvailableLanguage object', () => {
+    // Given, I have a single AvailableLanguage object.
+    const singleLanguage = {
+      key: 'en',
+      name: 'English'
+    } as unknown as AvailableLanguage;
+
+    // When, I map the AvailableLanguage object to an AvailableLanguagesList.
+    const result = mapper.mapToModel([singleLanguage]);
+
+    // Then, I should get an AvailableLanguagesList containing the single AvailableLanguage object.
+    expect(result).toBeInstanceOf(AvailableLanguagesList);
+    expect(result.languages).toHaveLength(1);
+    expect(result.languages[0]).toEqual(singleLanguage);
+  });
+});

--- a/packages/api/src/services/language/mappers/test/language-config-mapper.spec.ts
+++ b/packages/api/src/services/language/mappers/test/language-config-mapper.spec.ts
@@ -1,0 +1,29 @@
+import { LanguageConfigMapper } from '../language-config-mapper';
+import { LanguageConfig } from '../../../../models/language';
+
+describe('LanguageConfigMapper', () => {
+  let languageConfigMapper: LanguageConfigMapper;
+
+  beforeEach(() => {
+    languageConfigMapper = new LanguageConfigMapper();
+  });
+
+  test('should create a new LanguageConfig instance', () => {
+    // Given, I have a JSON input data object representing a LanguageConfig.
+    const inputData = {
+      defaultLanguage: 'en',
+      availableLanguages: [
+        {key: 'en', name: 'English'},
+        {key: 'fr', name: 'French'},
+      ]
+    } as unknown as LanguageConfig;
+
+    // When, I map the JSON input data to a LanguageConfig instance.
+    const result = languageConfigMapper.mapToModel(inputData);
+
+    // Then, I expect a new LanguageConfig instance to be created.
+    expect(result).toBeInstanceOf(LanguageConfig);
+    expect(result).toEqual(new LanguageConfig(inputData));
+    expect(result).not.toBe(inputData);
+  });
+});

--- a/packages/api/src/services/language/test/language-context.service.spec.ts
+++ b/packages/api/src/services/language/test/language-context.service.spec.ts
@@ -2,18 +2,32 @@ import {LanguageContextService} from '../language-context.service';
 import {LanguageStorageService} from '../language-storage.service';
 import {ServiceProvider} from '../../../providers';
 import {LanguageService} from '../language.service';
+import {LanguageConfig, TranslationBundle} from '../../../models/language';
 
 describe('LanguageContextService', () => {
   let languageContextService: LanguageContextService;
   let languageStorageServiceMock: jest.Mocked<LanguageStorageService>;
+  let languageServiceMock =
 
   beforeEach(() => {
     languageContextService = new LanguageContextService();
+
+    languageServiceMock = {
+      getDefaultLanguage: jest.fn(() => 'en'),
+    } as unknown as jest.Mocked<LanguageService>;
+
     languageStorageServiceMock = {
       set: jest.fn(),
     } as unknown as jest.Mocked<LanguageStorageService>;
 
-    jest.spyOn(ServiceProvider, 'get').mockReturnValue(languageStorageServiceMock);
+    jest.spyOn(ServiceProvider, 'get').mockImplementation((param) => {
+      if (param === LanguageStorageService) {
+        return languageStorageServiceMock;
+      }
+      if (param === LanguageService) {
+        return languageServiceMock;
+      }
+    });
   });
 
   afterEach(() => {
@@ -35,7 +49,8 @@ describe('LanguageContextService', () => {
 
     languageContextService.updateSelectedLanguage(undefined);
 
-    expect(languageStorageServiceMock.set).toHaveBeenCalledWith(languageContextService.SELECTED_LANGUAGE, LanguageService.DEFAULT_LANGUAGE);
+    const defaultLanguage = languageServiceMock.getDefaultLanguage();
+    expect(languageStorageServiceMock.set).toHaveBeenCalledWith(languageContextService.SELECTED_LANGUAGE, defaultLanguage);
     expect(updateContextPropertySpy).toHaveBeenCalledWith(languageContextService.SELECTED_LANGUAGE, undefined);
   });
 
@@ -50,5 +65,67 @@ describe('LanguageContextService', () => {
 
     // Then I expect the callback function to be called with the passed language.
     expect(onSelectLanguageCallbackFunction).toHaveBeenLastCalledWith(newLanguage);
+  });
+
+  test('updateLanguageBundle should update language bundle and notify subscribers', () => {
+    // Given I have a new translation bundle
+    const newBundle: TranslationBundle = {key: 'value'} as TranslationBundle;
+    const updateContextPropertySpy = jest.spyOn(languageContextService, 'updateContextProperty');
+
+    // When the language bundle is updated
+    languageContextService.updateLanguageBundle(newBundle);
+
+    // Then I expect the updateContextProperty method to be called with the correct parameters
+    expect(updateContextPropertySpy).toHaveBeenCalledWith(languageContextService.LANGUAGE_BUNDLE, newBundle);
+  });
+
+  test('should call the "onLanguageBundleChangedCallbackFunction" when the language bundle changes.', () => {
+    //Given, I have a new translation bundle
+    const onLanguageBundleChangedCallbackFunction = jest.fn();
+    const newBundle: TranslationBundle = {key: 'value'} as TranslationBundle;
+
+    // When I register a callback function for language bundle changes,
+    languageContextService.onLanguageBundleChanged(onLanguageBundleChangedCallbackFunction);
+    // And the language bundle is changed.
+    languageContextService.updateLanguageBundle(newBundle);
+
+    // Then I expect the callback function to be called with the passed language bundle.
+    expect(onLanguageBundleChangedCallbackFunction).toHaveBeenLastCalledWith(newBundle);
+  });
+
+  test('updateDefaultBundle should update default bundle and notify subscribers', () => {
+    // Given I have a new translation bundle
+    const newBundle: TranslationBundle = {key: 'value'} as TranslationBundle;
+    const updateContextPropertySpy = jest.spyOn(languageContextService, 'updateContextProperty');
+
+    // When the default bundle is updated
+    languageContextService.updateDefaultBundle(newBundle);
+
+    // Then I expect the updateContextProperty method to be called with the correct parameters
+    expect(updateContextPropertySpy).toHaveBeenCalledWith(languageContextService.DEFAULT_BUNDLE, newBundle);
+  });
+
+  test('should return the default bundle when getDefaultBundle is called', () => {
+    // Given I have a default translation bundle
+    const defaultBundle: TranslationBundle = {key: 'value'} as TranslationBundle;
+    languageContextService.updateDefaultBundle(defaultBundle);
+
+    // When I call getDefaultBundle
+    const returnedBundle = languageContextService.getDefaultBundle();
+
+    // Then I expect the returned bundle to be the default bundle
+    expect(returnedBundle).toEqual(defaultBundle);
+  });
+
+  test('should return the language configuration when getLanguageConfig is called', () => {
+    // Given I have a language configuration
+    const languageConfig: LanguageConfig = {defaultLanguage: 'en', availableLanguages: ['en', 'fr']} as unknown as LanguageConfig;
+    languageContextService.setLanguageConfig(new LanguageConfig(languageConfig));
+
+    // When I call getLanguageConfig
+    const returnedConfig = languageContextService.getLanguageConfig();
+
+    // Then I expect the returned config to be the language configuration
+    expect(returnedConfig).toEqual(new LanguageConfig(languageConfig));
   });
 });

--- a/packages/api/src/services/language/test/language-storage.service.spec.ts
+++ b/packages/api/src/services/language/test/language-storage.service.spec.ts
@@ -6,9 +6,10 @@ describe('LanguageStorageService', () => {
 
   beforeEach(() => {
     service = new LanguageStorageService();
+    service.remove('languageConfig');
   });
 
-  it('set should store the value in local storage with the correct key', () => {
+  test('set should store the value in local storage with the correct key', () => {
     const key = 'testKey';
     const value = 'testValue';
     const storeValueSpy = jest.spyOn(LocalStorageService.prototype, 'storeValue');

--- a/packages/api/src/services/language/test/language.service.spec.ts
+++ b/packages/api/src/services/language/test/language.service.spec.ts
@@ -1,13 +1,95 @@
 import {LanguageService} from '../language.service';
+import {ServiceProvider} from '../../../providers';
+import {LanguageConfig, TranslationBundle} from '../../../models/language';
+import {TestUtil} from '../../utils/test/test-util';
+import {ResponseMock} from '../../http/test/response-mock';
+import {LanguageContextService} from '../language-context.service';
 
 describe('LanguageService', () => {
   let languageService: LanguageService;
 
   beforeEach(() => {
     languageService = new LanguageService();
+    ServiceProvider.get(LanguageContextService).setLanguageConfig(undefined);
   });
 
-  test('Should return supported languages', () => {
+  test('Should return default languages, when there is no config', () => {
     expect(languageService.getSupportedLanguages()).toEqual(['en', 'fr']);
+  });
+
+  test('Should return supported languages from the configuration', () => {
+    // Given, I have a language configuration stored in the storage service with supported languages.
+    const availableLanguages = [{key: 'de', name: 'German'}, {key: 'es', name: 'Spanish'}];
+    const languageConfig = {
+      defaultLanguage: 'en',
+      availableLanguages
+    } as unknown as LanguageConfig;
+    ServiceProvider.get(LanguageContextService).setLanguageConfig(new LanguageConfig(languageConfig));
+
+    // When, I call getSupportedLanguages in a newly created instance of LanguageService
+    // to ensure it gets the languages from the mock configuration.
+    const result = new LanguageService().getSupportedLanguages();
+
+    // Then, I expect the supported languages to be returned from the configuration.
+    expect(result).toEqual(['de', 'es']);
+  });
+
+  test('Should return a default language', () => {
+    expect(languageService.getDefaultLanguage()).toBe('en');
+  });
+
+  test('Should return default language from configuration', () => {
+    // Given, I have a language configuration stored in the storage service with default language.
+    const languageConfig = {
+      defaultLanguage: 'fr',
+      availableLanguages: []
+    } as unknown as LanguageConfig;
+    ServiceProvider.get(LanguageContextService).setLanguageConfig(languageConfig);
+
+    // When, I call getDefaultLanguage
+    const result = new LanguageService().getDefaultLanguage();
+
+    // Then, I expect the default language to be returned from the configuration.
+    expect(result).toBe('fr');
+  });
+
+  test('Should get default language without configuration', () => {
+    expect(languageService.getDefaultLanguage()).toEqual('en');
+  });
+
+  test('Should retrieve the language, mapped to a TranslationBundle object', async () => {
+    // Given, I have a mocked language
+    const mockBundle = { hello: 'World' } as TranslationBundle;
+    TestUtil.mockResponse(new ResponseMock('/onto-i18n/en.json').setResponse(mockBundle));
+
+    // When I call the getLanguage method
+    const result = await languageService.getLanguage('en');
+
+    const expectedTranslationBundle = {
+      hello: 'World'
+    };
+
+    // Then, I should get a TranslationBundle object, with default property values
+    expect(result).toEqual(expectedTranslationBundle);
+  });
+
+  test('Should retrieve the language configuration', async () => {
+    // Given, I have a mocked language configuration
+    const mockLanguageConfig = {
+      defaultLanguage: 'en',
+      availableLanguages: [
+        {
+          key: 'en',
+          name: 'English'
+        }
+      ]
+    } as unknown as LanguageConfig;
+    TestUtil.mockResponse(new ResponseMock('/onto-i18n/language-config.json').setResponse(mockLanguageConfig));
+
+    // When I call the getLanguageConfiguration method
+    const result = await languageService.getLanguageConfiguration();
+
+    // Then, I should get a LanguageConfig object, with default property values
+    expect(result).toEqual(new LanguageConfig(mockLanguageConfig));
   });
 });

--- a/packages/root-config/src/assets/i18n/language-config.json
+++ b/packages/root-config/src/assets/i18n/language-config.json
@@ -1,0 +1,13 @@
+{
+  "defaultLanguage": "en",
+  "availableLanguages": [
+    {
+      "key": "en",
+      "name": "English"
+    },
+    {
+      "key": "fr",
+      "name": "Français"
+    }
+  ]
+}

--- a/packages/shared-components/cypress/e2e/footer/footer.cy.js
+++ b/packages/shared-components/cypress/e2e/footer/footer.cy.js
@@ -13,10 +13,14 @@ describe('Footer', () => {
 
     // Then, I expect the product information to be loaded and visible in the footer
     const currentYear = new Date().getFullYear();
-    const expectedFooterContent = `GraphDB 11.0-SNAPSHOT • RDF4J 4.3.15 • Connectors 16.2.13-RC2 • Workbench 2.8.0 • © 2002–${currentYear} Ontotext AD. All rights reserved.`;
+    const expectedFooterContent = `GraphDB 11.0-SNAPSHOT • RDF4J 4.3.15 • Connectors 16.2.13-RC2 • Workbench 2.8.0 • © 2002–${currentYear} Ontotext AD`;
     FooterSteps.getFooter()
       .invoke('text')
       .should('contain', expectedFooterContent);
+
+    // And the 'All rights reserved' label should be present and visible and
+    FooterSteps.getAllRightsReservedElement()
+      .should('be.visible')
 
     // And the GraphDB link should be present and valid
     FooterSteps.getGraphDBLink()

--- a/packages/shared-components/cypress/steps/footer/footer-steps.js
+++ b/packages/shared-components/cypress/steps/footer/footer-steps.js
@@ -24,4 +24,8 @@ export class FooterSteps extends BaseSteps {
   static loadProductInfo() {
     return cy.get('#load-product-info').click();
   }
+
+  static getAllRightsReservedElement() {
+    return FooterSteps.getFooter().get('translate-label');
+  }
 }

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -112,6 +112,12 @@ export namespace Components {
      */
     interface OntoTestContext {
         /**
+          * Changes the application's language by updating the language bundle.  This method uses the LanguageContextService to update the language bundle based on the provided language code. It retrieves the corresponding bundle from the predefined bundles object and updates the context.
+          * @param language - The language code (e.g., 'en' for English, 'fr' for French)   representing the desired language to switch to.
+          * @returns A Promise that resolves when the language update is complete.
+         */
+        "changeLanguage": (language: string) => Promise<void>;
+        /**
           * Loads the repositories in the application.
          */
         "loadRepositories": () => Promise<void>;

--- a/packages/shared-components/src/components/onto-footer/onto-footer.tsx
+++ b/packages/shared-components/src/components/onto-footer/onto-footer.tsx
@@ -1,6 +1,5 @@
 import { Component, Host, h, State } from '@stencil/core';
 import { ProductInfo, ServiceProvider, SubscriptionList, ProductInfoContextService } from '@ontotext/workbench-api';
-import { TranslationService } from '../../services/translation.service';
 
 /**
  * OntoFooter component for rendering the footer of the application.
@@ -41,7 +40,7 @@ export class OntoFooter {
           href="http://rdf4j.org" target="_blank" rel="noopener noreferrer">RDF4J&nbsp;</a
           >{this.productInfo?.sesame} &bull; Connectors {this.productInfo?.connectors} &bull; Workbench {this.productInfo?.workbench} &bull; &copy;
           2002&ndash;{this.currentYear}&nbsp;<a href="http://ontotext.com" target="_blank" rel="noopener noreferrer">Ontotext
-          AD</a>. {TranslationService.translate('footer.label.all_rights_reserved')}
+          AD</a>.&nbsp;<translate-label labelKey={'footer.label.all_rights_reserved'}></translate-label>
         </div>
       </Host>
     );

--- a/packages/shared-components/src/components/onto-footer/readme.md
+++ b/packages/shared-components/src/components/onto-footer/readme.md
@@ -17,9 +17,14 @@ as well as copyright information.
 
  - [onto-layout](../onto-layout)
 
+### Depends on
+
+- [translate-label](../translate-label)
+
 ### Graph
 ```mermaid
 graph TD;
+  onto-footer --> translate-label
   onto-layout --> onto-footer
   style onto-footer fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/shared-components/src/components/onto-language-selector/onto-language-selector.tsx
+++ b/packages/shared-components/src/components/onto-language-selector/onto-language-selector.tsx
@@ -34,7 +34,7 @@ export class OntoLanguageSelector {
     this.languageService = ServiceProvider.get(LanguageService);
     this.languageContextService = ServiceProvider.get(LanguageContextService);
     const selectedLanguage = ServiceProvider.get(LanguageStorageService).get(this.languageContextService.SELECTED_LANGUAGE);
-    this.changeLanguage(selectedLanguage?.getValueOrDefault(LanguageService.DEFAULT_LANGUAGE));
+    this.changeLanguage(selectedLanguage?.getValueOrDefault(this.languageService.getDefaultLanguage()));
     this.onLanguageChangeSubscription = this.languageContextService.onSelectedLanguageChanged((newLanguage) => this.changeLanguage(newLanguage));
     this.items = this.getLanguageDropdownOptions();
   }

--- a/packages/shared-components/src/components/onto-layout/readme.md
+++ b/packages/shared-components/src/components/onto-layout/readme.md
@@ -31,6 +31,7 @@ graph TD;
   onto-language-selector --> onto-dropdown
   onto-navbar --> translate-label
   onto-permission-banner --> translate-label
+  onto-footer --> translate-label
   style onto-layout fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
@@ -31,6 +31,7 @@ export class OntoRepositorySelector {
   private repositoryService = ServiceProvider.get(RepositoryService);
   private repositoryContextService = ServiceProvider.get(RepositoryContextService);
   private repositoryStorageService = ServiceProvider.get(RepositoryStorageService);
+  private readonly languageService: LanguageService = ServiceProvider.get(LanguageService);
   private totalTripletsFormatter: Intl.NumberFormat;
   private currentRepositoryId: string;
   private items: DropdownItem<Repository>[] = [];
@@ -245,7 +246,10 @@ export class OntoRepositorySelector {
     return repositorySizeInfoHtml;
   }
 
-  private setupTotalRepository(language = LanguageService.DEFAULT_LANGUAGE): void {
+  private setupTotalRepository(language?: string): void {
+    if (!language) {
+      language = this.languageService.getDefaultLanguage();
+    }
     this.totalTripletsFormatter = new Intl.NumberFormat(language, {
       style: 'decimal',
       minimumFractionDigits: 0,

--- a/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
+++ b/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
@@ -1,11 +1,14 @@
 import { Component, Method } from '@stencil/core';
 import {
+  LanguageContextService,
   License,
   LicenseContextService,
   ProductInfo,
   ProductInfoContextService, RepositoryContextService, RepositoryService,
   ServiceProvider
 } from '@ontotext/workbench-api';
+import en from '../../assets/i18n/en.json';
+import fr from '../../assets/i18n/fr.json';
 
 /**
  * A component for managing test context in the application. Used only for testing
@@ -14,6 +17,11 @@ import {
   tag: 'onto-test-context',
 })
 export class OntoTestContext {
+  private readonly bundles = { en, fr };
+
+  constructor() {
+    this.onLanguageChanged();
+  }
 
   /**
    * Updates the license information in the context.
@@ -54,5 +62,36 @@ export class OntoTestContext {
       ServiceProvider.get(RepositoryContextService).updateRepositoryList(repositories);
     });
     return Promise.resolve();
+  }
+
+    /**
+   * Changes the application's language by updating the language bundle.
+   *
+   * This method uses the LanguageContextService to update the language bundle
+   * based on the provided language code. It retrieves the corresponding bundle
+   * from the predefined bundles object and updates the context.
+   *
+   * @param language - The language code (e.g., 'en' for English, 'fr' for French)
+   *                   representing the desired language to switch to.
+   * @returns A Promise that resolves when the language update is complete.
+   */
+  @Method()
+  changeLanguage(language: string): Promise<void> {
+    ServiceProvider.get(LanguageContextService).updateLanguageBundle(this.bundles[language]);
+    return Promise.resolve();
+  }
+
+    /**
+   * Sets up a listener for language changes and updates the application language accordingly.
+   *
+   * This private method subscribes to language change events using the LanguageContextService.
+   * When a new language is selected, it calls the changeLanguage method to update the application's language.
+   */
+  private onLanguageChanged(): void {
+    ServiceProvider.get(LanguageContextService).onSelectedLanguageChanged((languageCode) => {
+      if (languageCode) {
+        this.changeLanguage(languageCode);
+      }
+    });
   }
 }

--- a/packages/shared-components/src/components/onto-test-context/readme.md
+++ b/packages/shared-components/src/components/onto-test-context/readme.md
@@ -11,6 +11,26 @@ A component for managing test context in the application. Used only for testing
 
 ## Methods
 
+### `changeLanguage(language: string) => Promise<void>`
+
+Changes the application's language by updating the language bundle.
+
+This method uses the LanguageContextService to update the language bundle
+based on the provided language code. It retrieves the corresponding bundle
+from the predefined bundles object and updates the context.
+
+#### Parameters
+
+| Name       | Type     | Description                                                                                                     |
+| ---------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `language` | `string` | - The language code (e.g., 'en' for English, 'fr' for French)   representing the desired language to switch to. |
+
+#### Returns
+
+Type: `Promise<void>`
+
+A Promise that resolves when the language update is complete.
+
 ### `loadRepositories() => Promise<void>`
 
 Loads the repositories in the application.

--- a/packages/shared-components/src/components/translate-label/readme.md
+++ b/packages/shared-components/src/components/translate-label/readme.md
@@ -28,6 +28,7 @@ Example of usage:
 
 ### Used by
 
+ - [onto-footer](../onto-footer)
  - [onto-license-alert](../onto-license-alert)
  - [onto-navbar](../onto-navbar)
  - [onto-permission-banner](../onto-permission-banner)
@@ -35,6 +36,7 @@ Example of usage:
 ### Graph
 ```mermaid
 graph TD;
+  onto-footer --> translate-label
   onto-license-alert --> translate-label
   onto-navbar --> translate-label
   onto-permission-banner --> translate-label

--- a/packages/shared-components/src/pages/js/main.js
+++ b/packages/shared-components/src/pages/js/main.js
@@ -1,5 +1,6 @@
 let testContext = document.createElement('onto-test-context');
 document.body.appendChild(testContext);
+testContext.changeLanguage('en');
 
 // Mock the navigateUrl function which is exposed by the single-spa via the root-config module
 // in order to allow the menu to work without going anywhere when clicking the menu items

--- a/packages/shared-components/src/pages/language-selector/index.html
+++ b/packages/shared-components/src/pages/language-selector/index.html
@@ -15,6 +15,7 @@
 
   <script type="module" src="/build/shared-components.esm.js"></script>
   <script nomodule src="/build/shared-components.js"></script>
+  <script src="../js/main.js" defer></script>
   <script src="./main.js" defer></script>
   <link rel="stylesheet" href="../css/bootstrap.min.css">
   <link rel="stylesheet" href="../css/font-awesome.min.css">

--- a/packages/shared-components/src/pages/navbar/index.html
+++ b/packages/shared-components/src/pages/navbar/index.html
@@ -16,6 +16,7 @@
   <script type="module" src="/build/shared-components.esm.js"></script>
   <script nomodule src="/build/shared-components.js"></script>
   <script src="./main.js" defer></script>
+  <script src="../js/main.js" defer></script>
   <link rel="stylesheet" href="../css/bootstrap.min.css">
   <link rel="stylesheet" href="../css/font-awesome.min.css">
 </head>

--- a/packages/shared-components/src/pages/permission-banner/index.html
+++ b/packages/shared-components/src/pages/permission-banner/index.html
@@ -15,6 +15,7 @@
 
   <script type="module" src="/build/shared-components.esm.js"></script>
   <script nomodule src="/build/shared-components.js"></script>
+  <script src="../js/main.js" defer></script>
   <script src="./main.js" defer></script>
   <link rel="stylesheet" href="../css/bootstrap.min.css">
   <link rel="stylesheet" href="../css/font-awesome.min.css">

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -6,6 +6,7 @@ const {merge} = require("webpack-merge");
 const singleSpaDefaults = require("webpack-config-single-spa");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const {MergeJsonPlugin} = require('./webpack/merge-json-plugin.js');
+const {MergeI18nPlugin} = require('./webpack/merge-i18n-plugin.js');
 const path = require("path");
 const fs = require('fs');
 
@@ -86,6 +87,10 @@ module.exports = (webpackConfigEnv, argv) => {
                         'packages/legacy-workbench/src/**/plugin.js'
                     ]
                 }
+            }),
+            new MergeI18nPlugin({
+              startDirectory: './packages',
+              outputDirectory: 'onto-i18n'
             }),
             new MergeJsonPlugin({
                 files: [

--- a/webpack/merge-i18n-plugin.js
+++ b/webpack/merge-i18n-plugin.js
@@ -1,0 +1,121 @@
+const fs = require('fs');
+const path = require('path');
+const webpack = require('webpack');
+const { RawSource } = webpack.sources;
+
+/**
+ * A Webpack plugin for merging internationalization (i18n) JSON files from multiple directories.
+ *
+ * This plugin scans specified directories for i18n files, merges them by language,
+ * and outputs the combined files to a specified directory, inside the output directory.
+ */
+class MergeI18nPlugin {
+  constructor(options) {
+    this.outputDirectory = options.outputDirectory;
+    this.startDirectory = options.startDirectory;
+  }
+
+  apply(compiler) {
+    const pluginName = 'MergeI18nPlugin';
+    compiler.hooks.thisCompilation.tap(pluginName, compilation => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: pluginName,
+          stage: compilation.constructor.PROCESS_ASSETS_STAGE_ADDITIONS,
+        },
+        () => {
+          try {
+            const topLevelDirectories = this.getTopLevelDirectories();
+            console.log(`Merge i18n started in directories: ${topLevelDirectories.join(', ')}`);
+
+            const mergedBundles = this.mergeBundles(topLevelDirectories);
+            this.emitAssets(mergedBundles, compilation);
+
+            console.log(`I18n bundles successfully merged and output to ${this.outputDirectory}`);
+          } catch (err) {
+            console.error(err);
+          }
+        }
+      );
+    });
+  }
+
+  /**
+   * Merges all bundles, found in the specified top level directories.
+   * Traverses the specified directories, checking each of them for a `src/assets/i18n` folders.
+   * If such a folder is found, the contents will be merged into grouped files.
+   *
+   * For example `packages/shared-components/src/assets/i18n/en.json` and `packages/workbench/src/assets/i18n/en.json`
+   * (provided they exist), will be merged into `this.outputDirectory/en.json`
+   *
+   * If duplicate keys are found, an error will be thrown.
+   *
+   * @param topLevelDirectories the directories to be checked for `src/assets/i18n` folders
+   * @returns The merged bundles
+   */
+  mergeBundles(topLevelDirectories) {
+    const mergedBundles = {};
+
+    topLevelDirectories.forEach(dir => {
+      const i18nPath = path.join(this.startDirectory, dir, 'src/assets/i18n');
+
+      if (fs.existsSync(i18nPath) && fs.statSync(i18nPath).isDirectory()) {
+        console.log(`Found i18n directory: ${i18nPath}`);
+        const files = fs.readdirSync(i18nPath);
+
+        files.forEach(file => {
+          console.log(`Processing file: ${file}`);
+          const language = path.basename(file, '.json');
+          const filePath = path.join(i18nPath, file);
+          const fileContent = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+
+          if (!mergedBundles[language]) {
+            mergedBundles[language] = {};
+          }
+
+          Object.entries(fileContent).forEach(([key, value]) => {
+            if (mergedBundles[language][key]) {
+              throw new Error(
+                `Conflict detected for key '${key}' in language '${language}' in file: ${filePath}`
+              );
+            }
+            mergedBundles[language][key] = value;
+          });
+        });
+      } else {
+        console.log(`${i18nPath} directory doesn't exist`);
+      }
+    });
+    return mergedBundles;
+  }
+
+  /**
+   * Gets the top level directories under {@link this.startDirectory}
+   * @returns {string[]} The directories, under {@link this.startDirectory}
+   */
+  getTopLevelDirectories() {
+    return fs.readdirSync(this.startDirectory).filter((file) =>
+      fs.statSync(path.join(this.startDirectory, file)).isDirectory()
+    );
+  }
+
+  /**
+   * Emits the assets in the output folder
+   *
+   * Takes the merged bundles as an object and writes them in the specified {@link this.outputDirectory}
+   * @param mergedBundles The merged bundles, which should be written in the output folder
+   * @param compilation The compilation object from the `thisCompilation` hook
+   */
+  emitAssets(mergedBundles, compilation) {
+    Object.entries(mergedBundles).forEach(([language, data]) => {
+      const outputPath = path.join(this.outputDirectory, `${language}.json`);
+      compilation.emitAsset(
+        outputPath,
+        new RawSource(JSON.stringify(data, null, 2))
+      );
+      console.log(`Wrote I18n bundle for language '${language}' to: ${outputPath}`);
+    });
+  }
+}
+
+module.exports = { MergeI18nPlugin };


### PR DESCRIPTION
## What
Implement dynamic language loading

## Why
To have the ability to add new languages and modify existing behaviour, code free

## How
- Added `language-config.json` to hold configuration about available languages and default language
- Added `merge-i18n-plugin.js` to merge bundles of different modules into one bundle per language
- Configuration is fetched upon app startup and the default language is then loaded from the config.
- Once a language bundle has been loaded it is emitted through the `language-context.service.ts` and modules can get the new bundle and do whatever they need with it

## Testing
Jest/Cypress

## Screenshots
Conflicting key:
![image](https://github.com/user-attachments/assets/3c520d3f-371a-4f8f-b66f-ef5bbb939083)

App in English: 
![image](https://github.com/user-attachments/assets/da9e5c5f-64ca-4cf1-921a-e072f6dcd9dd)

App in French:
![image](https://github.com/user-attachments/assets/cad02d9c-ff8f-473d-b841-4d988fa4b550)

## Checklist
- [x] Branch name
- [x] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [x] MR Description
- [X] Tests
