### PR TITLE
GDB-11463-support-security-mode-in-graphql-playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-graphql-playground-component": "^0.0.4",
+                "ontotext-graphql-playground-component": "^0.0.5",
                 "ontotext-yasgui-web-component": "1.3.20",
                 "shepherd.js": "^11.2.0"
             },
@@ -10173,9 +10173,9 @@
             }
         },
         "node_modules/ontotext-graphql-playground-component": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/ontotext-graphql-playground-component/-/ontotext-graphql-playground-component-0.0.4.tgz",
-            "integrity": "sha512-oVAig6m7Pr4Apg+uTI84IFTsVxF4xrxcMqjrQCS5b7neLcHaRKQ+QKV0knVvLepeiBX9pu5pS0jUVvZ/mAUWug==",
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/ontotext-graphql-playground-component/-/ontotext-graphql-playground-component-0.0.5.tgz",
+            "integrity": "sha512-EyWd/K7U1fw7+ClncVuNOX1DPRVdPaZnmp8wfGiOURK58hi7ufTvicE7pZob8JbBozANfbZSVB0ymdQcZiH53A==",
             "dependencies": {
                 "graphql": "^16.9.0"
             }

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-graphql-playground-component": "^0.0.4",
+        "ontotext-graphql-playground-component": "^0.0.5",
         "ontotext-yasgui-web-component": "1.3.20",
         "shepherd.js": "^11.2.0"
     },

--- a/src/js/angular/graphql/controllers/graphql-playground-view.controller.js
+++ b/src/js/angular/graphql/controllers/graphql-playground-view.controller.js
@@ -9,9 +9,9 @@ angular
     .module('graphdb.framework.graphql.controllers.graphql-playground-view', modules)
     .controller('GraphqlPlaygroundViewCtrl', GraphqlPlaygroundViewCtrl);
 
-GraphqlPlaygroundViewCtrl.$inject = ['$scope', '$repositories', 'toastr', 'GraphqlService'];
+GraphqlPlaygroundViewCtrl.$inject = ['$scope', '$repositories', 'toastr', 'GraphqlService', 'AuthTokenService'];
 
-function GraphqlPlaygroundViewCtrl($scope, $repositories, toastr, GraphqlService) {
+function GraphqlPlaygroundViewCtrl($scope, $repositories, toastr, GraphqlService, AuthTokenService) {
 
     // =========================
     // Private variables
@@ -74,15 +74,31 @@ function GraphqlPlaygroundViewCtrl($scope, $repositories, toastr, GraphqlService
     // =========================
 
     /**
+     * Builds the configuration object for the GraphQL Playground.
+     * @param {string} endpoint - The selected endpoint.
+     * @return {GraphqlPlaygroundConfig} - The configuration object.
+     */
+    const buildConfig = (endpoint) => {
+        const config = {
+            endpoint: endpoint
+        };
+        const authToken = AuthTokenService.getAuthToken();
+        if (authToken) {
+            config.headers = {
+                Authorization: authToken
+            };
+        }
+        return new GraphqlPlaygroundConfig(config);
+    };
+
+    /**
      * Initializes the view by setting all needed variables in the scope.
      * @param {SelectMenuOptionsModel[]} endpointsSelectMenuOptions
      */
     const initView = (endpointsSelectMenuOptions) => {
         $scope.graphqlEndpoints = endpointsSelectMenuOptions;
         $scope.selectedGraphqlEndpoint = $scope.graphqlEndpoints[0];
-        $scope.configuration = new GraphqlPlaygroundConfig({
-            endpoint: $scope.selectedGraphqlEndpoint.value
-        });
+        $scope.configuration = buildConfig($scope.selectedGraphqlEndpoint.value);
     };
 
     /**
@@ -115,9 +131,8 @@ function GraphqlPlaygroundViewCtrl($scope, $repositories, toastr, GraphqlService
      * @param {SelectMenuOptionsModel} endpoint
      */
     const updateConfiguration = (endpoint) => {
-        $scope.configuration = new GraphqlPlaygroundConfig({
-            endpoint: endpoint.value
-        });
+        const config = buildConfig(endpoint.value);
+        $scope.configuration = new GraphqlPlaygroundConfig(config);
     };
 
     /**

--- a/src/js/angular/graphql/templates/graphql-playground.html
+++ b/src/js/angular/graphql/templates/graphql-playground.html
@@ -21,7 +21,7 @@
             </div>
         </div>
 
-        <div class="graphql-playground-container" ng-show="!loadingEndpoints && configuration && getActiveRepositoryNoError()">
+        <div class="graphql-playground-container" ng-if="!loadingEndpoints && configuration && getActiveRepositoryNoError()">
             <div class="toolbar">
                 <select ng-model="selectedGraphqlEndpoint"
                         ng-options="endpoint as endpoint.label for endpoint in graphqlEndpoints"
@@ -31,8 +31,7 @@
                         tooltip-placement="top">
                 </select>
             </div>
-            <graphql-playground configuration="configuration"
-                                ng-if="configuration && getActiveRepositoryNoError()"></graphql-playground>
+            <graphql-playground configuration="configuration"></graphql-playground>
         </div>
     </div>
 </div>

--- a/src/js/angular/models/graphql/graphql-playground-config.js
+++ b/src/js/angular/models/graphql/graphql-playground-config.js
@@ -8,6 +8,11 @@ export class GraphqlPlaygroundConfig {
          * @private
          */
         this._endpoint = data.endpoint;
+        /**
+         * @type {Object}
+         * @private
+         */
+        this._headers = data.headers;
     }
 
     get endpoint() {
@@ -16,5 +21,13 @@ export class GraphqlPlaygroundConfig {
 
     set endpoint(value) {
         this._endpoint = value;
+    }
+
+    get headers() {
+        return this._headers;
+    }
+
+    set headers(value) {
+        this._headers = value;
     }
 }


### PR DESCRIPTION
## What
Allow the graphiql playground to work when GDB security is enabled.

## Why
Users should be able to use the feature when security is ON.

## How
* The graphiql component was extended to support `headers` property provided through the external configuration. 
* Extended the playground view to provide the Authorization header with the configuration so that the graphiql component to be able to configure its internal http fetcher to pass it through with each query request.

## Testing
The graphiql component has tests for supporting the new `headers` configuration.

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
