### PR TITLE
Gdb 11571 extend main menu guide step to support ttyg

### DIFF
--- a/src/css/ttyg/agent-settings-modal.css
+++ b/src/css/ttyg/agent-settings-modal.css
@@ -73,6 +73,17 @@
     padding: 0 10px;
 }
 
+.agent-settings-modal .agent-settings-form .extraction-method-heading .extraction-method-toggle {
+    display: flex;
+    align-items: center;
+}
+
+.agent-settings-modal .agent-settings-form .extraction-method-heading .extraction-method-toggle .panel-toggle-link {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+}
+
 .agent-settings-modal .agent-settings-form #sparqlQuery,
 .agent-settings-modal .agent-settings-form #queryTemplate {
     font-size: 1rem;

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -589,8 +589,21 @@
                         "method": {
                             "iri_discovery_search": {
                                 "label": "Full-text search in labels for IRI discovery",
-                                "tooltip": "Helps the model discover the IRIs for a particular incomplete query, for example the name Michael in “What’s Michael’s phone number?”"
+                                "tooltip": "Helps the model discover the IRIs (using FTS) for a particular incomplete query, for example the name Michael in \"What's Michael's phone number?\""
+                            },
+                            "autocomplete_iri_discovery_search": {
+                                "label": "Autocomplete for IRI discovery",
+                                "tooltip": "Helps the model discover the IRIs (using autocomplete) for a particular incomplete query, for example the name Michael in \"What's Michael's phone number?\""
                             }
+                        },
+                        "autocomplete_disabled_message": "You must <a href=\"{{autocompleteIndexPage}}\" target=\"_blank\">enable the Autocomplete index</a> on chosen repository to use this method",
+                        "autocomplete_max_number_of_results_per_call": {
+                            "label": "Max number of results (IRIs) per call",
+                            "placeholder": "Automatic value"
+                        },
+                        "autocomplete_search_predicates": {
+                            "label": "Search predicates",
+                            "tooltip": "Enter one or more predicates to use for label search with autocomplete."
                         }
                     }
                 },

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -589,8 +589,21 @@
                         "method": {
                             "iri_discovery_search": {
                                 "label": "Recherche de texte intégral dans les étiquettes pour la découverte d'IRI",
-                                "tooltip": "Aide le modèle à découvrir les IRI pour une requête incomplète particulière, par exemple le nom Michael dans \"Quel est le numéro de téléphone de Michael?\""
+                                "tooltip": "Aide le modèle à découvrir les IRI (à l'aide de FTS) pour une requête incomplète particulière, par exemple le nom Michael dans \"Quel est le numéro de téléphone de Michael?\""
+                            },
+                            "autocomplete_iri_discovery_search": {
+                                "label": "Saisie semi-automatique pour la découverte IRI",
+                                "tooltip": "Aide le modèle à découvrir les IRI (à l'aide de la saisie semi-automatique) pour une requête incomplète particulière, par exemple le nom Michael dans \"Quel est le numéro de téléphone de Michael?\""
                             }
+                        },
+                        "autocomplete_disabled_message": "Vous devez <a href=\"{{autocompleteIndexPage}}\" target=\"_blank\">activer complétion automatique</a> pour utiliser cette méthode",
+                        "autocomplete_max_number_of_results_per_call": {
+                            "label": "Nombre maximum de résultats (IRI) par appel",
+                            "placeholder": "Valeur automatique"
+                        },
+                        "autocomplete_search_predicates": {
+                            "label": "Rechercher des prédicats",
+                            "tooltip": "Saisissez un ou plusieurs prédicats à utiliser pour la recherche d'étiquettes avec saisie semi-automatique."
                         }
                     }
                 },

