### PR TITLE
feat(GDB-11566) Introduce dynamic configuration form

### DIFF
--- a/src/js/angular/core/directives/dynamic-form/dynamic-form.directive.js
+++ b/src/js/angular/core/directives/dynamic-form/dynamic-form.directive.js
@@ -1,0 +1,118 @@
+/**
+ * Enum for configuration types.
+ * @readonly
+ * @enum {string}
+ */
+export const FIELD_TYPE = {
+    STRING: 'string',
+    TEXT: 'text',
+    BOOLEAN: 'boolean',
+    CHECKBOX: 'checkbox',
+    JSON: 'json',
+    SELECT: 'select',
+    MULTI_SELECT: 'multi_select'
+}
+
+/**
+ * @function dynamicFormDirective
+ * @description
+ * A directive for rendering a dynamic form based on an array of field objects.
+ *
+ * This directive creates a form where each object in the provided fields defines the type of input to render
+ * (for example, text input, checkbox, dropdown, multi-select, or textarea for JSON data). The directive uses the
+ * {@link FIELD_TYPE} enum to determine which input type to display. For select and multi-select fields, the
+ * {@link SelectMenuOptionsModel} should be used to model the options.
+ *
+ * Additionally, the directive supports an optional `onValidityChange` callback that will be called whenever the overall
+ * validity of the form changes. This is useful for informing a parent component or controller about the current form validity.
+ *
+ * @example
+ * ### HTML Usage:
+ * ```html
+ * <dynamic-form fields="myFields" on-validity-change="handleValidityChange(valid)"></dynamic-form>
+ * ```
+ *
+ * ### Controller Example:
+ * ```javascript
+ * angular.module('myApp', [])
+ *   .controller('ExampleController', function($scope) {
+ *     $scope.myFields = [
+ *       { label: 'Name', type: FIELD_TYPE.STRING, value: 'John Doe', required: true },
+ *       { label: 'Favorite Color', type: FIELD_TYPE.SELECT, value: new SelectMenuOptionsModel({ label: 'Red', value: 'red' }), values: [
+ *         new SelectMenuOptionsModel({ label: 'Red', value: 'red' }),
+ *         new SelectMenuOptionsModel({ label: 'Blue', value: 'blue' })
+ *       ], required: true },
+ *       { label: 'Interests', type: FIELD_TYPE.MULTI_SELECT, value: [], values: [
+ *         new SelectMenuOptionsModel({ label: 'Sports', value: 'sports' }),
+ *         new SelectMenuOptionsModel({ label: 'Music', value: 'music' })
+ *       ] },
+ *       { label: 'Active', type: FIELD_TYPE.BOOLEAN, value: true },
+ *       { label: 'Description', type: FIELD_TYPE.TEXT, value: 'A short description' },
+ *       { label: 'Settings', type: FIELD_TYPE.JSON, value: '{ "key": "value" }' }
+ *     ];
+ *
+ *     $scope.handleValidityChange = (isValid) => {
+ *       console.log('Form valid:', isValid);
+ *     };
+ *   });
+ * ```
+ *
+ * @param {Object[]} field - The array of field objects used to render the form fields.
+ * @param {string} field[].label - The label displayed for the input.
+ * @param {string} field[].type - The type of field input. Should be one of the values defined in {@link FIELD_TYPE}.
+ * @param {*} field[].value - The current value of the field.
+ * @param {SelectMenuOptionsModel[]} [field[].values] - The array of possible options for select and multi-select fields.
+ * @param {(string|RegExp)} [field[].regex] - A regular expression or its string representation for validating the field value.
+ * @param {boolean} [field[].required=false] - Indicates whether the field is required.
+ *
+ * @returns {Object} The directive definition object.
+ */
+const modules = [];
+angular
+    .module('graphdb.framework.core.directives.dynamic-form', modules)
+    .directive('dynamicForm', dynamicFormDirective);
+
+dynamicFormDirective.$inject = [];
+
+function dynamicFormDirective() {
+    return {
+        restrict: 'E',
+        scope: {
+            fields: '=',
+            onValidityChange: '&?'
+        },
+        templateUrl: 'js/angular/core/directives/dynamic-form/templates/dynamic-form.html',
+        link: function($scope, element) {
+            // =========================
+            // Public variables
+            // =========================
+            $scope.FIELD_TYPE = FIELD_TYPE;
+
+            // =========================
+            // Private function
+            // =========================
+            const init = () => {
+                const formElement = element.find('form');
+                const formCtrl = formElement.controller('form');
+
+                if (!formCtrl) {
+                    console.error('Form controller not found!');
+                    return;
+                }
+
+                const originalSetValidity = formCtrl.$setValidity;
+                formCtrl.$setValidity = function (validationToken, isValid, modelCtrl) {
+                    originalSetValidity.call(formCtrl, validationToken, isValid, modelCtrl);
+                    if ($scope.onValidityChange) {
+                        $scope.onValidityChange({valid: formCtrl.$valid});
+                    }
+                };
+            };
+
+            // =========================
+            // Initialization
+            // =========================
+            init();
+        }
+    };
+}

