### PR TITLE
GDB-11802 allow deleting generated endpoint report

### DIFF
--- a/src/css/graphql/create-graphql-endpoint.css
+++ b/src/css/graphql/create-graphql-endpoint.css
@@ -144,25 +144,23 @@
 
 .create-graphql-endpoint-view .generate-endpoint-container {
     position: relative;
-    flex: 1;
-    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    height: auto;
     width: 50%;
+    overflow: hidden;
 }
 
 .create-graphql-endpoint-view .generate-endpoint-container .endpoints-generation-overview {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
     display: flex;
     flex-direction: column;
+    height: 100%;
 }
 
 .generate-endpoint-view .generate-endpoint-container .endpoints-overview {
     flex: 1;
-    overflow-y: auto;
     min-height: 0;
+    overflow-y: auto;
 }
 
 .generate-endpoint-view .generate-endpoint-container .endpoints-overview .endpoint-overview {
@@ -175,20 +173,18 @@
 }
 
 .generate-endpoint-view .generate-endpoint-container .generation-report {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    position: relative;
     display: flex;
     flex-direction: column;
+    height: 100%;
+    width: 100%;
 }
 
-.generate-endpoint-view .generate-endpoint-container .generation-report,
 .generate-endpoint-view .generate-endpoint-container .generation-report-list {
     flex: 1;
-    overflow-y: auto;
     min-height: 0;
+    overflow-y: auto;
+    padding: 10px;
 }
 
 .generate-endpoint-view .generate-endpoint-container .generation-report-list .endpoint-report {

--- a/src/css/graphql/graphql-endpoint-management.css
+++ b/src/css/graphql/graphql-endpoint-management.css
@@ -15,6 +15,10 @@
     width: 40px;
 }
 
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .status {
+    width: 40px;
+}
+
 .graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint_id {
     width: 10%;
 }
@@ -25,6 +29,11 @@
 
 .graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint-actions {
     width: 5%;
+}
+
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint-report-link {
+    padding-left: 0;
+    padding-right: 0;
 }
 
 .graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint-default-state,

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -975,6 +975,22 @@
                     "failed": "Failed",
                     "not_allowed": "Not allowed"
                 }
+            },
+            "generation_failure_report_modal": {
+                "title": "GraphQL endpoint creation report",
+                "failing_reason_message": "GraphQL endpoint creation failed because of errors/warnings during schema definition generation.",
+                "warning_reason_message": "Your GraphQL endpoint is now ready. Below are the warnings encountered during schema generation.",
+                "errors": "Validation error [{{errorCount}}]",
+                "warnings": "Warning [{{warningCount}}]",
+                "actions": {
+                    "download_report": {
+                        "label": "Download report"
+                    },
+                    "delete_report": {
+                        "label": "Delete report",
+                        "success": "The endpoint generation report was deleted successfully."
+                    }
+                }
             }
         },
         "create_endpoint": {
@@ -1012,7 +1028,11 @@
                             "endpoint_id": {
                                 "label": "Endpoint ID",
                                 "tooltip": "A unique identifier for this endpoint, used to reference and manage it.",
-                                "placeholder": "star-wars"
+                                "placeholder": "star-wars",
+                                "validation": {
+                                    "required": "The endpoint ID is required",
+                                    "pattern": "The endpoint ID must contain only letters, numbers, underscores, and hyphens"
+                                }
                             },
                             "vocabulary_prefix": {
                                 "label": "Vocabulary prefix",
@@ -1109,17 +1129,6 @@
                             "explore_in_playground_link_tooltip": "Explore in Playground (opens in a new tab)",
                             "view_report_link": "View report",
                             "view_report_link_tooltip": "Opens endpoint creation report in a modal dialog"
-                        }
-                    },
-                    "generation_failure_report": {
-                        "title": "GraphQL endpoint creation failed",
-                        "reason_message": "GraphQL endpoint creation failed because of errors/warnings during schema definition generation.",
-                        "errors": "Validation error [{{errorCount}}]",
-                        "warnings": "Warning [{{warningCount}}]",
-                        "actions": {
-                            "download_report": {
-                                "label": "Download report"
-                            }
                         }
                     },
                     "messages": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -975,6 +975,22 @@
                     "failed": "Échoué",
                     "not_allowed": "Non autorisé"
                 }
