### PR TITLE
GDB-11899 graphql endpoints polling improvement

### DIFF
--- a/src/js/angular/graphql/controllers/graphql-endpoint-management-view.controller.js
+++ b/src/js/angular/graphql/controllers/graphql-endpoint-management-view.controller.js
@@ -443,8 +443,15 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
      * Polls the GraphQL endpoints info.
      */
     const pollEndpointsInfo = () => {
+        // Cancel any existing timer first to prevent duplicates
+        if (endpointsInfoPollingTimer) {
+            $interval.cancel(endpointsInfoPollingTimer);
+            endpointsInfoPollingTimer = undefined;
+        }
+
         endpointsInfoPollingTimer = $interval(() => {
-            if (!endpointsInfoLoader) {
+            // Only start a new request if we're not already loading and if the controller is still active
+            if (!endpointsInfoLoader && !$scope.$$destroyed) {
                 endpointsInfoLoader = reloadEndpointsInfo();
             }
         }, ENDPOINTS_INFO_POLLING_INTERVAL);
@@ -456,6 +463,7 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
     const unsubscribeAll = () => {
         endpointsInfoPollingTimer && $interval.cancel(endpointsInfoPollingTimer);
         endpointsInfoPollingTimer = undefined;
+        endpointsInfoLoader = undefined;
         subscriptions.forEach((subscription) => subscription());
     };
 


### PR DESCRIPTION
## What
Improve the polling implementation in the graphql endpoints management view.

## Why
There were certain scenarios where the polling although there is an unsubscribe and clean up logic, to continue to run and also stack up. 

## How
Improved the polling logic to prevent stacking up polling requests and improved the clean up by removing the wrapped function that performs the http request.

## Testing
NA

## Screenshots
NA

## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
