### PR TITLE
GDB-11722 Fix broken file upload when maxUploadSize is less than 1MB

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -2003,7 +2003,7 @@
         "error.could.not.clear": "Could not clear status; {{data}}",
         "error.default.settings": "Could not get default settings; {{data}}",
         "could.not.send.file": "Could not send file for import; {{data}}",
-        "large.file": "File {{name}} too big {{size}} MB. Use Server Files import.",
+        "large.file": "File {{name}} too big {{size}}. Use Server Files import.",
         "could.not.upload": "Could not upload file {{name}}. BZip2 archives are not supported.",
         "no.such.file": "No such file; {{name}}",
         "could.not.send.data": "Could not send data for import; {{data}}",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -2001,7 +2001,7 @@
         "error.could.not.clear": "Impossible d'effacer le statut; {{data}}",
         "error.default.settings": "Impossible de récupérer les paramètres par défaut; {{data}}",
         "could.not.send.file": "Impossible d'envoyer le fichier à importer; {{data}}",
-        "large.file": "Fichier {{name}} trop grand {{size}} MB. Utilisez l'importation de fichiers du serveur.",
+        "large.file": "Fichier {{name}} trop grand {{size}}. Utilisez l'importation de fichiers du serveur.",
         "could.not.upload": "Impossible de télécharger le fichier {{name}}. Les archives BZip2 ne sont pas prises en charge.",
         "no.such.file": "Aucun fichier de ce type; {{name}}",
         "could.not.send.data": "Impossible d'envoyer des données pour l'importation; {{data}}",

--- a/src/js/angular/core/filters/bytes-filter.js
+++ b/src/js/angular/core/filters/bytes-filter.js
@@ -24,6 +24,12 @@ angular.module('graphdb.framework.core.filters.bytes', [])
             }
             const units = ['bytes', 'kB', 'MB', 'GB', 'TB', 'PB'];
             let number = Math.floor(Math.log(bytes) / Math.log(1024));
-            return (bytes / Math.pow(1024, number)).toFixed(precision) + ' ' + units[number];
+
+            const unit = units[number];
+            // If the unit is bytes, we don't need to display the decimal places.'
+            if ('bytes' === unit) {
+                precision = 0;
+            }
+            return (bytes / Math.pow(1024, number)).toFixed(precision) + ' ' + unit;
         };
     });

--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -78,7 +78,7 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
         $scope.fileFormatsExtended = FileFormats.getFileFormatsExtended();
         $scope.fileFormatsHuman = FileFormats.getFileFormatsHuman() + $translate.instant('import.gz.zip');
         $scope.textFileFormatsHuman = FileFormats.getTextFileFormatsHuman();
-        $scope.maxUploadFileSizeMB = 0;
+        $scope.maxUploadFileSizeBytes = 0;
         $scope.SORTING_TYPES = SortingType;
         $scope.TAB_IDS = TABS;
 
@@ -472,7 +472,7 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
                         value: data[i].value
                     };
                 }
-                $scope.maxUploadFileSizeMB = FileUtils.convertBytesToMegabytes($scope.appData.properties['graphdb.workbench.maxUploadSize'].value);
+                $scope.maxUploadFileSizeBytes = $scope.appData.properties['graphdb.workbench.maxUploadSize'].value;
             }).error(function (data) {
                 const msg = getError(data);
                 toastr.error(msg, $translate.instant('common.error'));
@@ -576,7 +576,7 @@ importViewModule.controller('ImportCtrl', ['$scope', 'toastr', '$controller', '$
     }
 }]);
 
-importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$uibModal', '$translate', '$repositories', 'ImportRestService', 'UploadRestService', 'ModalService', 'ImportContextService', 'EventEmitterService', function ($scope, toastr, $controller, $uibModal, $translate, $repositories, ImportRestService, UploadRestService, ModalService, ImportContextService, EventEmitterService) {
+importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$uibModal', '$translate', '$repositories', 'ImportRestService', 'UploadRestService', 'ModalService', 'ImportContextService', 'EventEmitterService', '$filter', function ($scope, toastr, $controller, $uibModal, $translate, $repositories, ImportRestService, UploadRestService, ModalService, ImportContextService, EventEmitterService, $filter) {
 
     // =========================
     // Private variables
@@ -754,7 +754,7 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
             invalidFiles.forEach(function (file) {
                 toastr.warning($translate.instant('import.large.file', {
                     name: file.name,
-                    size: FileUtils.convertBytesToMegabytes(file.size)
+                    size: $filter('bytes')(file.size)
                 }));
             });
         }

--- a/src/js/angular/utils/file-utils.js
+++ b/src/js/angular/utils/file-utils.js
@@ -1,14 +1,5 @@
 export class FileUtils {
     /**
-     * Convert bytes to megabytes.
-     * @param {number} bytes The bytes to convert
-     * @return {number} The bytes in megabytes
-     */
-    static convertBytesToMegabytes(bytes) {
-        return Math.floor(bytes / (1024 * 1024));
-    }
-
-    /**
      * Parses a file name and returns the filename and the extension.
      * @param {string} fileName The file name to parse
      * @return {{extension: string, filename: string}}

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -52,7 +52,7 @@
                                ngf-select
                                ngf-keep="false"
                                ngf-change="fileSelected($files, $file, $newFiles, $duplicateFiles, $invalidFiles)"
-                               ngf-max-size="maxUploadFileSizeMB + 'MB'">
+                               ngf-max-size="maxUploadFileSizeBytes">
                                 <div class="grid-container">
                                     <em class="icon-upload icon-lg"></em>
                                     <!-- Keep this a label, it points to the input element created by ngFileUpload
@@ -61,7 +61,7 @@
                                         <div>{{'upload.rdf.files.label' | translate}}</div>
                                         <small
                                             class="text-muted">{{'all.rdf.formats.label' | translate}}{{'up.to' | translate}}
-                                            {{maxUploadFileSizeMB | number}} MB
+                                            {{maxUploadFileSizeBytes | bytes}}
                                         </small>
                                     </label>
                                 </div>


### PR DESCRIPTION
## What
Fix broken file upload, when maxUploadSize is less than 1MB

## Why
File upload wasn't working

## How
Previously the maxUploadSize bytes were converted into integer MB. That value was also added as `ngf-max-size` to the import. Values, which were less than 1MB resulted in 0 as max value, hence nothing was allowed. Now the exact `maxUploadSize` value is used to set `ngf-max-size` and the value is converted into a readable label only for display purposes

## Testing
existing

## Screenshots
exceeded size
![Screenshot from 2025-03-13 11-41-49](https://github.com/user-attachments/assets/789500cb-6bba-4133-8b6d-a35ecf79b03e)

within boundaries
![Screenshot from 2025-03-13 11-47-24](https://github.com/user-attachments/assets/fa3389b2-1b07-4bb4-851b-4627c12784f7)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