+            },
+            "generation_failure_report_modal": {
+                "title": "Rapport de création de point de terminaison GraphQL",
+                "failing_reason_message": "La création du point de terminaison GraphQL a échoué en raison d'erreurs/avertissements lors de la génération de la définition de schéma.",
+                "warning_reason_message": "Votre point de terminaison GraphQL est maintenant prêt. Vous trouverez ci-dessous les avertissements rencontrés lors de la génération du schéma.",
+                "errors": "Erreur de validation [{{errorCount}}]",
+                "warnings": "Avertissement [{{warningCount}}",
+                "actions": {
+                    "download_report": {
+                        "label": "Télécharger le rapport"
+                    },
+                    "delete_report": {
+                        "label": "Supprimer le rapport",
+                        "success": "Le rapport de génération du point de terminaison a été supprimé avec succès."
+                    }
+                }
             }
         },
         "create_endpoint": {
@@ -1012,7 +1028,11 @@
                             "endpoint_id": {
                                 "label": "ID du point de terminaison",
                                 "tooltip": "Un identifiant unique pour ce point de terminaison, utilisé pour le référencer et le gérer.",
-                                "placeholder": "star-wars"
+                                "placeholder": "star-wars",
+                                "validation": {
+                                    "required": "L'identifiant du point de terminaison est requis",
+                                    "pattern": "L'identifiant du point de terminaison ne peut contenir que des lettres, des chiffres, des underscores et des tirets"
+                                }
                             },
                             "vocabulary_prefix": {
                                 "label": "Préfixe de vocabulaire",
@@ -1109,17 +1129,6 @@
                             "explore_in_playground_link_tooltip": "Explorer dans Playground (s'ouvre dans un nouvel onglet)",
                             "view_report_link": "Voir le rapport",
                             "view_report_link_tooltip": "Ouvre le rapport de création du point de terminaison dans une boîte de dialogue modale."
-                        }
-                    },
-                    "generation_failure_report": {
-                        "title": "La création du point de terminaison GraphQL a échoué",
-                        "reason_message": "La création du point de terminaison GraphQL a échoué en raison d'erreurs/avertissements lors de la génération de la définition de schéma.",
-                        "errors": "Erreur de validation [{{errorCount}}]",
-                        "warnings": "Avertissement [{{warningCount}}",
-                        "actions": {
-                            "download_report": {
-                                "label": "Télécharger le rapport"
-                            }
                         }
                     },
                     "messages": {

--- a/src/js/angular/core/services/graphql.service.js
+++ b/src/js/angular/core/services/graphql.service.js
@@ -242,6 +242,17 @@ function GraphqlService(GraphqlRestService) {
         return GraphqlRestService.importEndpointDefinition(repositoryId, payload);
     };
 
+    /**
+     * Deletes the endpoint generation report. This method should be called after the user has reviewed the warnings
+     * and accepted them.
+     * @param {string} repositoryId The repository ID.
+     * @param {string} endpointId The endpoint ID.
+     * @returns {Promise<unknown>}
+     */
+    const deleteEndpointGenerationReport = (repositoryId, endpointId) => {
+        return GraphqlRestService.deleteEndpointGenerationReport(repositoryId, endpointId);
+    };
+
     return {
         getEndpointsCountToGenerate,
         getGenerateEndpointsOverview,
@@ -260,6 +271,7 @@ function GraphqlService(GraphqlRestService) {
         generateEndpointFromGraphqlShapes,
         generateEndpointFromOwl,
         exportEndpointDefinition,
-        importEndpointDefinition
+        importEndpointDefinition,
+        deleteEndpointGenerationReport
     };
 }

--- a/src/js/angular/graphql/controllers/create-graphql-endpoint-view.controller.js
+++ b/src/js/angular/graphql/controllers/create-graphql-endpoint-view.controller.js
@@ -71,6 +71,13 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
      */
     $scope.currentStep = undefined;
 
+    /**
+     * A flag indicating if the endpoint generation is in progress. This allows to disable some UI elements during the
+     * generation process.
+     * @type {boolean}
+     */
+    $scope.generatingEndpoint = false;
+
     // =========================
     // Public methods
     // =========================
@@ -116,6 +123,7 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
      * @returns {Promise<void>}
      */
     const generateEndpointFromGraphqlShapes = (endpointConfiguration) => {
+        $scope.generatingEndpoint = true;
         const endpointCreateRequest = endpointConfiguration.toCreateEndpointFromShapesRequest($scope.selectedSourceRepository.value);
         let generationReport;
         return GraphqlService.generateEndpointFromGraphqlShapes($repositories.getActiveRepository(), endpointCreateRequest)
@@ -127,6 +135,7 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
             })
             .finally(() => {
                 GraphqlContextService.endpointGenerated(generationReport);
+                $scope.generatingEndpoint = false;
             });
     }
 
