### PR TITLE
GDB-10914: allow line break in VizGraph "Node Basics"

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -23,6 +23,7 @@ import {defineCustomElements as defineGraphQlElements} from 'ontotext-graphql-pl
 import {convertToHumanReadable} from "./js/angular/utils/size-util";
 import {DocumentationUrlResolver} from "./js/angular/utils/documentation-url-resolver";
 import {NumberUtils} from "./js/angular/utils/number-utils";
+import {HtmlUtil} from "./js/angular/utils/html-util";
 
 // $translate.instant converts <b> from strings to &lt;b&gt
 // and $sce.trustAsHtml could not recognise that this is valid html
@@ -252,6 +253,7 @@ const moduleDefinition = function (productInfo, translations) {
     workbench.filter('humanReadableSize', () => (size) => convertToHumanReadable(size));
     workbench.filter('trustAsHtml', ['$translate', '$sce', ($translate, $sce) => (message) => $sce.trustAsHtml(decodeHTML(message))]);
     workbench.filter('formatNumberToLocaleString', ['$translate', ($translate) => (number) => NumberUtils.formatNumberToLocaleString(number, $translate.use())]);
+    workbench.filter('htmlAsText', () => (html) => HtmlUtil.getText(html));
 
     angular.bootstrap(document, ['graphdb.workbench']);
 };

