### PR TITLE
GDB-11416: JSON-LD Context field should allow empty

### DIFF
--- a/src/js/angular/import/directives/validate-uri.directive.js
+++ b/src/js/angular/import/directives/validate-uri.directive.js
@@ -1,3 +1,13 @@
+/**
+ * This AngularJS directive validates whether an input value is a valid URI (IRI).
+ *
+ * @directive validateUri
+ * @restrict A (Attribute)
+ * @requires ngModel
+ *
+ * @example
+ * <input type="text" name="url" ng-model="url" validate-uri>
+ */
 const modules = [];
 
 angular
@@ -6,14 +16,21 @@ angular
 
 validateUri.$inject = ['UriUtils'];
 
+/**
+ * @function validateUri
+ * @param {UriUtils} UriUtils - Service for URI validation.
+ */
 function validateUri(UriUtils) {
     return {
         restrict: 'A',
         require: 'ngModel',
         link: function (scope, element, attr, ctrl) {
             ctrl.$parsers.unshift(function (value) {
-                const valid = UriUtils.isValidIri(value, value.toString());
-                ctrl.$setValidity('validateUri', valid);
+                ctrl.$setValidity('validateUri', true);
+                if (!ctrl.$isEmpty(value)) {
+                    const valid = UriUtils.isValidIri(value, value.toString());
+                    ctrl.$setValidity('validateUri', valid);
+                }
                 return value;
             });
         }

--- a/src/js/angular/import/templates/settingsModal.html
+++ b/src/js/angular/import/templates/settingsModal.html
@@ -48,7 +48,7 @@
                              ng-if="settingsForm.context.$dirty && settingsForm.context.$error.validateUri">
                             {{'import.alert.not.valid.iri' | translate}}
                         </div>
-                        <div class="alert alert-danger" ng-if="settingsForm.context.$error.required">
+                        <div class="alert alert-danger" ng-if="settingsForm.context.$touched && settingsForm.context.$error.required">
                             {{'required.field' | translate}}
                         </div>
                     </div>

--- a/src/js/angular/import/templates/urlImport.html
+++ b/src/js/angular/import/templates/urlImport.html
@@ -12,8 +12,11 @@
                    popover-placement="bottom"
                    popover-trigger="focus">
         </div>
-        <div class="text-danger" ng-show="urlForm.dataUrl.$error.validateUri">
+        <div class="text-danger" ng-if="urlForm.dataUrl.$dirty && urlForm.dataUrl.$error.validateUri">
             {{'import.invalid.url' | translate}}
+        </div>
+        <div class="text-danger" ng-if="urlForm.dataUrl.$touched && urlForm.dataUrl.$error.required">
+            {{'required.field' | translate}}
         </div>
     </form>
 </div>

--- a/test-cypress/integration/import/import-server-files.spec.js
+++ b/test-cypress/integration/import/import-server-files.spec.js
@@ -184,4 +184,26 @@ describe('Import server files', () => {
         ImportServerFilesSteps.getResource(18).should('contain', "test_turtlestar.ttls");
         ImportServerFilesSteps.getResource(19).should('contain', "bnodes.ttl");
     });
+
+    it('should allow importing jsonld with empty "JSON-LD Context"', () => {
+        // Given: The server files tab is loaded
+
+        // When: I open the import dialog for a file with JSON-LD content,
+        ImportServerFilesSteps.importResourceByName('import-resource-with-correct-data.jsonld');
+        // Then: I expect the import button be enabled, because the "JSON-LD Context" is not mandatory field.
+        ImportSettingsDialogSteps.getImportButton().should('be.enabled');
+
+        // When: I enter an invalid field.
+        ImportSettingsDialogSteps.getJSONLDContextInput().type('invalid context URL')
+        // Then I expect
+        // the import button be disabled because JSON-LD context URL is not valid
+        ImportSettingsDialogSteps.getImportButton().should('be.disabled');
+        // and an error message is displayed
+        ImportSettingsDialogSteps.getError().contains('Not a valid IRI!');
+
+        // When: I clear the URI
+        ImportSettingsDialogSteps.getJSONLDContextInput().clear().blur();
+        // Then: I expect the import button be enabled, because the "JSON-LD Context" is not mandatory field.
+        ImportSettingsDialogSteps.getImportButton().should('be.enabled');
+    });
 });

--- a/test-cypress/integration/import/import-user-data-url.spec.js
+++ b/test-cypress/integration/import/import-user-data-url.spec.js
@@ -21,6 +21,39 @@ describe('Import user data: URL import', () => {
         cy.deleteRepository(repositoryId);
     });
 
