### PR TITLE
Fix graphql cypress tests data provisioning

### DIFF
--- a/test-cypress/integration/graphql/activate-deactivate-graphql-endpoint.spec.js
+++ b/test-cypress/integration/graphql/activate-deactivate-graphql-endpoint.spec.js
@@ -17,8 +17,7 @@ describe('GraphQL: activate and deactivate endpoint', () => {
         cy.deleteRepository(repositoryId);
     });
 
-    // TODO: until the backend is implemented
-    it.skip('should be able to activate or deactivate an endpoint', () => {
+    it('should be able to activate or deactivate an endpoint', () => {
         // Given I have a repository with active GraphQL endpoints
         // When I visit the endpoint management view
         GraphqlEndpointManagementSteps.visit();

--- a/test-cypress/integration/graphql/edit-graphql-enpoint.spec.js
+++ b/test-cypress/integration/graphql/edit-graphql-enpoint.spec.js
@@ -83,7 +83,6 @@ describe('Graphql: edit endpoint settings', () => {
                     "enableGraphQLExplain": true,
                     "exposeSomlInGraphQL": false,
                     "disabledChecks": null,
-                    "defaultIntegrationRole": "Federation_SystemRole",
                     "queryPrefix": null,
                     "mutationPrefix": null
                 }

--- a/test-cypress/support/import-commands.js
+++ b/test-cypress/support/import-commands.js
@@ -10,10 +10,10 @@ Cypress.Commands.add('uploadGraphqlSchema', (repositoryId, schemaPath, schemaId 
     cy.fixture(schemaPath).then((schema) => {
         cy.request({
             method: 'POST',
-            url: `${REPOSITORIES_URL}${repositoryId}/soml`,
+            url: `${REPOSITORIES_URL}${repositoryId}/graphql/manage/endpoints/import`,
             headers: {'Content-type': 'text/yaml'},
             body: schema
-        }).should((response) => expect(response.status).to.equal(201));
+        }).should((response) => expect(response.status).to.equal(200));
         waitForGraphqlSchema(repositoryId, schemaId);
     });
 });
@@ -22,10 +22,10 @@ Cypress.Commands.add('uploadGraphqlSchema', (repositoryId, schemaPath, schemaId 
 function waitForGraphqlSchema(repositoryId, schemaId) {
     cy.request({
         method: 'GET',
-        url: `${REPOSITORIES_URL}${repositoryId}/soml/${schemaId}`
+        url: `${REPOSITORIES_URL}${repositoryId}/graphql/manage/endpoints/${schemaId}`
     }).then((response) => {
         // const importStatus = Cypress._.find(response.body, (importStatus) => importStatus.name === fileName);
-        if (response.status === 200 && response.body && response.body.id === `/soml/${schemaId}`) {
+        if (response.status === 200 && response.body && response.body.id === schemaId) {
             return;
         }
         cy.wait(POLL_INTERVAL);


### PR DESCRIPTION
## What
Fix graphql cypress tests data provisioning.

## Why
Most of the tests required provisioning of some test data whiich was done through the `/soml` API that is now removed.

## How
Updated cypress commands used for importing endpoint definitions to use the new import API.

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
