### PR TITLE
fix(GDB-11795) Fix cookie saving in free access mode

### DIFF
--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -252,7 +252,12 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         }, 400);
         if (previous) {
             // Recheck license status on navigation within the workbench (security is already inited)
-            $licenseService.checkLicenseStatus().then(() => TrackingService.init());
+            $licenseService.checkLicenseStatus()
+                .then(() => TrackingService.applyTrackingConsent())
+                .catch((error) => {
+                    const msg = getError(error.data, error.status);
+                    toastr.error(msg, $translate.instant('common.error'));
+                });
         }
     });
 
@@ -951,7 +956,12 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
                     // There are many places where setTimeout is used, see $jwtAuth#authenticate and $jwtAuth#setAuthHeaders.
                     setTimeout(() => $scope.getSavedQueries(), 500);
                 });
-            $licenseService.checkLicenseStatus().then(() => TrackingService.init());
+            $licenseService.checkLicenseStatus()
+                .then(() => TrackingService.applyTrackingConsent())
+                .catch((error) => {
+                    const msg = getError(error.data, error.status);
+                    toastr.error(msg, $translate.instant('common.error'));
+                });
         }
     });
 

--- a/src/js/angular/core/directives/cookie-policy/cookie-consent.directive.js
+++ b/src/js/angular/core/directives/cookie-policy/cookie-consent.directive.js
@@ -37,7 +37,14 @@ function cookieConsent($jwtAuth, $uibModal, $licenseService, $translate, toastr,
                     controller: CookiePolicyModalController,
                     backdrop: 'static',
                     keyboard: false,
-                    windowClass: 'cookie-policy-modal'
+                    windowClass: 'cookie-policy-modal',
+                    resolve: {
+                        data: () => {
+                            return {
+                                cookieConsent
+                            }
+                        }
+                    }
                 });
             };
 

--- a/src/js/angular/core/directives/cookie-policy/cookie-policy-modal-controller.js
+++ b/src/js/angular/core/directives/cookie-policy/cookie-policy-modal-controller.js
@@ -1,6 +1,6 @@
 import {ConsentTypes} from "../../../models/cookie-policy/cookie-consent";
 
-CookiePolicyModalController.$inject = ['$scope', '$translate', 'toastr', 'TrackingService'];
+CookiePolicyModalController.$inject = ['$scope', '$translate', 'toastr', 'TrackingService', 'data'];
 
 /**
  * Controller for managing cookie consent settings in a modal.
@@ -10,13 +10,14 @@ CookiePolicyModalController.$inject = ['$scope', '$translate', 'toastr', 'Tracki
  * @param {Object} $translate - Service for translating messages within the modal.
  * @param {Object} toastr - Service for displaying toast notifications.
  * @param {Object} TrackingService - Service responsible for tracking and managing consent data.
+ * @param {Object} data - Passes data from parent.
  */
