### PR TITLE
fix(GDB-11838) Add Cypress admin login & free access toggle commands

### DIFF
--- a/src/js/angular/graphql/plugin.js
+++ b/src/js/angular/graphql/plugin.js
@@ -7,8 +7,7 @@ PluginRegistry.add('route', [
         'controller': 'GraphqlEndpointManagementViewCtrl',
         'title': 'menu.graphql-endpoint-management.label',
         'helpInfo': 'graphql.endpoints_management.helpInfo',
-        'documentationUrl': 'graphql-endpoint-management.html',
-        'allowAuthorities': ['WRITE_REPO_{repoId}', 'WRITE_REPO_{repoId}:GRAPHQL']
+        'documentationUrl': 'graphql-endpoint-management.html'
     },
     {
         'url': '/graphql/endpoint/create',
@@ -18,8 +17,7 @@ PluginRegistry.add('route', [
         'controller': 'CreateGraphqlEndpointViewCtrl',
         'title': 'menu.create-graphql-endpoint.label',
         'helpInfo': 'graphql.create_endpoint.helpInfo',
-        'documentationUrl': 'create-graphql-endpoint.html',
-        'allowAuthorities': ['WRITE_REPO_{repoId}:GRAPHQL', 'WRITE_REPO_{repoId}:GRAPHQL']
+        'documentationUrl': 'create-graphql-endpoint.html'
     },
     {
         'url': '/graphql/playground',

--- a/test-cypress/steps/setup/user-and-access-steps.js
+++ b/test-cypress/steps/setup/user-and-access-steps.js
@@ -196,7 +196,7 @@ export class UserAndAccessSteps {
             .contains('Any data repository')
             .parent('tr')
             .find('.graphql')
-            .click({force: true});
+            .realClick();
     }
 
     static clickGraphqlAccessRepo(repoName) {
@@ -204,7 +204,7 @@ export class UserAndAccessSteps {
             .contains(repoName)
             .parent('tr')
             .find('.graphql')
-            .click({force: true});
+            .realClick();
     }
 
     static clickReadAccessAny() {
@@ -212,7 +212,7 @@ export class UserAndAccessSteps {
             .contains('Any data repository')
             .parent('tr')
             .find('.read')
-            .click({force: true});
+            .realClick();
     }
 
     static clickReadAccessRepo(repoName) {
@@ -220,7 +220,7 @@ export class UserAndAccessSteps {
             .contains(repoName)
             .parent('tr')
             .find('.read')
-            .click({force: true});
+            .realClick();
     }
 
     static clickWriteAccessAny() {
@@ -228,7 +228,7 @@ export class UserAndAccessSteps {
             .contains('Any data repository')
             .parent('tr')
             .find('.write')
-            .click({force: true});
+            .realClick();
     }
 
     static clickWriteAccessRepo(repoName) {
@@ -236,7 +236,7 @@ export class UserAndAccessSteps {
             .contains(repoName)
             .parent('tr')
             .find('.write')
-            .click({force: true});
+            .realClick();
     }
 
     static findUserRowAlias(username, aliasName = 'userRow') {

--- a/test-cypress/support/repository-commands.js
+++ b/test-cypress/support/repository-commands.js
@@ -18,7 +18,7 @@ Cypress.Commands.add('createRepository', (options = {}) => {
     });
 });
 
-Cypress.Commands.add('deleteRepository', (id) => {
+Cypress.Commands.add('deleteRepository', (id, secured = false) => {
     // Note: Going through /rest/repositories because it would not fail if the repo is missing
     const url = REPOSITORIES_URL + id;
 
@@ -26,10 +26,17 @@ Cypress.Commands.add('deleteRepository', (id) => {
     // if a test completes too fast and the tested view was about to load something
     // that needs the just deleted repo.
     cy.visit('/', {failOnStatusCode: false});
-
-    cy.request({
+    let headers = {'Content-Type': 'application/json'};
+    if (secured) {
+        const authHeader = Cypress.env('adminToken');
+        headers = {...headers,
+            'Authorization': authHeader
+        }
+    }
+    return cy.request({
             method: 'DELETE',
             url: url,
+            headers,
         // Prevent Cypress from failing the test on non-2xx status codes
             failOnStatusCode: false
         });

--- a/test-cypress/support/security-command.js
+++ b/test-cypress/support/security-command.js
@@ -1,5 +1,5 @@
 Cypress.Commands.add('switchOnSecurity', () => {
-    cy.request({
+    return cy.request({
         method: 'POST',
         url: `/rest/security`,
         body: 'true',
@@ -11,15 +11,56 @@ Cypress.Commands.add('switchOnSecurity', () => {
     });
 });
 
-Cypress.Commands.add('switchOffSecurity', () => {
-    cy.request({
+Cypress.Commands.add('loginAsAdmin', () => {
+    return cy.request({
         method: 'POST',
-        url: `/rest/security`,
-        body: 'false',
-        headers: {
-            'Content-Type': 'application/json'
+        url: '/rest/login',
+        body: {
+            username: 'admin',
+            password: 'root',
         },
-        // Prevent Cypress from failing the test on non-2xx status codes
-        failOnStatusCode: true
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        failOnStatusCode: true,
+    }).then((response) => {
+        const authHeader = response.headers['authorization'];
+        Cypress.env('adminToken', authHeader);
+    });
+});
+
+Cypress.Commands.add('switchOffSecurity', (secured = false) => {
+    let headers = {'Content-Type': 'application/json'};
+    if (secured) {
+        const authHeader = Cypress.env('adminToken');
+        headers = {...headers,
+            'Authorization': authHeader
+        }
+    }
+    return cy.request({
+        method: 'POST',
+        url: '/rest/security',
+        body: 'false',
+        headers,
+        failOnStatusCode: true,
+    });
+});
+
+Cypress.Commands.add('switchOffFreeAccess', (secured = false) => {
+    let headers = {'Content-Type': 'application/json'};
+    if (secured) {
+        const authHeader = Cypress.env('adminToken');
+        headers = {...headers,
+            'Authorization': authHeader
+        }
+    }
+    return cy.request({
+        method: 'POST',
+        url: '/rest/security/free-access',
+        body: {
+            'enabled': false
+        },
+        headers,
+        failOnStatusCode: true,
     });
 });

--- a/test-cypress/support/user-commands.js
+++ b/test-cypress/support/user-commands.js
@@ -21,10 +21,18 @@ Cypress.Commands.add('createUser', (options = {}) => {
     });
 });
 
-Cypress.Commands.add('deleteUser', (username = {}) => {
-    cy.request({
+Cypress.Commands.add('deleteUser', (username = {}, secured = false) => {
+    let headers = {'Content-Type': 'application/json'};
+    if (secured) {
+        const authHeader = Cypress.env('adminToken');
+        headers = {...headers,
+            'Authorization': authHeader
+        }
+    }
+    return cy.request({
         method: 'DELETE',
         url: `/rest/security/users/${username}`,
+        headers,
         // Prevent Cypress from failing the test on non-2xx status codes
         failOnStatusCode: false
     });


### PR DESCRIPTION
## WHAT
- Introduce new Cypress commands (loginAsAdmin, switchOffSecurity, switchOffFreeAccess) that capture and reuse the Authorization header.
- Update user, repository, and security commands to pass the admin token in requests.
- Adjust tests to use the new commands and reduce repetitive cleanup logic.

## WHY
- We need a standardized way to authenticate and manage security features in our Cypress tests.

## HOW
- Added loginAsAdmin to capture the Authorization token from the response and store it in Cypress.env.
- Reworked existing commands (switchOffSecurity, switchOffFreeAccess, etc.) to use the stored token.


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [X] Tests
