### PR TITLE
GDB-11920: GraphQL playground looks bad when OS theme is set to dark.

### DIFF
--- a/src/css/graphql/graphql-playground.css
+++ b/src/css/graphql/graphql-playground.css
@@ -8,6 +8,13 @@ html, body {
     height: 100vh;
 }
 
+.graphiql-dialog,
+.graphql-playground-view #graphiql .graphiql-container,
+.graphql-playground-view #graphiql .graphiql-container .graphiql-editors,
+.graphiql-container .CodeMirror {
+    background-color: #fff;
+}
+
 .page-content,
 .page-content .container-fluid {
     height: calc(100% - 50px);


### PR DESCRIPTION
## What
Certain background elements in the GraphQL Playground remain dark even when the workbench is set to light mode, provided the OS is in dark mode.

## Why
This issue comes from the GraphQL playground component, which automatically switches to dark mode when the OS theme is set to dark.

## How
Add a CSS rule to ensure the background color aligns with the workbench settings.

## Testing
N/A

## Screenshots
before
![image](https://github.com/user-attachments/assets/775ea0b4-b8de-4633-9dc2-cefdfae66eb8)

after
![image](https://github.com/user-attachments/assets/d17818f3-7e9a-482d-89c5-16dafc2c9ab4)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
