### PR TITLE
fix(GDB-11550) Remove npm-based Fontawesome PRO integration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,1 @@
 legacy-peer-deps=true
-@awesome.me:registry=https://npm.fontawesome.com/
-@fortawesome:registry=https://npm.fontawesome.com/
-//npm.fontawesome.com/:_authToken=05B5113B-1531-42E3-AB42-6619AEF7E822

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2,13 +2,38 @@
 
 ## Font awesome icons
 
-The font kit is our own and is installed using the following command:
-`npm install --save '@awesome.me/kit-94ffd2fc4a@latest'`
+The font kit used in the project is our own and is a custom PRO set. Below are the steps for manually updating and managing the fontawesome iconset:
 
-Because we use a PRO plan we have an authentication token which is used for install and update. The token is in the `.npmrc` file in the root of the project.
+---
 
-It can be updated by running the following command:
-`npm update '@awesome.me/kit-94ffd2fc4a'`
+### Updating the Font Kit
+If there is an update to the custom PRO font kit:
+
+1. Log in to [fontawesome.com](https://fontawesome.com) using our organization account.
+2. Navigate to the custom kit in our profile and download the latest version.
+3. Extract the downloaded files.
+4. Replace the relevant files in the following directory of the project:
+```angular2html
+src/js/lib/awesome_me/css
+```
+Make sure you copy all necessary CSS, fonts, and any other related files.
+
+5. Commit the updated files to the repository.
+
+---
+
+### Customizations
+If any icons or configurations within the PRO set are changed:
+
+1. Update the custom kit on [fontawesome.com](https://fontawesome.com).
+2. Download the updated kit.
+3. Follow the steps above to manually replace the files in:
+```angular2html
+src/js/lib/awesome_me/css
+```
+4. Test the changes locally to ensure the updated icons are working correctly.
+
+---
 
 ## Extending the GraphDB Workbench
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "3.0.0-TR4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@awesome.me/kit-94ffd2fc4a": "^1.0.105",
                 "angular-animate": "1.3.8",
                 "angular-bowser": "0.0.4",
                 "angular-cookies": "1.3.8",
@@ -78,18 +77,6 @@
                 "webpack-merge-and-include-globally": "^2.1.20"
             }
         },
-        "node_modules/@awesome.me/kit-94ffd2fc4a": {
-            "version": "1.0.113",
-            "resolved": "https://npm.fontawesome.com/@awesome.me/kit-94ffd2fc4a/-/1.0.113/kit-94ffd2fc4a-1.0.113.tgz",
-            "integrity": "sha512-IWHlQA+95a7UdCl4lasGnEailBfNJ9KQWHfflfWo6erCKzVq4bYzpT20MClP8Tp1SS+qwTM/f9gna26VI23tpQ==",
-            "license": "UNLICENSED",
-            "dependencies": {
-                "@fortawesome/fontawesome-common-types": "^6.7.2"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
         "node_modules/@babel/code-frame": {
             "version": "7.26.2",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
@@ -123,9 +110,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-            "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+            "version": "7.26.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
+            "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -159,38 +146,29 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.6.8",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
-            "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+            "version": "1.6.9",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+            "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/utils": "^0.2.8"
+                "@floating-ui/utils": "^0.2.9"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.6.12",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
-            "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+            "version": "1.6.13",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+            "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/core": "^1.6.0",
-                "@floating-ui/utils": "^0.2.8"
+                "@floating-ui/utils": "^0.2.9"
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-            "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+            "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
             "license": "MIT"
-        },
-        "node_modules/@fortawesome/fontawesome-common-types": {
-            "version": "6.7.2",
-            "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.7.2/fontawesome-common-types-6.7.2.tgz",
-            "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/@popperjs/core": {
             "version": "2.11.8",
@@ -241,9 +219,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.10.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-            "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+            "version": "22.12.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
+            "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1145,6 +1123,16 @@
             ],
             "license": "MIT"
         },
+        "node_modules/async-function": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+            "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/async-limiter": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -2043,17 +2031,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
         "node_modules/bl": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -2639,9 +2616,9 @@
             }
         },
         "node_modules/caniuse-api/node_modules/browserslist": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-            "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+            "version": "4.24.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "dev": true,
             "funding": [
                 {
@@ -2672,9 +2649,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001690",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
-            "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
+            "version": "1.0.30001695",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+            "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
             "dev": true,
             "funding": [
                 {
@@ -5041,9 +5018,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.76",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-            "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+            "version": "1.5.88",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.88.tgz",
+            "integrity": "sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==",
             "dev": true,
             "license": "ISC"
         },
@@ -5264,9 +5241,9 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-            "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6319,14 +6296,6 @@
                 "node": ">=4.0.0"
             }
         },
-        "node_modules/file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/fill-range": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -6502,13 +6471,19 @@
             }
         },
         "node_modules/for-each": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.4.tgz",