@@ -136,6 +145,7 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
      * @returns {Promise<void>}
      */
     const generateEndpointFromOntologies = (endpointConfiguration) => {
+        $scope.generatingEndpoint = true;
         const endpointCreateRequest = endpointConfiguration.toCreateEndpointFromOwlRequest($scope.selectedSourceRepository.value);
         let generationReport;
         return GraphqlService.generateEndpointFromOwl($repositories.getActiveRepository(), endpointCreateRequest)
@@ -146,6 +156,7 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
                 toastr.error(getError(error));
             })
             .finally(() => {
+                $scope.generatingEndpoint = false;
                 GraphqlContextService.endpointGenerated(generationReport);
             });
     }

--- a/src/js/angular/graphql/controllers/endpoint-generation-failure-result-modal.controller.js
+++ b/src/js/angular/graphql/controllers/endpoint-generation-failure-result-modal.controller.js
@@ -10,9 +10,9 @@ angular
     .module('graphdb.framework.graphql.controllers.endpoint-generation-failure-result-modal', modules)
     .controller('EndpointGenerationResultFailureModalController', EndpointGenerationResultFailureModalController);
 
-EndpointGenerationResultFailureModalController.$inject = ['$scope', '$uibModalInstance', 'data'];
+EndpointGenerationResultFailureModalController.$inject = ['$scope', '$uibModalInstance', 'data', 'GraphqlContextService'];
 
