### PR TITLE
GDB-11320 Fix cookie consent toggle without security

### DIFF
--- a/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
@@ -199,17 +199,20 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                                 authorities: overrideAuthData.authorities,
                                 appSettings: overrideAuthData.appSettings
                             };
+                            ServiceProvider.get(SecurityContextService).updateAuthenticatedUser(
+                              MapperProvider.get(AuthenticatedUserMapper).mapToModel(that.principal)
+                            );
                             $rootScope.$broadcast('securityInit', that.securityEnabled, true, that.hasOverrideAuth);
 
                         } else {
                             return SecurityRestService.getAdminUser().then(function (res) {
                                 that.principal = {username: 'admin', appSettings: res.data.appSettings, authorities: res.data.grantedAuthorities};
+                                ServiceProvider.get(SecurityContextService).updateAuthenticatedUser(
+                                  MapperProvider.get(AuthenticatedUserMapper).mapToModel(that.principal)
+                                );
                                 $rootScope.$broadcast('securityInit', that.securityEnabled, true, that.hasOverrideAuth);
                             });
                         }
-                        ServiceProvider.get(SecurityContextService).updateAuthenticatedUser(
-                          MapperProvider.get(AuthenticatedUserMapper).mapToModel(that.principal)
-                        );
                     }
                 });
             };


### PR DESCRIPTION
## What
Fix cookie consent error, upon toggle, with disabled security

## Why
There is an error currently, as there is no authenticated user set in the context.

## How
Updated authenticated user upon refresh, whenever we have disabled security. Currently in this scenario, the context wasn't being updated, which caused the error.

## Tests
none, as the context is populated in the legacy workbench

## Screenshots
![fix cookie consent](https://github.com/user-attachments/assets/86b9288f-ab1b-45ab-8e2a-3a89c709a8fc)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
