### PR TITLE
GDB-11292: Visual Graph View types for nodes are overflowing when hovering a node

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -2903,6 +2903,7 @@
     "sidepanel.limit.links.tooltip": "Limit the number of links when often they are too many",
     "sidepanel.maximum.links": "Maximum links to show",
     "visual.search.instance.placeholder": "Search instance properties",
+    "visual.node.tooltip.no_types": "No types",
     "sidepanel.invalid.limit.links.msg": "Invalid links limit",
     "sidepanel.invalid.limit.links.tooltip": "The valid limit range is 1-1000",
     "sidepanel.preferred.languages": "Preferred languages",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -2902,6 +2902,7 @@
     "sidepanel.limit.links.tooltip": "Limiter le nombre de liens quand souvent ils sont trop nombreux",
     "sidepanel.maximum.links": "Nombre maximal de liens à afficher",
     "visual.search.instance.placeholder": "Recherche des propriétés de l'instance",
+    "visual.node.tooltip.no_types": "Aucun type",
     "sidepanel.invalid.limit.links.msg": "Limite de liens non valide",
     "sidepanel.invalid.limit.links.tooltip": "La plage de limites valables est de 1 à 1000",
     "sidepanel.preferred.languages": "Langues préférées",

--- a/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -1331,14 +1331,12 @@ function GraphsVisualizationsCtrl(
                 }
 
                 if (d.types.length > 0) {
-                    // mid-dot delimited types
-                    html += _.join(_.map(d.types, function (t) {
-                        return $scope.replaceIRIWithPrefix(t);
-                    }), ' \u00B7 ');
+                    html += d.types
+                        .map((type) => `<div> \u00B7 ${$scope.replaceIRIWithPrefix(type)}</div>`)
+                        .join('');
                 } else {
-                    html += '<i>No types</i>';
+                    html += `<i>${$translate.instant('visual.node.tooltip.no_types')}</i>`;
                 }
-
                 return html;
             });
 

--- a/src/js/lib/d3-tip/d3-tip.css
+++ b/src/js/lib/d3-tip/d3-tip.css
@@ -5,7 +5,6 @@
   background: rgba(0, 0, 0, 0.8);
   color: #fff;
   pointer-events: none;
-  max-height: 30px;
 }
 
 /* Creates a small triangle extender for the tooltip */

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -2900,6 +2900,7 @@
     "sidepanel.limit.links.tooltip": "Limit the number of links when often they are too many",
     "sidepanel.maximum.links": "Maximum links to show",
     "visual.search.instance.placeholder": "Search instance properties",
+    "visual.node.tooltip.no_types": "No types",
     "sidepanel.invalid.limit.links.msg": "Invalid links limit",
     "sidepanel.invalid.limit.links.tooltip": "The valid limit range is 1-1000",
     "sidepanel.preferred.languages": "Preferred languages",


### PR DESCRIPTION
## What
Visual Graph View node types overflow the tooltip container when hovering over a node.

## Why
A maximum height of 30px was set on the tooltip container.

## How
The max-height constraint has been removed.

### Additional work
- The old implementation separated node types using a middle dot (·), but when the tooltip was opened, all types appeared one after another, making them hard to read. This has been refactored so that each type now appears on a separate line within the tooltip.
- Added a translation for the "No types" label, which was previously hardcoded.

## Testing
N/A

## Screenshots
before:

![image](https://github.com/user-attachments/assets/24699178-3102-4b22-898e-dd67222f5e7d)


after:

![image](https://github.com/user-attachments/assets/1e98d327-d599-4409-a15d-cf6382e5f185)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
