### PR TITLE
GDB-11854 graphql view ux improvements

### DIFF
--- a/src/css/bootstrap-graphdb-theme.css
+++ b/src/css/bootstrap-graphdb-theme.css
@@ -2057,6 +2057,7 @@ code {
 	Tooltips
 -------------------------------------------------------------*/
 .angular-tooltip {
+    max-width: 300px;
     background-color: var(--secondary-color);
 }
 

--- a/src/css/graphql/create-graphql-endpoint.css
+++ b/src/css/graphql/create-graphql-endpoint.css
@@ -184,7 +184,7 @@
     flex: 1;
     min-height: 0;
     overflow-y: auto;
-    padding: 10px;
+    padding: 10px 10px 10px 0;
 }
 
 .generate-endpoint-view .generate-endpoint-container .generation-report-list .endpoint-report {

--- a/src/css/graphql/graphql-endpoint-management.css
+++ b/src/css/graphql/graphql-endpoint-management.css
@@ -10,24 +10,21 @@
     position: relative;
 }
 
-.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .toggle {
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .toggle-col {
     /* fixed width to prevent expanding and shrinking of the first column when a row is expanded/collapsed  */
     width: 40px;
 }
 
-.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .status {
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .status-col {
     width: 40px;
 }
 
-.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint_id {
-    width: 10%;
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint-is-default-col,
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint-is-active-col {
+    text-align: center;
 }
 
-.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint_label {
-    width: 20%;
-}
-
-.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint-actions {
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint-actions-col {
     width: 5%;
 }
 
@@ -39,6 +36,16 @@
 .graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint-default-state,
 .graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint-default-state input {
     cursor: pointer;
+}
+
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint-actions,
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .numeric {
+    text-align: right;
+}
+
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .default-endpoint-selector,
+.graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .active-endpoint-selector {
+    text-align: center;
 }
 
 .graphql-endpoint-management-view .endpoint-management-container .endpoints-info-table .endpoint-description-row > td {

--- a/src/css/graphql/graphql-playground.css
+++ b/src/css/graphql/graphql-playground.css
@@ -1,10 +1,16 @@
+:root {
+    --default-btn-bgcolor: #ebebeb;
+    --default-btn-focus-bgcolor: #d4d4d4;
+    --default-btn-focus-color: #373a3c;
+}
+
 html, body {
     height: 100vh;
 }
 
 .page-content,
 .page-content .container-fluid {
-    height: calc(100% - 70px);
+    height: calc(100% - 50px);
 }
 
 .graphql-playground-view,
@@ -49,6 +55,10 @@ graphql-playground {
     font-family: var(--main-font);
 }
 
+.graphql-playground-view #graphiql .graphiql-container {
+    border: 1px solid #ddd;
+}
+
 .graphql-playground-view #graphiql .graphiql-container .graphiql-sidebar {
     padding-top: 0;
     padding-bottom: 0;
@@ -56,6 +66,19 @@ graphql-playground {
 
 .graphql-playground-view #graphiql .graphiql-sidebar button {
     color: var(--primary-color);
+    transition: all 0.15s ease-out;
+}
+
+.graphql-playground-view #graphiql .graphiql-sidebar button:hover {
+    transform: scale(1.2);
+    background-color: transparent;
+}
+
+.graphql-playground-view #graphiql .graphiql-sidebar button:active {
+    background-color: #fff;
+}
+.graphql-playground-view #graphiql .graphiql-sidebar button:focus {
+    outline: none;
 }
 
 /* Hide the settings button */
@@ -63,11 +86,65 @@ graphql-playground {
     display: none;
 }
 
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-session-header .graphiql-tabs {
+    margin-bottom: 0;
+    padding: 0;
+    font-size: 1rem;
+}
+
+.graphql-playground-view #graphiql .graphiql-tabs button {
+    transition: all 0.15s ease-out;
+}
+
+.graphql-playground-view #graphiql .graphiql-tab > button.graphiql-tab-close {
+    visibility: visible;
+}
+
+.graphql-playground-view #graphiql .graphiql-tabs button:focus {
+    outline: none;
+}
+
+.graphql-playground-view #graphiql .graphiql-tabs button:hover {
+    background-color: var(--base-background-hover-color);
+}
+
+.graphql-playground-view #graphiql .graphiql-tabs .graphiql-tab {
+    /*background-color: var(--base-background-color);*/
+    background-color: var(--base-background-hover-color);
+}
+
+.graphql-playground-view #graphiql .graphiql-tabs > :not(:first-child) {
+    margin-left: .2em;
+}
+
+.graphql-playground-view #graphiql .graphiql-tabs .graphiql-tab-active {
+    background-color: #fff !important;
+}
+
+.graphql-playground-view #graphiql .graphiql-tabs .graphiql-tab-add {
+    background-color: var(--base-background-hover-color);
+}
+
+.graphql-playground-view #graphiql .graphiql-tabs .graphiql-tab-add:hover svg,
+.graphql-playground-view #graphiql .graphiql-tabs .graphiql-tab-close:hover {
+    background-color: transparent;
+    color: var(--primary-color);
+}
+
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-session-header .graphiql-tabs .graphiql-tab-active {
+    background-color: var(--base-background-hover-color);
+}
+
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-session-header .graphiql-tabs .graphiql-tab-button {
+    padding: 4px 8px;
+    color: var(--base-text-color);
+}
+
 .graphql-playground-view #graphiql .graphiql-sessions {
     margin-top: 0;
     margin-right: 0 !important;
     margin-bottom: 0;
