### PR TITLE
GDB-10933 - Update Yasgui version with label update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
                 "ontotext-graphql-playground-component": "^0.0.8",
-                "ontotext-yasgui-web-component": "1.3.21",
+                "ontotext-yasgui-web-component": "1.3.22",
                 "shepherd.js": "^11.2.0"
             },
             "devDependencies": {
@@ -11954,9 +11954,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.21",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.21.tgz",
-            "integrity": "sha512-hX6tB0D2jgu2UKkaLmGVGEv/WS7CqPrvR9heFFs9nT24pvjnccMAPrkOKbR4BQghskT70XI0/GqWaz0V2DWArA==",
+            "version": "1.3.22",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.22.tgz",
+            "integrity": "sha512-DGiM4GUoe+SCgfFONlhpmh2HVCMDlFXFYl5mpiEYmxwXvlZBz60MUZ+500uJBEMX9kikp+Q2pqifWkZy4+CNaw==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
         "ontotext-graphql-playground-component": "^0.0.8",
-        "ontotext-yasgui-web-component": "1.3.21",
+        "ontotext-yasgui-web-component": "1.3.22",
         "shepherd.js": "^11.2.0"
     },
     "resolutions": {


### PR DESCRIPTION
## What
Increase the version of the ontotext-yasgui-web-component.
New in this version:
- GDB-10933 - add more descriptive label to "Download as" button

## Why
The new version of the component includes a more descriptive label for the **Download as** button in the Table tab.

## How
Version increased.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
