### PR TITLE
GDB-11741: Extend the Graphiql component with ability to terminate long running graphql queries in GDB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "ng-file-upload": "^12.2.13",
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
-                "ontotext-graphql-playground-component": "^0.0.7",
+                "ontotext-graphql-playground-component": "^0.0.8",
                 "ontotext-yasgui-web-component": "1.3.21",
                 "shepherd.js": "^11.2.0"
             },
@@ -11946,9 +11946,9 @@
             }
         },
         "node_modules/ontotext-graphql-playground-component": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/ontotext-graphql-playground-component/-/ontotext-graphql-playground-component-0.0.7.tgz",
-            "integrity": "sha512-kGbd8Ebfa4cstnrb3Go4o6YOu4uytwE61iTlzN+HZW+4mhjwA/7JTryDqhLEYbfiGNFyi9gW3mrcDF9p82BEeQ==",
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/ontotext-graphql-playground-component/-/ontotext-graphql-playground-component-0.0.8.tgz",
+            "integrity": "sha512-X4zH0fIm/rHYpPMc2HXObbDscW50vm8Yl/msHTxdrV32OZmkJBJ5ydy6hNoS5tRX7fJ4mBmZkC9Ab6XN1KhipQ==",
             "dependencies": {
                 "graphql": "^16.9.0"
             }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "ng-file-upload": "^12.2.13",
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
-        "ontotext-graphql-playground-component": "^0.0.7",
+        "ontotext-graphql-playground-component": "^0.0.8",
         "ontotext-yasgui-web-component": "1.3.21",
         "shepherd.js": "^11.2.0"
     },

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -748,7 +748,8 @@
     "graphql": {
         "playground": {
             "message": {
-                "no_schemas_in_repository": "No active endpoints found in the current repository. Manage the GraphQL schemas <a href=\"#\">here</a>"
+                "no_schemas_in_repository": "No active endpoints found in the current repository. Manage the GraphQL schemas <a href=\"#\">here</a>",
+                "abort_query": "Query canceled: The operation was stopped before completion."
             },
             "endpoint_selector": {
                 "tooltip": "Select a GraphQL endpoint"

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -748,7 +748,8 @@
     "graphql": {
         "playground": {
             "message": {
-                "no_schemas_in_repository": "Aucun point de terminaison actif n'a été trouvé dans le référentiel actuel. Gérez les schémas GraphQL <a href=\"#\">ici</a>"
+                "no_schemas_in_repository": "Aucun point de terminaison actif n'a été trouvé dans le référentiel actuel. Gérez les schémas GraphQL <a href=\"#\">ici</a>",
+                "abort_query": "Requête annulée : L'opération a été arrêtée avant son achèvement."
             },
             "endpoint_selector": {
                 "tooltip": "Sélectionnez un point de terminaison GraphQL"

--- a/src/js/angular/core/directives/graphql-playground/graphql-playground.directive.js
+++ b/src/js/angular/core/directives/graphql-playground/graphql-playground.directive.js
@@ -5,7 +5,7 @@ angular
     .module('graphdb.framework.core.directives.graphql-playground', modules)
     .directive('graphqlPlayground', graphqlPlaygroundDirective);
 
-graphqlPlaygroundDirective.$inject = [];
+graphqlPlaygroundDirective.$inject = ['$repositories', '$translate', 'MonitoringRestService', 'toastr'];
 
 /**
  * @function graphqlPlaygroundDirective
@@ -31,7 +31,7 @@ graphqlPlaygroundDirective.$inject = [];
  *
  * @return {Object} Directive definition object.
  */
-function graphqlPlaygroundDirective() {
+function graphqlPlaygroundDirective($repositories, $translate, MonitoringRestService, toastr) {
     return {
         restrict: 'E',
         templateUrl: 'js/angular/core/directives/graphql-playground/templates/graphql-playground.html',
@@ -48,6 +48,20 @@ function graphqlPlaygroundDirective() {
              */
             $scope.getGraphQLPlaygroundComponent = () => {
                 return new GraphQLPlaygroundComponent(getGraphQLPlaygroundElements()[0]);
+            };
+
+            /**
+             * Handles the event to abort a running query by sending a request to delete the associated SPARQL query.
+             * It retrieves the current repository and track alias from the event detail and notifies the user about
+             * the query abortion.
+             *
+             * @param {Object} event - The event object triggered by the abort query action.
+             */
+            $scope.abortQuery = (event) => {
+                const currentRepository = $repositories.getActiveRepository();
+                const currentTrackAlias = event.detail.headers['X-GraphDB-Track-Alias'];
+                toastr.info($translate.instant('graphql.playground.message.abort_query'));
+                MonitoringRestService.deleteQuery(currentTrackAlias, currentRepository);
             };
 
             // =========================

--- a/src/js/angular/core/directives/graphql-playground/templates/graphql-playground.html
+++ b/src/js/angular/core/directives/graphql-playground/templates/graphql-playground.html
@@ -1,6 +1,7 @@
 <div ng-if="!!configuration" class="graphql-playground-component">
     <graphql-playground-component
         ng-custom-element
-        ngce-prop-configuration="configuration">
+        ngce-prop-configuration="configuration"
+        ngce-on-abort_query="abortQuery($event)">
     </graphql-playground-component>
 </div>

--- a/src/js/angular/graphql/controllers/graphql-playground-view.controller.js
+++ b/src/js/angular/graphql/controllers/graphql-playground-view.controller.js
@@ -87,16 +87,24 @@ function GraphqlPlaygroundViewCtrl($scope, $location, $repositories, $languageSe
         let endpointUrl = endpoint.replace(/^\//, '');
         const config = {
             endpoint: endpointUrl,
+            headers: getHeaders,
             selectedLanguage: $languageService.getLanguage()
         };
-        const authToken = AuthTokenService.getAuthToken();
-        if (authToken) {
-            config.headers = {
-                Authorization: authToken
-            };
-        }
         return new GraphqlPlaygroundConfig(config);
     };
+
+    const getHeaders = () => {
+        // Generates a new tracking alias for queries based on time
+        const trackAlias = `graphql-playground-query-${performance.now()}-${Date.now()}`;
+        const headers = {
+            'X-GraphDB-Track-Alias': trackAlias,
+        }
+        const authToken = AuthTokenService.getAuthToken();
+        if (authToken) {
+            headers['Authorization'] = authToken;
+        }
+        return headers;
+    }
 
     /**
      * Finds the default endpoint from the list of endpoints.

--- a/src/js/angular/models/graphql/graphql-playground-config.js
+++ b/src/js/angular/models/graphql/graphql-playground-config.js
@@ -9,7 +9,7 @@ export class GraphqlPlaygroundConfig {
          */
         this._endpoint = data.endpoint;
         /**
-         * @type {Object}
+         * @type {Object | () => Object}
          * @private
          */
         this._headers = data.headers;


### PR DESCRIPTION
## What
- Added a new header, "X-GraphDB-Track-Alias", to each GraphQL query request. This header contains a unique value to differentiate internal SPARQL queries from other queries.
- Extended the graphql-playground.directive wrapper to listen for the "abortQuery" event triggered by the abort button in the updated ontotext-graphql-playground-component.
- Upon receiving the "abortQuery" event, a DELETE request is sent to cancel the corresponding SPARQL query using the unique value from the "X-GraphDB-Track-Alias" header.

## Why
To cancel an internal SPARQL query that is part of a GraphQL query.

## How
- Introduced a unique "X-GraphDB-Track-Alias" header to help identify and differentiate internal SPARQL queries.
- Modified graphql-playground.directive to listen for the "abortQuery" event and trigger a DELETE request to cancel the relevant query.

## Screenshots
![image](https://github.com/user-attachments/assets/275ec651-afb2-4b6d-a164-c92706adf4a9)

![image](https://github.com/user-attachments/assets/f35ad3fe-92ff-45e7-be2e-12055612b125)

## Checklist
- [X] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