-function EndpointGenerationResultFailureModalController($scope, $uibModalInstance, data) {
+function EndpointGenerationResultFailureModalController($scope, $uibModalInstance, data, GraphqlContextService) {
     // =========================
     // Private variables
     // =========================
@@ -48,6 +48,14 @@ function EndpointGenerationResultFailureModalController($scope, $uibModalInstanc
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
     };
+
+    /**
+     * Deletes generation report and dismisses the modal.
+     */
+    $scope.deleteReport = () => {
+        GraphqlContextService.deleteEndpointGenerationReport($scope.endpointReport);
+        $scope.close();
+    }
 
     /**
      * Cancels the operation and dismisses the modal.

--- a/src/js/angular/graphql/controllers/graphql-endpoint-management-view.controller.js
+++ b/src/js/angular/graphql/controllers/graphql-endpoint-management-view.controller.js
@@ -367,6 +367,22 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
     }
 
     /**
+     * Handles the event for deleting endpoint generation report.
+     * @param {EndpointGenerationReport} endpointReport The endpoint generation report.
+     */
+    const onDeleteEndpointReport = (endpointReport) => {
+        GraphqlService.deleteEndpointGenerationReport($repositories.getActiveRepository(), endpointReport.endpointId)
+            .then(() => {
+                toastr.success($translate.instant('graphql.endpoints_management.generation_failure_report_modal.actions.delete_report.success'));
+                return loadEndpointsInfo(false);
+            })
+            .catch((error) => {
+                toastr.error(getError(error));
+                console.error('Error deleting endpoint generation report', error);
+            });
+    };
+
+    /**
      * Handles the loaded GraphQL endpoints info.
      * @param {GraphqlEndpointsInfoList} endpointsInfoList
      */
@@ -448,6 +464,7 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
     // =========================
 
     subscriptions.push(GraphqlContextService.subscribe(GraphqlEventName.START_CREATE_ENDPOINT_WIZARD, onStartCreateEndpointWizard));
+    subscriptions.push(GraphqlContextService.subscribe(GraphqlEventName.DELETE_ENDPOINT_REPORT, onDeleteEndpointReport));
     subscriptions.push($scope.$watch($scope.getActiveRepositoryObject, getActiveRepositoryObjectHandler));
     $scope.$on('$destroy', unsubscribeAll);
 

--- a/src/js/angular/graphql/controllers/import-endpoint-definition-modal.controller.js
+++ b/src/js/angular/graphql/controllers/import-endpoint-definition-modal.controller.js
@@ -76,7 +76,7 @@ function ImportEndpointDefinitionModalController($scope, $q, toastr, $uibModal, 
      * @param {Array} $invalidFiles The invalid files selected.
      */
     $scope.onFilesChange = ($files, $file, $newFiles, $duplicateFiles, $invalidFiles) => {
-        let selectedFiles = $newFiles;
+        let selectedFiles = $newFiles || [];
 
         // find out files with invalid extensions in the list
         const invalidFiles = selectedFiles.filter(file => {

--- a/src/js/angular/graphql/services/endpoint-generation-report.mapper.js
+++ b/src/js/angular/graphql/services/endpoint-generation-report.mapper.js
@@ -12,30 +12,30 @@ export const endpointGenerationReportListMapper = (data, repositoryId) => {
         return new EndpointGenerationReportList();
     }
 
-    const reports = data.map((reportReponse) => endpointGenerationReportMapper(reportReponse, repositoryId));
+    const reports = data.map((reportResponse) => endpointGenerationReportMapper(reportResponse, repositoryId));
     return new EndpointGenerationReportList(reports);
 }
 
 /**
  * Maps the response data to an endpoint generation report.
- * @param {*} reportReponse The response data.
+ * @param {*} reportResponse The response data.
  * @param {string} repositoryId The repository id.
  * @returns {EndpointGenerationReport} The endpoint generation report.
  */
-export const endpointGenerationReportMapper = (reportReponse, repositoryId) => {
+export const endpointGenerationReportMapper = (reportResponse, repositoryId) => {
     return new EndpointGenerationReport({
-        endpointId: reportReponse.id,
-        endpointURI: resolveGraphqlEndpoint(repositoryId, reportReponse.id),
-        active: reportReponse.active,
-        default: reportReponse.default,
-        label: reportReponse.label,
-        description: reportReponse.description,
-        lastModified: reportReponse.lastModified,
-        objectsCount: reportReponse.objectsCount,
-        propertiesCount: reportReponse.propertiesCount,
-        warnings: reportReponse.warnings,
-        errors: reportReponse.errors,
-        messages: reportReponse.messages
+        endpointId: reportResponse.id,
+        endpointURI: resolveGraphqlEndpoint(repositoryId, reportResponse.id),
+        active: reportResponse.active,
+        default: reportResponse.default,
+        label: reportResponse.label,
+        description: reportResponse.description,
+        lastModified: reportResponse.lastModified,
+        objectsCount: reportResponse.objectsCount,
+        propertiesCount: reportResponse.propertiesCount,
+        warnings: reportResponse.warnings,
+        errors: reportResponse.errors,
+        messages: reportResponse.messages
     });
 }
 

--- a/src/js/angular/graphql/services/graphql-context.service.js
+++ b/src/js/angular/graphql/services/graphql-context.service.js
@@ -139,6 +139,14 @@ function GraphqlContextService(EventEmitterService) {
     }
 
     /**
+     * Emits an event to delete the endpoint generation report.
+     * @param {EndpointGenerationReport} endpointReport The endpoint generation report.
+     */
+    const deleteEndpointGenerationReport = (endpointReport) => {
+        emit(GraphqlEventName.DELETE_ENDPOINT_REPORT, endpointReport);
+    }
+
+    /**
      * Emits an event with a deep-cloned payload using the EventEmitterService.
      *
      * @param {string} event - The name of the event to emit. It must be a value from {@link GraphqlEventName}.
@@ -173,6 +181,7 @@ function GraphqlContextService(EventEmitterService) {
         endpointGenerated,
         exploreEndpointInPlayground,
         openEndpointGenerationReport,
+        deleteEndpointGenerationReport,
         cancelEndpointCreation,
         nextEndpointCreationStep,
         previousEndpointCreationStep,
@@ -213,6 +222,10 @@ export const GraphqlEventName = {
      * The event emitted when the user wants to open the endpoint generation report.
      */
     OPEN_ENDPOINT_GENERATION_REPORT: 'openEndpointGenerationReport',
+    /**
+     * The event emitted when the user wants to delete the endpoint generation report.
+     */
+    DELETE_ENDPOINT_REPORT: 'deleteEndpointReport',
     /**
      * The event emitted when the user wants to move to the next step in the create endpoint wizard.
      */

--- a/src/js/angular/graphql/templates/create-graphql-endpoint.html
+++ b/src/js/angular/graphql/templates/create-graphql-endpoint.html
@@ -19,6 +19,7 @@
                     <select id="sourceRepositorySelector" ng-model="selectedSourceRepository"
                             ng-options="repository as repository.label for repository in sourceRepositories"
                             ng-change="onSelectedSourceRepositoryChange(selectedSourceRepository)"
+                            ng-disabled="generatingEndpoint"
                             class="form-control source-repository-selector"
                             gdb-tooltip="{{'graphql.create_endpoint.toolbar.source_repository_selector.tooltip' | translate}}"
                             tooltip-placement="top">

--- a/src/js/angular/graphql/templates/graphql-endpoint-management.html
+++ b/src/js/angular/graphql/templates/graphql-endpoint-management.html
@@ -47,6 +47,7 @@
             <thead>
             <tr>
                 <th scope="col" class="toggle"></th>
+                <th scope="col" class="status"></th>
                 <th scope="col" class="endpoint-id">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.id.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.id.label' | translate}}
@@ -104,17 +105,22 @@
                         <i class="fa fa-chevron-down" ng-if="expandedRow === $index"></i>
                     </a>
                 </td>
+                <td class="status-cell">
+                    <a href="#" ng-if="endpoint.errors > 0 || endpoint.warnings > 0"
+                       ng-click="onShowEndpointReport(endpoint)"
+                       gdb-tooltip="{{'graphql.endpoints_management.table.actions.view_report.tooltip' | translate}}"
+                       class="endpoint-report-link btn btn-link">
+                        <i ng-if="!endpoint.createdSuccessfully" class="fa-regular fa-circle-xmark status-failed"></i>
+                        <i ng-if="endpoint.createdSuccessfully" class="fa-regular fa-circle-check status-success"></i>
+                    </a>
+                </td>
                 <td>
-                    <i ng-if="!endpoint.createdSuccessfully" class="fa-regular fa-circle-xmark status-failed"></i>
                     <span ng-if="!endpoint.active"
                           gdb-tooltip="{{'graphql.endpoints_management.table.actions.explore_endpoint.inactive.tooltip' | translate}}"
                           class="endpoint-link">{{endpoint.endpointId}}</span>
                     <a ng-if="endpoint.active" href="#" ng-click="onExploreEndpoint(endpoint)"
                        gdb-tooltip="{{'graphql.endpoints_management.table.actions.explore_endpoint.active.tooltip' | translate}}"
                        class="endpoint-link">{{endpoint.endpointId}}</a>
-                    <a href="#" ng-if="!endpoint.createdSuccessfully" ng-click="onShowEndpointReport(endpoint)"
-                       gdb-tooltip="{{'graphql.endpoints_management.table.actions.view_report.tooltip' | translate}}"
-                       class="endpoint-report-link btn btn-link">{{'graphql.endpoints_management.table.actions.view_report.label' | translate}}</a>
                 </td>
                 <td>{{endpoint.label}}</td>
                 <td>

--- a/src/js/angular/graphql/templates/modal/endpoint-generation-failure-result-modal.html
+++ b/src/js/angular/graphql/templates/modal/endpoint-generation-failure-result-modal.html
@@ -2,18 +2,28 @@
 
 <div class="modal-header">
     <button type="button" class="close" ng-click="close()"></button>
-    <h3 class="modal-title">{{'graphql.create_endpoint.wizard_steps.generate_endpoint.generation_failure_report.title' | translate}}</h3>
+    <h3 class="modal-title">
+        {{'graphql.endpoints_management.generation_failure_report_modal.title' | translate}}</h3>
 </div>
 
 <div class="modal-body endpoint-generation-failure-result-modal-body">
-    <p>{{'graphql.create_endpoint.wizard_steps.generate_endpoint.generation_failure_report.reason_message' | translate}}</p>
+    <div ng-if="endpointReport.errors > 0" class="alert alert-danger">
+        {{'graphql.endpoints_management.generation_failure_report_modal.failing_reason_message' | translate}}
+    </div>
+
+    <div ng-if="endpointReport.warnings > 0 && endpointReport.errors === 0" class="alert alert-info">
+        {{'graphql.endpoints_management.generation_failure_report_modal.warning_reason_message' | translate}}
+    </div>
+
     <table class="report table table-bordered" aria-label="Endpoint generation failure report table">
         <thead>
         <tr class="labels-row">
             <th scope="col">
-                <strong class="errors-count mr-2">{{'graphql.create_endpoint.wizard_steps.generate_endpoint.generation_failure_report.errors' |
+                <strong
+                    class="errors-count mr-2">{{'graphql.endpoints_management.generation_failure_report_modal.errors' |
                 translate: {errorCount: endpointReport.errors} }}</strong>
-                <strong class="warnings-count">{{'graphql.create_endpoint.wizard_steps.generate_endpoint.generation_failure_report.warnings' |
+                <strong
+                    class="warnings-count">{{'graphql.endpoints_management.generation_failure_report_modal.warnings' |
                 translate: {warningCount: endpointReport.warnings} }}</strong>
             </th>
         </tr>
@@ -34,8 +44,12 @@
 </div>
 
 <div class="modal-footer mt-0">
-    <button id="download-failure-report" class="btn btn-primary" ng-click="downloadReport()">
+    <button id="download-failure-report" class="btn btn-secondary mr-1" ng-click="downloadReport()">
         <i class="fa fa-arrow-down-to-line"></i>
-        <span>{{'graphql.create_endpoint.wizard_steps.generate_endpoint.generation_failure_report.actions.download_report.label' | translate}}</span>
+        <span>{{'graphql.endpoints_management.generation_failure_report_modal.actions.download_report.label' | translate}}</span>
+    </button>
+    <button ng-if="endpointReport.errors === 0 && endpointReport.warnings > 0" id="delete-warnings"
+            class="btn btn-primary" ng-click="deleteReport()">
+        <span>{{'graphql.endpoints_management.generation_failure_report_modal.actions.delete_report.label' | translate}}</span>
     </button>
 </div>

--- a/src/js/angular/graphql/templates/step-generate-endpoint.html
+++ b/src/js/angular/graphql/templates/step-generate-endpoint.html
@@ -19,8 +19,9 @@
 
             <div class="endpoints-overview">
                 <div ng-repeat="endpointOverview in endpointsOverview.endpointList" class="endpoint-overview">
-                    <strong class="label">{{endpointOverview.label}}</strong> | <span
-                    class="uri">{{endpointOverview.uri}}</span>
+                    <strong class="label">{{endpointOverview.label}}</strong>
+                    <span ng-if="endpointOverview.label && endpointOverview.uri">|</span>
+                    <span class="uri">{{endpointOverview.uri}}</span>
                 </div>
             </div>
         </div>
@@ -55,13 +56,11 @@
         </div>
     </div>
 
-    <div class="wizard-actions mt-2">
-        <button class="btn btn-secondary cancel-btn mr-1"
-                ng-click="cancel()">
+    <div class="wizard-actions mt-1">
+        <button class="btn btn-secondary cancel-btn mr-1" ng-disabled="generatingEndpoint" ng-click="cancel()">
             {{'graphql.create_endpoint.wizard_steps.actions.cancel.label' | translate}}
         </button>
-        <button class="btn btn-secondary back-btn mr-1"
-                ng-click="back()">
+        <button class="btn btn-secondary back-btn mr-1" ng-disabled="generatingEndpoint" ng-click="back()">
             {{'graphql.create_endpoint.wizard_steps.actions.back.label' | translate}}
         </button>
         <button class="btn btn-primary generate-endpoint-btn" ng-click="generateEndpoint()"

--- a/src/js/angular/graphql/templates/step-select-schema-sources.html
+++ b/src/js/angular/graphql/templates/step-select-schema-sources.html
@@ -57,13 +57,18 @@
                            uib-popover="{{'graphql.create_endpoint.wizard_steps.select_schema_sources.shacl_shapes.form.endpoint_id.tooltip' | translate}}"
                            popover-trigger="mouseenter">{{'graphql.create_endpoint.wizard_steps.select_schema_sources.shacl_shapes.form.endpoint_id.label' | translate}}*</label>
                     <input type="text" class="form-control" id="endpointId" name="endpointId"
-                           ng-model="endpointConfiguration.params.endpointId"
-                           required autocomplete="off"
+                           ng-model="endpointConfiguration.params.endpointId" autocomplete="off"
+                           required ng-pattern="/^[\w-]+$/"
                            placeholder="{{'graphql.create_endpoint.wizard_steps.select_schema_sources.shacl_shapes.form.endpoint_id.placeholder' | translate}}">
                 </div>
                 <div class="alert alert-danger"
                      ng-if="endpointParamsForm.endpointId.$touched && endpointParamsForm.endpointId.$invalid">
-                    {{'required.field' | translate}}
+                    <span ng-if="endpointParamsForm.endpointId.$error.required">
+                        {{'graphql.create_endpoint.wizard_steps.select_schema_sources.shacl_shapes.form.endpoint_id.validation.required' | translate}}
+                    </span>
+                    <span ng-if="endpointParamsForm.endpointId.$error.pattern">
+                        {{'graphql.create_endpoint.wizard_steps.select_schema_sources.shacl_shapes.form.endpoint_id.validation.pattern' | translate}}
+                    </span>
                 </div>
             </div>
 

--- a/src/js/angular/models/graphql/graphql-endpoint-configuration.js
+++ b/src/js/angular/models/graphql/graphql-endpoint-configuration.js
@@ -112,7 +112,7 @@ export class GraphqlEndpointConfiguration {
         if (this.generateFromShaclShapes()) {
             if (this.selectedGraphs.isEmpty) {
                 return [new GraphqlEndpointOverview({
-                    label: `[${this.params.endpointId}]`
+                    label: `${this.params.endpointId}`
                 })];
             }
             return this.selectedGraphs.processGraphList((graph) => {

--- a/src/js/angular/rest/graphql.rest.service.js
+++ b/src/js/angular/rest/graphql.rest.service.js
@@ -192,6 +192,16 @@ function GraphqlRestService($http, Upload) {
         });
     };
 
+    /**
+     * Deletes the endpoint generation report by calling the backend.
+     * @param {string} repositoryId The repository ID.
+     * @param {string} endpointId The endpoint ID.
+     * @returns {Promise<unknown>} The response from the backend.
+     */
+    const deleteEndpointGenerationReport = (repositoryId, endpointId) => {
+        return $http.patch(`${REPOSITORIES_ENDPOINT}/${repositoryId}/graphql/manage/endpoints/${endpointId}/messages`);
+    };
+
     return {
         getEndpoints,
         getEndpointsInfo,
@@ -206,6 +216,7 @@ function GraphqlRestService($http, Upload) {
         generateEndpointFromGraphqlShapes,
         generateEndpointFromOwl,
         exportEndpointDefinition,
-        importEndpointDefinition
+        importEndpointDefinition,
+        deleteEndpointGenerationReport
     };
 }

--- a/test-cypress/integration/graphql/graphql-endpoint-management-view.spec.js
+++ b/test-cypress/integration/graphql/graphql-endpoint-management-view.spec.js
@@ -71,19 +71,21 @@ describe('GraphQL endpoints management', () => {
             GraphqlEndpointManagementSteps.visit();
             // Then I should see the endpoints info
             GraphqlEndpointManagementSteps.getEndpointTable().within(() => {
-                cy.get('thead th').should('have.length', 9);
-                cy.get('thead th').eq(1).should('contain', 'Id');
-                cy.get('thead th').eq(2).should('contain', 'Label');
-                cy.get('thead th').eq(3).should('contain', 'Default');
-                cy.get('thead th').eq(4).should('contain', 'Active');
-                cy.get('thead th').eq(5).should('contain', 'Modified');
-                cy.get('thead th').eq(6).should('contain', 'Types');
-                cy.get('thead th').eq(7).should('contain', 'Properties');
-                cy.get('thead th').eq(8).should('contain', 'Actions');
+                cy.get('thead th').should('have.length', 10);
+                // the first column contains the status icon
+                cy.get('thead th').eq(2).should('contain', 'Id');
+                cy.get('thead th').eq(3).should('contain', 'Label');
+                cy.get('thead th').eq(4).should('contain', 'Default');
+                cy.get('thead th').eq(5).should('contain', 'Active');
+                cy.get('thead th').eq(6).should('contain', 'Modified');
+                cy.get('thead th').eq(7).should('contain', 'Types');
+                cy.get('thead th').eq(8).should('contain', 'Properties');
+                cy.get('thead th').eq(9).should('contain', 'Actions');
             });
             GraphqlEndpointManagementSteps.getEndpointsInfo().should('have.length', 3);
             GraphqlEndpointManagementSteps.verifyEndpointInfo([
                 {
+                    status: 'deleted',
                     id: 'swapi',
                     label: 'Ontotext Star Wars Ontology',
                     description: '',
@@ -94,6 +96,7 @@ describe('GraphQL endpoints management', () => {
                     properties: 68
                 },
                 {
+                    status: 'deleted',
                     id: 'swapi-planets',
                     label: 'Star Wars planets API',
                     description: '',
@@ -104,6 +107,7 @@ describe('GraphQL endpoints management', () => {
                     properties: 10
                 },
                 {
+                    status: 'deleted',
                     id: 'swapi-species',
                     label: 'Star Wars species API',
                     description: '',

--- a/test-cypress/integration/graphql/import-graphql-endpoint-definitions.spec.js
+++ b/test-cypress/integration/graphql/import-graphql-endpoint-definitions.spec.js
@@ -71,6 +71,7 @@ describe('Graphql: import endpoint definitions', () => {
 
         GraphqlEndpointManagementSteps.verifyEndpointInfo([
             {
+                status: 'deleted',
                 id: 'swapi',
                 label: 'Ontotext Star Wars Ontology',
                 description: '',
@@ -150,6 +151,7 @@ describe('Graphql: import endpoint definitions', () => {
 
         GraphqlEndpointManagementSteps.verifyEndpointInfo([
             {
+                status: 'deleted',
                 id: 'swapi',
                 label: 'Ontotext Star Wars Ontology',
                 description: '',
@@ -160,6 +162,7 @@ describe('Graphql: import endpoint definitions', () => {
                 properties: 68
             },
             {
+                status: 'deleted',
                 id: 'swapi-planets',
                 label: 'Star Wars planets API',
                 description: '',
@@ -203,6 +206,7 @@ describe('Graphql: import endpoint definitions', () => {
         GraphqlEndpointManagementSteps.getEndpointsInfo().should('have.length', 2);
         GraphqlEndpointManagementSteps.verifyEndpointInfo([
             {
+                status: 'deleted',
                 id: 'swapi-planets',
                 label: 'Star Wars planets API',
                 description: '',
@@ -213,6 +217,7 @@ describe('Graphql: import endpoint definitions', () => {
                 properties: 10
             },
             {
+                status: 'deleted',
                 id: 'swapi-species',
                 label: 'Star Wars species API',
                 description: '',

--- a/test-cypress/steps/graphql/graphql-endpoint-management-steps.js
+++ b/test-cypress/steps/graphql/graphql-endpoint-management-steps.js
@@ -88,16 +88,18 @@ export class GraphqlEndpointManagementSteps {
         this.getEndpointsInfo().each(($row, index) => {
             const endpointInfo = data[index];
             cy.wrap($row).within(() => {
-                cy.get('td').eq(1).should('contain', endpointInfo.id);
-                cy.get('td').eq(2).should('contain', endpointInfo.label);
+                const statusCheck = endpointInfo.status === 'deleted' ? 'not.exist' : 'be.visible';
+                cy.get('td').eq(1).find('.endpoint-link').should(statusCheck);
+                cy.get('td').eq(2).should('contain', endpointInfo.id);
+                cy.get('td').eq(3).should('contain', endpointInfo.label);
                 const isDefaultCheck = endpointInfo.default ? 'be.checked' : 'not.be.checked'
-                cy.get('td').eq(3).find('.endpoint-default-state input[type="radio"]').should(isDefaultCheck);
+                cy.get('td').eq(4).find('.endpoint-default-state input[type="radio"]').should(isDefaultCheck);
                 const isActiveCheck = endpointInfo.active ? 'be.checked' : 'not.be.checked'
-                cy.get('td').eq(4).find('.toggle-active-state input[type="checkbox"]').should(isActiveCheck);
-                cy.get('td').eq(5).should('contain', endpointInfo.modified);
-                cy.get('td').eq(6).should('contain', endpointInfo.types);
-                cy.get('td').eq(7).should('contain', endpointInfo.properties);
-                cy.get('td').eq(8).find('button').should('have.length', 4);
+                cy.get('td').eq(5).find('.toggle-active-state input[type="checkbox"]').should(isActiveCheck);
+                cy.get('td').eq(6).should('contain', endpointInfo.modified);
+                cy.get('td').eq(7).should('contain', endpointInfo.types);
+                cy.get('td').eq(8).should('contain', endpointInfo.properties);
+                cy.get('td').eq(9).find('button').should('have.length', 4);
             });
             // expand the row and check the description outside the wrapper
             this.toggleEndpointRow(index).closest('tr').next('tr')


### PR DESCRIPTION
## What
* Implemented a delete endpoint report operation.
* Did multiple improvements in the create endpoint workflow.

## Why
* This allows users to clear the current generation state for particular endpoint if they are not interested in it.
* Improves the UX.

## How
* Extended the graphql managment to support the delete operation.
* Did further improvments in the UI layout.
* Disabled the wizard buttons: back, cancel, generate, as well as the source repository selector during generation.
* Did some improvements in the layout and presentation of data in the endpoints generation overview page.
* Added pattern validator to the endpoint id field to prevent invalid data to be entered by the user which can lead to errors during the generation.

## Testing
Updated tests

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
