### PR TITLE
GDB-11854 improve styling of buttons in playground

### DIFF
--- a/src/css/graphql/graphql-playground.css
+++ b/src/css/graphql/graphql-playground.css
@@ -121,21 +121,22 @@ graphql-playground {
     background-color: #fff !important;
 }
 
-.graphql-playground-view #graphiql .graphiql-tabs .graphiql-tab-add {
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-session-header .graphiql-tab-add {
+    padding: 8px;
     background-color: var(--base-background-hover-color);
 }
 
-.graphql-playground-view #graphiql .graphiql-tabs .graphiql-tab-add:hover svg,
-.graphql-playground-view #graphiql .graphiql-tabs .graphiql-tab-close:hover {
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-session-header .graphiql-tab-add:hover svg,
+.graphql-playground-view #graphiql .graphiql-sessions .graphiql-session-header .graphiql-tab-close:hover {
     background-color: transparent;
     color: var(--primary-color);
 }
 
-.graphql-playground-view #graphiql .graphiql-sessions .graphiql-session-header .graphiql-tabs .graphiql-tab-active {
+.graphql-playground-view #graphiql .graphiql-tabs .graphiql-tab-active {
     background-color: var(--base-background-hover-color);
 }
 
-.graphql-playground-view #graphiql .graphiql-sessions .graphiql-session-header .graphiql-tabs .graphiql-tab-button {
+.graphql-playground-view #graphiql .graphiql-tabs .graphiql-tab-button {
     padding: 4px 8px;
     color: var(--base-text-color);
 }
@@ -155,10 +156,7 @@ graphql-playground {
 .graphql-playground-view #graphiql .graphiql-sessions .graphiql-session-header {
     height: unset;
     color: inherit;
-}
-
-.graphql-playground-view #graphiql .graphiql-sessions .graphiql-session-header button.graphiql-tab-add {
-    padding: 8px;
+    justify-content: start;
 }
 
 .graphql-playground-view #graphiql .graphiql-sessions .graphiql-session {
@@ -190,9 +188,9 @@ graphql-playground {
     font-weight: 300;
 }
 
-/* When there is a single opened tab in the editor */
+/* When there is a single opened tab in the editor the create tab button moves in the most right */
 .graphql-playground-view #graphiql .graphiql-sessions .graphiql-editors.full-height {
-    margin-top: -13px;
+    margin-top: 0;
 }
 
 .graphql-playground-view #graphiql .graphiql-sessions .graphiql-editors .graphiql-toolbar {
@@ -220,6 +218,10 @@ graphql-playground {
     color: var(--primary-color);
 }
 
+.graphql-playground-view #graphiql .graphiql-editor-tools {
+    padding: 0;
+}
+
 .graphql-playground-view #graphiql .graphiql-editor-tools button {
     background-color: #fff;
     color: var(--secondary-color);
@@ -233,6 +235,9 @@ graphql-playground {
     color: var(--default-btn-focus-color);
 }
 
+.graphql-playground-view #graphiql .graphiql-editor-tools .graphiql-toggle-editor-tools:hover svg {
+    color: var(--primary-color);
+}
 
 /* =============================================== */
 /*   overrides for graphql-playground history      */


### PR DESCRIPTION
## What
* Move the create tab button on the left when there aren't any tabs yet.
* Removed the all around padding from the bottom toolbar to reduce the taken space and make it more consistent with the rest elements in the playground.
* Made the toggle button of the variables and headers widgets in the bottom to look the primary color on hover as the rest of the buttons.

## Why
.

## How
.

## Testing
.

## Screenshots
![image](https://github.com/user-attachments/assets/20679a1d-9ad7-4f10-9905-6e0e9d3b4aea)
![image](https://github.com/user-attachments/assets/42347e1d-3f18-45a6-ae40-63e2f97abf57)
![image](https://github.com/user-attachments/assets/f236f80b-6ca9-49b6-81d3-5710219d9f9c)
![image](https://github.com/user-attachments/assets/242eb895-0382-4197-bc43-42f8cf512dd9)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
