### PR TITLE
fix(GDB-11028) Remove Backup & Restore and User Guides views for basic users

### DIFF
--- a/src/js/angular/backup-and-restore/plugin.js
+++ b/src/js/angular/backup-and-restore/plugin.js
@@ -7,8 +7,7 @@ PluginRegistry.add('route', {
     'templateUrl': 'pages/monitor/backup-and-restore.html',
     'title': 'view.monitoring.backup_and_restore.title',
     'helpInfo': 'view.monitoring.backup_and_restore.helpInfo',
-    'documentationUrl': 'backup-and-restore.html#monitoring-your-recovery-operations',
-    'allowAuthorities': ['READ_REPO_{repoId}']
+    'documentationUrl': 'backup-and-restore.html#monitoring-your-recovery-operations'
 });
 
 PluginRegistry.add('main.menu', {
@@ -19,7 +18,8 @@ PluginRegistry.add('main.menu', {
             href: 'monitor/backup-and-restore',
             order: 2,
             parent: 'Monitor',
-            guideSelector: 'sub-menu-backup-and-restore'
+            guideSelector: 'sub-menu-backup-and-restore',
+            role: 'ROLE_REPO_MANAGER'
         }
     ]
 });

--- a/src/js/angular/guides/plugin.js
+++ b/src/js/angular/guides/plugin.js
@@ -7,8 +7,7 @@ PluginRegistry.add('route', [
         title: 'view.guides.title',
         controller: 'GuidesCtrl',
         helpInfo: 'view.guides.helpInfo',
-        documentationUrl: 'index.html',
-        'allowAuthorities': ['READ_REPO_{repoId}']
+        documentationUrl: 'index.html'
     }
 ]);
 
@@ -21,7 +20,7 @@ PluginRegistry.add('main.menu', {
             parent: 'Help',
             icon: 'paste',
             href: 'guides',
-            role: 'ROLE_USER',
+            role: 'ROLE_REPO_MANAGER',
             guideSelector: 'sub-menu-guide'
         }
     ]

--- a/test-cypress/integration/setup/user-and-access.spec.js
+++ b/test-cypress/integration/setup/user-and-access.spec.js
@@ -563,11 +563,6 @@ describe('User and Access', () => {
             expectedTitle: 'Query and Update monitoring',
             checks: noAuthChecks
         },
-        {
-            path: ['Monitor', 'Backup and Restore'],
-            expectedUrl: '/monitor/backup-and-restore',
-            checks: noAuthChecks
-        },
 
         // 6) Setup
         {
@@ -630,11 +625,6 @@ describe('User and Access', () => {
 
         // 8) Help
         {
-            path: ['Help', 'Interactive guides'],
-            expectedUrl: '/guides',
-            checks: noAuthChecks
-        },
-        {
             path: ['Help', 'REST API'],
             expectedUrl: '/webapi',
             expectedTitle: 'REST API documentation',
@@ -658,6 +648,16 @@ describe('User and Access', () => {
         {
             path: ['GraphQL', 'GraphQL Playground'],
             expectedUrl: '/graphql/playground',
+            checks: hasAuthChecks
+        },
+        {
+            path: ['Monitor', 'Backup and Restore'],
+            expectedUrl: '/monitor/backup-and-restore',
+            checks: hasAuthChecks
+        },
+        {
+            path: ['Help', 'Interactive guides'],
+            expectedUrl: '/guides',
             checks: hasAuthChecks
         }
     ];


### PR DESCRIPTION
## WHAT:
- Removed the Backup & Restore and User Guides menu items from basic users by restricting them to users with the ROLE_REPO_MANAGER role.

## WHY:
The Backup & Restore view always returns a restricted message for basic users, regardless of the active repository

## HOW:
- Updated src/js/angular/backup-and-restore/plugin.js and src/js/angular/guides/plugin.js

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
