### PR TITLE
GDB-11583 Extend guide steps for repository

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -2892,6 +2892,8 @@
     "guide.step_plugin.create_repository.repository_id.content": "Enter repository ID: <b>{{repositoryId}}.</b>",
     "guide.step_plugin.create_repository.save_button.content": "Click on the <b>{{'common.create.btn'|translate}}</b> button.",
     "guide.step_plugin.create_repository.ruleset_dropdown.content": "Choose ruleset: <b>{{rulesetName}}</b>.",
+    "guide.step_plugin.create_repository.enable-fts.content": "Enable full-text search (FTS) index",
+    "guide.step_plugin.create_repository.enable-fts.extra-content": "The full text search index is used for finding specific strings within the values associated with a given entity. For example, you can search for the word \"feature\" within a larger context. This is very helpful in cases where a lot of data is stored in literals.",
     "guide.step_plugin.enable-autocomplete.content": "Click on the checkbox to enable the index.",
     "guide.step_plugin.visual_graph_input_IRI.content": "Enter <b>{{easyGraphInputText}}</b> in the <b>Easy graph</b> text input.",
     "guide.step_plugin.visual_graph_show_autocomplete.content": "Click on the <b>{{iri}}</b> IRI to show the visual graph.",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -2892,6 +2892,8 @@
     "guide.step_plugin.create_repository.repository_id.content": "Entrez l'ID du dépôt : <b>{{repositoryId}}.</b>",
     "guide.step_plugin.create_repository.save_button.content": "Cliquez sur le bouton <b>{{'common.create.btn'|translate}}</b>.",
     "guide.step_plugin.create_repository.ruleset_dropdown.content": "Choisissez l'ensemble de règles : <b>{{rulesetName}}</b>.",
+    "guide.step_plugin.create_repository.enable-fts.content": "Activer l'index de recherche en texte intégral (FTS)",
+    "guide.step_plugin.create_repository.enable-fts.extra-content": "L'index de recherche plein texte est utilisé pour trouver des chaînes de caractères spécifiques dans les valeurs associées à une entité donnée. Par exemple, vous pouvez rechercher le mot « feature » dans un contexte plus large. Cette fonction est très utile dans les cas où de nombreuses données sont stockées sous forme de valeurs littérales.",
     "guide.step_plugin.enable-autocomplete.content": "Cliquez sur la case à cocher pour activer l'indexation.",
     "guide.step_plugin.visual_graph_input_IRI.content": "Entrez <b>{{easyGraphInputText}}</b> dans la saisie de texte <b>Graphique facile</b>.",
     "guide.step_plugin.visual_graph_show_autocomplete.content": "Cliquez sur l'IRI <b>{{iri}}</b> pour afficher le graphique visuel.",

--- a/src/js/angular/guides/steps/complex/create-repository/plugin.js
+++ b/src/js/angular/guides/steps/complex/create-repository/plugin.js
@@ -69,7 +69,7 @@ PluginRegistry.add('guide.step', [
                                    extraContent: 'guide.step_plugin.create_repository.enable-fts.extra-content',
                                    extraContentClass: 'alert alert-help text-left',
                                    elementSelector: GuideUtils.getGuideElementSelector('enable-fts-search'),
-                                   onNextValidate: () => Promise.resolve(GuideUtils.isChecked(GuideUtils.getGuideElementSelector('enable-fts-search')))
+                                   onNextValidate: () => Promise.resolve(GuideUtils.isChecked(GuideUtils.getGuideElementSelector('enable-fts-search', 'input')))
                                }, options)
                            });
             }

--- a/src/js/angular/guides/steps/complex/create-repository/plugin.js
+++ b/src/js/angular/guides/steps/complex/create-repository/plugin.js
@@ -55,10 +55,23 @@ PluginRegistry.add('guide.step', [
                         elementSelector: GuideUtils.getGuideElementSelector('graphDBRepositoryRulesetSelect'),
                         show: () => () => {
                             GuideUtils.validateTextInput(repositoryIdInputSelector, repositoryId);
-                        },
-                        rulesetName: options.rulesetName
+                        }
                     }, options)
                 });
