### PR TITLE
GDB-11245 Disable entity index size in edit mode

### DIFF
--- a/src/pages/repository.html
+++ b/src/pages/repository.html
@@ -329,6 +329,7 @@
                                        min="entityIndexSizeMin"
                                        step="1"
                                        name="entityIndexSize"
+                                       ng-disabled="editRepoPage"
                                        ng-model="repositoryInfo.params.entityIndexSize.value"
                                        ng-model-options="{allowInvalid: true}"/>
                                 <div style="margin-top: 5px" ng-show="repositoryInfo.params.entityIndexSize.value < entityIndexSizeMin" class="alert alert-danger">

--- a/test-cypress/integration/repository/repositories.spec.js
+++ b/test-cypress/integration/repository/repositories.spec.js
@@ -333,6 +333,7 @@ describe('Repositories', () => {
         // Some fields should be disabled
         RepositorySteps.getRepositoryRulesetMenu().should('be.disabled');
         RepositorySteps.getRepositoryDisableSameAsCheckbox().should('be.disabled');
+        RepositorySteps.getEntityIndexSize().should('be.disabled');
 
         RepositorySteps.typeRepositoryTitle(newTitle);
         RepositorySteps.getRepositoryContextIndexCheckbox().check();


### PR DESCRIPTION
## What
Disable entity index size in edit repository mode

## Why
It should be allowed only, when creating a repository

## How
Added `ng-disable` to the form field, whenever the form is in edit mode

## Testing
cypress

## Screenshots
create repo: 
![image](https://github.com/user-attachments/assets/e4e70ae9-9336-4c60-b971-c308b9702e59)

edit repo: 
![image](https://github.com/user-attachments/assets/c99f9836-0084-4dcd-8d73-397459f3c4f1)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
