### PR TITLE
GDB-11536 Fix menu items not shown in prod mode

### DIFF
--- a/packages/root-config/src/ontotext-root-config.js
+++ b/packages/root-config/src/ontotext-root-config.js
@@ -77,40 +77,6 @@ const layoutEngine = constructLayoutEngine({routes, applications});
 applications.forEach(registerApplication);
 layoutEngine.activate();
 
-// This is a workaround to initialize the navbar when the root-config is loaded and the navbar is not yet initialized.
-const waitForNavbarElement = () => {
-  return new Promise((resolve, reject) => {
-    const navbar = document.querySelector('onto-navbar');
-    if (navbar) {
-      resolve(navbar);
-    } else {
-      setTimeout(() => {
-        waitForNavbarElement().then(resolve).catch(reject);
-      }, 100);
-    }
-  });
-};
-
-const initializeNavbar = () => {
-  waitForNavbarElement()
-    .then((navbar) => {
-      navbar.menuItems = PluginRegistry.get('main.menu');
-    })
-    .catch((e) => {
-      console.error('onto-navbar element not found', e);
-    });
-};
-
-const registerSingleSpaFirstMountListener = () => {
-  // register listener only if it's not already registered
-  if (!window.singleSpaFirstMountListenerRegistered) {
-    window.singleSpaFirstMountListenerRegistered = true;
-    window.addEventListener('single-spa:first-mount', () => {
-      initializeNavbar();
-    });
-  }
-};
-
 const registerSingleSpaRouterListener = () => {
   if (!window.singleSingleSpaRouterListenerRegistered) {
     window.singleSingleSpaRouterListenerRegistered = true;
@@ -134,7 +100,6 @@ const bootstrapApplication = () => {
     });
 };
 
-registerSingleSpaFirstMountListener();
 registerSingleSpaRouterListener();
 bootstrapApplication();
 

--- a/packages/shared-components/global.d.ts
+++ b/packages/shared-components/global.d.ts
@@ -1,7 +1,10 @@
-export {}
+import {PluginRegistry} from './src/models/plugin/plugin-registry';
 
 declare global {
   interface Window {
     wbDevMode: boolean;
+    PluginRegistry: PluginRegistry
   }
 }
+
+export {}

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -159,6 +159,14 @@ export class OntoLayout {
     this.navbarRef.menuItems = [...this.navbarRef.menuItems];
   }
 
+  private assignNavbarRef() {
+    return (navbar: HTMLOntoNavbarElement) => {
+      this.navbarRef = navbar;
+      this.navbarRef.menuItems = window.PluginRegistry.get('main.menu');
+      this.setNavbarItemVisibility();
+    }
+  }
+
   // ========================
   // Lifecycle methods
   // ========================
@@ -202,7 +210,7 @@ export class OntoLayout {
         </header>
 
         <nav class="wb-navbar">
-          <onto-navbar ref={(navbar) => this.navbarRef = navbar}
+          <onto-navbar ref={this.assignNavbarRef()}
                        navbar-collapsed={this.isLowResolution}
                        selected-menu={this.currentRoute}></onto-navbar>
         </nav>

--- a/packages/shared-components/src/models/plugin/plugin-registry.ts
+++ b/packages/shared-components/src/models/plugin/plugin-registry.ts
@@ -1,0 +1,5 @@
+import {ExternalMenuModel} from '../../components/onto-navbar/external-menu-model';
+
+export interface PluginRegistry {
+  get(extensionPoint: string): ExternalMenuModel;
+}


### PR DESCRIPTION
## What
Fix menu items, which weren't being shown sometimes in prod mode

## Why
Because menu items should be shown in those circumstances

## How
Previously the `ontotext-root-config` waited for the navbar to be available and added the menu items to it. The `onto-layout` component listens for changes to the security context and authenticated user. Every time a change is made, the menu items' visibility is recalculated. In prod mode, the requests sometimes finish, before root-config sets the menu items of the navbar, leaving nothing to be filtered so no elements are displayed. 
Now the initial population of the menu items is moved into `onto-layout`, immediately after the navbar reference is resolved. Then we recalculate the visibility of the items. This way it doesn't matter in what order the operations execute.

## Testing
Existing

## Screenshots
Multiple refreshes
![navbar-menu-items](https://github.com/user-attachments/assets/bcb67254-b3ea-4a1f-b553-24d36a026812)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
