### PR TITLE
GDB-11670 fix object property when predicate search query is built

### DIFF
--- a/src/js/angular/similarity/controllers/similarity-list.controller.js
+++ b/src/js/angular/similarity/controllers/similarity-list.controller.js
@@ -433,7 +433,9 @@ function SimilarityCtrl(
 
         if (SimilaritySearchType.isSearchEntityPredicateType(searchType)) {
             termOrSubject = psiSubject;
-        } else if (SimilaritySearchType.isSearchTermType(searchType)) {
+        }
+
+        if (SimilaritySearchType.isSearchTermType(searchType)) {
             termOrSubject = literalForQuery(termOrSubject);
         } else {
             termOrSubject = iriForQuery(termOrSubject);


### PR DESCRIPTION
## What
Fix the way object property is treated when the search query is built to prevent errors. 

## Why
Seems like there was a regression which caused the object property to be always treated as a literal for predicate search.

## How
Fixed the condition which was causing the property to not be wrapped in angle brackets for predicate searches

## Testing
NA

## Screenshots
NA

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
