### PR TITLE
GDB-11790: TTYG Guide – Extend Guides with an Option to Hide the "Previous" Button

### DIFF
--- a/src/js/angular/guides/tour-lib-services/shepherd.service.js
+++ b/src/js/angular/guides/tour-lib-services/shepherd.service.js
@@ -436,7 +436,7 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
             buttons.push(this._getSkipButton(guide));
         }
 
-        if (previousStepDescription) {
+        if (!this._isDisablePreviousFlow(currentStepDescription) && previousStepDescription) {
             buttons.push(this._getPreviousButton(guide));
         }
         if (nextStepDescription) {
@@ -471,6 +471,16 @@ function ShepherdService($location, $translate, LocalStorageAdapter, $route, $in
         // if there isn't next step with skipPoint set to true, then return last step id.
         return steps.at(steps.length - 1).id;
     };
+
+    /**
+     * Checks if the previous flow is disabled for the <code>stepDescription</code>.
+     * @param {*} stepDescription - The step to be checked.
+     * @return {boolean} - Returns true if the previous flow is disabled, otherwise false.
+     * @private
+     */
+    this._isDisablePreviousFlow = (stepDescription) => {
+        return angular.isDefined(stepDescription.disablePreviousFlow) ? stepDescription.disablePreviousFlow : false;
+    }
 
     /**
      * Pauses current ran guide.


### PR DESCRIPTION
## What
Extend guides with an option to hide the "Previous" button.

## Why
Currently, our guides always display a "Previous" button, which may not be necessary in certain cases. To improve flexibility, we have added a configuration option that allows users to hide the "Previous" button when needed.

## How
A new option, "disablePreviousFlow", has been introduced. When set to true, the "Previous" button will not be displayed.

You can use the following configuration to test this feature:
```
{
  "guideName": {
    "en": "Talk To Your Graph guide",
    "fr": "Le guide Star Wars"
  },
  "guideDescription": {
    "en": "This is the TTYG guide",
    "fr": "Le guide Star Wars est un guide pour débutant montrant la création d'un dépôt, l'importation de données RDF à partir d'un fichier, le début de l'exploration des données du graphe visuel et l'exécution de requêtes SPARQL. Le guide prend environ 30 minutes à compléter."
  },
  "guideLevel": 0,
  "guideOrder": 1,
  "options": {
    "repositoryIdBase": "ttyg",
    **"disablePreviousFlow": true**
  },
  "steps": [
    {
      "guideBlockName": "create-ttyg-agent",
      "options": {
        "methods": [
          {
            "guideBlockName": "enable-sparql-search-method",
            "options": {
              "ontologyGraph": "https://kg.ontotext.com/resource/ontology/"
            }
          },
          {
            "guideBlockName": "enable-fts-search-method"
          },
          {
            "guideBlockName": "enable-similarity_search-method"
          }
        ]
      }
    },
    {
      "guideBlockName": "guide-end"
    }
  ]
}
```

## Testing
N/A

## Screenshots
![image](https://github.com/user-attachments/assets/60ef0b7a-b0e5-4e47-bdfe-b604daa24d32)

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [-] Tests
