### PR TITLE
GDB-11575 don't send all graph when creating from OWL

### DIFF
--- a/src/js/angular/models/graphql/graphql-endpoint-configuration.js
+++ b/src/js/angular/models/graphql/graphql-endpoint-configuration.js
@@ -85,12 +85,14 @@ export class GraphqlEndpointConfiguration {
      * @returns {CreateEndpointFromOwlRequest}
      */
     toCreateEndpointFromOwlRequest(sourceRepositoryId) {
+        // when using all graphs, we don't need to send them all to the server
+        const namedGraphs = this._owlOrShaclSourceType === OntologyShaclShapeSource.USE_ALL_GRAPHS ? [] : this.selectedGraphs.getGraphIds();
         return new CreateEndpointFromOwlRequest({
             id: this.params.endpointId,
             label: this.params.endpointLabel,
             description: this.params.endpointDescription,
             fromRepo: sourceRepositoryId,
-            namedGraphs: this.selectedGraphs.getGraphIds(),
+            namedGraphs: namedGraphs,
             vocabPrefix: this.params.vocPrefix,
             config: this.settings.toFlatJSON()
         });


### PR DESCRIPTION
## What
When creating from OWL and `use all graphs` option is selected then we should not send all found graphs with the request but empty array.

## Why
The backend has logic that can handle this scenario and releave the client from the need to build and send potentially big requests if there tousands or even million graphs in the repository.

## How
Added a check when the request payload is prepared to handle the case when the `use all graphs` option is selected and pass an empty array instead of listing all graphs.

## Testing
NA

## Screenshots
NA

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