--- a/src/js/angular/core/directives/dynamic-form/templates/dynamic-form.html
+++ b/src/js/angular/core/directives/dynamic-form/templates/dynamic-form.html
@@ -1,0 +1,69 @@
+<div class="dynamic-form">
+    <form name="dynamicForm" novalidate>
+        <div ng-repeat="field in fields" class="row mb-1">
+            <!-- Label column -->
+            <label class="col-sm-2 col-form-label">
+                {{field.label}}
+                <sup ng-if="field.required">*</sup>
+            </label>
+
+            <!-- Input column -->
+            <div class="col-sm-10">
+                <!-- STRING -->
+                <div class="string-field" ng-if="field.type === FIELD_TYPE.STRING">
+                    <input type="text"
+                           class="form-control"
+                           name="{{field.key}}"
+                           ng-model="field.value"
+                           ng-pattern="field.regex"
+                           ng-required="field.required"/>
+                </div>
+
+                <!-- TEXT-->
+                <div class="string-field" ng-if="field.type === FIELD_TYPE.TEXT">
+                    <textarea type="text"
+                              class="form-control"
+                              name="{{field.key}}"
+                              ng-model="field.value"
+                              ng-required="field.required"></textarea>
+                </div>
+
+                <!-- BOOLEAN -->
+                <div class="boolean-field" ng-if="field.type === FIELD_TYPE.BOOLEAN">
+                    <input type="checkbox"
+                           name="{{field.key}}"
+                           ng-model="field.value"
+                           ng-required="field.required"/>
+                </div>
+
+                <!-- SINGLE SELECT -->
+                <div class="select-field" ng-if="field.type === FIELD_TYPE.SELECT">
+                    <select class="form-control"
+                            name="{{field.key}}"
+                            ng-model="field.value"
+                            ng-options="option as option.label for option in field.values track by option.value"
+                            ng-required="field.required">
+                    </select>
+                </div>
+
+                <!-- MULTI-SELECT -->
+                <div class="multiselect-field" ng-if="field.type === FIELD_TYPE.MULTI_SELECT">
+                    <multiselect-dropdown
+                        name="{{field.key}}"
+                        ng-model="field.value"
+                        options="field.values"
+                        ng-required="field.required"> </multiselect-dropdown>
+                </div>
+
+                <!-- JSON -->
+                <div class="json-field" ng-if="field.type === FIELD_TYPE.JSON">
+                    <textarea
+                        class="form-control"
+                        name="{{field.key}}"
+                        ng-model="field.value"
+                        ng-required="field.required"></textarea>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -204,6 +204,11 @@ module.exports = {
                 transform: replaceVersion
             },
             {
+                from: 'src/js/angular/core/directives/dynamic-form/templates',
+                to: 'js/angular/core/directives/dynamic-form/templates',
+                transform: replaceVersion
+            },
+            {
                 from: 'src/js/angular/core/directives/multiselect-dropdown/templates',
                 to: 'js/angular/core/directives/multiselect-dropdown/templates',
                 transform: replaceVersion


### PR DESCRIPTION
## WHAT:
- Added a new directive "dynamicConfigurationForm" to render dynamic configuration forms.
- Created an HTML template for the directive to support multiple configuration types (string, text, boolean, JSON, single select, multi-select).
- Updated the webpack configuration to copy the new directive's template into the build output.

## WHY:
- To enable dynamic rendering of configuration forms based on configuration objects.
- To support select and multi-select options modeled by SelectMenuOptionsModel.
- To improve modularity and maintainability by encapsulating the configuration form logic in its own directive.

## HOW:
- Implemented the directive
- Created the corresponding HTML template
- Modified `webpack.config.common.js` to include the new template directory in the build process

NB. Depends on https://github.com/Ontotext-AD/graphdb-workbench/pull/1799

## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
