### PR TITLE
GDB-11318 Fix blinking dropdown menu of operations notification

### DIFF
--- a/packages/api/src/models/monitoring/operation-group-summary.ts
+++ b/packages/api/src/models/monitoring/operation-group-summary.ts
@@ -1,7 +1,6 @@
 import {Model} from '../common';
 import {OperationGroup} from './operation-group';
 import {OperationStatus} from './operation-status';
-import {GeneratorUtils} from '../../services/utils/generator-utils';
 
 /**
  * Represents a summary of an operation group.
@@ -14,7 +13,7 @@ export class OperationGroupSummary extends Model<OperationGroupSummary> {
 
   constructor(data: OperationGroupSummary) {
     super();
-    this.id = GeneratorUtils.uuid();
+    this.id = `${data.group}-${data.status}-${data.totalOperations}`;
     this.group = data.group;
     this.totalOperations = data.totalOperations;
     this.status = data.status;

--- a/packages/api/src/models/monitoring/operation.ts
+++ b/packages/api/src/models/monitoring/operation.ts
@@ -2,7 +2,6 @@ import {Model} from '../common';
 import {OperationStatus} from './operation-status';
 import {OperationType} from './operation-type';
 import {OperationGroup} from './operation-group';
-import {GeneratorUtils} from '../../services/utils/generator-utils';
 
 /** Not all operations have counts as values */
 const OPERATIONS_WITH_COUNT = [OperationType.QUERIES, OperationType.UPDATES, OperationType.IMPORTS];
@@ -40,7 +39,7 @@ export class Operation extends Model<Operation> {
 
   constructor(operation: Operation) {
     super();
-    this.id = GeneratorUtils.uuid();
+    this.id = `${operation.status}-${operation.type}-${operation.value}`;
     this.value = operation.value;
     this.status = operation.status;
     this.type = operation.type;

--- a/packages/api/src/services/monitoring/mapper/test/operation-group-summary-list.mapper.spec.ts
+++ b/packages/api/src/services/monitoring/mapper/test/operation-group-summary-list.mapper.spec.ts
@@ -2,7 +2,6 @@ import {OperationGroupSummary, OperationGroupSummaryList} from '../../../../mode
 import {OperationGroupSummaryListMapper} from '../operation-group-summary-list.mapper';
 
 describe('OperationGroupSummaryListMapper', () => {
-  window.crypto.randomUUID = jest.fn();
   let mapper: OperationGroupSummaryListMapper;
 
   beforeEach(() => {

--- a/packages/api/src/services/monitoring/mapper/test/operation-list.mapper.spec.ts
+++ b/packages/api/src/services/monitoring/mapper/test/operation-list.mapper.spec.ts
@@ -2,7 +2,6 @@ import {OperationListMapper} from '../operation-list.mapper';
 import {Operation, OperationList, OperationStatus, OperationType} from '../../../../models/monitoring';
 
 describe('OperationListMapper', () => {
-  window.crypto.randomUUID = jest.fn();
   let mapper: OperationListMapper;
 
   beforeEach(() => {

--- a/packages/api/src/services/monitoring/mapper/test/operation-summary-mapper.spec.ts
+++ b/packages/api/src/services/monitoring/mapper/test/operation-summary-mapper.spec.ts
@@ -6,7 +6,6 @@ import {
 } from '../../../../models/monitoring';
 
 describe('OperationSummaryMapper', () => {
-  window.crypto.randomUUID = jest.fn();
   let mapper: OperationSummaryMapper;
 
   beforeEach(() => {
@@ -41,7 +40,7 @@ describe('OperationSummaryMapper', () => {
       count: 0,
       group: 'CLUSTER',
       href: 'cluster',
-      id: undefined,
+      id: 'WARNING-clusterHealth-UNAVAILABLE_NODES',
       value: 'UNAVAILABLE_NODES',
       labelKey: 'UNAVAILABLE_NODES',
       status: OperationStatus.WARNING,
@@ -51,7 +50,7 @@ describe('OperationSummaryMapper', () => {
       count: 0,
       group: 'BACKUP',
       href: 'monitor/backup-and-restore',
-      id: undefined,
+      id: 'INFORMATION-backupAndRestore-BACKUP_IN_PROGRESS',
       value: 'BACKUP_IN_PROGRESS',
       labelKey: 'BACKUP_IN_PROGRESS',
       status: OperationStatus.INFORMATION,

--- a/packages/api/src/services/monitoring/monitoring.service.ts
+++ b/packages/api/src/services/monitoring/monitoring.service.ts
@@ -16,6 +16,6 @@ export class MonitoringService implements Service {
    */
   getOperations(repositoryId: string): Promise<OperationStatusSummary> {
     return ServiceProvider.get(MonitoringRestService).getOperations(repositoryId)
-      .then((operations => MapperProvider.get(OperationSummaryMapper).mapToModel(operations)));
+      .then((operations) => MapperProvider.get(OperationSummaryMapper).mapToModel(operations));
   }
 }


### PR DESCRIPTION
## What
Fix blinking dropdown menu of operations notification

## Why
It shouldn't be blinking

## How
Changed the ids(keys) of the operations and operation groups to be a summary of their contents. This way when, we have identical results, stencil won't re-render elements. It will reuse them instead

## Testing
none

## Screenshots
none

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