-    background-color: var(--base-background-color);
+    background-color: #fff;
 }
 
 /* Hide the graphql logo */
@@ -84,23 +161,33 @@ graphql-playground {
     padding: 8px;
 }
 
-.graphql-playground-view #graphiql .graphiql-sessions .graphiql-session-header .graphiql-tabs {
-    margin-bottom: 0;
-    padding-left: 18px;
-    font-size: 1rem;
-}
-
-.graphql-playground-view #graphiql .graphiql-sessions .graphiql-session-header .graphiql-tabs .graphiql-tab-active {
-    background-color: var(--base-background-hover-color);
-}
-
-.graphql-playground-view #graphiql .graphiql-sessions .graphiql-session-header .graphiql-tabs .graphiql-tab-button {
-    padding: 4px 8px;
-    color: var(--base-text-color);
-}
-
 .graphql-playground-view #graphiql .graphiql-sessions .graphiql-session {
-    padding: 0 18px 18px;
+    padding: 0;
+}
+
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-editors,
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-response {
+    border: 1px solid #ddd;
+    border-bottom: none;
+    box-shadow: none;
+}
+
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-response {
+    border-right: none;
+}
+
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-editors .graphiql-query-editor {
+    padding: 0;
+}
+
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-editors .CodeMirror-gutters {
+    border-right: 1px solid #ddd;
+    background-color: #f7f7f7;
+}
+
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-editors .CodeMirror-gutter-wrapper * {
+    color: rgba(0, 0, 0, .66);
+    font-weight: 300;
 }
 
 /* When there is a single opened tab in the editor */
@@ -108,13 +195,44 @@ graphql-playground {
     margin-top: -13px;
 }
 
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-editors .graphiql-toolbar {
+    margin: .5em;
+}
+
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-editors .graphiql-toolbar button {
+    transition: all 0.15s ease-out;
+}
+
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-editors .graphiql-toolbar button:hover {
+    transform: scale(1.2);
+    background-color: transparent;
+}
+
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-editors .graphiql-toolbar button:focus {
+    outline: none;
+}
+
 .graphql-playground-view #graphiql .graphiql-sessions .graphiql-editors .graphiql-toolbar button.graphiql-execute-button {
     background-color: var(--primary-color);
 }
 
 .graphql-playground-view #graphiql .graphiql-sessions .graphiql-editors .graphiql-toolbar .graphiql-toolbar-icon {
-  color: var(--primary-color);
+    color: var(--primary-color);
 }
+
+.graphql-playground-view #graphiql .graphiql-editor-tools button {
+    background-color: #fff;
+    color: var(--secondary-color);
+    font-weight: 400;
+    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.graphql-playground-view #graphiql .graphiql-editor-tools button:hover {
+    background-color: var(--base-background-hover-color);
+    border-color: var(--base-background-hover-color);
+    color: var(--default-btn-focus-color);
+}
+
 
 /* =============================================== */
 /*   overrides for graphql-playground history      */
@@ -124,12 +242,34 @@ graphql-playground {
     color: var(--primary-color);
 }
 
