### PR TITLE
GDB-11745 Enable repositori rename in cluster

### DIFF
--- a/src/css/repositories.css
+++ b/src/css/repositories.css
@@ -257,11 +257,6 @@ span.required {
     color: #c53e3e
 }
 
-.edit-repository-denied {
-    cursor: not-allowed;
-    opacity: .65;
-}
-
 .ot-edit-input {
     position: absolute;
     right: 5px

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -2354,7 +2354,6 @@
     "repo.id.label": "Repository ID*",
     "repo.local": "Local",
     "edit.repo.id.tooltip": "Edit repository id",
-    "edit.repo.id.cannot_edit_in_cluster.tooltip": "Cannot rename repository while in cluster.",
     "invalid.repo.name.error": "Repository name can contain only letters (a-z, A-Z), numbers (0-9), \"-\" and \"_\"",
     "upload.custom.ruleset.file": "Upload a custom ruleset file.",
     "custom.ruleset": "Custom ruleset...",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -2353,7 +2353,6 @@
     "repo.id.label": "ID du dépôt*",
     "repo.local": "Local",
     "edit.repo.id.tooltip": "Modifier l'ID du dépôt",
-    "edit.repo.id.cannot_edit_in_cluster.tooltip": "Impossible de renommer le référentiel en mode cluster.",
     "invalid.repo.name.error": "Le nom du dépôt ne peut contenir que des lettres (a-z, A-Z), des chiffres (0-9), \"-\" et \"_\".",
     "upload.custom.ruleset.file": "Téléchargez un fichier de jeu de règles personnalisé.",
     "custom.ruleset": "Jeu de règles personnalisé...",

--- a/src/js/angular/repositories/controllers.js
+++ b/src/js/angular/repositories/controllers.js
@@ -936,9 +936,6 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
     };
 
     $scope.editRepositoryId = function () {
-        if ($scope.isRepoInCluster) {
-            return;
-        }
         let msg = decodeHTML($translate.instant('edit.repo.id.warning.msg'));
         if ($scope.isEnterprise()) {
             msg += decodeHTML($translate.instant('edit.repo.id.cluster.warning.msg'));

--- a/src/pages/repository.html
+++ b/src/pages/repository.html
@@ -38,9 +38,8 @@
                         <label for="id" class="col-md-3 col-lg-2 col-form-label">{{'repo.id.label' | translate}}</label>
                         <div class="col-md-7 col-lg-6 col-xl-5" gdb-tooltip="{{'repoTooltips.id' | translate}}">
                             <a class="btn btn-link ot-edit-input" ng-click="editRepositoryId()"
-                               ng-class="{'edit-repository-denied': isRepoInCluster}"
                                ng-if="!canEditRepoId && editRepoPage"
-                               gdb-tooltip="{{(isRepoInCluster ? 'edit.repo.id.cannot_edit_in_cluster.tooltip' : 'edit.repo.id.tooltip') | translate}}" tooltip-placement="right">
+                               gdb-tooltip="{{'edit.repo.id.tooltip' | translate}}" tooltip-placement="right">
                                 <span class="icon-edit"></span>
                             </a>
                             <input name="id" id="id" class="form-control" ng-disabled="!canEditRepoId && editRepoPage"

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -2203,7 +2203,6 @@
     "repo.id.label": "Repository ID*",
     "repo.local": "Local",
     "edit.repo.id.tooltip": "Edit repository id",
-    "edit.repo.id.cannot_edit_in_cluster.tooltip": "Cannot rename repository while in cluster.",
     "invalid.repo.name.error": "Repository name can contain only letters (a-z, A-Z), numbers (0-9), \"-\" and \"_\"",
     "upload.custom.ruleset.file": "Upload a custom ruleset file.",
     "custom.ruleset": "Custom ruleset...",

--- a/test-cypress/integration/repository/repositories.spec.js
+++ b/test-cypress/integration/repository/repositories.spec.js
@@ -480,7 +480,7 @@ describe('Repositories', () => {
         ImportUserDataSteps.checkImportedResource(0, 'Text snippet', 'org.eclipse.rdf4j.sail.shacl.GraphDBShaclSailValidationException: Failed SHACL validation');
     });
 
-    it('should not allow editing of repository name if repository is in cluster', () => {
+    it('should allow editing of repository name if repository is in cluster', () => {
         // When I create a repository,
         cy.createRepository({id: repositoryId});
         // set the repository be in a cluster.
@@ -491,15 +491,12 @@ describe('Repositories', () => {
         // When I try to edit the repository id.
         RepositorySteps.editRepositoryId();
 
-        // Then I expect the repository name can't be edited.
-        ModalDialogSteps.getDialog().should('not.exist');
-        RepositorySteps.getRepositoryIdEditElement().should('have.css', 'cursor').and('match', /not-allowed/);
+        // Then I expect to be allowed to edit.
+        ModalDialogSteps.getDialog().should('be.visible');
+        RepositorySteps.getRepositoryIdEditElement().should('have.css', 'cursor').and('match', /pointer/);
     });
 
-    /**
-     * Skip it temporarily because it needs backend changes to be merged
-     */
-    it.skip('should allow editing of repository name if repository is not in cluster', () => {
+    it('should allow editing of repository name if repository is not in cluster', () => {
         // When I create a repository,
         cy.createRepository({id: repositoryId});
         // and go to edit the repository page.


### PR DESCRIPTION
## What
Allow repository ID to be changed, whenever it is in a cluster

## Why
Previously the backend didn't allow it. Now it is possible

## How
- Removed the tooltip and styling, which didn't allow the user to click edit.
- Removed labels, associated with the disabling functionality.
- Removed cypress tests, which checked the functionality

## Tests
removed existing, since they are not needed

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
