### PR TITLE
GDB-11239: Internationalize the ontotext-graphql-playground Component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-graphql-playground-component": "^0.0.6",
+                "ontotext-graphql-playground-component": "^0.0.7",
                 "ontotext-yasgui-web-component": "1.3.20",
                 "shepherd.js": "^11.2.0"
             },
@@ -11946,10 +11946,9 @@
             }
         },
         "node_modules/ontotext-graphql-playground-component": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/ontotext-graphql-playground-component/-/ontotext-graphql-playground-component-0.0.6.tgz",
-            "integrity": "sha512-SdEsMmZjJWiC9obysQi14HpG5jJDJflsSIIKuWMh/+hNbbmFQQp9yg6c8+HQMYu809XOqjEgksiTsc5uFpbBFQ==",
-            "license": "MIT",
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/ontotext-graphql-playground-component/-/ontotext-graphql-playground-component-0.0.7.tgz",
+            "integrity": "sha512-kGbd8Ebfa4cstnrb3Go4o6YOu4uytwE61iTlzN+HZW+4mhjwA/7JTryDqhLEYbfiGNFyi9gW3mrcDF9p82BEeQ==",
             "dependencies": {
                 "graphql": "^16.9.0"
             }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-graphql-playground-component": "^0.0.6",
+        "ontotext-graphql-playground-component": "^0.0.7",
         "ontotext-yasgui-web-component": "1.3.20",
         "shepherd.js": "^11.2.0"
     },

--- a/src/css/graphql/graphql-playground.css
+++ b/src/css/graphql/graphql-playground.css
@@ -182,3 +182,8 @@ graphql-playground {
     border-radius: 0;
     color: var(--base-text-color);
 }
+
+.graphiql-dialog,
+.graphiql-dialog-overlay {
+    z-index: 1010;
+}

--- a/src/js/angular/core/directives/graphql-playground/graphql-playground-directive.util.js
+++ b/src/js/angular/core/directives/graphql-playground/graphql-playground-directive.util.js
@@ -1,0 +1,61 @@
+export class GraphqlPlaygroundDirectiveUtil {
+
+    /**
+     * Fetches GraphQL playground directive controller.
+     *
+     * @param {string} directiveSelector - the unique selector of the graphql playground directive component directive.
+     *
+     */
+    static getGraphqlPlaygroundDirectiveController(directiveSelector) {
+        const elementById = angular.element(document.querySelector(directiveSelector));
+        const directiveElement = angular.element(elementById);
+        return directiveElement.isolateScope();
+    }
+
+    /**
+     * Fetches GraphQL playground component.
+     *
+     * @param {string} directiveSelector - the unique selector of the graphql playground directive component directive.
+     *
+     * @return {GraphQLPlaygroundComponent}
+     */
+    static getGraphqlPlaygroundComponent = (directiveSelector) => {
+        const graphQLPlaygroundController = GraphqlPlaygroundDirectiveUtil.getGraphqlPlaygroundDirectiveController(directiveSelector);
+        if (graphQLPlaygroundController) {
+            return graphQLPlaygroundController.getGraphQLPlaygroundComponent();
+        }
+    };
+
+    /**
+     * Fetches GraphQL playground component.
+     *
+     * @param {string} directiveSelector - the unique selector of the graphql playground directive component directive.
+     *
+     * @param {number} timeoutInSeconds - how many times to looking for the directive.
+     * @return {Promise<GraphQLPlaygroundComponent>}
+     */
+    static getGraphqlPlaygroundComponentAsync = (directiveSelector, timeoutInSeconds = 1) => {
+        return new Promise((resolve, reject) => {
+            let graphqlPlaygroundComponent = GraphqlPlaygroundDirectiveUtil.getGraphqlPlaygroundComponent(directiveSelector);
+            if (graphqlPlaygroundComponent) {
+                resolve(graphqlPlaygroundComponent);
+            }
+            let iteration = timeoutInSeconds * 1000 | 1000;
+            const waitTime = 100;
+            const interval = setInterval(() => {
+                graphqlPlaygroundComponent = GraphqlPlaygroundDirectiveUtil.getGraphqlPlaygroundComponent(directiveSelector);
+                if (graphqlPlaygroundComponent) {
+                    clearInterval(interval);
+                    resolve(graphqlPlaygroundComponent);
+                } else {
+                    iteration -= waitTime;
+                    if (iteration < 0) {
+                        clearInterval(interval);
+                        console.log('GraphQL Playground component is not found', directiveSelector);
+                        reject(new Error('Element is not found: ' + directiveSelector));
+                    }
+                }
+            }, waitTime);
+        });
+    };
+}

