### PR TITLE
fix(GDB-11838) Require ROLE_REPO_MANAGER for GraphQL Endpoint Management

### DIFF
--- a/src/js/angular/graphql/plugin.js
+++ b/src/js/angular/graphql/plugin.js
@@ -48,7 +48,7 @@ PluginRegistry.add('main.menu', {
             labelKey: 'menu.graphql-endpoint-management.label',
             href: 'graphql/endpoints',
             order: 10,
-            role: 'IS_AUTHENTICATED_FULLY',
+            role: 'ROLE_REPO_MANAGER',
             parent: 'GraphQL',
             children: [
                 {

--- a/src/js/angular/security/templates/user.html
+++ b/src/js/angular/security/templates/user.html
@@ -263,14 +263,20 @@
                                             <em class="icon-info text-tertiary" gdb-tooltip="{{'security.data.repos' | translate}}"></em>
                                         </th>
                                         <th class="text-xs-center">
-                                            <input class="read" type="checkbox" ng-model="grantedAuthorities.READ_REPO['*']"  ng-checked="hasReadPermission('*')" ng-disabled="readCheckDisabled('*')" ng-click="setGrantedAuthorities()">
+                                            <span ng-click="setGrantedAuthorities()">
+                                                <input class="read" type="checkbox" ng-model="grantedAuthorities.READ_REPO['*']"  ng-checked="hasReadPermission('*')" ng-disabled="readCheckDisabled('*')">
+                                           </span>
                                         </th>
                                         <th class="text-xs-center write-any">
-                                            <input class="write" type="checkbox" ng-model="grantedAuthorities.WRITE_REPO['*']" ng-checked="hasWritePermission('*')" ng-disabled="writeCheckDisabled('*')" ng-click="setGrantedAuthorities()">
+                                            <span ng-click="setGrantedAuthorities()">
+                                                <input class="write" type="checkbox" ng-model="grantedAuthorities.WRITE_REPO['*']" ng-checked="hasWritePermission('*')" ng-disabled="writeCheckDisabled('*')">
+                                            </span>
                                         </th>
 
                                         <th class="text-xs-center">
-                                            <input class="graphql" type="checkbox" ng-model="grantedAuthorities.GRAPHQL['*']" ng-checked="hasGraphqlPermission('*')" ng-disabled="graphqlCheckDisabled('*')" ng-click="setGrantedAuthorities()">
+                                            <span ng-click="setGrantedAuthorities()">
+                                                <input class="graphql" type="checkbox" ng-model="grantedAuthorities.GRAPHQL['*']" ng-checked="hasGraphqlPermission('*')" ng-disabled="graphqlCheckDisabled('*')">
+                                            </span>
                                         </th>
 
                                     </tr>
@@ -279,9 +285,21 @@
                                     <div>
                                         <tr ng-repeat="repository in getAllAccessibleRepositories() | orderBy: ['location', 'id']">
                                             <td class="repository-name">{{repository.id}}<small><em ng-if="(hasGraphqlPermission(repository) || hasGraphqlPermission('*')) && (hasReadPermission(repository) || hasReadPermission('*') || hasWritePermission(repository) || hasWritePermission('*'))" class="fa-kit fa-gdb-graphql graphql-icon text-info" gdb-tooltip="{{'security.tooltip.graphql' | translate}}"></em> &middot; {{repository.location ? repository.location : 'repo.local' | translate}}</small></td>
-                                            <td class="text-xs-center read-rights"><input class="read" type="checkbox" ng-model="grantedAuthorities.READ_REPO[createUniqueKey(repository)]"  ng-checked="hasReadPermission(repository)" ng-disabled="readCheckDisabled(repository)" ng-click="setGrantedAuthorities()"></td>
-                                            <td class="text-xs-center write-rights"><input class="write" type="checkbox" ng-model="grantedAuthorities.WRITE_REPO[createUniqueKey(repository)]" ng-checked="hasWritePermission(repository)" ng-disabled="writeCheckDisabled(repository)" ng-click="setGrantedAuthorities()"></td>
-                                            <td class="text-xs-center graphql-rights"><input class="graphql" type="checkbox" ng-model="grantedAuthorities.GRAPHQL[createUniqueKey(repository)]" ng-checked="hasGraphqlPermission(repository)" ng-disabled="graphqlCheckDisabled(repository)" ng-click="setGrantedAuthorities()"></td>
+                                            <td class="text-xs-center read-rights">
+                                                <span ng-click="setGrantedAuthorities()">
+                                                    <input class="read" type="checkbox" ng-model="grantedAuthorities.READ_REPO[createUniqueKey(repository)]"  ng-checked="hasReadPermission(repository)" ng-disabled="readCheckDisabled(repository)">
+                                                </span>
+                                            </td>
+                                            <td class="text-xs-center write-rights">
+                                                <span ng-click="setGrantedAuthorities()">
+                                                    <input class="write" type="checkbox" ng-model="grantedAuthorities.WRITE_REPO[createUniqueKey(repository)]" ng-checked="hasWritePermission(repository)" ng-disabled="writeCheckDisabled(repository)">
+                                                </span>
+                                            </td>
+                                            <td class="text-xs-center graphql-rights">
+                                                <span ng-click="setGrantedAuthorities()">
+                                                    <input class="graphql" type="checkbox" ng-model="grantedAuthorities.GRAPHQL[createUniqueKey(repository)]" ng-checked="hasGraphqlPermission(repository)" ng-disabled="graphqlCheckDisabled(repository)">
+                                                </span>
+                                            </td>
                                         </tr>
                                     </div>
                                 </tbody>

--- a/test-cypress/steps/setup/user-and-access-steps.js
+++ b/test-cypress/steps/setup/user-and-access-steps.js
@@ -285,7 +285,7 @@ export class UserAndAccessSteps {
     }
 
     static toggleReadAccessForRepo(repoName) {
-        return this.getReadAccessForRepo(repoName).click({force: true});
+        return this.getReadAccessForRepo(repoName).realClick();
     }
 
     static getWriteAccessForRepo(repoName) {
@@ -297,7 +297,7 @@ export class UserAndAccessSteps {
     }
 
     static toggleWriteAccessForRepo(repoName) {
-        return this.getWriteAccessForRepo(repoName).click({force: true});
+        return this.getWriteAccessForRepo(repoName).realClick();
     }
 
     static getGraphqlAccessForRepo(repoName) {
@@ -309,7 +309,7 @@ export class UserAndAccessSteps {
     }
 
     static toggleGraphqlAccessForRepo(repoName) {
-        return this.getGraphqlAccessForRepo(repoName).click({force: true});
+        return this.getGraphqlAccessForRepo(repoName).realClick();
     }
 
     static clickMenuItem(label) {
@@ -325,7 +325,7 @@ export class UserAndAccessSteps {
             .contains(repoName)
             .parent('.row')
             .find('.read')
-            .click({force: true});
+            .realClick();
     }
 
     static clickFreeWriteAccessRepo(repoName) {
@@ -333,7 +333,7 @@ export class UserAndAccessSteps {
             .contains(repoName)
             .parent('.row')
             .find('.write')
-            .click({force: true});
+            .realClick();
     }
 
     static clickFreeGraphqlAccessRepo(repoName) {
@@ -341,7 +341,7 @@ export class UserAndAccessSteps {
             .contains(repoName)
             .parent('.row')
             .find('.graphql')
-            .click({force: true});
+            .realClick();
     }
 
 }


### PR DESCRIPTION
## WHAT:
- Changed GraphQL Endpoint Management menu role from IS_AUTHENTICATED_FULLY to ROLE_REPO_MANAGER.

## WHY:
- Ensures only repository managers or higher can manage GraphQL endpoints, improving security alignment.

## HOW:
- Updated plugin.js to specify ROLE_REPO_MANAGER for Endpoint Management.
- Added test coverage to confirm correct behavior with the new authority requirement.
- Modified user-and-access-steps.js and user.html to accommodate realClick() for checkboxes.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