+            }
+            if(options.fts) {
+                steps.push({
+                               guideBlockName: 'clickable-element',
+                               options: angular.extend({}, {
+                                   content: 'guide.step_plugin.create_repository.enable-fts.content',
+                                   url: '/repository/create/graphdb',
+                                   class: 'gdb-repository-enable-fts-guide-dialog',
+                                   extraContent: 'guide.step_plugin.create_repository.enable-fts.extra-content',
+                                   extraContentClass: 'alert alert-help text-left',
+                                   elementSelector: GuideUtils.getGuideElementSelector('enable-fts-search'),
+                                   onNextValidate: () => Promise.resolve(GuideUtils.isChecked(GuideUtils.getGuideElementSelector('enable-fts-search')))
+                               }, options)
+                           });
             }
             steps.push({
                 guideBlockName: 'clickable-element',

--- a/src/pages/repository.html
+++ b/src/pages/repository.html
@@ -312,7 +312,7 @@
                         </div>
                         <div class="form-group row indented-div">
                             <div class="checkbox offset-md-3 offset-lg-2">
-                                <label class="padding-label" gdb-tooltip="{{'repoTooltips.enableFtsIndex' | translate}}">
+                                <label class="padding-label" gdb-tooltip="{{'repoTooltips.enableFtsIndex' | translate}}" guide-selector="enable-fts-search">
                                     <input id="enableFtsIndex" name="enableFtsIndex" ng-true-value="'true'"
                                            ng-false-value="'false'" type="checkbox"
                                            ng-model="repositoryInfo.params.enableFtsIndex.value"/>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -802,11 +802,20 @@
                     },
                     "delete_endpoint": {
                         "label": "Delete endpoint",
-                        "tooltip": "Delete the GraphQL endpoint"
+                        "tooltip": "Delete the GraphQL endpoint",
+                        "confirmation": {
+                            "title": "Delete endpoint",
+                            "body": "Are you sure you want to delete the GraphQL endpoint '{{name}}'?"
+                        },
+                        "success": "The GraphQL endpoint '{{name}}' was deleted successfully."
                     },
                     "export_schema": {
                         "label": "Export schema definition",
                         "tooltip": "Export the GraphQL endpoint schema definition"
+                    },
+                    "view_report": {
+                        "label": "[View report]",
+                        "tooltip": "Opens the report in a modal dialog"
                     },
                     "set_as_default": {
                         "success": "Successfully set \"{{endpointId}}\" endpoint as default"
@@ -865,7 +874,7 @@
                             "vocabulary_prefix": {
                                 "label": "Vocabulary prefix",
                                 "tooltip": "Vocabulary prefix",
-                                "placeholder": "Select prefix"
+                                "placeholder": "Select prefix (from source repository)"
                             },
                             "endpoint_label": {
                                 "label": "Endpoint label",
@@ -877,21 +886,20 @@
                             "use_all_graphs": {
                                 "label": "Use all graphs",
                                 "messages": {
-                                    "all_graphs": "All {{count}} graphs are included for endpoint creation",
-                                    "no_graphs": "No graphs were found in the selected repository."
+                                    "use_all_data": "All data from the repository will be used for endpoint creation"
                                 }
                             },
                             "use_shacl_shape_graph": {
                                 "label": "Use SHACL shape graph",
                                 "messages": {
                                     "all_shacl_shape_graphs": "All {{count}} SHACL shape graphs are included for endpoint creation",
-                                    "no_graphs": "No SHACL shape graphs were found in the selected repository."
+                                    "no_graphs": "No SHACL shape graphs were found in the selected repository"
                                 }
                             },
                             "pick_graphs": {
                                 "label": "Select one or more graphs",
                                 "messages": {
-                                    "no_graphs": "No graphs were found in the selected repository."
+                                    "no_graphs": "No graphs were found in the selected repository"
                                 }
                             }
                         },
@@ -905,6 +913,34 @@
                     "endpoint_parameters": {
                         "title": "Parameters",
                         "form": {}
+                    }
+                },
+                "generate_endpoint": {
+                    "title": "Create",
+                    "overview": {
+                        "title": "Overview",
+                        "for_shapes": {
+                            "info": "{{endpointsCount}} GraphQL endpoints will be created in \"{{activeRepoId}}\" repository based on the GraphQL schema shapes listed below. To modify the selection, navigate back to Step 1 (Select schema source).",
+                            "included_endpoints": "Included GraphQL schema shapes",
+                            "generated_endpoints": "GraphQL endpoints",
+                            "manage_endpoints_info": "Navigate to <a href=\"{{managementUrl}}\">Endpoint Management</a> to manage the endpoints",
+                            "explore_in_playground_link_tooltip": "Explore in Playground (opens in a new tab)",
+                            "view_report_link": "[View report]"
+                        }
+                    },
+                    "generation_failure_report": {
+                        "title": "GraphQL endpoint creation failed",
+                        "reason_message": "GraphQL endpoint \"{{endpointId}}\" creation failed because of errors/warnings during schema definition generation.",
+                        "errors": "Validation error [{{errorCount}}]",
+                        "warnings": "Warning [{{warningCount}}]",
+                        "actions": {
+                            "download_report": {
+                                "label": "Download report"
+                            }
+                        }
+                    },
+                    "messages": {
+                        "generation_progress": "Endpoints creation in progress..."
                     }
                 },
                 "shapes_multiselect": {
@@ -975,7 +1011,7 @@
                         }
                     },
                     "generate_endpoint": {
-                        "label": "Generate"
+                        "label": "Create endpoint"
                     }
                 }
             },
@@ -2856,6 +2892,8 @@
     "guide.step_plugin.create_repository.repository_id.content": "Enter repository ID: <b>{{repositoryId}}.</b>",
     "guide.step_plugin.create_repository.save_button.content": "Click on the <b>{{'common.create.btn'|translate}}</b> button.",
     "guide.step_plugin.create_repository.ruleset_dropdown.content": "Choose ruleset: <b>{{rulesetName}}</b>.",
+    "guide.step_plugin.create_repository.enable-fts.content": "Enable full-text search (FTS) index",
+    "guide.step_plugin.create_repository.enable-fts.extra-content": "The full text search index is used for finding specific strings within the values associated with a given entity. For example, you can search for the word \"feature\" within a larger context. This is very helpful in cases where a lot of data is stored in literals.",
     "guide.step_plugin.enable-autocomplete.content": "Click on the checkbox to enable the index.",
     "guide.step_plugin.visual_graph_input_IRI.content": "Enter <b>{{easyGraphInputText}}</b> in the <b>Easy graph</b> text input.",
     "guide.step_plugin.visual_graph_show_autocomplete.content": "Click on the <b>{{iri}}</b> IRI to show the visual graph.",


### PR DESCRIPTION
## What
Extend  guide steps when creating repository to be able to enable FTS

## Why
This will allow enabling of FTS to be included in the guides

## How
- added a step configuration option `fts` which would add the step to enable fts to the guide

## Testing
Testing will be done on whole guide

## Screenshots
![image](https://github.com/user-attachments/assets/d314e5a2-312f-4507-8570-47f5c5ed3e0c)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
