### PR TITLE
GDB-11717: UI not responsive when trying to delete a lot of uploaded files from the imports screen

### DIFF
--- a/src/js/angular/core/controllers.js
+++ b/src/js/angular/core/controllers.js
@@ -10,11 +10,6 @@ function SimpleModalCtrl($scope, $uibModalInstance, $sce, config) {
     $scope.confirmButtonKey = config.confirmButtonKey;
     $scope.title = config.title;
     $scope.message = $sce.trustAsHtml(config.message);
-    $scope.onClick = ($event) => {
-        if (config.stopPropagation) {
-            $event.stopPropagation();
-        }
-    };
 
     $scope.ok = function () {
         $uibModalInstance.close();

--- a/src/js/angular/core/templates/modal/modal-warning.html
+++ b/src/js/angular/core/templates/modal/modal-warning.html
@@ -1,17 +1,12 @@
-<div ng-click="onClick($event)">
-    <div class="modal-header">
-        <button ng-click="cancel();" class="close" aria-hidden="true"></button>
-        <h3 class="modal-title">{{title}}</h3>
+<div class="modal-header">
+	<button ng-click="cancel();" class="close" aria-hidden="true"></button>
+    <h3 class="modal-title">{{title}}</h3>
+</div>
+<div class="modal-body">
+    <div class="lead" ng-bind-html="message">
     </div>
-    <div class="modal-body">
-        <div class="lead" ng-bind-html="message">
-        </div>
-    </div>
-    <div class="modal-footer">
-        <button type="button" class="btn btn-secondary cancel-btn" ng-click="cancel()">{{'common.cancel.btn' |
-            translate}}
-        </button>
-        <button class="btn btn-primary confirm-btn" ng-click="ok()">{{ (confirmButtonKey || 'common.yes.btn') | translate}}
-        </button>
-    </div>
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-secondary cancel-btn" ng-click="cancel()">{{'common.cancel.btn' | translate}}</button>
+    <button class="btn btn-primary confirm-btn" ng-click="ok()">{{ (confirmButtonKey || 'common.yes.btn') | translate}}</button>
 </div>

--- a/src/pages/cluster-management/clusterInfo.html
+++ b/src/pages/cluster-management/clusterInfo.html
@@ -68,6 +68,8 @@
            onopen="onopen"
            onclose="onclose"
            ps-side="right"
+           ps-click-outside="false"
+           ps-key-listener="true"
            ps-custom-height="calc(100vh - 55px)"
            ps-size="{{ clusterConfigurationPanelSize }}">
     <cluster-configuration current-node="currentNode"


### PR DESCRIPTION
## What
The dialog content overflow is broken.
 Steps to reproduce:
  - Add many files for import (20–30);
  - Select all of them;
  - Click on the "Remove" button.

## Why
The confirmation dialog in the import view uses the "modal-warning.html" template for confirmation. It is passed to the $uibModal service to open the dialog. This creates a <div> container with the class "modal-content", which has a display: flex declaration. Its children include three elements with the classes "modal-header", "modal-body", and "modal-footer". The dialog has a max-height of 90vh, and the "modal-body" has CSS rules that make it fit all available height within the dialog. If the content exceeds this height, a scrollbar should appear. Event handling is properly set up and should not cause this issue. However, [in this merge request (MR)](https://github.com/Ontotext-AD/graphdb-workbench/pull/1632), we added an additional container around these children, which broke the flex functionality.

## How
- The changes made aimed to prevent the right sidebar from closing when clicking on a dialog opened from it (for example, in the cluster view). The additional container had an onClick handler that prevented event propagation, ensuring that clicks on the dialog did not close the sidebar. However, this fix only worked when clicking inside the dialog—clicking outside still closed the sidebar. As a result, I removed this fix;
- Disabled automatic closing of the sidebar when the user clicks outside the panel;
- Added the ability to close the sidebar by pressing "Esc".

## Testing
N/A

## Screenshots
broken
![image](https://github.com/user-attachments/assets/999aafc1-828a-48df-a031-9001ee09bb5f)

Fixed
![image](https://github.com/user-attachments/assets/56532184-18b9-44ca-96e2-cb38f307a96f)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [-] Tests
