### PR TITLE
GDB-11563 set endpoint default state

### DIFF
--- a/src/css/graphql/graphql-endpoint-management.css
+++ b/src/css/graphql/graphql-endpoint-management.css
@@ -6,6 +6,10 @@
     justify-content: space-between;
 }
 
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table {
+    position: relative;
+}
+
 .graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .toggle {
     /* fixed width to prevent expanding and shrinking of the first column when a row is expanded/collapsed  */
     width: 40px;
@@ -32,6 +36,35 @@
 }
 
 .graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .row-overlay:after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.2);
+    z-index: 1;
+}
+
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .overlay-row {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+}
+
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .overlay-row td {
+    padding: 0;
+    border: none;
+}
+
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .body-overlay:after {
     content: "";
     position: absolute;
     top: 0;

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -796,6 +796,9 @@
                     "view_report": {
                         "label": "[View report]",
                         "tooltip": "Opens the report in a modal dialog"
+                    },
+                    "set_as_default": {
+                        "success": "Successfully set \"{{endpointId}}\" endpoint as default"
                     }
                 },
                 "messages": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -796,6 +796,9 @@
                     "view_report": {
                         "label": "[Voir le rapport]",
                         "tooltip": "Ouvre le rapport dans une boîte de dialogue modale"
+                    },
+                    "set_as_default": {
+                        "success": "Le point de terminaison \"{{endpointId}}\" a été défini avec succès comme point de terminaison par défaut"
                     }
                 },
                 "messages": {

--- a/src/js/angular/core/services/graphql.service.js
+++ b/src/js/angular/core/services/graphql.service.js
@@ -86,7 +86,7 @@ function GraphqlService(GraphqlRestService) {
      */
     const getEndpointsInfo = (repositoryId) => {
         return GraphqlRestService.getEndpointsInfo(repositoryId)
-            .then((response) => endpointsInfoListMapper(response.data));
+            .then((response) => endpointsInfoListMapper(response.data, repositoryId));
     };
 
     /**
@@ -167,14 +167,15 @@ function GraphqlService(GraphqlRestService) {
     };
 
     /**
-     * Save the GraphQL endpoint configuration settings.
+     * Save the GraphQL endpoint configuration. All of UpdateEndpointRequest properties are optional, so this method
+     * can be used to update any of them. The request object should contain only the properties that need to be updated.
      * @param {string} repositoryId - The repository id.
      * @param {string} endpointId - The endpoint id.
-     * @param {UpdateEndpointRequest} updateEndpointRequest - The endpoint update request.
+     * @param {PartialUpdateEndpointRequest} updateEndpointRequest - The endpoint update request.
      * @returns {Promise<unknown> | *}
      */
     const editEndpointConfiguration = (repositoryId, endpointId, updateEndpointRequest) => {
-        return GraphqlRestService.editEndpointConfiguration(repositoryId, endpointId, updateEndpointRequest.toJSON());
+        return GraphqlRestService.editEndpointConfiguration(repositoryId, endpointId, updateEndpointRequest);
     };
 
     /**
@@ -185,6 +186,16 @@ function GraphqlService(GraphqlRestService) {
      */
     const deleteEndpoint = (repositoryId, endpointId) => {
         return GraphqlRestService.deleteEndpoint(repositoryId, endpointId);
+    };
+
+    /**
+     * Makes the provided graphql endpoint the default one for the given repository.
+     * @param {string} repositoryId The id of the repository.
+     * @param {string} endpointId The id of the endpoint to be set as default.
+     * @returns {Promise<unknown>}
+     */
+    const setDefaultEndpoint = (repositoryId, endpointId) => {
+        return GraphqlRestService.setDefaultEndpoint(repositoryId, endpointId);
     };
 
     /**
@@ -225,6 +236,7 @@ function GraphqlService(GraphqlRestService) {
         editEndpointConfiguration,
         deleteEndpoint,
         generateEndpointFromGraphqlShapes,
-        generateEndpointFromOwl
+        generateEndpointFromOwl,
+        setDefaultEndpoint
     };
 }

--- a/src/js/angular/graphql/controllers/create-graphql-endpoint-view.controller.js
+++ b/src/js/angular/graphql/controllers/create-graphql-endpoint-view.controller.js
@@ -12,6 +12,7 @@ import 'angular/graphql/directives/configure-endpoint.directive';
 import 'angular/graphql/directives/generate-endpoint.directive';
 import {GraphqlEventName} from "../services/graphql-context.service";
 import {GraphqlEndpointConfiguration} from "../../models/graphql/graphql-endpoint-configuration";
+import {resolvePlaygroundUrlWithEndpoint} from "../services/endpoint-utils";
 
 const modules = [
     'graphdb.framework.core.services.graphql-service',
@@ -191,7 +192,7 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
      * @param {EndpointGenerationReport} endpointInfo The endpoint info.
      */
     const onExploreEndpointInPlayground = (endpointInfo) => {
-        const url = `${endpointUrl.PLAYGROUND}?endpointId=${endpointInfo.endpointId}`;
+        const url = resolvePlaygroundUrlWithEndpoint(endpointInfo.endpointId);
         GraphqlContextService.setSelectedEndpoint(endpointInfo);
         window.open(url, '_blank', 'noopener,noreferrer');
     }

--- a/src/js/angular/graphql/controllers/graphql-endpoint-configuration-modal.controller.js
+++ b/src/js/angular/graphql/controllers/graphql-endpoint-configuration-modal.controller.js
@@ -108,7 +108,7 @@ function GraphqlEndpointConfigurationModalController($scope, $uibModalInstance, 
     const save = () => {
         $scope.savingEndpointSettings = true;
         const updateEndpointRequest = $scope.endpointConfiguration.toUpdateEndpointRequest($scope.endpointConfigurationSettings);
-        GraphqlService.editEndpointConfiguration($scope.repositoryId, $scope.endpointConfiguration.endpointId, updateEndpointRequest)
+        GraphqlService.editEndpointConfiguration($scope.repositoryId, $scope.endpointConfiguration.endpointId, updateEndpointRequest.getUpdateEndpointSettingsRequest())
             .then(() => {
                 $uibModalInstance.close();
                 toastr.success($translate.instant('graphql.endpoints_management.endpoint_configuration_modal.messages.success_saving_configuration'));

--- a/src/js/angular/graphql/models/endpoints.js
+++ b/src/js/angular/graphql/models/endpoints.js
@@ -1,5 +1,3 @@
-import {REPOSITORIES_ENDPOINT} from "../../rest/repositories.rest.service";
-
 /**
  * Constants for the view URLs.
  * @type {{[string]: string}}
@@ -8,14 +6,4 @@ export const endpointUrl = {
     PLAYGROUND: '/graphql/playground',
     CREATE_ENDPOINT: '/graphql/endpoint/create',
     ENDPOINT_MANAGEMENT: '/graphql/endpoints'
-}
-
-/**
- * Utility function to resolve the GraphQL endpoint URL based on the active repository and the actual graphql endpoint IDs.
- * @param {string} repositoryId The active repository ID.
- * @param {string} graphqlEndpointId The GraphQL endpoint ID.
- * @returns {`rest/repositories/${string}/graphql/${string}`}
- */
-export const resolveGraphqlEndpoint = (repositoryId, graphqlEndpointId) => {
-    return `${REPOSITORIES_ENDPOINT}/${repositoryId}/graphql/${graphqlEndpointId}`;
-}
+};

--- a/src/js/angular/graphql/services/endpoint-generation-report.mapper.js
+++ b/src/js/angular/graphql/services/endpoint-generation-report.mapper.js
@@ -1,5 +1,5 @@
 import {EndpointGenerationReport, EndpointGenerationReportList} from "../../models/graphql/endpoint-generation-report";
-import {resolveGraphqlEndpoint} from "../models/endpoints";
+import {resolveGraphqlEndpoint} from "./endpoint-utils";
 
 /**
  * Maps the response from the endpoint generation to a list of endpoint generation reports.

--- a/src/js/angular/graphql/services/endpoint-info-list.mapper.js
+++ b/src/js/angular/graphql/services/endpoint-info-list.mapper.js
@@ -1,5 +1,5 @@
 import {GraphqlEndpointInfo, GraphqlEndpointsInfoList} from "../../models/graphql/graphql-endpoints-info";
-import {resolveGraphqlEndpoint} from "../models/endpoints";
+import {resolveGraphqlEndpoint} from "./endpoint-utils";
 
 /**
  * Maps the response from the server to a GraphqlEndpointsInfoList model.

--- a/src/js/angular/graphql/services/endpoint-utils.js
+++ b/src/js/angular/graphql/services/endpoint-utils.js
@@ -1,0 +1,21 @@
+import {endpointUrl} from "../models/endpoints";
+import {REPOSITORIES_ENDPOINT} from "../../rest/repositories.rest.service";
+
+/**
+ * Utility function to resolve the GraphQL endpoint URL based on the active repository and the actual graphql endpoint IDs.
+ * @param {string} repositoryId The active repository ID.
+ * @param {string} graphqlEndpointId The GraphQL endpoint ID.
+ * @returns {`rest/repositories/${string}/graphql/${string}`}
+ */
+export const resolveGraphqlEndpoint = (repositoryId, graphqlEndpointId) => {
+    return `${REPOSITORIES_ENDPOINT}/${repositoryId}/graphql/${graphqlEndpointId}`;
+}
+
+/**
+ * Resolves the playground URL with the given endpoint ID as a query parameter.
+ * @param {string} endpointId - The endpoint ID.
+ * @returns {`/graphql/playground?endpointId=${string}`}
+ */
+export const resolvePlaygroundUrlWithEndpoint = (endpointId) => {
+    return `${endpointUrl.PLAYGROUND}?endpointId=${endpointId}`;
+}

--- a/src/js/angular/graphql/services/endpoints.mapper.js
+++ b/src/js/angular/graphql/services/endpoints.mapper.js
@@ -1,6 +1,6 @@
 import {GraphqlEndpoint, GraphqlEndpointList} from "../../models/graphql/graphql-endpoints";
 import {SelectMenuOptionsModel} from "../../models/form-fields";
-import {resolveGraphqlEndpoint} from "../models/endpoints";
+import {resolveGraphqlEndpoint} from "./endpoint-utils";
 
 /**
  * Maps the response from the server to a GraphqlEndpointList model.
@@ -48,7 +48,8 @@ export const endpointsToSelectMenuOptionsMapper = (data, repositoryId) => {
             label: endpoint.id,
             selected: endpoint.default,
             data: {
-                active: endpoint.active
+                active: endpoint.active,
+                default: endpoint.default
             }
         });
     });

--- a/src/js/angular/graphql/templates/graphql-endpoint-management.html
+++ b/src/js/angular/graphql/templates/graphql-endpoint-management.html
@@ -71,9 +71,15 @@
                 </th>
             </tr>
             </thead>
+
+            <tr ng-if="operationInProgress" class="overlay-row">
+                <td colspan="9">
+                    <div class="endpoint-operation-progress" onto-loader-fancy size="100" hide-message="true"></div>
+                </td>
+            </tr>
+
             <tbody>
-            <tr ng-repeat-start="endpoint in endpointsInfoList.endpoints track by endpoint.endpointId"
-                ng-class="{'row-overlay': deletingEndpoint}">
+            <tr ng-repeat-start="endpoint in endpointsInfoList.endpoints track by endpoint.endpointId">
                 <td class="toggle-row">
                     <a href="#" ng-click="toggleRow($event, $index)">
                         <i class="fa fa-chevron-right" ng-if="expandedRow !== $index"></i>
@@ -95,8 +101,10 @@
                 </td>
                 <td>{{endpoint.label}}</td>
                 <td>
-                    <span ng-if="endpoint.default" class="is-default">yes</span>
-                    <span ng-if="!endpoint.default" class="is-not-default">no</span>
+                    <label class="endpoint-default-state">
+                        <input type="radio" ng-model="selectedDefaultEndpoint.default" ng-value="endpoint.default"
+                               ng-change="setEndpointAsDefault(endpoint)"/>
+                    </label>
                 </td>
                 <td>
                     <span ng-if="endpoint.active" class="is-active">yes</span>
@@ -106,7 +114,7 @@
                 <td>{{endpoint.objectsCount}}</td>
                 <td>{{endpoint.propertiesCount}}</td>
                 <td>
-                    <div ng-if="!deletingEndpoint" class="btn-group">
+                    <div class="btn-group">
                         <button class="btn btn-link secondary btn-sm open-endpoint-actions-btn"
                                 data-toggle="dropdown" aria-expanded="false"
                                 ng-if="true"
@@ -132,8 +140,6 @@
                             </button>
                         </div>
                     </div>
-                    <div class="endpoint-operation-progress" ng-if="deletingEndpoint" onto-loader-fancy size="25"
-                         hide-message="true"></div>
                 </td>
             </tr>
             <tr ng-repeat-end ng-if="expandedRow === $index" class="endpoint-description-row">

--- a/src/js/angular/models/graphql/graphql-endpoints-info.js
+++ b/src/js/angular/models/graphql/graphql-endpoints-info.js
@@ -216,6 +216,14 @@ export class GraphqlEndpointsInfoList {
             });
     }
 
+    /**
+     * Finds the default endpoint.
+     * @returns {GraphqlEndpointInfo|undefined} - The default endpoint if any.
+     */
+    findDefaultEndpoint() {
+        return this._endpoints.find((endpoint) => endpoint.default);
+    }
+
     get endpoints() {
         return this._endpoints;
     }

--- a/src/js/angular/models/graphql/update-endpoint-request.js
+++ b/src/js/angular/models/graphql/update-endpoint-request.js
@@ -1,3 +1,16 @@
+/**
+ * @typedef {Object} PartialUpdateEndpointRequest
+ * @property {string} [id]
+ * @property {string} [label]
+ * @property {string} [description]
+ * @property {boolean} [active]
+ * @property {boolean} [default]
+ * @property {GraphqlEndpointConfigurationSettings} [options]
+ */
+
+/**
+ * A class representing the update endpoint request.
+ */
 export class UpdateEndpointRequest {
     /**
      * @type {string}
@@ -31,22 +44,23 @@ export class UpdateEndpointRequest {
     _options
 
     constructor(data) {
-        this._id = data.id || '';
-        this._label = data.label || '';
-        this._description = data.description || '';
-        this._active = data.active || false;
-        this._default = data.default || false;
+        this._id = data.id;
+        this._label = data.label;
+        this._description = data.description;
+        this._active = data.active;
+        this._default = data.default;
         this._options = data.options;
     }
 
-    toJSON() {
+    getUpdateDefaultEndpointRequest() {
         return {
-            id: this.id,
-            label: this.label,
-            description: this.description,
-            active: this.active,
-            default: this.default,
-            options: this.options.toFlatJSON()
+            default: this.default
+        };
+    }
+
+    getUpdateEndpointSettingsRequest() {
+        return {
+            options: this.options ? this.options.toFlatJSON() : null
         };
     }
 

--- a/src/js/angular/rest/graphql.rest.service.js
+++ b/src/js/angular/rest/graphql.rest.service.js
@@ -177,6 +177,19 @@ function GraphqlRestService($http) {
         // });
     };
 
+    /**
+     * Makes the provided GraphQL endpoint the default one for the given repository.
+     * @param {string} repositoryId The ID of the repository.
+     * @param {string} endpointId The ID of the endpoint to be set as default.
+     * @returns {Promise<unknown>} The response from the backend.
+     */
+    const setDefaultEndpoint = (repositoryId, endpointId) => {
+        if (DEVELOPMENT) {
+            return _mockBackend.setDefaultEndpointMock();
+        }
+        return $http.post(`${REPOSITORIES_ENDPOINT}/${repositoryId}/manage/graphql/${endpointId}/default`);
+    }
+
     return {
         getEndpoints,
         getEndpointsInfo,
@@ -189,7 +202,8 @@ function GraphqlRestService($http) {
         editEndpointConfiguration,
         deleteEndpoint,
         generateEndpointFromGraphqlShapes,
-        generateEndpointFromOwl
+        generateEndpointFromOwl,
+        setDefaultEndpoint
     };
 }
 

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -787,6 +787,9 @@
                     "export_schema": {
                         "label": "Export schema definition",
                         "tooltip": "Export the GraphQL endpoint schema definition"
+                    },
+                    "set_as_default": {
+                        "success": "Successfully set \"{{endpointId}}\" endpoint as default"
                     }
                 },
                 "messages": {
@@ -795,6 +798,13 @@
                 },
                 "labels": {
                     "description": "Description"
+                }
+            },
+            "endpoint_configuration_modal": {
+                "title": "Configure GraphQL endpoint",
+                "messages": {
+                    "error_saving_configuration": "Error saving endpoint configuration",
+                    "success_saving_configuration": "Endpoint configuration saved"
                 }
             }
         },
@@ -806,7 +816,7 @@
                 }
             },
             "wizard_steps": {
-                "select_schema_source": {
+                "select_schema_sources": {
                     "title": "Select schema source",
                     "source_type": {
                         "graphql_schema_shapes": {
@@ -819,7 +829,8 @@
                     "graphql_schema_shapes": {
                         "title": "GraphQL schema shapes",
                         "messages": {
-                            "no_schemas": "No GraphQL schema shapes were found in the selected repository. You can choose or browse other repositories or choose the other source.",
+                            "loading_graphql_shapes": "Loading GraphQL schema shapes...",
+                            "no_schemas": "No GraphQL schema shapes were found in the selected repository. You can browse other repositories or change the source.",
                             "endpoint_per_shape": "Each GraphQL schema shape results in one endpoint"
                         }
                     },
@@ -846,17 +857,22 @@
                             "use_all_graphs": {
                                 "label": "Use all graphs",
                                 "messages": {
-                                    "all_graphs": "All {{count}} graphs are included for endpoint creation"
+                                    "all_graphs": "All {{count}} graphs are included for endpoint creation",
+                                    "no_graphs": "No graphs were found in the selected repository."
                                 }
                             },
                             "use_shacl_shape_graph": {
                                 "label": "Use SHACL shape graph",
                                 "messages": {
-                                    "all_shacl_shape_graphs": "All {{count}} SHACL shape graphs are included for endpoint creation"
+                                    "all_shacl_shape_graphs": "All {{count}} SHACL shape graphs are included for endpoint creation",
+                                    "no_graphs": "No SHACL shape graphs were found in the selected repository."
                                 }
                             },
                             "pick_graphs": {
-                                "label": "Select one or more graphs"
+                                "label": "Select one or more graphs",
+                                "messages": {
+                                    "no_graphs": "No graphs were found in the selected repository."
+                                }
                             }
                         },
                         "messages": {
@@ -869,6 +885,58 @@
                     "endpoint_parameters": {
                         "title": "Parameters",
                         "form": {}
+                    }
+                },
+                "shapes_multiselect": {
+                    "available_options": {
+                        "title": "Available (not included)",
+                        "filter_placeholder": "Filter to select specific shapes"
+                    },
+                    "selected_options": {
+                        "title": "Included for generation",
+                        "count": "{{count}} GraphQL schema shapes included"
+                    },
+                    "actions": {
+                        "add": {
+                            "tooltip": "Add the shape to the list of included shapes"
+                        },
+                        "add_all": {
+                            "label": "Add all",
+                            "tooltip": "Add all shapes to the list of included shapes"
+                        },
+                        "remove": {
+                            "tooltip": "Remove the shape from the list of included shapes"
+                        },
+                        "remove_all": {
+                            "label": "Remove all",
+                            "tooltip": "Remove all shapes from the list of included shapes"
+                        }
+                    }
+                },
+                "graphs_multiselect": {
+                    "available_options": {
+                        "title": "Available (not included)",
+                        "filter_placeholder": "Filter to select specific graphs"
+                    },
+                    "selected_options": {
+                        "title": "Included for generation",
+                        "count": "{{count}} SHACL shape graphs are included"
+                    },
+                    "actions": {
+                        "add": {
+                            "tooltip": "Add the graph to the list of included graphs"
+                        },
+                        "add_all": {
+                            "label": "Add all",
+                            "tooltip": "Add all graphs to the list of included graphs"
+                        },
+                        "remove": {
+                            "tooltip": "Remove the graph from the list of included graphs"
+                        },
+                        "remove_all": {
+                            "label": "Remove all",
+                            "tooltip": "Remove all graphs from the list of included graphs"
+                        }
                     }
                 },
                 "actions": {
@@ -889,6 +957,12 @@
                     "generate_endpoint": {
                         "label": "Generate"
                     }
+                }
+            },
+            "messages": {
+                "source_repository_changed": {
+                    "title": "Confirm source repository change",
+                    "body": "Changing the source repository may affect your current setup and data. Are you sure you want to proceed?"
                 }
             }
         }
@@ -2064,6 +2138,7 @@
     "common.error": "Error",
     "common.warning": "Warning",
     "common.loading": "Loading...",
+    "common.select": "Select...",
     "common.on.btn": "ON",
     "common.off.btn": "OFF",
     "common.search.btn": "Search",

--- a/test-cypress/integration/graphql/edit-graphql-enpoint.spec.js
+++ b/test-cypress/integration/graphql/edit-graphql-enpoint.spec.js
@@ -68,11 +68,6 @@ describe('Graphql: edit endpoint settings', () => {
         EditGraphqlEndpointSteps.getSavingLoader().should('be.visible');
         cy.wait('@save-endpoint-configuration').then((interception) => {
             expect(interception.request.body).to.deep.equal({
-                "id": "swapi",
-                "label": "Ontotext Star Wars Ontology",
-                "description": "",
-                "active": true,
-                "default": true,
                 "options": {
                     "enableTypeCount": true,
                     "enableCollectionCount": false,

--- a/test-cypress/integration/graphql/graphql-set-default-endpoint.spec.js
+++ b/test-cypress/integration/graphql/graphql-set-default-endpoint.spec.js
@@ -1,0 +1,42 @@
+import {GraphqlEndpointManagementSteps} from "../../steps/graphql/graphql-endpoint-management-steps";
+import {ApplicationSteps} from "../../steps/application-steps";
+import {GraphqlPlaygroundSteps} from "../../steps/graphql/graphql-playground-steps";
+
+describe('Graphql: set default endpoint', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'graphql-endpoint-management-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        cy.importServerFile(repositoryId, 'swapi-dataset.ttl');
+        cy.uploadGraphqlSchema(repositoryId, 'graphql/soml/swapi-schema.yaml', 'swapi');
+        cy.uploadGraphqlSchema(repositoryId, 'graphql/soml/swapi-schema-film-restricted.yaml', 'swapi');
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('should be able to change the default endpoint', () => {
+        // Given I have a repository with active GraphQL endpoint
+        // And I have visited the endpoint management view
+        GraphqlEndpointManagementSteps.visit();
+        GraphqlEndpointManagementSteps.getView().should('be.visible');
+        GraphqlEndpointManagementSteps.getEndpointsInfo().should('have.length', 2);
+        // And there is a default endpoint
+        GraphqlEndpointManagementSteps.getEndpointDefaultStatusRadio(0).should('be.checked');
+        // When I click on the second endpoint to set it as default
+        GraphqlEndpointManagementSteps.setEndpointAsDefault(1);
+        // Then I should see a success toast
+        ApplicationSteps.getSuccessNotifications().should('be.visible');
+        // And the default endpoint should be changed
+        GraphqlEndpointManagementSteps.getEndpointDefaultStatusRadio(1).should('be.checked');
+        GraphqlEndpointManagementSteps.getEndpointDefaultStatusRadio(0).should('not.be.checked');
+        // When I open the GraphQL Playground
+        GraphqlEndpointManagementSteps.exploreEndpoint(1);
+        // Then the default endpoint should be selected by default in the playground
+        GraphqlPlaygroundSteps.getView().should('be.visible');
+        GraphqlPlaygroundSteps.getSelectedEndpoint().should('contain', 'film-restricted');
+    });
+});

--- a/test-cypress/steps/graphql/graphql-endpoint-management-steps.js
+++ b/test-cypress/steps/graphql/graphql-endpoint-management-steps.js
@@ -81,7 +81,8 @@ export class GraphqlEndpointManagementSteps {
             cy.wrap($row).within(() => {
                 cy.get('td').eq(1).should('contain', endpointInfo.id);
                 cy.get('td').eq(2).should('contain', endpointInfo.label);
-                cy.get('td').eq(3).should('contain', endpointInfo.default ? 'yes' : 'no');
+                const isDefaultCheck = endpointInfo.default ? 'be.checked' : 'not.be.checked'
+                cy.get('td').eq(3).find('.endpoint-default-state input[type="radio"]').should(isDefaultCheck);
                 cy.get('td').eq(4).should('contain', endpointInfo.active ? 'yes' : 'no');
                 cy.get('td').eq(5).should('contain', endpointInfo.modified);
                 cy.get('td').eq(6).should('contain', endpointInfo.types);
@@ -110,5 +111,13 @@ export class GraphqlEndpointManagementSteps {
     static editEndpointConfiguration(index) {
         this.openEndpointActionMenu(index);
         return cy.get('.configure-endpoint-btn').eq(index).click();
+    }
+
+    static getEndpointDefaultStatusRadio(index) {
+        return this.getEndpointInfo(index).find('.endpoint-default-state input[type="radio"]');
+    }
+
+    static setEndpointAsDefault(index) {
+        this.getEndpointDefaultStatusRadio(index).check();
     }
 }


### PR DESCRIPTION
## What
Allow changing which is the default graphql endpoint. There can be only one default endpoint.

## Why
This allows the user to switch which is the default endpoint from the UI.

## How
Implemented operation handler in the controller and a UI control for the user to interact with.

## Testing
Implemented tests.

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
