### PR TITLE
GDB-11722 Fix broken file upload when maxUploadSize is less than 1MB

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -48,7 +48,8 @@ const modules = [
     'graphdb.framework.core.directives.operationsstatusesmonitor',
     'graphdb.framework.core.directives.autocomplete',
     'ngCustomElement',
-    'graphdb.framework.core.services.language-service'
+    'graphdb.framework.core.services.language-service',
+    'graphdb.framework.core.filters.bytes'
 ];
 
 const providers = [

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1442,7 +1442,7 @@
         "error.could.not.clear": "Could not clear status; {{data}}",
         "error.default.settings": "Could not get default settings; {{data}}",
         "could.not.send.file": "Could not send file for import; {{data}}",
-        "large.file": "File {{name}} too big {{size}} MB. Use Server Files import.",
+        "large.file": "File {{name}} too big {{size}}. Use Server Files import.",
         "could.not.upload": "Could not upload file {{name}}. BZip2 archives are not supported.",
         "no.such.file": "No such file; {{name}}",
         "could.not.send.data": "Could not send data for import; {{data}}",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1442,7 +1442,7 @@
         "error.could.not.clear": "Impossible d'effacer le statut; {{data}}",
         "error.default.settings": "Impossible de récupérer les paramètres par défaut; {{data}}",
         "could.not.send.file": "Impossible d'envoyer le fichier à importer; {{data}}",
-        "large.file": "Fichier {{name}} trop grand {{size}} MB. Utilisez l'importation de fichiers du serveur.",
+        "large.file": "Fichier {{name}} trop grand {{size}}. Utilisez l'importation de fichiers du serveur.",
         "could.not.upload": "Impossible de télécharger le fichier {{name}}. Les archives BZip2 ne sont pas prises en charge.",
         "no.such.file": "Aucun fichier de ce type; {{name}}",
         "could.not.send.data": "Impossible d'envoyer des données pour l'importation; {{data}}",

--- a/src/js/angular/core/directives/autocomplete/autocomplete.directive.js
+++ b/src/js/angular/core/directives/autocomplete/autocomplete.directive.js
@@ -1,5 +1,6 @@
 import {decodeHTML} from "../../../../../app";
 import {mapUriAsNtripleAutocompleteResponse} from "../../../rest/mappers/autocomplete-mapper";
+import 'angular/core/filters/bytes-filter';
 
 angular
     .module('graphdb.framework.core.directives.autocomplete', [])

--- a/src/js/angular/core/filters/bytes-filter.js
+++ b/src/js/angular/core/filters/bytes-filter.js
@@ -1,0 +1,35 @@
+/**
+ * @ngdoc filter
+ * @name bytes
+ * @module graphdb.framework.core.filters.bytes
+ * @description Converts a number of bytes into a human-readable string with units
+ * @param {number} bytes The number of bytes to convert
+ * @param {number} [precision=1] Number of decimal places to display
+ * @returns {string} Formatted string with appropriate unit (bytes, kB, MB, GB, TB, PB)
+ * @example
+ * // returns "1.5 MB"
+ * {{ 1572864 | bytes }}
+ *
+ * // returns "1.50 MB"
+ * {{ 1572864 | bytes:2 }}
+ */
+angular.module('graphdb.framework.core.filters.bytes', [])
+    .filter('bytes', function () {
+        return function (bytes, precision) {
+            if (isNaN(parseFloat(bytes)) || !isFinite(bytes)) {
+                return '-';
+            }
+            if (typeof precision === 'undefined') {
+                precision = 1;
+            }
+            const units = ['bytes', 'kB', 'MB', 'GB', 'TB', 'PB'];
+            let number = Math.floor(Math.log(bytes) / Math.log(1024));
+
+            const unit = units[number];
+            // If the unit is bytes, we don't need to display the decimal places.'
+            if ('bytes' === unit) {
+                precision = 0;
+            }
+            return (bytes / Math.pow(1024, number)).toFixed(precision) + ' ' + unit;
+        };
+    });

--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -78,7 +78,7 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
         $scope.fileFormatsExtended = FileFormats.getFileFormatsExtended();
         $scope.fileFormatsHuman = FileFormats.getFileFormatsHuman() + $translate.instant('import.gz.zip');
         $scope.textFileFormatsHuman = FileFormats.getTextFileFormatsHuman();
-        $scope.maxUploadFileSizeMB = 0;
+        $scope.maxUploadFileSizeBytes = 0;
         $scope.SORTING_TYPES = SortingType;
         $scope.TAB_IDS = TABS;
 
@@ -472,7 +472,7 @@ importViewModule.controller('ImportViewCtrl', ['$scope', 'toastr', '$interval', 
                         value: data[i].value
                     };
                 }
-                $scope.maxUploadFileSizeMB = FileUtils.convertBytesToMegabytes($scope.appData.properties['graphdb.workbench.maxUploadSize'].value);
+                $scope.maxUploadFileSizeBytes = $scope.appData.properties['graphdb.workbench.maxUploadSize'].value;
             }).error(function (data) {
                 const msg = getError(data);
                 toastr.error(msg, $translate.instant('common.error'));
@@ -576,7 +576,7 @@ importViewModule.controller('ImportCtrl', ['$scope', 'toastr', '$controller', '$
     }
 }]);
 
-importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$uibModal', '$translate', '$repositories', 'ImportRestService', 'UploadRestService', 'ModalService', 'ImportContextService', 'EventEmitterService', function ($scope, toastr, $controller, $uibModal, $translate, $repositories, ImportRestService, UploadRestService, ModalService, ImportContextService, EventEmitterService) {
+importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$uibModal', '$translate', '$repositories', 'ImportRestService', 'UploadRestService', 'ModalService', 'ImportContextService', 'EventEmitterService', '$filter', function ($scope, toastr, $controller, $uibModal, $translate, $repositories, ImportRestService, UploadRestService, ModalService, ImportContextService, EventEmitterService, $filter) {
 
     // =========================
     // Private variables
@@ -754,7 +754,7 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
             invalidFiles.forEach(function (file) {
                 toastr.warning($translate.instant('import.large.file', {
                     name: file.name,
-                    size: FileUtils.convertBytesToMegabytes(file.size)
+                    size: $filter('bytes')(file.size)
                 }));
             });
         }

--- a/src/js/angular/utils/file-utils.js
+++ b/src/js/angular/utils/file-utils.js
@@ -1,14 +1,5 @@
 export class FileUtils {
     /**
-     * Convert bytes to megabytes.
-     * @param {number} bytes The bytes to convert
-     * @return {number} The bytes in megabytes
-     */
-    static convertBytesToMegabytes(bytes) {
-        return Math.floor(bytes / (1024 * 1024));
-    }
-
-    /**
      * Parses a file name and returns the filename and the extension.
      * @param {string} fileName The file name to parse
      * @return {{extension: string, filename: string}}

--- a/src/pages/import.html
+++ b/src/pages/import.html
@@ -52,7 +52,7 @@
                                ngf-select
                                ngf-keep="false"
                                ngf-change="fileSelected($files, $file, $newFiles, $duplicateFiles, $invalidFiles)"
-                               ngf-max-size="maxUploadFileSizeMB + 'MB'">
+                               ngf-max-size="maxUploadFileSizeBytes">
                                 <div class="grid-container">
                                     <em class="icon-upload icon-lg"></em>
                                     <!-- Keep this a label, it points to the input element created by ngFileUpload
@@ -61,7 +61,7 @@
                                         <div>{{'upload.rdf.files.label' | translate}}</div>
                                         <small
                                             class="text-muted">{{'all.rdf.formats.label' | translate}}{{'up.to' | translate}}
-                                            {{maxUploadFileSizeMB | number}} MB
+                                            {{maxUploadFileSizeBytes | bytes}}
                                         </small>
                                     </label>
                                 </div>


### PR DESCRIPTION
## What
Fix broken file upload, when maxUploadSize is less than 1MB

## Why
File upload wasn't working

## How
Previously the maxUploadSize bytes were converted into integer MB. That value was also added as `ngf-max-size` to the import. Values, which were less than 1MB resulted in 0 as max value, hence nothing was allowed. Now the exact `maxUploadSize` value is used to set `ngf-max-size` and the value is converted into a readable label only for display purposes

## Testing
existing

## Screenshots

![Screenshot from 2025-03-21 09-32-52](https://github.com/user-attachments/assets/3af08bbe-1613-452e-a058-ee09388ebb3b)



## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