+            "integrity": "sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-callable": "^1.1.3"
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/for-in": {
@@ -6604,21 +6579,6 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -7417,9 +7377,9 @@
             }
         },
         "node_modules/http-parser-js": {
-            "version": "0.5.8",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
-            "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
+            "version": "0.5.9",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.9.tgz",
+            "integrity": "sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw==",
             "dev": true,
             "license": "MIT"
         },
@@ -7964,12 +7924,13 @@
             "license": "MIT"
         },
         "node_modules/is-async-function": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
-            "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+            "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "async-function": "^1.0.0",
                 "call-bound": "^1.0.3",
                 "get-proto": "^1.0.1",
                 "has-tostringtag": "^1.0.2",
@@ -9570,14 +9531,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/nan": {
-            "version": "2.22.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-            "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -10768,9 +10721,9 @@
             }
         },
         "node_modules/postcss-colormin/node_modules/browserslist": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-            "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+            "version": "4.24.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "dev": true,
             "funding": [
                 {
@@ -10922,9 +10875,9 @@
             }
         },
         "node_modules/postcss-merge-rules/node_modules/browserslist": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-            "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+            "version": "4.24.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "dev": true,
             "funding": [
                 {
@@ -11032,9 +10985,9 @@
             }
         },
         "node_modules/postcss-minify-params/node_modules/browserslist": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-            "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+            "version": "4.24.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "dev": true,
             "funding": [
                 {
@@ -11297,9 +11250,9 @@
             }
         },
         "node_modules/postcss-normalize-unicode/node_modules/browserslist": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-            "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+            "version": "4.24.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "dev": true,
             "funding": [
                 {
@@ -11429,9 +11382,9 @@
             }
         },
         "node_modules/postcss-reduce-initial/node_modules/browserslist": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-            "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+            "version": "4.24.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "dev": true,
             "funding": [
                 {
@@ -11838,13 +11791,13 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.13.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
-            "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.0.6"
+                "side-channel": "^1.1.0"
             },
             "engines": {
                 "node": ">=0.6"
@@ -13506,9 +13459,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.20",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
-            "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
+            "version": "3.0.21",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+            "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
             "dev": true,
             "license": "CC0-1.0"
         },
@@ -13982,9 +13935,9 @@
             }
         },
         "node_modules/stylehacks/node_modules/browserslist": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-            "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+            "version": "4.24.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "dev": true,
             "funding": [
                 {
@@ -14269,9 +14222,9 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+            "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14897,9 +14850,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "5.28.4",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-            "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+            "version": "5.28.5",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+            "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
             "license": "MIT",
             "dependencies": {
                 "@fastify/busboy": "^2.0.0"
@@ -15066,9 +15019,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-            "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+            "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
             "dev": true,
             "funding": [
                 {
@@ -15087,7 +15040,7 @@
             "license": "MIT",
             "dependencies": {
                 "escalade": "^3.2.0",
-                "picocolors": "^1.1.0"
+                "picocolors": "^1.1.1"
             },
             "bin": {
                 "update-browserslist-db": "cli.js"
@@ -15428,26 +15381,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "^1.2.7"
-            }
-        },
-        "node_modules/watchpack-chokidar2/node_modules/fsevents": {
-            "version": "1.2.13",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-            "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-            "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "dependencies": {
-                "bindings": "^1.5.0",
-                "nan": "^2.12.1"
-            },
-            "engines": {
-                "node": ">= 4.0"
             }
         },
         "node_modules/watchpack-chokidar2/node_modules/is-binary-path": {
@@ -16056,26 +15989,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/fsevents": {
-            "version": "1.2.13",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-            "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-            "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "dependencies": {
-                "bindings": "^1.5.0",
-                "nan": "^2.12.1"
-            },
-            "engines": {
-                "node": ">= 4.0"
             }
         },
         "node_modules/webpack-dev-server/node_modules/is-absolute-url": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
         "webpack-merge-and-include-globally": "^2.1.20"
     },
     "dependencies": {
-        "@awesome.me/kit-94ffd2fc4a": "^1.0.105",
         "angular-animate": "1.3.8",
         "angular-bowser": "0.0.4",
         "angular-cookies": "1.3.8",


### PR DESCRIPTION
## WHAT:
- Removed the integration of Fontawesome PRO iconset via `npm`.
- Updated `.npmrc` to eliminate authentication token for Fontawesome.
- Deleted Fontawesome-specific dependencies from `package.json` and `package-lock.json`.
- Revised the developer's guide to reflect manual updates of Fontawesome files.

## WHY:
- Storing sensitive authentication tokens in `.npmrc` poses a security risk.
- Switching to manual file updates reduces dependency

## HOW:
- Authentication token and references to Fontawesome PRO were removed from `.npmrc`.
- Dependencies on `@awesome.me/kit-94ffd2fc4a` and related packages were deleted from the package files.
- Developer's Guide now includes detailed steps for manually downloading and replacing Fontawesome PRO files from our Fontawesome account.



## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