--- a/src/js/angular/core/directives/graphql-playground/graphql-playground.directive.js
+++ b/src/js/angular/core/directives/graphql-playground/graphql-playground.directive.js
@@ -1,3 +1,5 @@
+import {GraphQLPlaygroundComponent} from "../../../models/graphql/graphql-playground-component";
+
 const modules = [];
 angular
     .module('graphdb.framework.core.directives.graphql-playground', modules)
@@ -37,7 +39,23 @@ function graphqlPlaygroundDirective() {
             configuration: '='
         },
         link: ($scope, element, attrs) => {
-            // not implemented
+            // =========================
+            // Public function
+            // =========================
+            /**
+             * Getter for GraphQl playground component.
+             * @return {GraphQLPlaygroundComponent}
+             */
+            $scope.getGraphQLPlaygroundComponent = () => {
+                return new GraphQLPlaygroundComponent(getGraphQLPlaygroundElements()[0]);
+            };
+
+            // =========================
+            // Private function
+            // =========================
+            const getGraphQLPlaygroundElements = () => {
+                return element.find('graphql-playground-component');
+            };
         }
     };
 }

--- a/src/js/angular/graphql/controllers/graphql-playground-view.controller.js
+++ b/src/js/angular/graphql/controllers/graphql-playground-view.controller.js
@@ -1,6 +1,9 @@
 import {GraphqlPlaygroundConfig} from '../../models/graphql/graphql-playground-config';
 import '../../core/services/graphql.service';
 import 'angular/core/directives/graphql-playground/graphql-playground.directive';
