### PR TITLE
GDB-11459 move graphql endpoint selector in the page heading row

### DIFF
--- a/src/js/angular/graphql/templates/graphql-playground.html
+++ b/src/js/angular/graphql/templates/graphql-playground.html
@@ -4,6 +4,16 @@
     <h1 id="title-container">
         <span id="graphql-playground-title-label">{{title}}</span>
         <page-info-tooltip></page-info-tooltip>
+
+        <div class="toolbar pull-right">
+            <select ng-model="selectedGraphqlEndpoint"
+                    ng-options="endpoint as endpoint.label for endpoint in graphqlEndpoints"
+                    ng-change="onGraphqlEndpointChange(selectedGraphqlEndpoint)"
+                    class="form-control graphql-endpoint-selector"
+                    gdb-tooltip="{{'graphql.playground.endpoint_selector.tooltip' | translate}}"
+                    tooltip-placement="top">
+            </select>
+        </div>
     </h1>
 
     <div core-errors></div>
@@ -22,15 +32,6 @@
         </div>
 
         <div class="graphql-playground-container" ng-if="!loadingEndpoints && configuration && getActiveRepositoryNoError()">
-            <div class="toolbar">
-                <select ng-model="selectedGraphqlEndpoint"
-                        ng-options="endpoint as endpoint.label for endpoint in graphqlEndpoints"
-                        ng-change="onGraphqlEndpointChange(selectedGraphqlEndpoint)"
-                        class="form-control graphql-endpoint-selector"
-                        gdb-tooltip="{{'graphql.playground.endpoint_selector.tooltip' | translate}}"
-                        tooltip-placement="top">
-                </select>
-            </div>
             <graphql-playground configuration="configuration"></graphql-playground>
         </div>
     </div>


### PR DESCRIPTION
## What
Move graphql endpoint selector in the page heading row.

## Why
To save some vertical space on the page.

## How
Moved the select component in the heading.

## Testing
NA

## Screenshots
![image](https://github.com/user-attachments/assets/660bd7c5-94e5-49ef-9ba8-5f23067cf5dd)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
