### PR TITLE
GDB-11410 Increase cypress default command timeout

### DIFF
--- a/packages/shared-components/cypress.config.js
+++ b/packages/shared-components/cypress.config.js
@@ -1,6 +1,7 @@
 const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
+  defaultCommandTimeout: 10000,
   e2e: {
     baseUrl: 'http://localhost:3333/',
     video: false,


### PR DESCRIPTION
## What
Increase `defaultCommandTimeout`

## Why
The the previous timeout was too short and didn't leave time for some tests to complete

## How
Increased the timeout to 10000 milliseconds in `cypress.config.js`

## Tests
N/a

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