--- a/src/js/angular/guides/steps/complex/main-menu/plugin.js
+++ b/src/js/angular/guides/steps/complex/main-menu/plugin.js
@@ -75,6 +75,17 @@ PluginRegistry.add('guide.step', [
                     helpInfo = 'view.class.hierarchy.helpInfo';
 
                     break;
+                case "ttyg":
+                    menuSelector = 'menu-lab';
+                    menuTitle = 'menu.lab.label';
+                    menuDialogClass = 'menu-lab-guide-dialog';
+                    submenuSelector = 'sub-menu-ttyg';
+                    submenuTitle = 'menu.ttyg.label';
+                    submenuDialogClass = 'sub-menu-ttyg-guide-dialog';
+                    viewName = 'menu.ttyg.label';
+                    helpInfo = 'ttyg.helpInfo';
+
+                    break;
             }
 
             const mainMenuClickElementPostSelector = submenuSelector ? ' div' : ' a';

--- a/src/js/angular/models/ttyg/agent-form.js
+++ b/src/js/angular/models/ttyg/agent-form.js
@@ -88,7 +88,8 @@ export class AgentFormModel {
 
     getDefaultAdditionalExtractionMethod() {
         const additionalExtractionMethods = [];
-        additionalExtractionMethods.push(new AdditionalExtractionMethodFormModel({method: AdditionalExtractionMethod.IRI_DISCOVERY_SEARCH}));
+        additionalExtractionMethods.push(new AdditionalExtractionMethodFormModel({method: AdditionalExtractionMethod.IRI_DISCOVERY_SEARCH}),
+            new AdditionalExtractionMethodFormModel({ method: AdditionalExtractionMethod.AUTOCOMPLETE_IRI_DISCOVERY_SEARCH }));
         return new AdditionalExtractionMethodsFormModel(additionalExtractionMethods);
     }
 
@@ -491,10 +492,11 @@ export class AdditionalExtractionMethodFormModel {
     constructor(data) {
         this._selected = data.selected || false;
         /**
-         * @type {'iri_discovery_search'}
+         * @type {'iri_discovery_search', 'autocomplete_iri_discovery_search'}
          * @private
          */
         this._method = data.method;
+        this._expanded = data.expanded || false;
     }
 
     toPayload() {
@@ -517,6 +519,18 @@ export class AdditionalExtractionMethodFormModel {
 
     set method(value) {
         this._method = value;
+    }
+
+    get expanded() {
+        return this._expanded;
+    }
+
+    set expanded(value) {
+        this._expanded = value;
+    }
+
+    toggleCollapse() {
+        this._expanded = !this._expanded;
     }
 }
 

--- a/src/js/angular/models/ttyg/agents.js
+++ b/src/js/angular/models/ttyg/agents.js
@@ -336,7 +336,7 @@ export class AdditionalExtractionMethodsModel {
 export class AdditionalExtractionMethodModel {
     constructor(data) {
         /**
-         * @type {'iri_discovery_search'}
+         * @type {'iri_discovery_search', 'autocomplete_iri_discovery_search'}
          * @private
          */
         this._method = data.method;
@@ -434,7 +434,8 @@ export const ExtractionMethod = {
 };
 
 export const AdditionalExtractionMethod = {
-    IRI_DISCOVERY_SEARCH: 'iri_discovery_search'
+    IRI_DISCOVERY_SEARCH: 'iri_discovery_search',
+    AUTOCOMPLETE_IRI_DISCOVERY_SEARCH: 'autocomplete_iri_discovery_search'
 };
 
 /**

--- a/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -1,5 +1,5 @@
 import {decodeHTML} from "../../../../app";
-import {ExtractionMethod} from "../../models/ttyg/agents";
+import {AdditionalExtractionMethod, ExtractionMethod} from "../../models/ttyg/agents";
 import 'angular/core/services/similarity.service';
 import 'angular/core/services/connectors.service';
 import 'angular/core/services/ttyg.service';
@@ -16,6 +16,10 @@ angular
         'graphdb.framework.rest.repositories.service',
         'graphdb.framework.ttyg.controllers.agent-instructions-explain-modal'
     ])
+    .constant('ExtractionMethodTemplates', {
+    'iri_discovery_search': 'iri-discovery-search',
+    'autocomplete_iri_discovery_search': 'autocomplete-iri-discovery-search'
+    })
     .controller('AgentSettingsModalController', AgentSettingsModalController);
 
 AgentSettingsModalController.$inject = [
@@ -32,7 +36,9 @@ AgentSettingsModalController.$inject = [
     '$translate',
     'dialogModel',
     'TTYGContextService',
-    'TTYGService'];
+    'TTYGService',
+    'ExtractionMethodTemplates',
+    'AutocompleteService'];
 
 function AgentSettingsModalController(
     $scope,
@@ -48,7 +54,9 @@ function AgentSettingsModalController(
     $translate,
     dialogModel,
     TTYGContextService,
-    TTYGService) {
+    TTYGService,
+    ExtractionMethodTemplates,
+    AutocompleteService) {
 
     // =========================
     // Private variables
@@ -107,6 +115,18 @@ function AgentSettingsModalController(
     $scope.extractionMethods = ExtractionMethod;
 
     /**
+     * The additional extraction method types constants.
+     * @type {{IRI_DISCOVERY_SEARCH: string, AUTOCOMPLETE_IRI_DISCOVERY_SEARCH: string}}
+     */
+    $scope.additionalExtractionMethods = AdditionalExtractionMethod;
+
+    /**
+     * The names of the template files, containing the Extraction Method Templates.
+     * @type {Object<string, string>}
+     */
+    $scope.ExtractionMethodTemplates = ExtractionMethodTemplates;
+
+    /**
      * Flag used to show/hide the advanced settings in the modal.
      * @type {boolean}
      */
@@ -142,6 +162,12 @@ function AgentSettingsModalController(
      */
     $scope.ftsEnabled = false;
 
+    /**
+     * The user input autocomplete field predicates.
+     * @type {*[]}
+     */
+    $scope.autocompletePredicates = [];
+
     // =========================
     // Public functions
     // =========================
@@ -170,6 +196,29 @@ function AgentSettingsModalController(
     };
 
     /**
+     * Sets the UI touched state and validation state for the additional extraction methods property so that the UI can show if
+     * the user has selected at least one extraction method.
+     *
+     * @param {AdditionalExtractionMethodFormModel} extractionMethod
+     */
+    $scope.toggleAdditionalExtractionMethod = (extractionMethod) => {
+        extractionMethod.expanded = extractionMethod.selected;
+        //$scope.agentSettingsForm.additionalExtractionMethods.$setTouched();
+        //setExtractionMethodValidityStatus();
+        additionalExtractionPanelToggleHandlers[extractionMethod.method](extractionMethod);
+    };
+
+     /**
+     * Handles the panel toggle event for the additional extraction method. This is used to do some initialization when the user
+     * opens the panel for a specific extraction method.
+     * @param {AdditionalExtractionMethodFormModel} extractionMethod
+     */
+    $scope.onAdditionalExtractionMethodPanelToggle = (extractionMethod) => {
+        extractionMethod.toggleCollapse();
+        additionalExtractionPanelToggleHandlers[extractionMethod.method](extractionMethod);
+    };
+
+    /**
      * Resolves the hint message for the agent model property. This is needed because the hint contains a html link that
      * should be properly rendered.
      * @return {*}
@@ -191,6 +240,22 @@ function AgentSettingsModalController(
             $translate.instant(
                 'ttyg.agent.create_agent_modal.form.fts_search.fts_disabled_message',
                 {repositoryEditPage: '#/repository/edit/' + $scope.agentFormModel.repositoryId}
+            )
+        );
+        return $sce.trustAsHtml(message);
+    };
+
+    /**
+     * Resolves the hint for the Autocomplete Index not enabled message. This is needed because the hint contains a html link that
+     * should be properly rendered.
+     * @return {*}
+     */
+    $scope.getAutocompleteDisabledHelpMessage = () => {
+        // The hint contains a html link which should be properly rendered.
+        const message = decodeHTML(
+            $translate.instant(
+                'ttyg.agent.create_agent_modal.form.additional_query_methods.autocomplete_disabled_message',
+                {autocompleteIndexPage: '#/autocomplete'}
             )
         );
         return $sce.trustAsHtml(message);
@@ -302,6 +367,16 @@ function AgentSettingsModalController(
     $scope.onRepositoryChange = () => {
         refreshValidations(true, true);
     };
+
+    $scope.checkAutocompleteIndexEnabled = () => {
+        AutocompleteService.checkAutocompleteStatus().then((autocompleteEnabled) => {
+            $scope.autocompleteEnabled = autocompleteEnabled;
+            console.log(autocompleteEnabled);
+        })
+            .catch((error) => {
+                toastr.error(getError(error));
+            });
+    }
 
     /**
      * Restores the default system instructions.
@@ -570,6 +645,14 @@ function AgentSettingsModalController(
         [ExtractionMethod.SIMILARITY]: (extractionMethod) => handleSimilaritySearchExtractionMethodPanelToggle(extractionMethod),
         [ExtractionMethod.RETRIEVAL]: (extractionMethod) => handleRetrievalConnectorExtractionMethodPanelToggle(extractionMethod)
     };
+
+    const additionalExtractionPanelToggleHandlers = {
+        [AdditionalExtractionMethod.AUTOCOMPLETE_IRI_DISCOVERY_SEARCH]: (extractionMethod) => handleAutocompleteExtractionMethodPanelToggle(extractionMethod),
+    };
+
+    const handleAutocompleteExtractionMethodPanelToggle = (extractionMethod) => {
+        console.log('Toggling: ', extractionMethod);
+    }
 
     const refreshValidations = (clearIndexSelection = false, clearRetrievalConnectorSelection = false) => {
         $scope.checkIfFTSEnabled();

--- a/src/js/angular/ttyg/templates/autocomplete-iri-discovery-search.html
+++ b/src/js/angular/ttyg/templates/autocomplete-iri-discovery-search.html
@@ -1,0 +1,71 @@
+<div id="{{extractionMethod.method + '_method_heading'}}" class="extraction-method-heading"
+     ng-class="{'selected': extractionMethod.selected}">
+    <div class="mr-0 extraction-method-toggle">
+        <input type="checkbox" id="{{extractionMethod.method + '_checkbox'}}"
+               name="{{extractionMethod}}" class="switch"
+               ng-click="toggleAdditionalExtractionMethod(extractionMethod, $event)"
+               ng-model="extractionMethod.selected"/>
+        <label for="{{extractionMethod.method + '_checkbox'}}"></label>
+        <a class="btn btn-link panel-toggle-link"
+           aria-expanded="false" aria-controls="{{extractionMethod.method + '_method_content'}}"
+           ng-click="onAdditionalExtractionMethodPanelToggle(extractionMethod)">
+                                <span class="mr-1"
+                                      uib-popover="{{'ttyg.agent.create_agent_modal.form.additional_query_methods.method.' + extractionMethod.method + '.tooltip' | translate}}"
+                                      popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.additional_query_methods.method.' + extractionMethod.method + '.label' | translate}}</span>
+            <i class="fa fa-chevron-down toggle-icon"
+               ng-class="{'expanded': extractionMethod.expanded}">
+            </i>
+        </a>
+    </div>
+
+    <div id="{{extractionMethod.method + '_method_content'}}"
+         class="show extraction-method-content"
+         aria-labelledby="{{extractionMethod.method + '_method_heading'}}"
+         data-parent="#extractionMethods">{{extractionMethod}}
+        <!--        <div
+            ng-if="extractionMethod.expanded && extractionMethod.method === additionalExtractionMethods.autocomplete_iri_discovery_search"-->
+           <div ng-if="true"
+            class="extraction-method-options">
+            <button class="btn btn-link btn-sm pull-right"
+                    ng-click="checkAutocompleteIndexEnabled()"
+                    gdb-tooltip="{{'btn.reload.tooltip' | translate}}">
+                <i class="fa fa-arrows-rotate"></i>
+            </button>
+            <div class="alert alert-danger missing-repositoryid-error mb-0"
+                 ng-if="!agentFormModel.repositoryId">
+                {{'ttyg.agent.create_agent_modal.form.missing_repository_id' | translate}}
+            </div>
+            <div ng-if="agentFormModel.repositoryId" class="autocomplete-disabled-message"
+                 ng-bind-html="getAutocompleteDisabledHelpMessage()">
+            </div>
+            <div class="form-group max-triples" ng-show="agentFormModel.repositoryId">
+                <label for="{{extractionMethod + '_maxNumberOfTriplesPerCall'}}"
+                       popover-trigger="mouseenter">
+                    {{'ttyg.agent.create_agent_modal.form.additional_query_methods.autocomplete_max_number_of_results_per_call.label' | translate}}
+                </label>
+                <input type="number" class="form-control"
+                       id="{{extractionMethod + '_maxNumberOfTriplesPerCall'}}"
+                       name="maxNumberOfTriplesPerCall" min="0"
+                       ng-model="extractionMethod.maxNumberOfTriplesPerCall"
+                       placeholder="{{'ttyg.agent.create_agent_modal.form.additional_query_methods.autocomplete_max_number_of_results_per_call.placeholder' | translate}}">
+            </div>
+               <div class="autocomplete-predicate-tags">
+                   <label>{{'ttyg.agent.create_agent_modal.form.additional_query_methods.autocomplete_search_predicates.label' | translate}}</label>
+                   <tags-input id="autocompletePredicateField" class="wb-tags-input" ng-model="autocompletePredicates" min-length="1"
+                               use-strings="true"
+                               add-on-space="true"
+                               add-on-comma="true"
+                               add-on-paste="true"
+                               replace-spaces-with-dashes="false"
+                               paste-split-pattern="[\s+]"
+                               on-tag-adding=""
+                               on-tag-added=""
+                               ng-keydown=""
+                               ng-cut=""
+                               placeholder="{{'ttyg.agent.create_agent_modal.form.additional_query_methods.autocomplete_search_predicates.tooltip' | translate}}">
+<!--                       <auto-complete source="loadSuggestions(input)"></auto-complete> TODO-->
+                   </tags-input>
+               </div>
+        </div>
+    </div>
+</div>

--- a/src/js/angular/ttyg/templates/iri-discovery-search.html
+++ b/src/js/angular/ttyg/templates/iri-discovery-search.html
@@ -1,0 +1,11 @@
+<div class="simple-method">
+    <input type="checkbox" id="{{extractionMethod.method + '_checkbox'}}"
+           name="{{extractionMethod.method}}" class="switch"
+           ng-model="extractionMethod.selected"/>
+    <label for="{{extractionMethod.method + '_checkbox'}}"></label>
+    <a class="btn btn-link extraction-method-label"
+       uib-popover="{{'ttyg.agent.create_agent_modal.form.additional_query_methods.method.' + extractionMethod.method + '.tooltip' | translate}}"
+       popover-trigger="mouseenter">
+        {{'ttyg.agent.create_agent_modal.form.additional_query_methods.method.' + extractionMethod.method + '.label' | translate}}
+    </a>
+</div>

--- a/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -320,22 +320,18 @@
 
         <div class="form-group additional-extraction-methods">
             <label uib-popover="{{'ttyg.agent.create_agent_modal.form.additional_query_methods.tooltip' | translate}}"
-                   popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.additional_query_methods.label' |
-                translate}}</label>
-            <div
-                ng-repeat="additionalExtractionMethod in agentFormModel.additionalExtractionMethods.additionalExtractionMethods"
-                class="additional-extraction-method">
-                <input type="checkbox" id="{{additionalExtractionMethod.method + '_checkbox'}}"
-                       name="{{additionalExtractionMethod.method}}" class="switch"
-                       ng-model="additionalExtractionMethod.selected"/>
-                <label for="{{additionalExtractionMethod.method + '_checkbox'}}"></label>
-                <a class="btn btn-link extraction-method-label" uib-popover="{{'ttyg.agent.create_agent_modal.form.additional_query_methods.method.' +
-                    additionalExtractionMethod.method + '.tooltip' | translate}}"
-                   popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.additional_query_methods.method.'
-                    +
-                    additionalExtractionMethod.method + '.label' | translate}}</a>
+                   popover-trigger="mouseenter">
+                {{'ttyg.agent.create_agent_modal.form.additional_query_methods.label' | translate}}
+            </label>
+
+            <div ng-repeat="extractionMethod in agentFormModel.additionalExtractionMethods.additionalExtractionMethods"
+                 class="additional-extraction-method">
+                <div ng-if="template = ExtractionMethodTemplates[extractionMethod.method]">
+                    <div ng-include="'js/angular/ttyg/templates/' + template + '.html'"></div>
+                </div>
             </div>
         </div>
+
 
         <div class="form-row clearfix">
             <div class="form-group gpt-model col-md-4">

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -589,8 +589,21 @@
                         "method": {
                             "iri_discovery_search": {
                                 "label": "Full-text search in labels for IRI discovery",
-                                "tooltip": "Helps the model discover the IRIs for a particular incomplete query, for example the name Michael in “What’s Michael’s phone number?”"
+                                "tooltip": "Helps the model discover the IRIs (using FTS) for a particular incomplete query, for example the name Michael in \"What's Michael's phone number?\""
+                            },
+                            "autocomplete_iri_discovery_search": {
+                                "label": "Autocomplete for IRI discovery",
+                                "tooltip": "Helps the model discover the IRIs (using autocomplete) for a particular incomplete query, for example the name Michael in \"What's Michael's phone number?\""
                             }
+                        },
+                        "autocomplete_disabled_message": "You must <a href=\"{{autocompleteIndexPage}}\" target=\"_blank\">enable the Autocomplete index</a> on chosen repository to use this method",
+                        "autocomplete_max_number_of_results_per_call": {
+                            "label": "Max number of results (IRIs) per call",
+                            "placeholder": "Automatic value"
+                        },
+                        "autocomplete_search_predicates": {
+                            "label": "Search predicates",
+                            "tooltip": "Enter one or more predicates to use for label search with autocomplete."
                         }
                     }
                 },


### PR DESCRIPTION
## What
Extend the `click-main-menu` block to support navigating to TTYG view

## Why
This will allow the guides to be configured to go to the TTYG page

## How
- add another condition in the `click-main-menu` guide block for `ttyg` route

## Testing
A test for the complete TTYG guide will be implemented at the end

## Screenshots
![image](https://github.com/user-attachments/assets/68359874-9806-4874-8698-a82805fbd2d3)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