--- a/src/css/graphs-vizualizations.css
+++ b/src/css/graphs-vizualizations.css
@@ -132,11 +132,12 @@
 }
 
 .node-label-body div {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     margin: auto;
     max-height: 3em;
     text-align: center;
-    word-wrap: break-word;
-    word-break: break-word;
 }
 
 .node-wrapper .pinned {

--- a/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -7,6 +7,7 @@ import 'angular/utils/local-storage-adapter';
 import {NUMBER_PATTERN} from "../../repositories/repository.constants";
 import {removeSpecialChars} from "../../utils/string-utils";
 import {NamespacesListModel} from "../../models/namespaces/namespaces-list";
+import {HtmlUtil} from "../../utils/html-util";
 
 const modules = [
     'ui.scroll.jqlite',
@@ -472,33 +473,9 @@ function GraphsVisualizationsCtrl(
                 return d.fontSize + 'px';
             })
             .append('xhtml:div')
-            .text(function (d) {
-                return d.labels[0].label;
+            .html(function (d) {
+                return HtmlUtil.getText(d.labels[0].label).replaceAll("\n", "<br>");
             });
-
-        // Our own implementation of what browsers should really do but they either can't or don't do properly.
-        // This code will look at each node's label element and check if the text fits. This is achieved by
-        // checking the DOM properties scrollHeight/-Width and clientHeight/-Width. Generally if the scroll ones
-        // are bigger than the client ones the content doesn't fit.
-        $timeout(function () {
-            $('.node-label-body div').each(function (i, e) {
-                // Initial text is minus one character as we'll be adding a one-character suffix if we need to truncate
-                let text = e.textContent.substring(0, e.textContent.length - 1);
-                const suffixToInsert = '…';
-                let endlessLoopGuard = 0;
-
-                // Loop until the text fits
-                while (endlessLoopGuard < 200 && (e.scrollHeight > e.clientHeight || e.scrollWidth > e.clientWidth)) {
-                    // Take previous text minus one character
-                    text = text.substring(0, text.length - 1);
-
-                    // Set the new text + suffix as textContent
-                    e.textContent = text + suffixToInsert;
-
-                    endlessLoopGuard++;
-                }
-            });
-        }, 50);
     };
 
     const initSettings = (principal) => {

--- a/src/js/angular/utils/html-util.js
+++ b/src/js/angular/utils/html-util.js
@@ -1,0 +1,20 @@
+export class HtmlUtil {
+
+    /**
+     * Extracts and returns the plain text content from a given HTML string by removing any HTML tags.
+     *
+     * @param {string} html - The HTML string from which to extract plain text.
+     *
+     * @example
+     * const plainText = HtmlUtil.getText('<div>Hello <strong>World</strong></div>');
+     * console.log(plainText); // Outputs: "Hello World"
+     */
+    static getText(html) {
+        if (!html) {
+            return html;
+        }
+        const tempDiv = document.createElement("div");
+        tempDiv.innerHTML = html;
+        return tempDiv.innerText;
+    }
+}

--- a/src/pages/graphs-visualizations.html
+++ b/src/pages/graphs-visualizations.html
@@ -390,7 +390,7 @@
 
         <div ng-if="showNodeInfo" class="tab-content">
             <h3 class="hovered-parent">
-                <a class="uri" rel="noopener" target="_blank" href="resource?{{resourceType}}={{encodedIri}}" style="text-decoration: underline;">{{rdfsLabel}}</a>
+                <a class="uri" rel="noopener" target="_blank" href="resource?{{resourceType}}={{encodedIri}}" style="text-decoration: underline;">{{rdfsLabel | htmlAsText}}</a>
                 <button class="btn btn-link btn-sm px-0 hovered-item"
                         style="opacity: 1"
                         ng-click="copyToClipboard(nodeIri)"
@@ -414,7 +414,8 @@
                 </div>
                 <div class="media-body">
 					<span ng-repeat="l in nodeLabels">
-                        {{l.label}}<span class="language-tag" ng-if="l.lang">{{l.lang}}</span>
+                        {{l.label | htmlAsText}}
+                        <span class="language-tag" ng-if="l.lang">{{l.lang}}</span>
                         <span ng-if="!$last"> &middot; </span>
 					</span>
                 </div>

--- a/test-cypress/integration/explore/visual-graph/visual-graph-node-labels.spec.js
+++ b/test-cypress/integration/explore/visual-graph/visual-graph-node-labels.spec.js
@@ -1,0 +1,68 @@
+import { LicenseStubs } from "../../../stubs/license-stubs";
+import { VisualGraphSteps } from "../../../steps/visual-graph-steps";
+import { HtmlUtil } from "../../../utils/html-util";
+
+/**
+ * RDF snippet with the necessary data to test all possible label scenarios:
+ * 1. (ex:node1) Node with a plain text label;
+ * 2. (ex:node2) Node with an HTML label;
+ * 3. (ex:node3) Node with a label that contains a new line ("\n") character;
+ * 4. (ex:node4) Node with a long label.
+ *
+ * @type {string}
+ */
+const RDF_SNIPPETS_WITH_NODE_LABELS_DATA =
+    '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n' +
+    '@prefix ex: <http://example.com/> .\n' +
+    '\n' +
+    '# Define Nodes with Labels\n' +
+    'ex:node1 rdfs:label "Node One" .\n' +
+    'ex:node2 rdfs:label "Node<br>Two" .\n' +
+    'ex:node3 rdfs:label "Node\\nThree" .\n' +
+    'ex:node4 rdfs:label "A longer label for Node Four" .\n' +
+    '\n' +
+    '# Relationships Between Nodes\n' +
+    'ex:node1 ex:connectedTo ex:node2 .\n' +
+    'ex:node1 ex:connectedTo ex:node3 .\n' +
+    'ex:node1 ex:connectedTo ex:node4 .\n';
+
+describe("Node Basics", () => {
+
+    let repositoryId;
+
+    beforeEach(() => {
+        cy.clearLocalStorage('ls.graphs-viz');
+        repositoryId = 'graphRepo-node-labels-' + Date.now();
+        cy.createRepository({ id: repositoryId });
+        cy.presetRepository(repositoryId);
+        // cy.importServerFile(repositoryId, FILE_WITH_NODE_LABELS_DATA);
+        cy.importRDFTextSnippet(repositoryId, RDF_SNIPPETS_WITH_NODE_LABELS_DATA);
+        LicenseStubs.spyGetLicense();
+    });
+
+    afterEach(() => {
+        cy.clearLocalStorage('ls.graphs-viz');
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('should allow the node label to be displayed on multiple lines only when a new line character is used', () => {
+        // When: I open a visual graph of a node that has links to other nodes.
+        VisualGraphSteps.openNodeLabelGraph();
+
+        // Then: I expect:
+        // The label of ex:node1 to be displayed as is, because it is short plain text.
+        VisualGraphSteps.getNodeLabel('http://example.com/node1').should('have.html', 'Node One');
+
+        // The label of ex:node2 to be displayed with all HTML tags removed.
+        VisualGraphSteps.getNodeLabel('http://example.com/node2').should('have.html', 'NodeTwo');
+
+        // The label of ex:node3 to be displayed with the new line character replaced by a <br> tag.
+        VisualGraphSteps.getNodeLabel('http://example.com/node3').should('have.html', 'Node<br>Three');
+
+        // The label of ex:node4 to be displayed with a long label (no truncation).
+        VisualGraphSteps.getNodeLabel('http://example.com/node4').should('have.html', 'A longer label for Node Four');
+
+        // The label of ex:node4 should be truncated with ellipsis because it has a long label.
+        HtmlUtil.verifyEllipsis(VisualGraphSteps.getNodeLabel('http://example.com/node4'));
+    });
+});

--- a/test-cypress/steps/visual-graph-steps.js
+++ b/test-cypress/steps/visual-graph-steps.js
@@ -19,6 +19,12 @@ export class VisualGraphSteps {
         cy.visit('/graphs-visualizations?uri=http:%2F%2Fwww.w3.org%2FTR%2F2003%2FPR-owl-guide-20031209%2Fwine%23Dry');
     }
 
+    static openNodeLabelGraph() {
+        cy.visit('/graphs-visualizations?uri=http:%2F%2Fexample.com%2Fnode1');
+        // Wait for at least one predicate to be displayed, to ensure that the visual graph is open and ready for testing.
+        VisualGraphSteps.getPredicates().should('contain', 'connectedTo');
+    }
+
     static verifyUrl() {
         cy.url().should('include', `${Cypress.config('baseUrl')}${VIEW_URL}`);
     }
@@ -114,6 +120,14 @@ export class VisualGraphSteps {
 
     static getNodes() {
         return cy.get('.node-wrapper').should('be.visible');
+    }
+
+    static getNode(nodeId) {
+        return cy.get(`.node-wrapper[id="${nodeId}"]`);
+    }
+
+    static getNodeLabel(nodeId) {
+        return this.getNode(nodeId).find('.node-label-body div');
     }
 
     static getPredicates() {

--- a/test-cypress/utils/html-util.js
+++ b/test-cypress/utils/html-util.js
@@ -1,0 +1,21 @@
+export class HtmlUtil {
+
+    /**
+     * Verifies that an element's content is truncated with an ellipsis by checking that
+     * the scroll width of the element is greater than its offset width.
+     * This is used to assert that the element's text is overflowing and is being clipped with ellipsis.
+     *
+     * @param {Cypress.Chainable<JQuery<HTMLElement>>} element - The Cypress chainable element to check.
+     * @throws {AssertionError} If the element's content is not truncated with ellipsis.
+     *
+     * @example
+     * // Example usage in a test
+     * HtmlUtil.verifyEllipsis(cy.get('.node-wrapper'));
+     */
+    static verifyEllipsis(element) {
+        element.should(($el) => {
+            const el = $el[0];
+            expect(el.scrollWidth).to.be.greaterThan(el.offsetWidth);
+        });
+    }
+}


### PR DESCRIPTION
## What
The node label did not break into a new line, even when containing '\n' or '&lt;br&gt;'.

## Why
The node label was originally implemented to display text, which is why '\n' and '&lt;br&gt;' did not work as expected.

## How
Enhanced the visual graph functionality to allow node labels to span multiple lines. We use the D3.js library for graph visualization. Previously, the node label was implemented using the "text" function. This has been changed to "html", allowing the label to be displayed across multiple lines. During label processing, all HTML tags are removed, and the \n character is replaced with &lt;br&gt;.

Summary: Node labels now support multiline visualization using the \n character.

## Additional work
Removed the function that processed the ellipsis for long node labels and replaced it with CSS declarations, allowing browsers to handle it naturally.

## Screenshots
before
![image](https://github.com/user-attachments/assets/efc03a20-8ec0-4a34-a9e0-578cbeb54a62)


after
![image](https://github.com/user-attachments/assets/52c8be1a-7146-4a4d-8a5e-0db2259946a2)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