+.graphql-playground-view #graphiql .graphiql-history .graphiql-button {
+    background-color: var(--default-btn-bgcolor);
+    border-color: var(--default-btn-bgcolor);
+    color: var(--secondary-color);
+    font-weight: 400;
+    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.graphql-playground-view #graphiql .graphiql-history .graphiql-button:hover {
+    background-color: var(--default-btn-focus-bgcolor);
+    border-color: var(--default-btn-focus-bgcolor);
+    color: var(--default-btn-focus-color);
+}
+
 .graphql-playground-view #graphiql .graphiql-history .graphiql-history-header {
     color: var(--base-text-color);
 }
 
+.graphql-playground-view #graphiql .graphiql-history .graphiql-history-item:hover {
+    background-color: var(--base-background-hover-color);
+}
+
 .graphql-playground-view #graphiql .graphiql-history .graphiql-history-item-label {
-    color: var(--text-muted-color);
+    color: var(--secondary-color);
+}
+
+.graphql-playground-view #graphiql .graphiql-history .graphiql-history-item-label:hover {
+    background-color: var(--base-background-selected-color);
 }
 
 .graphql-playground-view #graphiql .graphiql-history .graphiql-history-item.editable {
@@ -138,15 +278,37 @@ graphql-playground {
 
 .graphql-playground-view #graphiql .graphiql-history .graphiql-history-item.editable input {
     border: 1px solid hsla(var(--secondary-color-hsl), 0.5);
+    font-weight: 300;
 }
 
 .graphql-playground-view #graphiql .graphiql-history .graphiql-history-item.editable button {
     color: var(--primary-color);
 }
 
+.graphql-playground-view #graphiql .graphiql-history .graphiql-history-item.editable button:focus,
+.graphql-playground-view #graphiql .graphiql-history .graphiql-history-item.editable button:active {
+    background-color: hsla(219, 28%, 32%, 0.1);;
+    outline: none;
+}
+
 .graphql-playground-view #graphiql .graphiql-history .graphiql-history-item.editable button:nth-of-type(2) {
     /* using the color for .btn-link.secondary */
     color: rgba(0, 0, 0, .66);
+}
+
+.graphql-playground-view #graphiql .graphiql-history .graphiql-history-item.editable button:nth-of-type(2):active {
+    background-color: #fff;
+}
+
+div[data-radix-popper-content-wrapper] * {
+    background-color: var(--secondary-color);
+    border-top-color: var(--secondary-color);
+    color: #fff;
+    border-radius: 0;
+    padding-top: 1px;
+    padding-bottom: 1px;
+    font-size: .875rem;
+    font-weight: 400;
 }
 
 /* =============================================== */
@@ -174,6 +336,10 @@ graphql-playground {
     color: inherit;
 }
 
+.graphql-playground-view #graphiql .CodeMirror-lint-tooltip {
+color(var(--primary-color));
+}
+
 /* ================================================ */
 /*   overrides for graphiql dialog (hotkeys dialog) */
 /* ================================================ */
@@ -186,4 +352,15 @@ graphql-playground {
 .graphiql-dialog,
 .graphiql-dialog-overlay {
     z-index: 1010;
+}
+
+.graphiql-dialog .graphiql-dialog-section a,
+.graphiql-dialog .graphiql-dialog-section a:hover,
+.graphiql-dialog .graphiql-dialog-section a:focus {
+    color: var(--primary-color);
+    text-decoration-line: underline;
+    text-decoration-style: dotted;
+    text-decoration-thickness: var(--link-decoration-thickness);
+    text-underline-offset: var(--link-underline-offset);
+    outline: none;
 }

--- a/src/css/wizard.css
+++ b/src/css/wizard.css
@@ -21,6 +21,10 @@
     border-bottom: 1px solid var(--primary-color);
 }
 
