### PR TITLE
GDB-11781: TTYG guide: Extend End Guide Step with Option to Change Content

### DIFF
--- a/src/js/angular/guides/steps/complex/ttyg/create-ttyg-agent/plugin.js
+++ b/src/js/angular/guides/steps/complex/ttyg/create-ttyg-agent/plugin.js
@@ -14,7 +14,7 @@ PluginRegistry.add('guide.step', [
                     }, options)
                 },
                 {
-                    guideBlockName: 'info-message',
+                    guideBlockName: 'guide-end',
                     options: angular.extend({}, {
                         title: 'guide.step_plugin.create-ttyg-agent.missing-key.title',
                         content: 'guide.step_plugin.create-ttyg-agent.missing-key.content',

--- a/src/js/angular/guides/steps/core/plugin.js
+++ b/src/js/angular/guides/steps/core/plugin.js
@@ -102,8 +102,9 @@ PluginRegistry.add('guide.step', [
         getStep: (options, services) => {
             const notOverridable = {
                 type: 'readonly',
-                title: 'guide.step_plugin.guide-ended.title',
-                content: 'guide.step_plugin.guide-ended.content',
+                title: options.title || 'guide.step_plugin.guide-ended.title',
+                content: options.content || 'guide.step_plugin.guide-ended.content',
+                lastStep: true,
                 show: (guide) => () => {
                     guide.options.confirmCancel = false;
                 },

--- a/src/js/angular/guides/tour-lib-services/shepherd.service.js
+++ b/src/js/angular/guides/tour-lib-services/shepherd.service.js
@@ -295,7 +295,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
 
         // Check if stepsDescriptions more than 1 element, this mean that we have process last step. The last step has no next step.
         if (stepsDescriptions.length > 1) {
-            guide.addStep(this._getLastStep(guide, stepsDescriptions));
+            guide.addStep(this._getLastStep(guide, stepsDescriptions[stepsDescriptions.length - 1]));
         }
     };
 
@@ -370,18 +370,22 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
      * @private
      */
     this._getMiddleStep = (guide, stepsDescriptions, indexOfProcessedStep) => {
-        return this._toGuideStep(guide, stepsDescriptions[indexOfProcessedStep - 1], stepsDescriptions[indexOfProcessedStep], stepsDescriptions[indexOfProcessedStep + 1]);
+        let currentStep = stepsDescriptions[indexOfProcessedStep];
+        if (currentStep.lastStep) {
+            return this._getLastStep(guide, currentStep);
+        }
+        return this._toGuideStep(guide, stepsDescriptions[indexOfProcessedStep - 1], currentStep, stepsDescriptions[indexOfProcessedStep + 1]);
     };
 
     /**
      * Creates last step from <code>stepsDescriptions</code>.
      * @param {Shepherd.Tour} guide - the guide.
-     * @param {array} stepsDescriptions - array with descriptions of steps.
+     * @param {*} lastStepDescription - description of last step.
      * @return {Shepherd.Step} the last step.
      * @private
      */
-    this._getLastStep = (guide, stepsDescriptions) => {
-        const step = this._toGuideStep(guide, null, stepsDescriptions[stepsDescriptions.length - 1]);
+    this._getLastStep = (guide, lastStepDescription) => {
+        const step = this._toGuideStep(guide, null, lastStepDescription);
         step.buttons.push(this._getBackToGuidesButton(guide));
         step.buttons.push(this._getCancelButton(guide));
         return step;


### PR DESCRIPTION
## What
- Extends the 'guide-end' options with the ability to configure its content and title.
- Changes the setup of steps to allow 'guide-end' to be placed in the middle of a guide.

## Why
The newly implemented guide has a branch in the middle. There is a configuration step that the user can complete before starting the GraphDB server. If this configuration is not set, the guide must be completed in the middle of the process.

## How
- Enhanced the configuration of the 'guide-end' step by adding a new field, "lastStep", and the ability to read content from the configuration;
- Modified the service behavior for adding step buttons to support cases where an end step can be positioned in the middle of a guide.

The step configuration now supports content option:
```
{
      "guideBlockName": "guide-end",
      "options": {
        "title": {
            "en": "Title in Englis",
            "fr": "Titre en français"
        },
        "content": {
           "en": "Content in Englis",
           "fr": "Contenu en français"
        }
      }
    }
```
The new options, content and title, are optional. If they are not provided, the default ones will be used.

## Testing
N/A

## Screenshots
![image](https://github.com/user-attachments/assets/22473521-1466-49ac-b4bc-9b0f4fb012f2)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
