### PR TITLE
GDB-11784: Set Default Query in GraphQL Playground Component for New Tabs

### DIFF
--- a/src/js/angular/graphql/controllers/graphql-playground-view.controller.js
+++ b/src/js/angular/graphql/controllers/graphql-playground-view.controller.js
@@ -88,7 +88,8 @@ function GraphqlPlaygroundViewCtrl($scope, $location, $repositories, $languageSe
         const config = {
             endpoint: endpointUrl,
             headers: getHeaders,
-            selectedLanguage: $languageService.getLanguage()
+            selectedLanguage: $languageService.getLanguage(),
+            defaultQuery: 'query Object {\n  object(limit: 100) {\n    id\n  }\n}'
         };
         return new GraphqlPlaygroundConfig(config);
     };

--- a/src/js/angular/models/graphql/graphql-playground-config.js
+++ b/src/js/angular/models/graphql/graphql-playground-config.js
@@ -20,6 +20,11 @@ export class GraphqlPlaygroundConfig {
          * @private
          */
         this._selectedLanguage = data.selectedLanguage;
+
+        /**
+         * The default query that will be used when a new tab is added.
+         */
+        this._defaultQuery = data.defaultQuery;
     }
 
     get endpoint() {
@@ -44,5 +49,13 @@ export class GraphqlPlaygroundConfig {
 
     set selectedLanguage(value) {
         this._selectedLanguage = value;
+    }
+
+    get defaultQuery() {
+        return this._defaultQuery;
+    }
+
+    set defaultQuery(value) {
+        this._defaultQuery = value;
     }
 }

--- a/test-cypress/integration/graphql/graphql-playground.spec.js
+++ b/test-cypress/integration/graphql/graphql-playground.spec.js
@@ -90,5 +90,21 @@ describe('GraphQL Playground', () => {
             // Then: I expect to see GraphQL playground translated.
             GraphiQLEditorToolsSteps.getGraphiQLEditorTabButton(1).contains('En-têtes');
         });
+
+        it('should set default query', () => {
+            // Given: I have opened the workbench on the GraphQL Playground page.
+            GraphqlPlaygroundSteps.visit();
+            GraphiqlPlaygroundSteps.getPlayground().should('be.visible');
+
+            // Then: I expect the default query to be set in the GraphQL query editor.
+            GraphqlPlaygroundSteps.getEditorContent().should('equal', 'query Object {\n  object(limit: 100) {\n    id\n  }\n}');
+
+            // When: I open a new tab.
+            GraphqlPlaygroundSteps.addTab();
+            GraphqlPlaygroundSteps.getTabs().should('have.length', 2);
+
+            // Then: I expect the default query to be set in the GraphAL query editor for the newly opened tab.
+            GraphqlPlaygroundSteps.getEditorContent().should('equal', 'query Object {\n  object(limit: 100) {\n    id\n  }\n}');
+        });
     });
 });

--- a/test-cypress/steps/graphql/graphql-playground-steps.js
+++ b/test-cypress/steps/graphql/graphql-playground-steps.js
@@ -71,4 +71,20 @@ export class GraphqlPlaygroundSteps {
     static getResponse() {
         return this.getView().find('.graphiql-response');
     }
+
+    static getAddTabButton() {
+        return cy.get('.graphiql-tab-add');
+    }
+
+    static addTab() {
+        this.getAddTabButton().click();
+    }
+
+    static getTabsContainer() {
+        return cy.get('.graphiql-tabs');
+    }
+
+    static getTabs() {
+        return this.getTabsContainer().find('.graphiql-tab');
+    }
 }


### PR DESCRIPTION
## What
When the GraphQL Playground is opened for the first time or a new tab is opened, the query editor is empty.

## Why
There is no set default value for the GraphQl query.

## How
A default query has been added to the GraphQL Playground configuration.

## Screenshots
![image](https://github.com/user-attachments/assets/20414022-9b64-4549-858b-13eceb3db238)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