+.wizard .wizard-steps .wizard-step.completed {
+    cursor: pointer;
+}
+
 .wizard .wizard-steps .wizard-step .step-title {
     text-decoration: none;
     color: unset;

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1122,10 +1122,9 @@
                     "overview": {
                         "title": "Overview",
                         "for_shapes": {
-                            "info": "{{endpointsCount}} GraphQL endpoints will be created in \"{{activeRepoId}}\" repository based on the GraphQL schema shapes listed below. To modify the selection, navigate back to Step 1 (Select schema source).",
+                            "info": "GraphDB will attempt to create {{endpointsCount}} GraphQL endpoints in the \"{{activeRepoId}}\" based on the selected resources. To modify the selection, go back to Step 1 (Select schema source).",
                             "included_endpoints": "Included GraphQL schema shapes",
                             "generated_endpoints": "GraphQL endpoints",
-                            "manage_endpoints_info": "Navigate to <a href=\"{{managementUrl}}\">Endpoint Management</a> to manage the endpoints",
                             "explore_in_playground_link_tooltip": "Explore in Playground (opens in a new tab)",
                             "view_report_link": "View report",
                             "view_report_link_tooltip": "Opens endpoint creation report in a modal dialog"
@@ -1204,6 +1203,10 @@
                     },
                     "generate_endpoint": {
                         "label": "Create endpoint"
+                    },
+                    "finish_workflow": {
+                        "label": "Finish",
+                        "tooltip": "Finish the workflow and return to the endpoint management"
                     }
                 }
             },

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1122,10 +1122,9 @@
                     "overview": {
                         "title": "Aperçu",
                         "for_shapes": {
-                            "info": "{{endpointsCount}} points de terminaison GraphQL seront créés dans le référentiel \"{{activeRepoId}}\" en fonction des formes de schéma GraphQL répertoriées ci-dessous. Pour modifier la sélection, revenez à l'étape 1 (Sélectionner la source du schéma).",
+                            "info": "GraphDB tentera de créer {{endpointsCount}} points de terminaison GraphQL dans \"{{activeRepoId}}\" en fonction des ressources sélectionnées. Pour modifier la sélection, retournez à l'étape 1 (Sélectionner la source du schéma).",
                             "included_endpoints": "Formes de schéma GraphQL incluses",
                             "generated_endpoints": "Points de terminaison GraphQL",
-                            "manage_endpoints_info": "Accédez à la <a href=\"{{managementUrl}}\">gestion des points de terminaison</a> pour gérer les points de terminaison",
                             "explore_in_playground_link_tooltip": "Explorer dans Playground (s'ouvre dans un nouvel onglet)",
                             "view_report_link": "Voir le rapport",
                             "view_report_link_tooltip": "Ouvre le rapport de création du point de terminaison dans une boîte de dialogue modale."
@@ -1204,6 +1203,10 @@
                     },
                     "generate_endpoint": {
                         "label": "Créer un point de terminaison"
+                    },
+                    "finish_workflow": {
+                        "label": "Terminer",
+                        "tooltip": "Terminez le flux de travail et retournez à la gestion des points de terminaison"
                     }
                 }
             },

--- a/src/js/angular/graphql/controllers/create-graphql-endpoint-view.controller.js
+++ b/src/js/angular/graphql/controllers/create-graphql-endpoint-view.controller.js
@@ -113,6 +113,17 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
         setCurrentStep(step);
     };
 
+    /**
+     * Handles the click on the step in the wizard. We allow only to go back to previous steps.
+     * @param {WizardStep} step The step to go to.
+     */
+    $scope.onStepClick = (step) => {
+        if ($scope.wizardModel.isAPreviousStep(step)) {
+            $scope.wizardModel.setStepActive(step);
+            setCurrentStep(step);
+        }
+    }
+
     // =========================
     // Private methods
     // =========================
@@ -195,6 +206,13 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
      * Handles the termination of the create endpoint wizard.
      */
     const onCancelEndpointCreation = () => {
+        $location.path(endpointUrl.ENDPOINT_MANAGEMENT);
+    };
+
+    /**
+     * Handles the finish of the endpoint generation workflow by redirecting to the endpoint management view.
+     */
+    const onFinishEndpointGeneration = () => {
         $location.path(endpointUrl.ENDPOINT_MANAGEMENT);
     };
 
@@ -289,6 +307,7 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
     subscriptions.push(GraphqlContextService.subscribe(GraphqlEventName.PREVIOUS_ENDPOINT_CREATION_STEP, onPreviousEndpointCreationStep));
     subscriptions.push(GraphqlContextService.subscribe(GraphqlEventName.NEXT_ENDPOINT_CREATION_STEP, onNextEndpointCreationStep));
     subscriptions.push(GraphqlContextService.subscribe(GraphqlEventName.CANCEL_ENDPOINT_CREATION, onCancelEndpointCreation));
