### PR TITLE
GDB-11480 Fix logo not showing

### DIFF
--- a/packages/shared-components/src/components/onto-navbar/onto-navbar.tsx
+++ b/packages/shared-components/src/components/onto-navbar/onto-navbar.tsx
@@ -4,7 +4,6 @@ import {
   Event,
   EventEmitter,
   Fragment,
-  getAssetPath,
   h,
   Host,
   Prop,
@@ -207,8 +206,8 @@ export class OntoNavbar {
     if (!this.menuModel) {
       return;
     }
-    const logoImg1 = getAssetPath(`./assets/graphdb-logo.svg#Layer_1`);
-    const logoImg2 = getAssetPath(`./assets/graphdb-logo-sq.svg#Layer_1`);
+    const logoImg1 = '/assets/graphdb-logo.svg#Layer_1';
+    const logoImg2 = '/assets/graphdb-logo-sq.svg#Layer_1';
     return (
       <Host>
         <ul class="navbar-component">

--- a/packages/shared-components/stencil.config.ts
+++ b/packages/shared-components/stencil.config.ts
@@ -23,6 +23,7 @@ export const config: Config = {
       serviceWorker: null, // disable service workers
       copy: [
         {src: 'pages'},
+        {src: 'assets'},
         {src: '../node_modules/font-awesome/css/', dest: 'pages/css'},
         {src: '../node_modules/font-awesome/fonts/', dest: 'pages/fonts'},
         {src: '../../api/dist/ontotext-workbench-api.js', dest: 'resources/ontotext-workbench-api.js'},

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -111,6 +111,14 @@ module.exports = (webpackConfigEnv, argv) => {
                         to: 'plugin-registry.js'
                     },
                     {
+                        from: 'packages/shared-components/src/assets',
+                        to: 'assets',
+                        filter: (sourcePath) => {
+                          // Exclude i18n directory, as it is handled by the MergeI18nPlugin and doesn't need to be in assets
+                          return !sourcePath.includes('i18n');
+                        }
+                    },
+                    {
                         from: 'packages/legacy-workbench/node_modules/angularjs-slider/dist/rzslider.min.css',
                         to: 'js/lib/rzslider/rzslider.min.css'
                     },


### PR DESCRIPTION
## What
Fix the navbar logo

## Why
It wasn't being displayed

## How
- Added copy instructions in webpack, to copy the `assets` folder into `dist`, since stenciljs doesn't take care of that
- Removed the use of `getAssetPath` from `@stencil/core` as it is unreliable and returns wrong paths. Currently, we control the destination of the copied resources, hence we can statically reference them.

## Testing
None. There is no new testable code

## Screenshots
Expanded:
![image](https://github.com/user-attachments/assets/75b63090-cbdc-4e9d-b13e-445baff3fc82)

Not expanded: 
![image](https://github.com/user-attachments/assets/99cde7be-25db-4b93-bbeb-dac725138ad2)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