+import {
+    GraphqlPlaygroundDirectiveUtil
+} from "../../core/directives/graphql-playground/graphql-playground-directive.util";
 
 const modules = [
     'graphdb.framework.core.services.graphql-service',
@@ -11,9 +14,9 @@ angular
     .module('graphdb.framework.graphql.controllers.graphql-playground-view', modules)
     .controller('GraphqlPlaygroundViewCtrl', GraphqlPlaygroundViewCtrl);
 
-GraphqlPlaygroundViewCtrl.$inject = ['$scope', '$repositories', 'toastr', 'GraphqlService', 'GraphqlContextService', 'AuthTokenService'];
+GraphqlPlaygroundViewCtrl.$inject = ['$scope', '$repositories', '$languageService', 'toastr', 'GraphqlService', 'GraphqlContextService', 'AuthTokenService'];
 
-function GraphqlPlaygroundViewCtrl($scope, $repositories, toastr, GraphqlService, GraphqlContextService, AuthTokenService) {
+function GraphqlPlaygroundViewCtrl($scope, $repositories, $languageService, toastr, GraphqlService, GraphqlContextService, AuthTokenService) {
 
     // =========================
     // Private variables
@@ -82,7 +85,8 @@ function GraphqlPlaygroundViewCtrl($scope, $repositories, toastr, GraphqlService
      */
     const buildConfig = (endpoint) => {
         const config = {
-            endpoint: endpoint
+            endpoint: endpoint,
+            selectedLanguage: $languageService.getLanguage()
         };
         const authToken = AuthTokenService.getAuthToken();
         if (authToken) {
@@ -165,6 +169,20 @@ function GraphqlPlaygroundViewCtrl($scope, $repositories, toastr, GraphqlService
     };
 
     /**
+     * Handles language change events and updates the GraphQL Playground component's language.
+     *
+     * @param {Event} event - The event triggered by the language change.
+     * @param {Object} args - The arguments containing language details.
+     * @param {string} args.locale - The new locale to be set for the GraphQL Playground.
+     */
+    const getLanguageChangeHandler = (event, args) => {
+        GraphqlPlaygroundDirectiveUtil.getGraphqlPlaygroundComponentAsync("#graphql-playground")
+            .then((graphqlPlayground) => {
+                graphqlPlayground.setLanguage(args.locale);
+            })
+    }
+
+    /**
      * Resets the scope variables. This is used to clear the view when there are no GraphQL endpoints for example
      */
     const resetScope = () => {
@@ -185,6 +203,7 @@ function GraphqlPlaygroundViewCtrl($scope, $repositories, toastr, GraphqlService
     // =========================
 
     subscriptions.push($scope.$watch($scope.getActiveRepositoryObject, getActiveRepositoryObjectHandler));
+    subscriptions.push($scope.$on('language-changed', getLanguageChangeHandler));
     $scope.$on('$destroy', unsubscribeAll);
 
     // =========================

--- a/src/js/angular/graphql/templates/graphql-playground.html
+++ b/src/js/angular/graphql/templates/graphql-playground.html
@@ -32,7 +32,7 @@
         </div>
 
         <div class="graphql-playground-container" ng-if="!loadingEndpoints && configuration && getActiveRepositoryNoError()">
-            <graphql-playground configuration="configuration"></graphql-playground>
+            <graphql-playground id="graphql-playground" configuration="configuration"></graphql-playground>
         </div>
     </div>
 </div>

--- a/src/js/angular/models/graphql/graphql-playground-component.js
+++ b/src/js/angular/models/graphql/graphql-playground-component.js
@@ -1,0 +1,23 @@
+/**
+ * Wrapper class for the GraphQL Playground component.
+ * This class provides a clearer interface for all exposed methods of the GraphQL playground component.
+ */
+export class GraphQLPlaygroundComponent {
+
+    /**
+     * Creates an instance of GraphQLPlaygroundComponent.
+     * @param graphQLPlaygroundComponent - The underlying GraphQL Playground component instance.
+     */
+    constructor(graphQLPlaygroundComponent) {
+        this.graphQLPlaygroundComponent = graphQLPlaygroundComponent;
+    }
+
+    /**
+     * Sets the language for the GraphQL Playground.
+     *
+     * @param {string} language - The language code to be set (e.g., "en", "fr").
+     */
+    setLanguage(language) {
+        this.graphQLPlaygroundComponent.setLanguage(language);
+    }
+}

--- a/src/js/angular/models/graphql/graphql-playground-config.js
+++ b/src/js/angular/models/graphql/graphql-playground-config.js
@@ -13,6 +13,13 @@ export class GraphqlPlaygroundConfig {
          * @private
          */
         this._headers = data.headers;
+
+        /**
+         * A code of selected language. For example "en".
+         * @type {string}
+         * @private
+         */
+        this._selectedLanguage = data.selectedLanguage;
     }
 
     get endpoint() {
@@ -29,5 +36,13 @@ export class GraphqlPlaygroundConfig {
 
     set headers(value) {
         this._headers = value;
+    }
+
+    get selectedLanguage() {
+        return this._selectedLanguage;
+    }
+
+    set selectedLanguage(value) {
+        this._selectedLanguage = value;
     }
 }

--- a/test-cypress/integration/graphql/graphql-playground.spec.js
+++ b/test-cypress/integration/graphql/graphql-playground.spec.js
@@ -1,5 +1,8 @@
 import {GraphqlPlaygroundSteps} from "../../steps/graphql/graphql-playground-steps";
 import {GraphqlStubs} from "../../stubs/graphql/graphql-stubs";
+import {GraphiqlPlaygroundSteps} from "../../steps/graphql/graphiql-playground-steps";
+import {GraphiQLEditorToolsSteps} from "../../steps/graphql/graphiql-editor-tools-steps";
+import {LanguageSelectorSteps} from "../../steps/language-selector-steps";
 
 describe('GraphQL Playground', () => {
     let repositoryId;
@@ -70,5 +73,20 @@ describe('GraphQL Playground', () => {
         GraphqlPlaygroundSteps.executeQuery();
         // Then I get expected result from the new endpoint
         GraphqlPlaygroundSteps.getResponse().should('contain', '"name": "Morty Smith"');
+    });
+
+    it('should be able to translate the labels', () => {
+        // Given: I have opened the workbench on the GraphQL Playground page.
+        GraphqlStubs.stubGetEndpoints(repositoryId);
+        GraphqlStubs.stubCountriesSchema();
+        GraphqlPlaygroundSteps.visit();
+        GraphiqlPlaygroundSteps.getPlayground().should('be.visible');
+        // the GraphQL is translated on english
+        GraphiQLEditorToolsSteps.getGraphiQLEditorTabButton(1).contains('Headers');
+
+        // When: I change the language.
+        LanguageSelectorSteps.changeLanguage('fr');
+        // Then: I expect to see GraphQL playground translated.
+        GraphiQLEditorToolsSteps.getGraphiQLEditorTabButton(1).contains('En-têtes');
     });
 });

--- a/test-cypress/steps/graphql/graphiql-editor-tools-steps.js
+++ b/test-cypress/steps/graphql/graphiql-editor-tools-steps.js
@@ -1,0 +1,10 @@
+export class GraphiQLEditorToolsSteps {
+  
+  static getGraphiQLEditorTools() {
+    return cy.get(".graphiql-editor-tools");
+  }
+  
+  static getGraphiQLEditorTabButton(index) {
+    return GraphiQLEditorToolsSteps.getGraphiQLEditorTools().find('button').eq(index);
+  }
+}

--- a/test-cypress/steps/graphql/graphiql-playground-steps.js
+++ b/test-cypress/steps/graphql/graphiql-playground-steps.js
@@ -1,0 +1,6 @@
+export class GraphiqlPlaygroundSteps {
+  
+  static getPlayground() {
+    return cy.get('.graphiql-query-editor');
+  }
+}


### PR DESCRIPTION
## What
Internationalized the ontotext-graphql-playground component.

## Why
The ontotext-graphql-playground component must support multiple languages.

## How
- Added a language change event listener;
- Updated the GraphQL Playground component to reflect the selected language.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
