### PR TITLE
GDB-11676: Changing Pages Does Not Work on the Namespaces View

### DIFF
--- a/src/js/angular/namespaces/controllers.js
+++ b/src/js/angular/namespaces/controllers.js
@@ -69,7 +69,7 @@ namespaces.controller('NamespacesCtrl', ['$scope', '$http', '$repositories', 'to
                             return 0;
                         });
                         $scope.matchedElements = $scope.namespaces;
-                        changePagination();
+                        $scope.changePagination();
                     }
                     if ($scope.namespaces.length === 0) {
                         // Remove the loader ourselves
@@ -82,7 +82,7 @@ namespaces.controller('NamespacesCtrl', ['$scope', '$http', '$repositories', 'to
                 });
         };
 
-        const changePagination = function () {
+        $scope.changePagination = function () {
             if (angular.isDefined($scope.namespaces)) {
                 $scope.displayedNamespaces = $scope.namespaces.slice($scope.pageSize * ($scope.page - 1), $scope.pageSize * $scope.page);
             }

--- a/test-cypress/integration/setup/namespaces.spec.js
+++ b/test-cypress/integration/setup/namespaces.spec.js
@@ -277,4 +277,23 @@ describe('Namespaces', () => {
         NamespaceSteps.getNamespacesTable().should('not.be.visible');
         NamespaceSteps.getNoNamespacesAlert().should('be.visible');
     });
+
+    it('Should got to the second page when click on second page button', () => {
+        // Given: I visited the namespaces view, and there is more than one page.
+        NamespaceSteps.getNamespacesPageElements()
+            // First page + three-page buttons + Last page.
+            .should('have.length', 5);
+        // The table with namespaces should contain the "geoext" namespace because it is among the first 10 namespaces (the paginator is set to 10 namespaces per page).
+        NamespaceSteps.getNamespace('geoext').should('be.visible');
+        // The namespace with the prefix "omgeo" should not exist because it is the fourteenth namespace and is only visible on the second page.
+        NamespaceSteps.verifyNamespaceNotExist('omgeo');
+
+        // When I go to the second page.
+        NamespaceSteps.getNamespacePageElement(2).click()
+
+        // Then I expect the "geoext" namespace to no longer be visible, as it is part of the first 10 namespaces.
+        NamespaceSteps.verifyNamespaceNotExist('geoext');
+        // The namespace with the prefix "omgeo" should now be visible because it appears on the second page.
+        NamespaceSteps.getNamespace('omgeo').should('be.visible');
+    });
 });

--- a/test-cypress/steps/setup/namespace-steps.js
+++ b/test-cypress/steps/setup/namespace-steps.js
@@ -77,6 +77,14 @@ export class NamespaceSteps {
         return this.getNamespacesResultHeader().find('.namespaces-header-pagination .pagination');
     }
 
+    static getNamespacesPageElements() {
+        return this.getNamespacesHeaderPagination().find('li ')
+    }
+
+    static getNamespacePageElement(index) {
+        return this.getNamespacesPageElements().eq(index);
+    }
+
     static getNamespacesHeaderPaginationInfo() {
         return this.getNamespacesResultHeader().find('.showing-info-namespaces');
     }
@@ -121,6 +129,15 @@ export class NamespaceSteps {
             .should('be.visible')
             .parentsUntil('tbody')
             .last();
+    }
+
+    static verifyNamespaceNotExist(prefix) {
+        return this.getNamespacesTable().find('.namespace')
+            .should('be.visible')
+            .find('.namespace-prefix')
+            .should('be.visible')
+            .contains(prefix)
+            .should('not.exist');
     }
 
     static getSelectNamespaceCheckbox(prefix) {


### PR DESCRIPTION
## What
The pagination in the "Namespaces" view is not working.

## Why
With the changes made for [MR for GDB-11134](https://github.com/Ontotext-AD/graphdb-workbench/pull/1661), the changePagination function was accidentally removed from $scope. This caused the issue because the paginator relies on this function to navigate to the next page.

## How
Reintroduced the changePagination function as a $scope function.

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
