### PR TITLE
GDB-11858 fix relative path to graphql endpoint management view

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -749,7 +749,7 @@
         "playground": {
             "helpInfo": "Use the GraphQL Playground to build and test queries in real time. Explore your schema, send requests, and inspect responses effortlessly.",
             "message": {
-                "no_schemas_in_repository": "No active endpoints found in the current repository. Manage the GraphQL schemas <a href=\"/graphql/endpoints\">here</a>",
+                "no_schemas_in_repository": "No active endpoints found in the current repository. Manage the GraphQL schemas <a href=\"graphql/endpoints\">here</a>",
                 "abort_query": "Query canceled: The operation was stopped before completion."
             },
             "endpoint_selector": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -748,7 +748,7 @@
         "playground": {
             "helpInfo": "Utilisez le GraphQL Playground pour créer et tester des requêtes en temps réel. Explorez votre schéma, envoyez des requêtes et inspectez les réponses en toute simplicité.",
             "message": {
-                "no_schemas_in_repository": "Aucun point de terminaison actif n'a été trouvé dans le référentiel actuel. Gérez les schémas GraphQL <a href=\"/graphql/endpoints\">ici</a>",
+                "no_schemas_in_repository": "Aucun point de terminaison actif n'a été trouvé dans le référentiel actuel. Gérez les schémas GraphQL <a href=\"graphql/endpoints\">ici</a>",
                 "abort_query": "Requête annulée : L'opération a été arrêtée avant son achèvement."
             },
             "endpoint_selector": {

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -749,7 +749,7 @@
         "playground": {
             "helpInfo": "Use the GraphQL Playground to build and test queries in real time. Explore your schema, send requests, and inspect responses effortlessly.",
             "message": {
-                "no_schemas_in_repository": "No active endpoints found in the current repository. Manage the GraphQL schemas <a href=\"/graphql/endpoints\">here</a>",
+                "no_schemas_in_repository": "No active endpoints found in the current repository. Manage the GraphQL schemas <a href=\"graphql/endpoints\">here</a>",
                 "abort_query": "Query canceled: The operation was stopped before completion."
             },
             "endpoint_selector": {


### PR DESCRIPTION
## What
Fix relative path to graphql endpoint management view so that they can open correctly when GDB is working behind context path different from the base `/`

## Why
When a relative path in the web application starts with a `/`, then it can't be properly forwarded by the reverse proxy, hence the 404 we are seeing in such cases.

## How
Removed the forward slash from the link that opens the endpoint managament view.

## Testing
NA

## Screenshots
NA

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
