### PR TITLE
GDB-11275 Fix i18n in prod mode

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -807,7 +807,7 @@ module.exports = {
   plugins: [
     new MergeI18nPlugin({
       startDirectory: 'packages',
-      outputDirectory: 'onto-i18n',
+      outputDirectory: 'assets/i18n',
     }),
   ],
 };
@@ -820,7 +820,7 @@ module.exports = {
    Avoid conflicting keys in your new bundle, as it will cause an error.
 3. Build the application
 4. Check merged output: After building the application, check the `${webpack.outputFolder}/${mergeI18nPlugin.outputDirectory}`
-   (currently `dist/onto-i18n`) folder to verify that all translations are included and correctly merged.
+   (currently `dist/assets/i18n`) folder to verify that all translations are included and correctly merged.
 5. Listen for bundle changes in the new module, using [language-context.service.ts#onLanguageBundleChanged](packages/api/src/services/language/language-context.service.ts)
 6. Use the new bundle for module translation (may be different, depending on the module).
 

--- a/packages/api/src/services/language/language-rest.service.ts
+++ b/packages/api/src/services/language/language-rest.service.ts
@@ -5,6 +5,8 @@ import { LanguageConfig, TranslationBundle } from '../../models/language';
  * Service for handling language-related REST operations.
  */
 export class LanguageRestService extends HttpService {
+  private readonly I18N_ENDPOINT = '/assets/i18n';
+
   /**
    * Retrieves the translation bundle for a specific language.
    *
@@ -12,7 +14,7 @@ export class LanguageRestService extends HttpService {
    * @returns A Promise that resolves to a TranslationBundle containing the translations for the specified language.
    */
   getLanguage(languageCode: string): Promise<TranslationBundle> {
-    return this.get<TranslationBundle>(`/onto-i18n/${languageCode}.json`);
+    return this.get<TranslationBundle>(`${this.I18N_ENDPOINT}/${languageCode}.json`);
   }
 
   /**
@@ -21,6 +23,6 @@ export class LanguageRestService extends HttpService {
    * @returns A Promise that resolves to a {@link LanguageConfig} object containing the language configuration settings.
    */
   getLanguageConfiguration(): Promise<LanguageConfig> {
-    return this.get<LanguageConfig>('/onto-i18n/language-config.json');
+    return this.get<LanguageConfig>(`${this.I18N_ENDPOINT}/language-config.json`);
   }
 }

--- a/packages/api/src/services/language/test/language.service.spec.ts
+++ b/packages/api/src/services/language/test/language.service.spec.ts
@@ -60,7 +60,7 @@ describe('LanguageService', () => {
   test('Should retrieve the language, mapped to a TranslationBundle object', async () => {
     // Given, I have a mocked language
     const mockBundle = { hello: 'World' } as TranslationBundle;
-    TestUtil.mockResponse(new ResponseMock('/onto-i18n/en.json').setResponse(mockBundle));
+    TestUtil.mockResponse(new ResponseMock('/assets/i18n/en.json').setResponse(mockBundle));
 
     // When I call the getLanguage method
     const result = await languageService.getLanguage('en');
@@ -84,7 +84,7 @@ describe('LanguageService', () => {
         }
       ]
     } as unknown as LanguageConfig;
-    TestUtil.mockResponse(new ResponseMock('/onto-i18n/language-config.json').setResponse(mockLanguageConfig));
+    TestUtil.mockResponse(new ResponseMock('/assets/i18n/language-config.json').setResponse(mockLanguageConfig));
 
     // When I call the getLanguageConfiguration method
     const result = await languageService.getLanguageConfiguration();

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -92,7 +92,7 @@ module.exports = (webpackConfigEnv, argv) => {
             }),
             new MergeI18nPlugin({
               startDirectory: './packages',
-              outputDirectory: 'onto-i18n'
+              outputDirectory: 'assets/i18n'
             }),
             new MergeJsonPlugin({
                 files: [


### PR DESCRIPTION
## What
Fix i18n in prod mode

## Why
Labels weren't being translated

## How
Moved and renamed the output folder. Previously it was `onto-i18n` and placed directly under `dist`. This is a new folder and access to it in prod mode is not allowed. The `assets` folder, however is allowed, so `onto-i18n` is renamed to `i18n` and moved into the allowed `assets` folder. This way there is no collision with the existing `i18n` folder for the legacy workbench and the new labels are loaded correctly

## Testing
existing

## Screenshots
![image](https://github.com/user-attachments/assets/edf93a76-1c5d-4d8f-9643-384cf92f02f5)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
