### PR TITLE
fix(GDB-11550) Remove npm-based Fontawesome PRO integration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,1 @@
 legacy-peer-deps=true
-@awesome.me:registry=https://npm.fontawesome.com/
-@fortawesome:registry=https://npm.fontawesome.com/
-//npm.fontawesome.com/:_authToken=05B5113B-1531-42E3-AB42-6619AEF7E822

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2,13 +2,38 @@
 
 ## Font awesome icons
 
-The font kit is our own and is installed using the following command:
-`npm install --save '@awesome.me/kit-94ffd2fc4a@latest'`
+The font kit used in the project is our own and is a custom PRO set. Below are the steps for manually updating and managing the fontawesome iconset:
 
-Because we use a PRO plan we have an authentication token which is used for install and update. The token is in the `.npmrc` file in the root of the project.
+---
 
-It can be updated by running the following command:
-`npm update '@awesome.me/kit-94ffd2fc4a'`
+### Updating the Font Kit
+If there is an update to the custom PRO font kit:
+
+1. Log in to [fontawesome.com](https://fontawesome.com) using our organization account.
+2. Navigate to the custom kit in our profile and download the latest version.
+3. Extract the downloaded files.
+4. Replace the relevant files in the following directory of the project:
+```angular2html
+src/js/lib/awesome_me/css
+```
+Make sure you copy all necessary CSS, fonts, and any other related files.
+
+5. Commit the updated files to the repository.
+
+---
+
+### Customizations
+If any icons or configurations within the PRO set are changed:
+
+1. Update the custom kit on [fontawesome.com](https://fontawesome.com).
+2. Download the updated kit.
+3. Follow the steps above to manually replace the files in:
+```angular2html
+src/js/lib/awesome_me/css
+```
+4. Test the changes locally to ensure the updated icons are working correctly.
+
+---
 
 ## Extending the GraphDB Workbench
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "2.8.4-RC1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@awesome.me/kit-94ffd2fc4a": "^1.0.105",
                 "angular-animate": "1.3.8",
                 "angular-bowser": "0.0.4",
                 "angular-cookies": "1.3.8",
@@ -75,17 +74,6 @@
                 "webpack-dev-server": "^3.11.0",
                 "webpack-merge": "^4.2.1",
                 "webpack-merge-and-include-globally": "^2.1.20"
-            }
-        },
-        "node_modules/@awesome.me/kit-94ffd2fc4a": {
-            "version": "1.0.105",
-            "resolved": "https://npm.fontawesome.com/@awesome.me/kit-94ffd2fc4a/-/1.0.105/kit-94ffd2fc4a-1.0.105.tgz",
-            "integrity": "sha512-0QYhbPhm95hFXPBrGC65zg+3LWDythhlZ9QsxVNyM8xQshtSn71AzZcdCvSVahuTjTSm1+vzUd88SNCwvDxiFQ==",
-            "dependencies": {
-                "@fortawesome/fontawesome-common-types": "^6.6.0"
-            },
-            "engines": {
-                "node": ">=16"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -223,14 +211,6 @@
             "version": "0.2.8",
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
             "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
-        },
-        "node_modules/@fortawesome/fontawesome-common-types": {
-            "version": "6.6.0",
-            "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.6.0/fontawesome-common-types-6.6.0.tgz",
-            "integrity": "sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==",
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/@popperjs/core": {
             "version": "2.11.8",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
         "webpack-merge-and-include-globally": "^2.1.20"
     },
     "dependencies": {
-        "@awesome.me/kit-94ffd2fc4a": "^1.0.105",
         "angular-animate": "1.3.8",
         "angular-bowser": "0.0.4",
         "angular-cookies": "1.3.8",


### PR DESCRIPTION
## WHAT:
- Removed the integration of Fontawesome PRO iconset via `npm`.
- Updated `.npmrc` to eliminate authentication token for Fontawesome.
- Deleted Fontawesome-specific dependencies from `package.json` and `package-lock.json`.
- Revised the developer's guide to reflect manual updates of Fontawesome files.

## WHY:
- Storing sensitive authentication tokens in `.npmrc` poses a security risk.
- Switching to manual file updates reduces dependency

## HOW:
- Authentication token and references to Fontawesome PRO were removed from `.npmrc`.
- Dependencies on `@awesome.me/kit-94ffd2fc4a` and related packages were deleted from the package files.
- Developer's Guide now includes detailed steps for manually downloading and replacing Fontawesome PRO files from our Fontawesome account.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests