### PR TITLE
feat(GDB-11565) Implement GraphQL Endpoint Configuration Modal

### DIFF
--- a/src/css/graphql/graphql-endpoint-configuration-modal.css
+++ b/src/css/graphql/graphql-endpoint-configuration-modal.css
@@ -1,0 +1,19 @@
+.graphql-endpoint-configuration-modal .graphql-endpoint-configuration-modal-body {
+    position: relative;
+    min-height: 300px;
+}
+
+.graphql-endpoint-configuration-modal .graphql-endpoint-configuration-loader {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1050;
+    pointer-events: all;
+}

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -796,6 +796,13 @@
                 "labels": {
                     "description": "Description"
                 }
+            },
+            "endpoint_configuration_modal": {
+                "title": "Configure GraphQL endpoint",
+                "messages": {
+                    "error_saving_configuration": "Error saving endpoint configuration",
+                    "success_saving_configuration": "Endpoint configuration saved"
+                }
             }
         },
         "create_endpoint": {
@@ -2128,6 +2135,7 @@
     "common.error": "Error",
     "common.warning": "Warning",
     "common.loading": "Loading...",
+    "common.select": "Select...",
     "common.on.btn": "ON",
     "common.off.btn": "OFF",
     "common.search.btn": "Search",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -796,6 +796,13 @@
                 "labels": {
                     "description": "Description"
                 }
+            },
+            "endpoint_configuration_modal": {
+                "title": "Configurer le point de terminaison GraphQL",
+                "messages": {
+                    "error_saving_configuration": "Erreur lors de l'enregistrement de la configuration du point de terminaison",
+                    "success_saving_configuration": "Configuration du point de terminaison enregistrée"
+                }
             }
         },
         "create_endpoint": {
@@ -2128,6 +2135,7 @@
     "common.error": "Erreur",
     "common.warning": "Avertissement",
     "common.loading": "Chargement...",
+    "common.select": "Sélectionner...",
     "common.on.btn": "AU",
     "common.off.btn": "DÉSACTIVÉ",
     "common.search.btn": "Rechercher",

--- a/src/js/angular/core/directives/dynamic-form/dynamic-form.directive.js
+++ b/src/js/angular/core/directives/dynamic-form/dynamic-form.directive.js
@@ -1,5 +1,5 @@
 /**
- * Enum for configuration types.
+ * Enum for field types.
  * @readonly
  * @enum {string}
  */
@@ -7,7 +7,6 @@ export const FIELD_TYPE = {
     STRING: 'string',
     TEXT: 'text',
     BOOLEAN: 'boolean',
-    CHECKBOX: 'checkbox',
     JSON: 'json',
     SELECT: 'select',
     MULTI_SELECT: 'multi_select'
@@ -79,7 +78,8 @@ function dynamicFormDirective() {
         restrict: 'E',
         scope: {
             fields: '=',
-            onValidityChange: '&?'
+            onValidityChange: '&?',
+            formCtrl: '=?'
         },
         templateUrl: 'js/angular/core/directives/dynamic-form/templates/dynamic-form.html',
         link: function($scope, element) {
@@ -87,6 +87,7 @@ function dynamicFormDirective() {
             // Public variables
             // =========================
             $scope.FIELD_TYPE = FIELD_TYPE;
+            $scope.formCtrl = undefined;
 
             // =========================
             // Private function
@@ -100,8 +101,9 @@ function dynamicFormDirective() {
                     return;
                 }
 
+                $scope.formCtrl = formCtrl;
                 const originalSetValidity = formCtrl.$setValidity;
-                formCtrl.$setValidity = function (validationToken, isValid, modelCtrl) {
+                $scope.formCtrl.$setValidity = function (validationToken, isValid, modelCtrl) {
                     originalSetValidity.call(formCtrl, validationToken, isValid, modelCtrl);
                     if ($scope.onValidityChange) {
                         $scope.onValidityChange({valid: formCtrl.$valid});

--- a/src/js/angular/core/directives/dynamic-form/templates/dynamic-form.html
+++ b/src/js/angular/core/directives/dynamic-form/templates/dynamic-form.html
@@ -1,17 +1,18 @@
 <div class="dynamic-form">
     <form name="dynamicForm" novalidate>
-        <div ng-repeat="field in fields" class="row mb-1">
+        <div ng-repeat="field in fields" class="row mb-1 form-field">
             <!-- Label column -->
-            <label class="col-sm-2 col-form-label">
+            <label class="col-sm-3 col-form-label field-label">
                 {{field.label}}
                 <sup ng-if="field.required">*</sup>
             </label>
 
             <!-- Input column -->
-            <div class="col-sm-10">
+            <div class="col-sm-9">
                 <!-- STRING -->
-                <div class="string-field" ng-if="field.type === FIELD_TYPE.STRING">
+                <div class="string-field  input-field" ng-if="field.type === FIELD_TYPE.STRING">
                     <input type="text"
+                           placeholder="{{field.regex.toString()}}"
                            class="form-control"
                            name="{{field.key}}"
                            ng-model="field.value"
@@ -20,7 +21,7 @@
                 </div>
 
                 <!-- TEXT-->
-                <div class="string-field" ng-if="field.type === FIELD_TYPE.TEXT">
+                <div class="string-field  text-field" ng-if="field.type === FIELD_TYPE.TEXT">
                     <textarea type="text"
                               class="form-control"
                               name="{{field.key}}"

--- a/src/js/angular/core/services/graphql.service.js
+++ b/src/js/angular/core/services/graphql.service.js
@@ -6,6 +6,9 @@ import {prefixModelToSelectMenuOptionsMapper} from "../../graphql/services/prefi
 import {
     shaclShapeGraphListOptionsMapper
 } from "../../graphql/services/shacl-shape-list.mapper";
+import {GraphqlEndpointConfiguration} from "../../models/graphql/graphql-endpoint-configuration";
+import {dynamicFormModelMapper} from "../../rest/mappers/dynamic-form-fied-mapper";
+import {GraphqlEndpointConfigurationSettings} from "../../models/graphql/graphql-endpoint-configuration-setting";
 
 const modules = ['graphdb.framework.rest.graphql.service'];
 
@@ -34,7 +37,9 @@ function GraphqlService(GraphqlRestService) {
      */
     const getEndpointsAsSelectMenuOptions = (repositoryId) => {
         return GraphqlRestService.getEndpoints(repositoryId)
-            .then((response) => endpointsToSelectMenuOptionsMapper(response.data));
+            .then((response) => {
+                return endpointsToSelectMenuOptionsMapper(response.data)
+            });
     };
 
     /**
@@ -77,12 +82,39 @@ function GraphqlService(GraphqlRestService) {
             .then((response) => shaclShapeGraphListOptionsMapper(response.data));
     }
 
+    /**
+     * Get the GraphQL endpoint configuration settings.
+     * @param {string} repositoryId - The repository id.
+     * @param {string} endpointId - The endpoint id.
+     * @returns {Promise<DynamicFormField[]>}
+     */
+    const getGraphqlEndpointConfigurationSettings = (repositoryId, endpointId) => {
+        return GraphqlRestService.getGraphqlEndpointConfigurationSettings(repositoryId, endpointId)
+            .then((response) => {
+                const fieldsModel = dynamicFormModelMapper(response.data);
+                return new GraphqlEndpointConfigurationSettings(fieldsModel);
+            });
+    };
+
+    /**
+     * Save the GraphQL endpoint configuration settings.
+     * @param {string} repositoryId - The repository id.
+     * @param {string} endpointId - The endpoint id.
+     * @param endpointSettings - The endpoint settings.
+     * @returns {Promise<unknown> | *}
+     */
+    const saveEndpointConfigurationSettings = (repositoryId, endpointId, endpointSettings) => {
+        return GraphqlRestService.saveEndpointConfigurationSettings(repositoryId, endpointId, endpointSettings);
+    };
+
     return {
         getEndpoints,
         getEndpointsAsSelectMenuOptions,
         getEndpointsInfo,
         getGraphqlSchemaShapes,
         getPrefixListAsSelectOptions,
-        getShaclShapeGraphs
+        getShaclShapeGraphs,
+        getGraphqlEndpointConfigurationSettings,
+        saveEndpointConfigurationSettings
     };
 }

--- a/src/js/angular/graphql/app.js
+++ b/src/js/angular/graphql/app.js
@@ -2,13 +2,19 @@ import 'angular/graphql/controllers/graphql-playground-view.controller';
 import 'angular/graphql/controllers/graphql-endpoint-management-view.controller';
 import 'angular/graphql/controllers/create-graphql-endpoint-view.controller';
 import 'angular/core/directives/graphql-playground/graphql-playground.directive';
+import 'angular/core/directives/dynamic-form/dynamic-form.directive';
+import 'angular/graphql/controllers/graphql-endpoint-configuration-modal.controller';
+import 'angular/core/directives/multiselect-dropdown/multiselect-dropdown.directive';
 
 const modules = [
     'ngRoute',
     'graphdb.framework.graphql.controllers.graphql-endpoint-management-view',
     'graphdb.framework.graphql.controllers.graphql-playground-view',
     'graphdb.framework.graphql.controllers.create-graphql-endpoint-view',
-    'graphdb.framework.core.directives.graphql-playground'
+    'graphdb.framework.core.directives.graphql-playground',
+    'graphdb.framework.core.directives.dynamic-form',
+    'graphdb.framework.graphql.controllers.graphql-endpoint-configuration-modal',
+    'graphdb.framework.core.directives.multiselect-dropdown'
 ];
 
 angular.module('graphdb.framework.graphql', modules);

--- a/src/js/angular/graphql/controllers/graphql-endpoint-configuration-modal.controller.js
+++ b/src/js/angular/graphql/controllers/graphql-endpoint-configuration-modal.controller.js
@@ -1,0 +1,104 @@
+import '../../core/services/graphql.service';
+
+const modules = [
+    'graphdb.framework.core.services.graphql-service'
+];
+
+angular
+    .module('graphdb.framework.graphql.controllers.graphql-endpoint-configuration-modal', modules)
+    .controller('GraphqlEndpointConfigurationModalController', GraphqlEndpointConfigurationModalController);
+
+GraphqlEndpointConfigurationModalController.$inject = ['$scope', '$uibModalInstance', 'data', '$translate', 'toastr', 'GraphqlService'];
+
+function GraphqlEndpointConfigurationModalController($scope, $uibModalInstance, data, $translate, toastr, GraphqlService) {
+    // =========================
+    // Private variables
+    // =========================
+
+    // =========================
+    // Public variables
+    // =========================
+
+    /**
+     * The endpoint configuration settings model.
+     * @type {GraphqlEndpointConfigurationSettings|undefined}
+     */
+    $scope.endpointConfigurationSettings = undefined;
+
+    /**
+     * Flag indicating if the endpoint configuration settings are valid.
+     * @type {boolean}
+     */
+    $scope.endpointConfigurationSettingsValid = false;
+
+    /**
+     * Flag indicating if the endpoint configuration settings are being loaded.
+     * @type {boolean}
+     */
+    $scope.loadingEndpointConfigurationSettings = false;
+
+    /**
+     * Flag indicating if the endpoint configuration settings are being saved.
+     * @type {boolean}
+     */
+    $scope.savingEndpointSettings = false;
+
+    /**
+     * Handles the save button click event in the dialog.
+     */
+    $scope.ok = () => {
+        save();
+    };
+
+    /**
+     * Cancels the operation and dismisses the modal.
+     */
+    $scope.cancel = () => {
+        $uibModalInstance.dismiss('cancel')
+    };
+
+    /**
+     * Handles the validity change of the endpoint configuration settings form
+     * @param {boolean} isValid - The validity of the form.
+     */
+    $scope.handleValidityChange = (isValid) => {
+        $scope.endpointConfigurationSettingsValid = isValid;
+    };
+
+    // =========================
+    // Private functions
+    // =========================
+    const init = () => {
+        $scope.loadingEndpointConfigurationSettings = true;
+        GraphqlService.getGraphqlEndpointConfigurationSettings(data.repository, data.endpoint)
+            .then((endpointConfigurationSettings) => {
+                $scope.endpointConfigurationSettings = endpointConfigurationSettings;
+            })
+            .catch((error) => {
+                toastr.error(getError(error));
+            })
+            .finally(() => {
+                $scope.loadingEndpointConfigurationSettings = false;
+            });
+    }
+
+    const save = () => {
+        $scope.savingEndpointSettings = true;
+        GraphqlService.saveEndpointConfigurationSettings(data.repository, data.endpoint, $scope.endpointConfigurationSettings.toJSON())
+            .then(() => {
+                $uibModalInstance.close();
+                toastr.success($translate.instant('graphql.endpoints_management.endpoint_configuration_modal.messages.success_saving_configuration'));
+            })
+            .catch((data) => {
+                toastr.error(getError(data), $translate.instant('graphql.endpoints_management.endpoint_configuration_modal.messages.error_saving_configuration'));
+            })
+            .finally(() => {
+                $scope.savingEndpointSettings = false;
+            });
+    }
+
+    // =========================
+    // Initialization
+    // =========================
+    init();
+}

--- a/src/js/angular/graphql/controllers/graphql-endpoint-management-view.controller.js
+++ b/src/js/angular/graphql/controllers/graphql-endpoint-management-view.controller.js
@@ -1,20 +1,22 @@
 import '../../core/services/graphql.service';
 import '../services/graphql-context.service';
+import './graphql-endpoint-configuration-modal.controller';
 import {GraphqlEventName} from "../services/graphql-context.service";
 import {endpointUrl} from "../models/endpoints";
 
 const modules = [
     'graphdb.framework.core.services.graphql-service',
-    'graphdb.framework.graphql.services.graphql-context'
+    'graphdb.framework.graphql.services.graphql-context',
+    'graphdb.framework.graphql.controllers.graphql-endpoint-configuration-modal'
 ];
 
 angular
     .module('graphdb.framework.graphql.controllers.graphql-endpoint-management-view', modules)
     .controller('GraphqlEndpointManagementViewCtrl', GraphqlEndpointManagementViewCtrl);
 
-GraphqlEndpointManagementViewCtrl.$inject = ['$scope', '$location', '$repositories', 'toastr', 'GraphqlService', 'GraphqlContextService', 'AuthTokenService'];
+GraphqlEndpointManagementViewCtrl.$inject = ['$scope', '$location', '$repositories', '$uibModal', 'toastr', 'GraphqlService', 'GraphqlContextService', 'AuthTokenService'];
 
-function GraphqlEndpointManagementViewCtrl($scope, $location, $repositories, toastr, GraphqlService, GraphqlContextService, AuthTokenService) {
+function GraphqlEndpointManagementViewCtrl($scope, $location, $repositories, $uibModal, toastr, GraphqlService, GraphqlContextService, AuthTokenService) {
 
     // =========================
     // Private variables
@@ -108,7 +110,22 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $repositories, toa
     };
 
     $scope.onConfigureEndpoint = (endpoint) => {
-        // TODO: implement endpoint configuration
+        return $uibModal.open({
+            templateUrl: 'js/angular/graphql/templates/modal/endpoint-configuration-modal.html',
+            controller: 'GraphqlEndpointConfigurationModalController',
+            windowClass: 'graphql-endpoint-configuration-modal',
+            size: 'lg',
+            backdrop: 'static',
+            keyboard: false,
+            resolve: {
+                data: () => {
+                    return {
+                        repository: $repositories.getActiveRepository(),
+                        endpoint: endpoint.endpointId
+                    };
+                }
+            }
+        }).result;
     };
 
     $scope.onDeleteEndpoint = (endpoint) => {

--- a/src/js/angular/graphql/services/graphql-context.service.js
+++ b/src/js/angular/graphql/services/graphql-context.service.js
@@ -1,6 +1,5 @@
 import {cloneDeep} from 'lodash';
 import {GraphqlEndpointConfiguration} from "../../models/graphql/graphql-endpoint-configuration";
-import {TTYGEventName} from "../../ttyg/services/ttyg-context.service";
 
 angular
     .module('graphdb.framework.graphql.services.graphql-context', [])

--- a/src/js/angular/graphql/templates/graphql-endpoint-management.html
+++ b/src/js/angular/graphql/templates/graphql-endpoint-management.html
@@ -101,14 +101,13 @@
                 <td>{{endpoint.propertiesCount}}</td>
                 <td>
                     <div class="btn-group">
-                        <button class="btn btn-link secondary btn-sm open-agent-actions-btn"
+                        <button class="btn btn-link secondary btn-sm open-endpoint-actions-btn"
                                 data-toggle="dropdown" aria-expanded="false"
                                 ng-if="true"
-                                ng-click="openAgentActionMenu()"
                                 ng-disabled="false">
                             <i class="fa fa-ellipsis"></i>
                         </button>
-                        <div class="dropdown-menu dropdown-menu-right agent-actions-menu">
+                        <div class="dropdown-menu dropdown-menu-right endpoint-actions-menu">
                             <button class="dropdown-item export-schema-btn" type="button"
                                     ng-click="onExportSchema(endpoint)">
                                 <i class="fa fa-arrow-down-to-line"></i>&nbsp;

--- a/src/js/angular/graphql/templates/modal/endpoint-configuration-modal.html
+++ b/src/js/angular/graphql/templates/modal/endpoint-configuration-modal.html
@@ -1,0 +1,25 @@
+<link href="css/graphql/graphql-endpoint-configuration-modal.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+
+<div class="modal-header">
+    <h3 class="modal-title">{{'graphql.endpoints_management.endpoint_configuration_modal.title' | translate}}</h3>
+</div>
+<div class="modal-body graphql-endpoint-configuration-modal-body">
+    <div class="graphql-endpoint-configuration-loader" onto-loader-new hide-message="true"
+         size="100" ng-show="loadingEndpointConfigurationSettings"></div>
+
+    <dynamic-form ng-if="!loadingEndpointConfigurationSettings" fields="endpointConfigurationSettings.settings"
+                  on-validity-change="handleValidityChange(valid)"
+                  form-ctrl="formCtrl">
+    </dynamic-form>
+</div>
+<div class="modal-footer mt-0">
+    <button type="button" class="btn btn-secondary cancel-btn" ng-click="cancel()">{{'common.cancel.btn' | translate}}</button>
+    <button id="graphql-endpoint-configuration-modal-submit"
+            class="btn btn-primary"
+            ng-disabled="!endpointConfigurationSettingsValid || savingEndpointSettings || formCtrl.$pristine"
+            ng-click="ok()" type="submit">
+        <span>{{'save.changes.label' | translate}}</span>
+        <span class="saving-endpoint-settings" ng-if="savingEndpointSettings" onto-loader-fancy hide-message="true"
+              size="15"></span>
+    </button>
+</div>

--- a/src/js/angular/models/dynamic-form/dynamic-form-field.js
+++ b/src/js/angular/models/dynamic-form/dynamic-form-field.js
@@ -1,0 +1,129 @@
+/**
+ * A model representing a dynamic form field used by the dynamic form component.
+ */
+export class DynamicFormField {
+    /**
+     * The unique key of the setting.
+     * @type {string}
+     * @private
+     */
+    _key = '';
+    /**
+     * The label displayed for the setting.
+     * @type {string}
+     * @private
+     */
+    _label = '';
+    /**
+     * The type of the field (e.g., string, boolean, select, etc.).
+     * @type {string}
+     * @private
+     */
+    _type = '';
+    /**
+     * Whether the value is a collection.
+     * @type {boolean}
+     * @private
+     */
+    _collection = false;
+    /**
+     * The current value of the setting.
+     * @private
+     */
+    _value;
+    /**
+     * The possible values (used for select-type fields).
+     * @private
+     */
+    _values;
+    /**
+     * A regular expression or its string representation for validating the value.
+     * @private
+     */
+    _regex;
+    /**
+     * Whether the field is required.
+     * @type {boolean}
+     * @private
+     */
+    _required = false;
+
+    /**
+     * Creates an instance of GraphqlEndpointConfigurationSetting.
+     * @param {Object} options - The setting options.
+     */
+    constructor(options) {
+        this._key = options.key;
+        this._label = options.label;
+        this._type = options.type;
+        this._collection = options.collection;
+        this._value = options.value;
+        this._values = options.values;
+        this._regex = typeof options.regex === 'string' ? new RegExp(options.regex) : options.regex;
+        this._required = options.required;
+    }
+
+    get key() {
+        return this._key;
+    }
+
+    set key(value) {
+        this._key = value;
+    }
+
+    get label() {
+        return this._label;
+    }
+
+    set label(value) {
+        this._label = value;
+    }
+
+    get type() {
+        return this._type;
+    }
+
+    set type(value) {
+        this._type = value;
+    }
+
+    get collection() {
+        return this._collection;
+    }
+
+    set collection(value) {
+        this._collection = value;
+    }
+
+    get value() {
+        return this._value;
+    }
+
+    set value(value) {
+        this._value = value;
+    }
+
+    get values() {
+        return this._values;
+    }
+
+    set values(value) {
+        this._values = value;
+    }
+
+    get regex() {
+        return this._regex;
+    }
+
+    set regex(value) {
+        this._regex = typeof value === 'string' ? new RegExp(value) : value;
+    }
+
+    get required() {
+        return this._required;
+    }
+
+    set required(value) {
+        this._required = value;
+    }
+}

--- a/src/js/angular/models/graphql/graphql-endpoint-configuration-setting.js
+++ b/src/js/angular/models/graphql/graphql-endpoint-configuration-setting.js
@@ -1,0 +1,43 @@
+import {DynamicFormField} from "../dynamic-form/dynamic-form-field";
+
+/**
+ * Enum for configuration types.
+ * @readonly
+ * @enum {string}
+ */
+export const CONFIG_TYPE = {
+    STRING: 'string',
+    TEXT: 'text',
+    BOOLEAN: 'boolean',
+    JSON: 'json'
+}
+
+export class GraphqlEndpointConfigurationSettings {
+    /**
+     * Endpoint configuration settings model.
+     * @type {DynamicFormField[]}
+     * @private
+     */
+    _settings;
+
+    constructor(data) {
+        this._settings = data || [];
+    }
+
+    get settings() {
+        return this._settings;
+    }
+
+    set settings(value) {
+        this._settings = value;
+    }
+
+    toJSON() {
+        return this.settings.map((config) => {
+            return {
+                key: config.key,
+                value: config.value,
+            }
+        })
+    }
+}

--- a/src/js/angular/models/graphql/graphql-endpoint-configuration.js
+++ b/src/js/angular/models/graphql/graphql-endpoint-configuration.js
@@ -16,12 +16,28 @@ export class GraphqlEndpointConfiguration {
      * @private
      */
     _params;
+
     _graphqlShapes = [];
+
+    /**
+     * The endpoint configuration settings model.
+     * @type {GraphqlEndpointConfigurationSettings|undefined}
+     * @private
+     */
+    _settings ;
 
     constructor() {
         this._selectedGraphqlSchemaShapes = new GraphqlSchemaShapes();
         this._selectedGraphs = new GraphListOptions();
         this._params = new GraphqlEndpointParams({});
+    }
+
+    get settings() {
+        return this._settings;
+    }
+
+    set settings(value) {
+        this._settings = value;
     }
 
     get selectedGraphs() {

--- a/src/js/angular/rest/graphql.rest.service.js
+++ b/src/js/angular/rest/graphql.rest.service.js
@@ -38,6 +38,11 @@ function GraphqlRestService($http) {
         return $http.get(`${REPOSITORIES_ENDPOINT}/${repositoryId}/manage/graphql/endpoints`);
     };
 
+    /**
+     * Get the GraphQL schema shapes for the given repository.
+     * @param {string} repositoryId The repository ID.
+     * @returns {*|Promise}
+     */
     const getGraphqlSchemaShapes = (repositoryId) => {
         if (DEVELOPMENT) {
             return _mockBackend.getGraphqlSchemaShapesMock(repositoryId);
@@ -79,11 +84,40 @@ function GraphqlRestService($http) {
         // });
     }
 
+    /**
+     * Get the GraphQL endpoint configuration settings from the backend.
+     * @param {string} repositoryId The repository ID.
+     * @param {string} endpointId The endpoint ID.
+     * @returns {*|Promise<unknown>}
+     */
+    const getGraphqlEndpointConfigurationSettings = (repositoryId, endpointId) => {
+        if (DEVELOPMENT) {
+            return _mockBackend.getEndpointConfigurationMock();
+        }
+        return $http.get(`${REPOSITORIES_ENDPOINT}/${repositoryId}/manage/graphql/${endpointId}/config`);
+    };
+
+    /**
+     * Save the GraphQL endpoint configuration settings.
+     * @param {string} repositoryId The repository ID.
+     * @param {string} endpointId The endpoint ID.
+     * @param {*} endpointSettings The endpoint settings.
+     * @returns {*|Promise<unknown>}
+     */
+    const saveEndpointConfigurationSettings = (repositoryId, endpointId, endpointSettings) => {
+        if (DEVELOPMENT) {
+            return _mockBackend.saveEndpointConfigurationMock();
+        }
+        return $http.put(`${REPOSITORIES_ENDPOINT}/${repositoryId}/manage/graphql/${endpointId}/config`, endpointSettings);
+    };
+
     return {
         getEndpoints,
         getEndpointsInfo,
         getGraphqlSchemaShapes,
         getPrefixes,
-        getShaclShapeGraphs
+        getShaclShapeGraphs,
+        getGraphqlEndpointConfigurationSettings,
+        saveEndpointConfigurationSettings
     };
 }

--- a/src/js/angular/rest/mappers/dynamic-form-fied-mapper.js
+++ b/src/js/angular/rest/mappers/dynamic-form-fied-mapper.js
@@ -1,0 +1,74 @@
+import {FIELD_TYPE} from "../../core/directives/dynamic-form/dynamic-form.directive";
+import {SelectMenuOptionsModel} from "../../models/form-fields";
+import {DynamicFormField} from "../../models/dynamic-form/dynamic-form-field";
+import {CONFIG_TYPE} from "../../models/graphql/graphql-endpoint-configuration-setting";
+
+/**
+ * Maps the dynamic form data to the dynamic form model.
+ * @param {*} data - The dynamic form data.
+ * @returns {DynamicFormField[]|*[]}
+ */
+export const dynamicFormModelMapper = (data) => {
+    if (!data || !data.configs) {
+        return [];
+    }
+
+    return data.configs.map((config) => {
+        let type;
+        if(config.type === CONFIG_TYPE.TEXT) {
+            type = FIELD_TYPE.TEXT;
+        } else if (config.type === CONFIG_TYPE.BOOLEAN) {
+            type = FIELD_TYPE.BOOLEAN;
+        } else if (config.type === CONFIG_TYPE.JSON) {
+            type = FIELD_TYPE.JSON;
+        } else if (config.type === CONFIG_TYPE.STRING) {
+            if (config.values && config.values.length > 0) {
+                type = config.collection ? FIELD_TYPE.MULTI_SELECT : FIELD_TYPE.SELECT;
+            } else {
+                type = FIELD_TYPE.STRING;
+            }
+        }
+        let mappedValues = config.values;
+        let selectedValue = [];
+
+        if (type === FIELD_TYPE.MULTI_SELECT || type === FIELD_TYPE.SELECT) {
+            mappedValues = mappedValues.map((option) => {
+                const isSelected =
+                    (Array.isArray(config.value) && config.value.indexOf(option) > -1) ||
+                    (typeof config.value === 'string' && config.value === option);
+
+                const menuOption = new SelectMenuOptionsModel({
+                    label: option,
+                    value: option,
+                    selected: isSelected
+                });
+
+                if (isSelected) {
+                    selectedValue.push(menuOption);
+                }
+                return menuOption;
+            });
+
+            if (type === FIELD_TYPE.SELECT) {
+                config.value = selectedValue[0] ? selectedValue[0] : [];
+            } else if (type === FIELD_TYPE.MULTI_SELECT) {
+                config.value = selectedValue;
+            }
+        }
+        return dynamicFormFieldMapper(config, type, mappedValues);
+    });
+};
+
+const dynamicFormFieldMapper = (config, type, mappedValues) => {
+    return new DynamicFormField({
+        key: config.key,
+        label: config.label,
+        description: config.description,
+        type: type,
+        collection: config.collection || false,
+        value: config.value,
+        values: mappedValues,
+        regex: config.regex,
+        required: config.required || false
+    });
+}

--- a/src/js/angular/rest/mock-backend/graphql-rest-service-mock.js
+++ b/src/js/angular/rest/mock-backend/graphql-rest-service-mock.js
@@ -23,6 +23,18 @@ export class GraphqlRestServiceMock {
             setTimeout(() => resolve({data: cloneDeep(graphqlSchemaShapes)}), GET_ENDPOINTS_INFO_DELAY);
         });
     }
+
+    getEndpointConfigurationMock() {
+        return new Promise((resolve) => {
+            setTimeout(() => resolve({data: cloneDeep(endpointConfiguration)}), GET_ENDPOINTS_INFO_DELAY);
+        });
+    }
+
+    saveEndpointConfigurationMock() {
+        return new Promise((resolve) => {
+            setTimeout(() => resolve({data: {"message": "Data saved successfully."}}), GET_ENDPOINTS_INFO_DELAY);
+        });
+    }
 }
 
 const endpoints = {
@@ -191,3 +203,51 @@ const graphqlSchemaShapes = {
         }
     ]
 }
+
+const endpointConfiguration = {
+    configs: [
+        {
+            key: 'str',
+            label: 'String',
+            type: 'string',
+            collection: false,
+            value: 'strValue',
+            values: [],
+            regex: '^(?:ALL:?)?(?:(?:-?[\\w]{2}(?:-[\\w]*)?~?|-?NONE|ANY|BROWSER)?(?:,(?:-?[\\w]{2}(?:-[\\w]*)?~?|-?NONE|ANY|BROWSER))*)$'
+        },
+        {
+            key: 'bool',
+            label: 'Boolean value',
+            description: '',
+            type: 'boolean',
+            collection: false,
+            value: false,
+            values: []
+        },
+        {
+            key: 'select',
+            label: 'Select',
+            type: '',
+            collection: false,
+            value: 'Two',
+            values: ['One', 'Two', 'Three']
+        },
+        {
+            key: 'multiselect',
+            label: 'Multiselect',
+            type: '',
+            collection: true,
+            value: ['Angular', 'JavaScript'],
+            values: ['Angular', 'JavaScript', 'WebDevelopment']
+        },
+        {
+            key: 'json',
+            label: 'JSON',
+            type: 'json',
+            collection: false,
+            value: '{"foo": "bar"}',
+            values: [],
+            required: true
+        }
+    ]
+};

--- a/test-cypress/fixtures/graphql/endpoints/graphql-endpoint-configuration-types.json
+++ b/test-cypress/fixtures/graphql/endpoints/graphql-endpoint-configuration-types.json
@@ -1,0 +1,46 @@
+{
+    "configs": [
+        {
+            "key": "str",
+            "label": "String",
+            "type": "string",
+            "collection": false,
+            "value": "strValue",
+            "values": [],
+            "regex": "^(?:ALL:?)?(?:(?:-?[\\w]{2}(?:-[\\w]*)?~?|-?NONE|ANY|BROWSER)?(?:,(?:-?[\\w]{2}(?:-[\\w]*)?~?|-?NONE|ANY|BROWSER))*)$"
+        },
+        {
+            "key": "bool",
+            "label": "Boolean value",
+            "type": "boolean",
+            "collection": false,
+            "value": false,
+            "values": []
+        },
+        {
+            "key": "select",
+            "label": "Select",
+            "type": "string",
+            "collection": false,
+            "value": "Two",
+            "values": ["One", "Two", "Three"]
+        },
+        {
+            "key": "multiselect",
+            "label": "Multiselect",
+            "type": "string",
+            "collection": true,
+            "value": ["Angular", "JavaScript"],
+            "values": ["Angular", "JavaScript", "WebDevelopment"]
+        },
+        {
+            "key": "json",
+            "label": "JSON",
+            "type": "json",
+            "collection": false,
+            "value": "{\"foo\": \"bar\"}",
+            "values": [],
+            "required": true
+        }
+    ]
+}

--- a/test-cypress/fixtures/graphql/endpoints/graphql-endpoint-configuration.json
+++ b/test-cypress/fixtures/graphql/endpoints/graphql-endpoint-configuration.json
@@ -1,0 +1,227 @@
+{
+    "configs": [
+        {
+            "key": "enable_mutations",
+            "label": "enable_mutations",
+            "description": "Controls whether the generated GraphQL schema should include object mutations or not.",
+            "type": "boolean",
+            "collection": false,
+            "value": null,
+            "values": null,
+            "required": false,
+            "regex": null
+        },
+        {
+            "key": "lang.fetch",
+            "label": "fetch",
+            "description": "Default language fetch configuration",
+            "type": "string",
+            "collection": false,
+            "value": null,
+            "values": null,
+            "required": false,
+            "regex": "^(?:ALL:?)?(?:(?:-?[\\w]{2}(?:-[\\w]*)?~?|-?NONE|ANY|BROWSER)?(?:,(?:-?[\\w]{2}(?:-[\\w]*)?~?|-?NONE|ANY|BROWSER))*)$"
+        },
+        {
+            "key": "lang.validate",
+            "label": "validate",
+            "description": "Default language validation configuration",
+            "type": "string",
+            "collection": false,
+            "value": "UNIQ",
+            "values": null,
+            "required": false,
+            "regex": "^(?:[\\w]{2}~?|NONE|ANY|ALL)?(?:,(?:[\\w]{2}~?|NONE|ANY|ALL))*(?:;?UNIQ)?$"
+        },
+        {
+            "key": "lang.implicit",
+            "label": "implicit",
+            "description": "Default language to use when inserting rdf:langString values.",
+            "type": "string",
+            "collection": false,
+            "value": "en",
+            "values": null,
+            "required": false,
+            "regex": "[\\w]{2}(?:-[\\w]*)?"
+        },
+        {
+            "key": "lang.defaultNameFetch",
+            "label": "defaultNameFetch",
+            "description": "Default language spec to apply when loading values for the name property",
+            "type": "string",
+            "collection": false,
+            "value": "ANY",
+            "values": null,
+            "required": false,
+            "regex": "^(?:(?:-?[\\w]{2}(?:-[\\w]*)?~?|-?NONE|ANY|BROWSER)?(?:,(?:-?[\\w]{2}(?:-[\\w]*)?~?|-?NONE|ANY|BROWSER))*)$"
+        },
+        {
+            "key": "lang.appendDefaultNameFetch",
+            "label": "appendDefaultNameFetch",
+            "description": "Specifies whether the default spec, if any, should be appended or not to any user-defined name fetch spec",
+            "type": "boolean",
+            "collection": false,
+            "value": true,
+            "values": null,
+            "required": false,
+            "regex": null
+        },
+        {
+            "key": "queryPfx",
+            "label": "queryPfx",
+            "description": "Allows setting a prefix that will be put in all queries in the GraphQL schema.",
+            "type": "string",
+            "collection": false,
+            "value": null,
+            "values": null,
+            "required": false,
+            "regex": "[\\w]*"
+        },
+        {
+            "key": "mutationPfx",
+            "label": "mutationPfx",
+            "description": "Allows setting a prefix that will be put in all mutations in the GraphQL schema.",
+            "type": "string",
+            "collection": false,
+            "value": null,
+            "values": null,
+            "required": false,
+            "regex": "[\\w]*"
+        },
+        {
+            "key": "search",
+            "label": "search",
+            "description": "Allows you to define a structure of the searchable data for fields that are not specified in the configuration of the objects and/or properties",
+            "type": "dictionary",
+            "collection": false,
+            "value": null,
+            "values": null,
+            "required": false,
+            "regex": null
+        },
+        {
+            "key": "repository",
+            "label": "repository",
+            "description": "Changes the default repository used for the entire schema.",
+            "type": "string",
+            "collection": false,
+            "value": null,
+            "values": null,
+            "required": false,
+            "regex": "[\\w]*"
+        },
+        {
+            "key": "includeInferred",
+            "label": "includeInferred",
+            "description": "Controls whether query inference is enabled or disabled by default for all queries and mutations.",
+            "type": "boolean",
+            "collection": false,
+            "value": true,
+            "values": null,
+            "required": false,
+            "regex": null
+        },
+        {
+            "key": "expandOwlSameAs",
+            "label": "expandOwlSameAs",
+            "description": "Controls whether owl:sameAs expansion is enabled or disabled by default for all queries and mutations.",
+            "type": "boolean",
+            "collection": false,
+            "value": true,
+            "values": null,
+            "required": false,
+            "regex": null
+        },
+        {
+            "key": "disabledChecks",
+            "label": "disabledChecks",
+            "description": "Specifies which checks could be disabled during the schema validation.",
+            "type": "string",
+            "collection": true,
+            "value": true,
+            "values": [
+                "regexInheritanceCheck",
+                "rangeCheck"
+            ],
+            "required": false,
+            "regex": null
+        },
+        {
+            "key": "defaultRole",
+            "label": "defaultRole",
+            "description": "The default RBAC role the user will receive if no roles are found in the security JWT token or none of the roles match any in the rbac section of the current SOML schema.",
+            "type": "string",
+            "collection": false,
+            "value": "defaultRole",
+            "values": null,
+            "required": false,
+            "regex": "[\\w]*"
+        },
+        {
+            "key": "defaultIntegrationRole",
+            "label": "defaultIntegrationRole",
+            "description": "The default RBAC role that will have read-only access to the data and could be used for system integrations.",
+            "type": "string",
+            "collection": false,
+            "value": "Federation_SystemRole",
+            "values": null,
+            "required": false,
+            "regex": "[\\w]*"
+        },
+        {
+            "key": "exposeSomlInGraphQL",
+            "label": "exposeSomlInGraphQL",
+            "description": "Controls whether GraphQL schema should include directives that expose the effective SOML configurations for each output type and property.",
+            "type": "boolean",
+            "collection": false,
+            "value": false,
+            "values": null,
+            "required": false,
+            "regex": null
+        },
+        {
+            "key": "enableCollectionCount",
+            "label": "enableCollectionCount",
+            "description": "Controls whether the collections should have a companion property that provides counting of the collection properties.",
+            "type": "boolean",
+            "collection": false,
+            "value": false,
+            "values": null,
+            "required": false,
+            "regex": null
+        },
+        {
+            "key": "enableTypeCount",
+            "label": "enableTypeCount",
+            "description": "Controls whether new counting queries should be generated for all queryable types.",
+            "type": "boolean",
+            "collection": false,
+            "value": false,
+            "values": null,
+            "required": false,
+            "regex": null
+        },
+        {
+            "key": "compactErrorMessages",
+            "label": "compactErrorMessages",
+            "description": "Controls the default behavior of the GraphQL Responder how to process the errors that are returned to the client.",
+            "type": "boolean",
+            "collection": false,
+            "value": false,
+            "values": null,
+            "required": false,
+            "regex": null
+        },
+        {
+            "key": "enableGraphQlExplain",
+            "label": "enableGraphQlExplain",
+            "description": "Controls whether SemanticObjects should provide the generated SPARQL query or its explain plan.",
+            "type": "boolean",
+            "collection": false,
+            "value": true,
+            "values": null,
+            "required": false,
+            "regex": null
+        }
+    ]
+}

--- a/test-cypress/integration/graphql/edit-graphql-enpoint.spec.js
+++ b/test-cypress/integration/graphql/edit-graphql-enpoint.spec.js
@@ -1,0 +1,196 @@
+import {GraphqlStubs} from "../../stubs/graphql/graphql-stubs";
+import {GraphqlEndpointManagementSteps} from "../../steps/graphql/graphql-endpoint-management-steps";
+import {EditGraphqlEndpointSteps} from "../../steps/graphql/edit-graphql-endpoint-steps";
+import {ApplicationSteps} from "../../steps/application-steps";
+
+describe('Graphql: edit endpoint settings', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'create-graphql-endpoint-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        // TODO: remove stubs and enable next imports when REST API is ready
+        // cy.importServerFile(repositoryId, 'swapi-dataset.ttl');
+        // cy.uploadGraphqlSchema(repositoryId, 'graphql/soml/swapi-schema.yaml', 'swapi');
+        GraphqlStubs.stubGetEndpointsInfo(repositoryId);
+        GraphqlStubs.stubGetEndpoints(repositoryId, 'graphql-swapi-endpoints.json');
+        GraphqlStubs.stubGetEndpointConfiguration(repositoryId, 'swapi', undefined, 1000);
+
+        // Visit the endpoint management view
+        GraphqlEndpointManagementSteps.visit();
+        // Ensure the endpoints list is loaded
+        GraphqlEndpointManagementSteps.getEndpointsInfo().should('have.length.at.least', 1);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('should display and edit different types dynamic form fields', () => {
+        GraphqlStubs.stubGetEndpointConfiguration(repositoryId, 'swapi', 'graphql-endpoint-configuration-types.json');
+        GraphqlEndpointManagementSteps.editEndpointConfiguration(0);
+        EditGraphqlEndpointSteps.getDialog().should('be.visible');
+
+        EditGraphqlEndpointSteps.getInputField(0).should('have.value', 'strValue');
+        EditGraphqlEndpointSteps.fillInputField(0, 'Foo')
+
+        EditGraphqlEndpointSteps.getBooleanField(0).should('not.be.checked');
+        EditGraphqlEndpointSteps.toggleBooleanField(0);
+
+        EditGraphqlEndpointSteps.getSelectField(0).should('have.value', 'Two');
+        EditGraphqlEndpointSteps.selectOption(0, 'One');
+
+        EditGraphqlEndpointSteps.verifyMultiSelectOptionSelected(0, 'Angular', 'JavaScript');
+        EditGraphqlEndpointSteps.toggleMultiSelectOption(0, 'Angular');
+        EditGraphqlEndpointSteps.verifyMultiSelectOptionSelected(0, 'JavaScript');
+
+        EditGraphqlEndpointSteps.getJsonField(0).should('have.value', '{"foo": "bar"}');
+        EditGraphqlEndpointSteps.clearJsonField(0);
+    });
+
+    it('should allow saving the configuration changes successfully', () => {
+        GraphqlStubs.stubSaveEndpointConfiguration(repositoryId, 'swapi', 1000);
+        // Open the modal
+        GraphqlEndpointManagementSteps.editEndpointConfiguration(0);
+        EditGraphqlEndpointSteps.getDialog().should('be.visible');
+
+        // Then the save button is disabled
+        EditGraphqlEndpointSteps.getOKButton().should('be.disabled');
+
+        // When I change some fields
+        EditGraphqlEndpointSteps.fillInputField(0, 'ANY');
+        EditGraphqlEndpointSteps.fillInputField(2, 'bg');
+        EditGraphqlEndpointSteps.toggleBooleanField(0);
+        EditGraphqlEndpointSteps.toggleBooleanField(1);
+
+        // Then the save button is enabled
+        EditGraphqlEndpointSteps.getOKButton().should('be.enabled');
+
+        // Submit the form
+        EditGraphqlEndpointSteps.clickOKButton();
+        EditGraphqlEndpointSteps.getSavingLoader().should('be.visible');
+        cy.wait('@save-endpoint-configuration').then((interception) => {
+            expect(interception.request.body).to.deep.equal([
+                {
+                    "key": "enable_mutations",
+                    "value": true
+                },
+                {
+                    "key": "lang.fetch",
+                    "value": "ANY"
+                },
+                {
+                    "key": "lang.validate",
+                    "value": "UNIQ"
+                },
+                {
+                    "key": "lang.implicit",
+                    "value": "bg"
+                },
+                {
+                    "key": "lang.defaultNameFetch",
+                    "value": "ANY"
+                },
+                {
+                    "key": "lang.appendDefaultNameFetch",
+                    "value": false
+                },
+                {
+                    "key": "queryPfx",
+                    "value": null
+                },
+                {
+                    "key": "mutationPfx",
+                    "value": null
+                },
+                {
+                    "key": "search",
+                    "value": null
+                },
+                {
+                    "key": "repository",
+                    "value": null
+                },
+                {
+                    "key": "includeInferred",
+                    "value": true
+                },
+                {
+                    "key": "expandOwlSameAs",
+                    "value": true
+                },
+                {
+                    "key": "disabledChecks",
+                    "value": []
+                },
+                {
+                    "key": "defaultRole",
+                    "value": "defaultRole"
+                },
+                {
+                    "key": "defaultIntegrationRole",
+                    "value": "Federation_SystemRole"
+                },
+                {
+                    "key": "exposeSomlInGraphQL",
+                    "value": false
+                },
+                {
+                    "key": "enableCollectionCount",
+                    "value": false
+                },
+                {
+                    "key": "enableTypeCount",
+                    "value": false
+                },
+                {
+                    "key": "compactErrorMessages",
+                    "value": false
+                },
+                {
+                    "key": "enableGraphQlExplain",
+                    "value": true
+                }
+            ]);
+        });
+
+        // Modal should close after successful save
+        EditGraphqlEndpointSteps.getDialog().should('not.exist');
+        ApplicationSteps.getSuccessNotifications().should('be.visible');
+    });
+
+    it('should show an error message if saving configuration fails', () => {
+        // Force the stub for save configuration to fail
+        GraphqlStubs.stubSaveEndpointConfiguration(repositoryId, 'swapi', 1000, true);
+
+        // Open the modal
+        GraphqlEndpointManagementSteps.editEndpointConfiguration(0);
+        EditGraphqlEndpointSteps.getDialog().should('be.visible');
+
+        // Fill in a field to allow form submission
+        EditGraphqlEndpointSteps.fillInputField(0, 'ANY');
+
+        // Submit the form
+        EditGraphqlEndpointSteps.clickOKButton();
+        EditGraphqlEndpointSteps.getSavingLoader().should('be.visible');
+
+        // I see a toast error
+        ApplicationSteps.getErrorNotifications().should('be.visible');
+
+        // The modal remains open after failure
+        EditGraphqlEndpointSteps.getSavingLoader().should('not.exist');
+        EditGraphqlEndpointSteps.getDialog().should('be.visible');
+    });
+
+    it.only('should close the modal when cancel is clicked', () => {
+        GraphqlEndpointManagementSteps.editEndpointConfiguration(0);
+        EditGraphqlEndpointSteps.getDialog().should('be.visible');
+
+        // Click cancel
+        EditGraphqlEndpointSteps.cancel();
+
+        // Verify that the modal is dismissed
+        EditGraphqlEndpointSteps.getDialog().should('not.exist');
+    });
+});

--- a/test-cypress/steps/graphql/edit-graphql-endpoint-steps.js
+++ b/test-cypress/steps/graphql/edit-graphql-endpoint-steps.js
@@ -1,0 +1,90 @@
+import {ModalDialogSteps} from "../modal-dialog-steps";
+
+export class EditGraphqlEndpointSteps extends ModalDialogSteps {
+    static getModalTitle() {
+        return this.getDialog().find('.modal-title');
+    }
+
+    static getDynamicForm() {
+        return this.getDialog().find('dynamic-form');
+    }
+
+    static getFormFields() {
+        return this.getDynamicForm().find('.form-field');
+    }
+
+    static getInputField(index) {
+        return this.getFormFields().find('.input-field input').eq(index);
+    }
+
+    static getBooleanField(index) {
+        return this.getFormFields().find('.boolean-field input').eq(index);
+    }
+
+    static getSelectField(index) {
+        return this.getFormFields().find('.select-field select').eq(index);
+    }
+
+    static getMultiSelectField(index) {
+        return this.getFormFields().find('.multiselect-field multiselect-dropdown').eq(index);
+    }
+
+    static toggleMultiSelectOption(index, optionLabel) {
+        this.getMultiSelectField(index)
+            .within(() => {
+                cy.get('button.dropdown-toggle').click();
+                cy.get('ul.dropdown-menu li')
+                    .contains(optionLabel)
+                    .click();
+            });
+    }
+
+    static verifyMultiSelectOptionSelected(index, optionLabel) {
+        this.getModalTitle().click();
+        this.getMultiSelectField(index)
+            .within(() => {
+                cy.get('button.dropdown-toggle')
+                    .should('contain.text', optionLabel);
+            });
+    }
+
+    static getJsonField(index) {
+        return this.getFormFields().find('.json-field textarea').eq(index);
+    }
+
+    static clearJsonField(index) {
+        return this.getJsonField(index).clear();
+    }
+
+    static setJsonField(index, value) {
+        return this.clearJsonField(index).type(value, {parseSpecialCharSequences:false});
+    }
+
+    static fillInputField(index, value) {
+        return this.getInputField(index).clear().type(value);
+    }
+
+    static checkBooleanField(index) {
+        return this.getBooleanField(index).check();
+    }
+
+    static uncheckBooleanField(index) {
+        return this.getBooleanField(index).uncheck();
+    }
+
+    static toggleBooleanField(index) {
+        return this.getBooleanField(index).click();
+    }
+
+    static selectOption(index, option) {
+        this.getSelectField(index).select(option);
+    }
+
+    static getLoader() {
+        return this.getDialog().find('.graphql-endpoint-configuration-loader')
+    }
+
+    static getSavingLoader() {
+        return this.getDialog().find('.saving-endpoint-settings')
+    }
+}

--- a/test-cypress/steps/graphql/graphql-endpoint-management-steps.js
+++ b/test-cypress/steps/graphql/graphql-endpoint-management-steps.js
@@ -81,4 +81,21 @@ export class GraphqlEndpointManagementSteps {
             this.toggleEndpointRow(index);
         });
     }
+
+    static getEndpointInfo(index) {
+        return this.getEndpointsInfo().eq(index);
+    }
+
+    static getEndpointActionsButton(index) {
+        return this.getEndpointInfo(index).realHover().find('.open-endpoint-actions-btn');
+    }
+
+    static openEndpointActionMenu(index) {
+        return this.getEndpointActionsButton(index).click();
+    }
+
+    static editEndpointConfiguration(index) {
+        this.openEndpointActionMenu(index);
+        return cy.get('.configure-endpoint-btn').eq(index).click();
+    }
 }

--- a/test-cypress/steps/modal-dialog-steps.js
+++ b/test-cypress/steps/modal-dialog-steps.js
@@ -39,8 +39,12 @@ export class ModalDialogSteps {
         ModalDialogSteps.getConfirmButton().click();
     }
 
+    static getOKButton() {
+        return ModalDialogSteps.getDialogFooter().find('.btn-primary');
+    }
+
     static clickOKButton() {
-        ModalDialogSteps.getDialogFooter().find('.btn-primary').click();
+        ModalDialogSteps.getOKButton().click();
     }
 
     static confirm() {

--- a/test-cypress/stubs/graphql/graphql-stubs.js
+++ b/test-cypress/stubs/graphql/graphql-stubs.js
@@ -57,6 +57,23 @@ export class GraphqlStubs {
             });
         }).as('rickmorty');
     }
+
+    static stubGetEndpointConfiguration(repositoryId, endpoint, fixture = 'graphql-endpoint-configuration.json',  delay = 0) {
+        console.log(endpoint)
+        console.log(`/rest/repositories/${repositoryId}/manage/graphql/${endpoint}/config`)
+        cy.intercept('GET', `/rest/repositories/${repositoryId}/manage/graphql/${endpoint}/config`, {
+            fixture: `/graphql/endpoints/${fixture}`,
+            statusCode: 200,
+            delay: delay
+        }).as('get-endpoint-configuration');
+    }
+
+    static stubSaveEndpointConfiguration(repositoryId, endpoint,  delay = 0, shouldFail = false) {
+        cy.intercept('PUT', `/rest/repositories//${repositoryId}/manage/graphql/${endpoint}/config`, {
+            statusCode: shouldFail ? 400 : 200,
+            delay: delay
+        }).as('save-endpoint-configuration');
+    }
 }
 
 const defaultHeaders = {


### PR DESCRIPTION
## WHAT:
- Added a new modal dialog for configuring GraphQL endpoints via a dynamic form.
- Updated the dynamic form directive to expose its form controller (formCtrl) for parent-level state checks.
- Introduced new REST service methods (getGraphqlEndpointConfiguration and saveEndpointConfiguration) to fetch and save endpoint configurations.
- Added a dedicated controller (GraphqlEndpointConfigurationModalController) and its template to manage the modal’s behavior, including cancel and save actions
- Updated i18n files to include modal titles and messages in both English and French.
- Extended Cypress stubs and tests

## WHY:
- To enable re-configuration of each GraphQL endpoint from the endpoints management view
- To integrate the new configuration flow into the existing GraphQL endpoint management workflow

## HOW:
- Dynamic Form Directive: Modified the directive to expose formCtrl via a two-way binding
- REST Service: Added new methods in graphql.rest.service.js for fetching and saving endpoint configurations
- Modal Implementation: Created a new controller (GraphqlEndpointConfigurationModalController) and modal template to manage configuration dialogs, including logic for loading configuration data, handling save and cancel actions, and displaying success/error notifications via toastr.
- Styling & UX: Updated CSS to add an inactive state to the modal during save operations
- Testing: Enhanced Cypress stubs and integration tests to cover various scenarios (field editing, toggling, form submission, error handling)

## Screenshots
![image](https://github.com/user-attachments/assets/53ef0f7d-1a5e-40b0-b671-b593ffca2294)


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [X] Tests
