### PR TITLE
feat(GDB-11772) Enable GraphQL-Only Authority Setting for Free Access

### DIFF
--- a/src/js/angular/core/services/security.service.js
+++ b/src/js/angular/core/services/security.service.js
@@ -125,7 +125,8 @@ function SecurityService(SecurityRestService) {
      * @return {Promise<Object>} A promise that resolves to the free access data.
      */
     const getFreeAccess = () => {
-        return SecurityRestService.getFreeAccess();
+        return SecurityRestService.getFreeAccess()
+            .then((response) => toUserModelMapper(response.data, 'authorities'));
     };
 
     /**
@@ -135,7 +136,7 @@ function SecurityService(SecurityRestService) {
      * @return {Promise<Object>} A promise that resolves when the free access data is set.
      */
     const setFreeAccess = (data) => {
-        return SecurityRestService.setFreeAccess(data);
+        return SecurityRestService.setFreeAccess(fromUserModelMapper(data, 'authorities'));
     };
 
     /**

--- a/src/js/angular/graphql/plugin.js
+++ b/src/js/angular/graphql/plugin.js
@@ -48,7 +48,7 @@ PluginRegistry.add('main.menu', {
             labelKey: 'menu.graphql-endpoint-management.label',
             href: 'graphql/endpoints',
             order: 10,
-            role: 'ROLE_USER',
+            role: 'IS_AUTHENTICATED_FULLY',
             parent: 'GraphQL',
             children: [
                 {
@@ -62,7 +62,7 @@ PluginRegistry.add('main.menu', {
             labelKey: 'menu.graphql-playground.label',
             href: 'graphql/playground',
             order: 15,
-            role: 'ROLE_USER',
+            role: 'IS_AUTHENTICATED_FULLY',
             parent: 'GraphQL'
         }]
 });

--- a/src/js/angular/security/templates/modal/default-authorities.html
+++ b/src/js/angular/security/templates/modal/default-authorities.html
@@ -23,15 +23,17 @@
                 </p>
             </div>
             <div class="row" style="margin-top: 0">
-                <h5 class="boldless col-xs-10">{{'security.repository.title' | translate}}</h5>
+                <h5 class="boldless col-xs-9">{{'security.repository.title' | translate}}</h5>
                 <span class="fa fa-eye fa-1andAhalfx col-xs-1" gdb-tooltip="{{'security.tooltip.read' | translate}}"
                       tooltip-placement="top" style="margin-top: 10px"></span>
                 <span class="fa fa-pencil fa-1andAhalfx col-xs-1" gdb-tooltip="{{'security.tooltip.write' | translate}}"
                       tooltip-placement="top" style="margin-top: 10px"></span>
+                <span class="fa-kit fa-gdb-graphql fa-1andAhalfx col-xs-1" gdb-tooltip="{{'security.tooltip.graphql' | translate}}"
+                      tooltip-placement="top" style="margin-top: 10px"></span>
             </div>
             <div id="access-user-repos access-user-rights" class="row"
                  ng-repeat="repository in getRepositories() | orderBy: ['id', 'location']">
-                <p class="col-xs-10">{{repository.id}}<small> &middot; {{repository.location ? repository.location : 'Local'}}</small></p>
+                <p class="col-xs-9">{{repository.id}}<small> &middot; {{repository.location ? repository.location : 'Local'}}</small></p>
                 <label class="col-xs-1">
                     <input class="animated read" type="checkbox"
                            ng-model="grantedAuthorities.READ_REPO[createUniqueKey(repository)]"
@@ -44,6 +46,12 @@
                     <input class="animated write" type="checkbox"
                            ng-model="grantedAuthorities.WRITE_REPO[createUniqueKey(repository)]"
                            ng-checked="grantedAuthorities.WRITE_REPO[createUniqueKey(repository)]"
+                           ng-click="setGrantedAuthorities()">
+                </label>
+                <label class="col-xs-1">
+                    <input class="animated graphql" type="checkbox"
+                           ng-model="grantedAuthorities.GRAPHQL[createUniqueKey(repository)]"
+                           ng-checked="grantedAuthorities.GRAPHQL[createUniqueKey(repository)]"
                            ng-click="setGrantedAuthorities()">
                 </label>
             </div>

--- a/test-cypress/integration-flaky/setup/users-and-access/security-and-free-access.spec.js
+++ b/test-cypress/integration-flaky/setup/users-and-access/security-and-free-access.spec.js
@@ -2,6 +2,7 @@ import {UserAndAccessSteps} from "../../../steps/setup/user-and-access-steps";
 import {RepositoriesStubs} from "../../../stubs/repositories/repositories-stubs";
 import {ModalDialogSteps} from "../../../steps/modal-dialog-steps";
 import {ToasterSteps} from "../../../steps/toaster-steps";
+import {LoginSteps} from "../../../steps/login-steps";
 
 const DEFAULT_ADMIN_PASSWORD = "root";
 // Moved out of the standard test suite, because Cypress can't verify Free Access is ON in CI
@@ -30,7 +31,7 @@ describe('Security and Free Access', () => {
         // When I enable security
         UserAndAccessSteps.toggleSecurity();
         // When I log in as an Admin
-        UserAndAccessSteps.loginWithUser("admin", DEFAULT_ADMIN_PASSWORD);
+        LoginSteps.loginWithUser("admin", DEFAULT_ADMIN_PASSWORD);
         // Then the page should load
         UserAndAccessSteps.getSplashLoader().should('not.be.visible');
         UserAndAccessSteps.getUsersTable().should('be.visible');

--- a/test-cypress/integration/sparql-editor/saved-query/readonly-query.spec.js
+++ b/test-cypress/integration/sparql-editor/saved-query/readonly-query.spec.js
@@ -4,6 +4,7 @@ import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
 import {UserAndAccessSteps} from "../../../steps/setup/user-and-access-steps";
 import {SavedQuery} from "../../../steps/yasgui/saved-query";
 import {SavedQueriesDialog} from "../../../steps/yasgui/saved-queries-dialog";
+import {LoginSteps} from "../../../steps/login-steps";
 
 const USER_NAME = 'saved_query_user';
 const USER_ADMINISTRATOR = 'admin';
@@ -31,25 +32,25 @@ describe.skip('Readonly saved query', () => {
     });
 
     afterEach(() => {
-        UserAndAccessSteps.logout();
+        LoginSteps.logout();
         cy.deleteRepository(repositoryId);
         UserAndAccessSteps.visit();
-        UserAndAccessSteps.loginWithUser(USER_ADMINISTRATOR, PASSWORD);
+        LoginSteps.loginWithUser(USER_ADMINISTRATOR, PASSWORD);
         UserAndAccessSteps.toggleSecurity();
         cy.deleteUser(USER_NAME);
     });
 
     it('Should not allow modifying a saved query if it is readonly', () => {
         // Given: There is a public saved query created by a user.
-        UserAndAccessSteps.loginWithUser(USER_NAME, PASSWORD);
+        LoginSteps.loginWithUser(USER_NAME, PASSWORD);
         SparqlEditorSteps.visitSparqlEditorPage();
         YasguiSteps.getYasgui().should('be.visible');
         const savedQueryName = SavedQuery.generateQueryName();
         SavedQuery.create(savedQueryName);
-        UserAndAccessSteps.logout();
+        LoginSteps.logout();
 
         // When: I log in with another user
-        UserAndAccessSteps.loginWithUser(USER_ADMINISTRATOR, PASSWORD);
+        LoginSteps.loginWithUser(USER_ADMINISTRATOR, PASSWORD);
         // and open the popup with the saved query.
         SparqlEditorSteps.visitSparqlEditorPage();
         YasguiSteps.showSavedQueries();

--- a/test-cypress/integration/ttyg/ttyg-permission.spec.js
+++ b/test-cypress/integration/ttyg/ttyg-permission.spec.js
@@ -3,6 +3,7 @@ import {RepositoriesStub} from "../../stubs/repositories-stub";
 import {UserAndAccessSteps} from "../../steps/setup/user-and-access-steps";
 import {TTYGStubs} from "../../stubs/ttyg/ttyg-stubs";
 import {TTYGViewSteps} from "../../steps/ttyg/ttyg-view-steps";
+import {LoginSteps} from "../../steps/login-steps";
 
 const USER_WITH_ROLE_USER = 'ttyg_user';
 const USER_WITH_ROLE_REPO_MANAGER = 'ttyg_repo_manager';
@@ -30,7 +31,7 @@ describe('TTYG permissions', () => {
 
     after(() => {
         UserAndAccessSteps.visit();
-        UserAndAccessSteps.loginWithUser(USER_ADMINISTRATOR, PASSWORD);
+        LoginSteps.loginWithUser(USER_ADMINISTRATOR, PASSWORD);
         UserAndAccessSteps.toggleSecurity();
         cy.deleteUser(USER_WITH_ROLE_USER);
         cy.deleteUser(USER_WITH_ROLE_REPO_MANAGER);
@@ -52,7 +53,7 @@ describe('TTYG permissions', () => {
         const shouldBe = enable ? 'be.enabled' : 'be.disabled';
         TTYGStubs.stubAgentListGet('/ttyg/agent/get-agent-list-0.json');
         TTYGViewSteps.visit();
-        UserAndAccessSteps.loginWithUser(user, password);
+        LoginSteps.loginWithUser(user, password);
         TTYGViewSteps.getCreateFirstAgentButton().should(shouldBe);
         TTYGStubs.stubChatsListGet();
         TTYGStubs.stubAgentListGet();
@@ -61,6 +62,6 @@ describe('TTYG permissions', () => {
         TTYGViewSteps.getCreateAgentButton().should(shouldBe);
         TTYGViewSteps.getEditCurrentAgentButton().should(shouldBe);
         TTYGViewSteps.getToggleAgentsSidebarButton().should(shouldBe);
-        UserAndAccessSteps.logout();
+        LoginSteps.logout();
     }
 });

--- a/test-cypress/steps/login-steps.js
+++ b/test-cypress/steps/login-steps.js
@@ -1,0 +1,20 @@
+export class LoginSteps {
+    static visitLoginPage() {
+        cy.visit('/login');
+    }
+
+    static loginWithUser(username, password) {
+        cy.get('#wb-login-username').type(username);
+        cy.get('#wb-login-password').type(password);
+        cy.get('#wb-login-submitLogin').click();
+    }
+
+    static logout() {
+        cy.get('#btnGroupDrop2').click();
+        cy.get('.dropdown-item')
+            .contains('Logout')
+            .closest('a')
+            // Force the click because Cypress sometimes determines that the item has 0x0 dimensions
+            .click({force: true});
+    }
+}

--- a/test-cypress/steps/setup/user-and-access-steps.js
+++ b/test-cypress/steps/setup/user-and-access-steps.js
@@ -191,21 +191,6 @@ export class UserAndAccessSteps {
             });
     }
 
-    static loginWithUser(username, password) {
-        cy.get('#wb-login-username').type(username);
-        cy.get('#wb-login-password').type(password);
-        cy.get('#wb-login-submitLogin').click();
-    }
-
-    static logout() {
-        cy.get('#btnGroupDrop2').click();
-        cy.get('.dropdown-item')
-            .contains('Logout')
-            .closest('a')
-            // Force the click because Cypress sometimes determines that the item has 0x0 dimensions
-            .click({force: true});
-    }
-
     static clickGraphqlAccessAny() {
         cy.get('#user-repos')
             .contains('Any data repository')
@@ -334,4 +319,29 @@ export class UserAndAccessSteps {
     static clickSubmenuItem(label) {
         return cy.get('.sub-menu').contains(label).click({force: true});
     }
+
+    static clickFreeReadAccessRepo(repoName) {
+        cy.get('.repo-fields')
+            .contains(repoName)
+            .parent('.row')
+            .find('.read')
+            .click({force: true});
+    }
+
+    static clickFreeWriteAccessRepo(repoName) {
+        cy.get('.repo-fields')
+            .contains(repoName)
+            .parent('.row')
+            .find('.write')
+            .click({force: true});
+    }
+
+    static clickFreeGraphqlAccessRepo(repoName) {
+        cy.get('.repo-fields')
+            .contains(repoName)
+            .parent('.row')
+            .find('.graphql')
+            .click({force: true});
+    }
+
 }


### PR DESCRIPTION
## WHAT:
- Updated the default authorities modal template to include GraphQL authority settings.
- Enhanced the free access API endpoints in the security service with mapping functions to correctly handle authority data.

## WHY:
- Administrators need the ability to assign GraphQL-only authorities in the free access configuration.

## HOW:
- Updated the security service methods (getFreeAccess and setFreeAccess) to transform the data properly for authority mapping.
- Enhanced the modal template for default authorities to include a new GraphQL checkbox and adjusted the grid layout for consistent display.
- Modified the Angular plugin configuration to change the required role to 'IS_AUTHENTICATED_FULLY' in the GraphQL plugin.

Depends on https://github.com/Ontotext-AD/graphdb-workbench/pull/1809

## Screenshots
![image](https://github.com/user-attachments/assets/b15bdb1a-50a5-47a7-b422-2b105cfadd54)


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [x] Tests