-export function CookiePolicyModalController($scope, $translate, toastr, TrackingService) {
+export function CookiePolicyModalController($scope, $translate, toastr, TrackingService, data) {
     let callCount = 0;
     // =========================
     // Public variables
     // =========================
-    $scope.cookieConsent = undefined;
+    $scope.cookieConsent = data.cookieConsent;
     $scope.ConsentTypes = ConsentTypes;
 
     // =========================
@@ -53,21 +54,4 @@ export function CookiePolicyModalController($scope, $translate, toastr, Tracking
 
         $scope.$close(didAbusedThirdPartyToggle && hasThirdPartyConsent && hasPolicyAccepted);
     };
-
-    // =========================
-    // Private functions
-    // =========================
-    const init = () => {
-        TrackingService.getCookieConsent()
-            .then((cookieConsent) => $scope.cookieConsent = cookieConsent)
-            .catch((error) => {
-                const msg = getError(error.data, error.status);
-                toastr.error(msg, $translate.instant('common.error'));
-            });
-    };
-
-    // =========================
-    // Initialization
-    // =========================
-    init();
 }

--- a/src/js/angular/security/controllers.js
+++ b/src/js/angular/security/controllers.js
@@ -35,7 +35,11 @@ securityModule.controller('LoginCtrl', ['$scope', '$http', 'toastr', '$jwtAuth',
         // Reinitialize security settings, if failed for some reason
         $jwtAuth.reinitializeSecurity();
 
-        TrackingService.init();
+        TrackingService.applyTrackingConsent()
+            .catch((error) => {
+                const msg = getError(error.data, error.status);
+                toastr.error(msg, $translate.instant('common.error'));
+            });
 
         $scope.loginWithOpenID = function () {
             $jwtAuth.loginOpenID();

--- a/src/js/angular/security/controllers/user-settings.controller.js
+++ b/src/js/angular/security/controllers/user-settings.controller.js
@@ -192,8 +192,18 @@ function UserSettingsController($scope, toastr, $window, $timeout, $jwtAuth, $ro
             controller: CookiePolicyModalController,
             backdrop: 'static',
             keyboard: false,
-            windowClass: 'cookie-policy-modal'
-        })
+            windowClass: 'cookie-policy-modal',
+            resolve: {
+                data: () => {
+                    return TrackingService.getCookieConsent()
+                        .then(consent => {
+                            return {
+                                cookieConsent: consent
+                            };
+                        });
+                    }
+                }
+            })
             // If the modal returns `shouldReload` as true, we reload the page.
             // Reloading is crucial here due to potential memory leaks that arise from dynamically
             // adding and removing Google Tag Manager (GTM) scripts based on the user's consent choice.
@@ -209,7 +219,7 @@ function UserSettingsController($scope, toastr, $window, $timeout, $jwtAuth, $ro
     // Private functions
     // =========================
 
-    const showCookiePolicyLink = () => {
+     const showCookiePolicyLink = () => {
         $licenseService.checkLicenseStatus().then(() => {
             $scope.showCookiePolicyLink = TrackingService.isTrackingAllowed();
         });

--- a/src/js/angular/settings/controllers.js
+++ b/src/js/angular/settings/controllers.js
@@ -78,7 +78,12 @@ function LicenseCtrl($scope, LicenseRestService, $licenseService, toastr, $rootS
             .then(function () {
                 LicenseRestService.unregisterLicense()
                     .success(function () {
-                        $licenseService.checkLicenseStatus().then(() => TrackingService.init());
+                        $licenseService.checkLicenseStatus()
+                            .then(() => TrackingService.applyTrackingConsent())
+                            .catch((error) => {
+                                const msg = getError(error.data, error.status);
+                                toastr.error(msg, $translate.instant('common.error'));
+                            });
                     });
             });
     };

--- a/src/js/angular/utils/local-storage-adapter.js
+++ b/src/js/angular/utils/local-storage-adapter.js
@@ -29,7 +29,8 @@ angular
         'JSONLD_EXPORT_SETTINGS': 'jsonld-export-settings',
         'IMPORT_VIEW': 'import-view',
         'SPARQL_LAST_REPO': 'sparql-last-repo',
-        'TTYG': 'ttyg'
+        'TTYG': 'ttyg',
+        'COOKIE_CONSENT': 'cookie-consent'
     });
 
 LocalStorageAdapter.$inject = ['localStorageService', 'LSKeys'];


### PR DESCRIPTION
## WHAT:
- Ensures that local storage is used properly for free-access users.
- Updates the TrackingService to read from local storage or backend consistently, depending on the access mode

## WHY:
- Cookie handling was not working in freaa access mode.

## HOW:
- Removes the internal getCookieConsent() call in the CookiePolicyModalController and injects the same instance from the directive
- Ensures that isTrackingAllowed() and getCookieConsent() are used consistently in TrackingService, and re-initializes tracking when user consent updates.
- Adds LSKeys.COOKIE_CONSENT as a known local storage key and leverages LocalStorageAdapter appropriately.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