+    subscriptions.push(GraphqlContextService.subscribe(GraphqlEventName.FINISH_GENERATION_WORKFLOW, onFinishEndpointGeneration));
     subscriptions.push(GraphqlContextService.subscribe(GraphqlEventName.EXPLORE_ENDPOINT_IN_PLAYGROUND, onExploreEndpointInPlayground));
     subscriptions.push(GraphqlContextService.subscribe(GraphqlEventName.OPEN_ENDPOINT_GENERATION_REPORT, onShowEndpointReport));
     subscriptions.push($scope.$watch($scope.getActiveRepositoryObject, getActiveRepositoryObjectHandler));

--- a/src/js/angular/graphql/directives/generate-endpoint.directive.js
+++ b/src/js/angular/graphql/directives/generate-endpoint.directive.js
@@ -97,7 +97,15 @@ function GenerateEndpointComponent(ModalService, $uibModal, $translate, $reposit
              */
             $scope.generateEndpoint = () => {
                 $scope.generatingEndpoint = true;
+                $scope.generationReport = undefined;
                 GraphqlContextService.generateEndpoint();
+            };
+
+            /**
+             * Handles the completion of the endpoint generation workflow.
+             */
+            $scope.finishGenerationWorkflow = () => {
+                GraphqlContextService.finishGenerationWorkflow();
             };
 
             /**

--- a/src/js/angular/graphql/models/endpoints.js
+++ b/src/js/angular/graphql/models/endpoints.js
@@ -3,7 +3,7 @@
  * @type {{[string]: string}}
  */
 export const endpointUrl = {
-    PLAYGROUND: '/graphql/playground',
-    CREATE_ENDPOINT: '/graphql/endpoint/create',
-    ENDPOINT_MANAGEMENT: '/graphql/endpoints'
+    PLAYGROUND: 'graphql/playground',
+    CREATE_ENDPOINT: 'graphql/endpoint/create',
+    ENDPOINT_MANAGEMENT: 'graphql/endpoints'
 };

--- a/src/js/angular/graphql/services/graphql-context.service.js
+++ b/src/js/angular/graphql/services/graphql-context.service.js
@@ -102,6 +102,10 @@ function GraphqlContextService(EventEmitterService) {
         emit(GraphqlEventName.CANCEL_ENDPOINT_CREATION, {});
     }
 
+    const finishGenerationWorkflow = () => {
+        emit(GraphqlEventName.FINISH_GENERATION_WORKFLOW, {});
+    }
+
     const nextEndpointCreationStep = () => {
         emit(GraphqlEventName.NEXT_ENDPOINT_CREATION_STEP, {});
     }
@@ -183,6 +187,7 @@ function GraphqlContextService(EventEmitterService) {
         openEndpointGenerationReport,
         deleteEndpointGenerationReport,
         cancelEndpointCreation,
+        finishGenerationWorkflow,
         nextEndpointCreationStep,
         previousEndpointCreationStep,
         subscribe
@@ -214,6 +219,10 @@ export const GraphqlEventName = {
      * The event emitted when the user wants to cancel the endpoint creation.
      */
     CANCEL_ENDPOINT_CREATION: 'cancelEndpointCreation',
+    /**
+     * The event emitted when the user wants to finish the endpoint generation workflow.
+     */
+    FINISH_GENERATION_WORKFLOW: 'finishGenerationWorkflow',
     /**
      * The event emitted when the user wants to explore the generated endpoint in the GraphQL Playground.
      */

--- a/src/js/angular/graphql/templates/create-graphql-endpoint.html
+++ b/src/js/angular/graphql/templates/create-graphql-endpoint.html
@@ -30,7 +30,8 @@
             <div class="wizard-container mt-2">
                 <div class="wizard">
                     <div class="wizard-steps">
-                        <div ng-repeat="step in wizardModel.steps" class="wizard-step" ng-class="{active: step.active}">
+                        <div ng-repeat="step in wizardModel.steps" ng-click="onStepClick(step); $event.preventDefault()"
+                             class="wizard-step" ng-class="{active: step.active, completed: step.visited}">
                             <span class="step-title">{{'graphql.create_endpoint.wizard_steps.' + step.id + '.title' | translate}}</span>
                             <span class="fa fa-chevron-right step-decoration"></span>
                         </div>

--- a/src/js/angular/graphql/templates/graphql-endpoint-management.html
+++ b/src/js/angular/graphql/templates/graphql-endpoint-management.html
@@ -46,44 +46,44 @@
                aria-describedby="GraphQL endpoints info table">
             <thead>
             <tr>
-                <th scope="col" class="toggle"></th>
-                <th scope="col" class="status"></th>
-                <th scope="col" class="endpoint-id">
+                <th scope="col" class="toggle-col"></th>
+                <th scope="col" class="status-col"></th>
+                <th scope="col" class="endpoint-id-col">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.id.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.id.label' | translate}}
                     </span>
                 </th>
-                <th scope="col" class="endpoint-label">
+                <th scope="col" class="endpoint-label-col">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.label.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.label.label' | translate}}
                     </span>
                 </th>
-                <th scope="col" class="endpoint-is-default">
+                <th scope="col" class="endpoint-is-default-col text-center">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.is_default.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.is_default.label' | translate}}
                     </span>
                 </th>
-                <th scope="col" class="endpoint-is-active">
+                <th scope="col" class="endpoint-is-active-col text-center">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.is_active.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.is_active.label' | translate}}
                     </span>
                 </th>
-                <th scope="col" class="endpoint-modified-on">
+                <th scope="col" class="endpoint-modified-on-col">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.modified_on.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.modified_on.label' | translate}}
                     </span>
                 </th>
-                <th scope="col" class="endpoint-types-count">
+                <th scope="col" class="endpoint-types-count-col numeric">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.types_count.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.types_count.label' | translate}}
                     </span>
                 </th>
-                <th scope="col" class="endpoint-props-count">
+                <th scope="col" class="endpoint-props-count-col numeric">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.props_count.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.props_count.label' | translate}}
                     </span>
                 </th>
-                <th scope="col" class="endpoint-actions">
+                <th scope="col" class="endpoint-actions-col">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.actions.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.actions.label' | translate}}
                     </span>
@@ -123,14 +123,14 @@
                        class="endpoint-link">{{endpoint.endpointId}}</a>
                 </td>
                 <td>{{endpoint.label}}</td>
-                <td>
+                <td class="default-endpoint-selector">
                     <label class="endpoint-default-state">
                         <input type="radio" ng-model="selectedDefaultEndpoint.default" ng-value="endpoint.default"
                                ng-disabled="!endpoint.createdSuccessfully"
                                ng-change="setEndpointAsDefault(endpoint)"/>
                     </label>
                 </td>
-                <td>
+                <td class="active-endpoint-selector">
                     <span ng-click="!endpoint.createdSuccessfully || toggleEndpointActiveState(endpoint)"
                           class="toggle-active-state">
                         <input type="checkbox" class="switch" ng-checked="endpoint.active"
@@ -139,9 +139,9 @@
                     </span>
                 </td>
                 <td title="{{endpoint.lastModified}}">{{endpoint.lastModified | date: 'yyyy-MM-dd'}}</td>
-                <td>{{endpoint.objectsCount}}</td>
-                <td>{{endpoint.propertiesCount}}</td>
-                <td>
+                <td class="objects-count numeric">{{endpoint.objectsCount}}</td>
+                <td class="properties-count numeric">{{endpoint.propertiesCount}}</td>
+                <td class="endpoint-actions">
                     <div class="btn-group">
                         <button class="btn btn-link secondary btn-sm open-endpoint-actions-btn"
                                 data-toggle="dropdown" aria-expanded="false"

--- a/src/js/angular/graphql/templates/step-generate-endpoint.html
+++ b/src/js/angular/graphql/templates/step-generate-endpoint.html
@@ -26,7 +26,8 @@
             </div>
         </div>
 
-        <div class="generation-progress" ng-if="generatingEndpoint && !generationReport" onto-loader-fancy size="25"
+        <div class="generation-progress my-3" ng-if="generatingEndpoint && !generationReport" onto-loader-fancy
+             size="25"
              message="{{'graphql.create_endpoint.wizard_steps.generate_endpoint.messages.generation_progress' | translate}}"></div>
 
         <div ng-if="!generatingEndpoint && generationReport" class="generation-report">
@@ -49,23 +50,25 @@
                        class="btn btn-link endpoint-report-link">{{'graphql.create_endpoint.wizard_steps.generate_endpoint.overview.for_shapes.view_report_link' | translate}}</a>
                 </div>
             </div>
-
-            <div class="alert alert-info manage-endpoints-info mt-2"
-                 ng-bind-html="'graphql.create_endpoint.wizard_steps.generate_endpoint.overview.for_shapes.manage_endpoints_info' | translate :
-                 {managementUrl: endpointUrl.ENDPOINT_MANAGEMENT} | trustAsHtml"></div>
         </div>
     </div>
 
     <div class="wizard-actions mt-1">
-        <button class="btn btn-secondary cancel-btn mr-1" ng-disabled="generatingEndpoint" ng-click="cancel()">
+        <button ng-if="!generationReport" ng-disabled="generatingEndpoint" ng-click="cancel()"
+                class="btn btn-secondary cancel-btn mr-1">
             {{'graphql.create_endpoint.wizard_steps.actions.cancel.label' | translate}}
         </button>
-        <button class="btn btn-secondary back-btn mr-1" ng-disabled="generatingEndpoint" ng-click="back()">
+        <button ng-disabled="generatingEndpoint" ng-click="back()" class="btn btn-secondary back-btn mr-1">
             {{'graphql.create_endpoint.wizard_steps.actions.back.label' | translate}}
         </button>
-        <button class="btn btn-primary generate-endpoint-btn" ng-click="generateEndpoint()"
-                ng-disabled="generatingEndpoint">
+        <button ng-if="!generationReport" ng-disabled="generatingEndpoint" ng-click="generateEndpoint()"
+                class="btn btn-primary generate-endpoint-btn">
             {{'graphql.create_endpoint.wizard_steps.actions.generate_endpoint.label' | translate}}
+        </button>
+        <button ng-if="generationReport" ng-click="finishGenerationWorkflow()"
+                class="btn btn-primary finish-generation-workflow-btn"
+                gdb-tooltip="{{'graphql.create_endpoint.wizard_steps.actions.finish_workflow.tooltip' | translate}}">
+            {{'graphql.create_endpoint.wizard_steps.actions.finish_workflow.label' | translate}}
         </button>
     </div>
 </div>

--- a/src/js/angular/models/graphql/wizard.js
+++ b/src/js/angular/models/graphql/wizard.js
@@ -32,6 +32,10 @@ export class Wizard {
         return this.#steps.find((step) => step.active);
     }
 
+    isAPreviousStep(step) {
+        return this.#steps.indexOf(step) < this.#currentStep;
+    }
+
     /**
      * Makes a step active.
      * @param {WizardStep} step
@@ -39,6 +43,15 @@ export class Wizard {
     setStepActive(step) {
         this.#steps.forEach((wizardStep) => wizardStep.active = false);
         step.active = true;
+
+        const stepIndex = this.#steps.indexOf(step);
+        this.#currentStep = stepIndex;
+
+        // Reset all visited statuses
+        this.#steps.forEach((current, currentStepIndex) => {
+            // Mark steps as visited only if they come before the current step
+            current.visited = currentStepIndex < stepIndex;
+        });
     }
 
     /**
@@ -96,6 +109,11 @@ export class WizardStep {
      */
     #active = false;
     /**
+     * The visited status of the step.
+     * @type {boolean}
+     */
+    #visited = false;
+    /**
      * The URL of the template of the step.
      * @type {string}
      */
@@ -111,6 +129,7 @@ export class WizardStep {
         this.#active = active;
         this.#templateUrl = templateUrl;
         this.#page = page;
+        this.#visited = false;
     }
 
     get page() {
@@ -143,5 +162,13 @@ export class WizardStep {
 
     set id(value) {
         this.#id = value;
+    }
+
+    get visited() {
+        return this.#visited;
+    }
+
+    set visited(value) {
+        this.#visited = value;
     }
 }


### PR DESCRIPTION
## What
* Align endpoint links list with the heading above it
* Allow going back in the workflow by clicking on the wizard's step handlers.
* Remove the forward slash from the endpoint urls used for navigation between views to prevent issues when WB works behind context path.
* When generation is complete, hide the Create button and show the Finish button which opens the management view.
* Removed the info message that used to appear after the endpoint generation and changed the info text appearing before the generation in the overview panel.
* Graphiql playground was restyled to better fit the workbench look and feel.

## Why
To boost the UX

## How
--

## Testing
NA

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
