### PR TITLE
Skip unstable security-related test

### DIFF
--- a/test-cypress/integration/sparql-editor/saved-query/readonly-query.spec.js
+++ b/test-cypress/integration/sparql-editor/saved-query/readonly-query.spec.js
@@ -9,7 +9,13 @@ const USER_NAME = 'saved_query_user';
 const USER_ADMINISTRATOR = 'admin';
 const PASSWORD = 'root';
 
-describe('Readonly saved query', () => {
+/**
+ * Skipped because this type of implementation is not ideal. If the test fails and the `afterEach` hook
+ * fails to toggle security, all remaining tests will fail because security remains enabled.
+ *
+ * Tests like this should be refactored to use stubs or other alternative implementations.
+ */
+describe.skip('Readonly saved query', () => {
 
     let repositoryId;
 


### PR DESCRIPTION
## What
Skipped a test that relies on security toggling in the afterEach hook, which can cause cascading failures.

## Why
If the test fails and the afterEach hook does not properly reset security, all subsequent tests will also fail due to security remaining enabled.

## How
- Skipped the test to prevent instability.
- Added a reminder to refactor it using stubs or a better implementation in the future.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [-] Tests