+    it('should not allow import if the URL is not valid or empty', () => {
+        // Given: I have opened the "Import" view.
+
+        // When: I open the import menu
+        ImportUserDataSteps.openImportURLDialog();
+        // Then: I expect the import button to be disabled because the URL is a mandatory field.
+        ImportUserDataSteps.getImportUrlButton().should('be.disabled');
+
+        // When: I type an invalid URL
+        ImportUserDataSteps.getImportUrlInput().type('invalid url');
+        // Then: I expect
+        // an error message to be displayed,
+        ImportUserDataSteps.getError().contains('Not valid url!');
+        // and the import button to remain disabled because the URL is not valid.
+        ImportUserDataSteps.getImportUrlButton().should('be.disabled');
+
+        // When: I clear the URL
+        ImportUserDataSteps.getImportUrlInput().clear().blur();
+        // Then: I expect an error message to be displayed
+        ImportUserDataSteps.getError().contains('This field is required');
+        // and the import button to remain disabled because the URL is a mandatory field.
+        ImportUserDataSteps.getImportUrlButton().should('be.disabled');
+
+        // When: I type a valid URL
+        ImportUserDataSteps.getImportUrlInput().type(IMPORT_URL);
+        // Then: I expect
+        // no errors to be displayed,
+        ImportUserDataSteps.getErrors().should('have.length', 0);
+        // and the import button to be enabled because the URL is valid.
+        ImportUserDataSteps.getImportUrlButton().should('be.enabled');
+    });
+
+
     it('Test import file via URL successfully with Auto format selected', () => {
         ImportUserDataSteps.openImportURLDialog(IMPORT_URL);
         ImportUserDataSteps.clickImportUrlButton();

--- a/test-cypress/steps/import/import-settings-dialog-steps.js
+++ b/test-cypress/steps/import/import-settings-dialog-steps.js
@@ -68,6 +68,10 @@ export class ImportSettingsDialogSteps extends ModalDialogSteps {
         this.getSettingsForm().find('input[name="contextLink"]').type(contextLink).should('have.value', contextLink);
     }
 
+    static getJSONLDContextInput() {
+        return this.getSettingsForm().find('.contextLinkRow .form-control');
+    }
+
     static setContextLinkToBeVisible() {
         this.getSettingsForm().within(() => {
             cy.get('.contextLinkRow').invoke('attr', 'style', 'display: block !important');
@@ -76,5 +80,13 @@ export class ImportSettingsDialogSteps extends ModalDialogSteps {
 
     static getReplaceExistingDataCheckbox() {
         return this.getSettingsForm().find('input.existing-data-replacement');
+    }
+
+    static getErrors() {
+        return cy.get('.alert-danger');
+    }
+
+    static getError(index = 0) {
+        return this.getErrors().eq(index);
     }
 }

--- a/test-cypress/steps/import/import-steps.js
+++ b/test-cypress/steps/import/import-steps.js
@@ -312,14 +312,19 @@ class ImportSteps {
         cy.get('#import-user .import-from-url-btn').click();
         // Forces the popover to disappear as it covers the modal and Cypress refuses to continue
         this.closePopover();
-        this.getImportUrlInput().type(importURL).should('have.value', importURL);
-        this.closePopover();
+        if (importURL) {
+            this.getImportUrlInput().type(importURL).should('have.value', importURL);
+            this.closePopover();
+        }
         return this;
     }
 
-    static clickImportUrlButton() {
-        cy.get('#wb-import-importUrl').click();
+    static getImportUrlButton() {
+        return cy.get('#wb-import-importUrl');
+    }
 
+    static clickImportUrlButton() {
+        this.getImportUrlButton().click();
         return this;
     }
 

--- a/test-cypress/steps/import/import-user-data-steps.js
+++ b/test-cypress/steps/import/import-user-data-steps.js
@@ -44,6 +44,14 @@ export class ImportUserDataSteps extends ImportSteps {
         cy.intercept('POST', `/rest/repositories/${repositoryId}/import/upload/url`).as('postJsonldUrl');
     }
 
+    static getErrors() {
+        return cy.get('.text-danger');
+    }
+
+    static getError(index = 0) {
+        return this.getErrors().eq(index);
+    }
+
     // ==========================================================================
     // utilities from text snippet tests
     // ==========================================================================


### PR DESCRIPTION
## What
Cannot import file(s) if the "JSON-LD context" field is marked as dirty and empty.

## Why
The input is validated using the validate-uri directive, but an empty string is not a valid URI. As a result, the directive marks the input as invalid.

## How
Added a check to the validate-uri directive to skip validation if the field is empty. Validating whether the field is empty is the responsibility of other functionality that checks for required fields

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
