### PR TITLE
GDB-11317 Implement user menu

### DIFF
--- a/packages/root-config/src/styles/partials/_core.scss
+++ b/packages/root-config/src/styles/partials/_core.scss
@@ -1,3 +1,4 @@
 @forward './button/button';
 @forward './alert/alert';
 @forward './animations/fade-button';
+@forward './responsive/responsive';

--- a/packages/root-config/src/styles/partials/responsive/_responsive.scss
+++ b/packages/root-config/src/styles/partials/responsive/_responsive.scss
@@ -1,0 +1,5 @@
+@media (max-width: 1439px) {
+  html {
+    font-size: 14px;
+  }
+}

--- a/packages/shared-components/cypress/e2e/header/header.cy.js
+++ b/packages/shared-components/cypress/e2e/header/header.cy.js
@@ -1,5 +1,6 @@
 import {HeaderSteps} from "../../steps/header/header-steps";
 import {TooltipSteps} from "../../steps/tooltip-steps";
+import {UserMenuSteps} from "../../steps/user-menu/user-menu-steps";
 
 describe('Header', () => {
   it('Should render header and various tools inside', () => {
@@ -55,12 +56,6 @@ describe('Header', () => {
   });
 
   describe('OperationsNotification', () => {
-    beforeEach(() => {
-      cy.on('window:before:load', (win) => {
-        win.crypto.randomUUID = () => '123e4567-e89b-12d3-a456-426655440000';
-      });
-    });
-
     it('Should be shown, when there are active operations', () => {
       // Given, I visit the header page
       HeaderSteps.visit();
@@ -79,5 +74,34 @@ describe('Header', () => {
       // Then, I expect to see the operations notification component
       HeaderSteps.getOperationsNotification().should('be.visible');
     });
-  })
+  });
+
+  describe('OntoUserMenu', () => {
+    it('Should show/hide user menu', () => {
+      // Given, I visit the header page
+      HeaderSteps.visit();
+
+      // Then, I expect to not see the user menu
+      // Because I have not enabled security and haven't logged in
+      UserMenuSteps.getUserMenu().should('not.exist');
+
+      // When, I enable security
+      HeaderSteps.enableSecurity();
+
+      // Then, I expect to still not see the user menu, as I am not logged in
+      UserMenuSteps.getUserMenu().should('not.exist');
+
+      // When, I am logged in
+      HeaderSteps.setAuthenticatedUser();
+
+      // Then, I expect to see the user menu in the header, because I am both logged in and security is enabled
+      UserMenuSteps.getUserMenu().should('be.visible');
+
+      // When, I disable security
+      HeaderSteps.disableSecurity();
+
+      // Then, I expect to not see the user menu in the header
+      UserMenuSteps.getUserMenu().should('not.exist');
+    });
+  });
 });

--- a/packages/shared-components/cypress/e2e/user-menu/user-menu.cy.js
+++ b/packages/shared-components/cypress/e2e/user-menu/user-menu.cy.js
@@ -1,0 +1,52 @@
+import {UserMenuSteps} from "../../steps/user-menu/user-menu-steps";
+
+describe('User Menu', () => {
+  it('should render user menu', () => {
+    // Given I've opened a page with the user menu
+    UserMenuSteps.visit();
+
+    // And the user menu is visible
+    UserMenuSteps.getUserMenu()
+      .should('be.visible')
+      .and('have.text', 'john.doe');
+
+    // When, I click on the menu
+    UserMenuSteps.openUserMenu();
+
+    const dropdownOptions = ['My settings', 'Logout'];
+    // Then the dropdown should be displayed and have My Settings and Logout options
+    UserMenuSteps.getDropdownItems()
+      .each(($item, index) => {
+        cy.wrap($item).should('have.text', dropdownOptions[index]);
+      });
+
+    // When, I am logged in as external user
+    UserMenuSteps.setExternalUser();
+
+    // Then I expect to not see a logout option in the dropdown
+    UserMenuSteps.getDropdownItems()
+      .should('have.length', 1)
+      .and('not.contain', 'Logout');
+  });
+
+  it('should redirect to the correct URL when clicking on a dropdown option', () => {
+    // Given I've opened a page with the user menu
+    UserMenuSteps.visit();
+
+    // And the user menu is visible
+    UserMenuSteps.getUserMenu().should('be.visible');
+
+    // When, I click on the menu
+    UserMenuSteps.openUserMenu();
+
+    // And click on My Settings option from the dropdown, which should be the first option
+    UserMenuSteps.selectDropdownItem(0)
+
+    // Then I should be redirected to the My Settings page
+    UserMenuSteps.getRedirectUrl().should('have.text', `redirect to /settings`);
+    // And the dropdown should be closed
+    UserMenuSteps.getDropdown().should('not.exist');
+  });
+
+  // TODO: add assertions for Logout option
+});

--- a/packages/shared-components/cypress/steps/header/header-steps.js
+++ b/packages/shared-components/cypress/steps/header/header-steps.js
@@ -41,4 +41,16 @@ export class HeaderSteps extends BaseSteps {
   static loadRepositories() {
     cy.get('#load-repositories').click();
   }
+
+  static enableSecurity() {
+    cy.get('#enable-security').click();
+  }
+
+  static setAuthenticatedUser() {
+    cy.get('#set-authenticated-user').click();
+  }
+
+  static disableSecurity() {
+    return cy.get('#disable-security').click();
+  }
 }

--- a/packages/shared-components/cypress/steps/user-menu/user-menu-steps.js
+++ b/packages/shared-components/cypress/steps/user-menu/user-menu-steps.js
@@ -1,0 +1,31 @@
+import {BaseSteps} from "../base-steps";
+
+export class UserMenuSteps extends BaseSteps {
+  static visit() {
+    super.visit('user-menu');
+  }
+
+  static getUserMenu() {
+    return cy.get('.onto-user-menu');
+  }
+
+  static getDropdown() {
+    return this.getUserMenu().find('.onto-user-menu-dropdown');
+  }
+
+  static setExternalUser() {
+    cy.get('#set-external-user').click();
+  }
+
+  static openUserMenu() {
+    return this.getUserMenu().click();
+  }
+
+  static getDropdownItems() {
+    return this.getDropdown().children();
+  }
+
+  static selectDropdownItem(index) {
+    this.getDropdownItems().eq(index).click();
+  }
+}

--- a/packages/shared-components/global.d.ts
+++ b/packages/shared-components/global.d.ts
@@ -1,9 +1,11 @@
 import {PluginRegistry} from './src/models/plugin/plugin-registry';
+import {SingleSpa} from './src/models/single-spa/single-spa';
 
 declare global {
   interface Window {
     wbDevMode: boolean;
-    PluginRegistry: PluginRegistry
+    PluginRegistry: PluginRegistry;
+    singleSpa: SingleSpa;
   }
 }
 

--- a/packages/shared-components/src/assets/i18n/en.json
+++ b/packages/shared-components/src/assets/i18n/en.json
@@ -158,5 +158,9 @@
       "OUT_OF_SYNC": "Out of sync",
       "UNAVAILABLE_NODES": "Unavailable nodes"
     }
+  },
+  "user_menu": {
+    "my_settings": "My settings",
+    "logout": "Logout"
   }
 }

--- a/packages/shared-components/src/assets/i18n/fr.json
+++ b/packages/shared-components/src/assets/i18n/fr.json
@@ -161,5 +161,9 @@
       "OUT_OF_SYNC": "Désynchronisé",
       "UNAVAILABLE_NODES": "Nœuds indisponibles"
     }
+  },
+  "user_menu": {
+    "my_settings": "Mes paramètres",
+    "logout": "Déconnexion"
   }
 }

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -227,6 +227,16 @@ export namespace Components {
     interface OntoTooltip {
     }
     /**
+     * This component displays the current user's name and provides options
+     * for navigating to settings and logging out.
+     */
+    interface OntoUserMenu {
+        /**
+          * Currently authenticated user
+         */
+        "user": AuthenticatedUser;
+    }
+    /**
      * The purpose of this component is to display translated literals in the DOM. A Stencil component re-renders when a prop or state changes,
      * but it may not re-render when the language changes. In such cases, this component should be used. It handles language change events
      * and re-translates the passed language and translation parameters.
@@ -439,6 +449,16 @@ declare global {
         new (): HTMLOntoTooltipElement;
     };
     /**
+     * This component displays the current user's name and provides options
+     * for navigating to settings and logging out.
+     */
+    interface HTMLOntoUserMenuElement extends Components.OntoUserMenu, HTMLStencilElement {
+    }
+    var HTMLOntoUserMenuElement: {
+        prototype: HTMLOntoUserMenuElement;
+        new (): HTMLOntoUserMenuElement;
+    };
+    /**
      * The purpose of this component is to display translated literals in the DOM. A Stencil component re-renders when a prop or state changes,
      * but it may not re-render when the language changes. In such cases, this component should be used. It handles language change events
      * and re-translates the passed language and translation parameters.
@@ -472,6 +492,7 @@ declare global {
         "onto-toastr": HTMLOntoToastrElement;
         "onto-toggle-switch": HTMLOntoToggleSwitchElement;
         "onto-tooltip": HTMLOntoTooltipElement;
+        "onto-user-menu": HTMLOntoUserMenuElement;
         "translate-label": HTMLTranslateLabelElement;
     }
 }
@@ -639,6 +660,16 @@ declare namespace LocalJSX {
     interface OntoTooltip {
     }
     /**
+     * This component displays the current user's name and provides options
+     * for navigating to settings and logging out.
+     */
+    interface OntoUserMenu {
+        /**
+          * Currently authenticated user
+         */
+        "user"?: AuthenticatedUser;
+    }
+    /**
      * The purpose of this component is to display translated literals in the DOM. A Stencil component re-renders when a prop or state changes,
      * but it may not re-render when the language changes. In such cases, this component should be used. It handles language change events
      * and re-translates the passed language and translation parameters.
@@ -676,6 +707,7 @@ declare namespace LocalJSX {
         "onto-toastr": OntoToastr;
         "onto-toggle-switch": OntoToggleSwitch;
         "onto-tooltip": OntoTooltip;
+        "onto-user-menu": OntoUserMenu;
         "translate-label": TranslateLabel;
     }
 }
@@ -728,6 +760,11 @@ declare module "@stencil/core" {
             "onto-toastr": LocalJSX.OntoToastr & JSXBase.HTMLAttributes<HTMLOntoToastrElement>;
             "onto-toggle-switch": LocalJSX.OntoToggleSwitch & JSXBase.HTMLAttributes<HTMLOntoToggleSwitchElement>;
             "onto-tooltip": LocalJSX.OntoTooltip & JSXBase.HTMLAttributes<HTMLOntoTooltipElement>;
+            /**
+             * This component displays the current user's name and provides options
+             * for navigating to settings and logging out.
+             */
+            "onto-user-menu": LocalJSX.OntoUserMenu & JSXBase.HTMLAttributes<HTMLOntoUserMenuElement>;
             /**
              * The purpose of this component is to display translated literals in the DOM. A Stencil component re-renders when a prop or state changes,
              * but it may not re-render when the language changes. In such cases, this component should be used. It handles language change events

--- a/packages/shared-components/src/components/onto-header/readme.md
+++ b/packages/shared-components/src/components/onto-header/readme.md
@@ -22,6 +22,7 @@ repository selector, and language selector.
 - [onto-operations-notification](../onto-operations-notification)
 - [onto-license-alert](../onto-license-alert)
 - [onto-repository-selector](../onto-repository-selector)
+- [onto-user-menu](../onto-user-menu)
 - [onto-language-selector](../onto-language-selector)
 
 ### Graph
@@ -30,10 +31,12 @@ graph TD;
   onto-header --> onto-operations-notification
   onto-header --> onto-license-alert
   onto-header --> onto-repository-selector
+  onto-header --> onto-user-menu
   onto-header --> onto-language-selector
   onto-operations-notification --> translate-label
   onto-license-alert --> translate-label
   onto-repository-selector --> onto-dropdown
+  onto-user-menu --> translate-label
   onto-language-selector --> onto-dropdown
   onto-layout --> onto-header
   style onto-header fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/shared-components/src/components/onto-layout/readme.md
+++ b/packages/shared-components/src/components/onto-layout/readme.md
@@ -28,10 +28,12 @@ graph TD;
   onto-header --> onto-operations-notification
   onto-header --> onto-license-alert
   onto-header --> onto-repository-selector
+  onto-header --> onto-user-menu
   onto-header --> onto-language-selector
   onto-operations-notification --> translate-label
   onto-license-alert --> translate-label
   onto-repository-selector --> onto-dropdown
+  onto-user-menu --> translate-label
   onto-language-selector --> onto-dropdown
   onto-navbar --> translate-label
   onto-permission-banner --> translate-label

--- a/packages/shared-components/src/components/onto-user-menu/onto-user-menu.scss
+++ b/packages/shared-components/src/components/onto-user-menu/onto-user-menu.scss
@@ -1,0 +1,96 @@
+:root {
+  --user-menu-primary-color: var(--primary-color, #9e2b0a);
+}
+
+.onto-user-menu {
+  position: relative;
+  width: fit-content;
+
+  button {
+    display: flex;
+    flex-direction: row;
+    line-height: 1.5;
+    font-weight: 400;
+    font-size: 1rem;
+    text-align: center;
+    user-select: none;
+    border: 1px solid transparent;
+    padding: .4em 1rem;
+    cursor: pointer;
+    white-space: nowrap;
+    place-items: center;
+    transition: all 0.15s ease-out;
+
+    & .username {
+      padding: 0 5px;
+    }
+
+    &:hover {
+      background-color: #d4d4d4;
+      border-color: #d4d4d4;
+
+      & .fa-user {
+        transform: scale(1.2);
+      }
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &.open {
+      color: white;
+      background-color: var(--user-menu-primary-color);
+      border-color: var(--user-menu-primary-color);
+
+      & .fa-user {
+        color: var(--icon-on-primary-color, #ffffffcc);
+      }
+
+      &:hover {
+        .fa-user {
+          transform: scale(1.2);
+        }
+      }
+    }
+
+    i {
+      color: var(--user-menu-primary-color);
+      line-height: .75;
+      font-size: 1.2em;
+      transition: 0.15s ease-out;
+
+      &.fa-angle-down {
+        color: rgba(0, 0, 0, .35);
+        font-size: 1.1em;
+        transition: all 0.2s ease-in;
+      }
+    }
+  }
+
+  & .onto-user-menu-dropdown {
+    position: absolute;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    cursor: pointer;
+    color: white;
+    text-decoration: none;
+    right: 0;
+    min-width: 7rem;
+    font-size: 1rem;
+    width: 100%;
+    background-color: var(--user-menu-primary-color);
+
+    & translate-label {
+      padding: .4rem 1rem;
+      user-select: none;
+      white-space: nowrap;
+      font-weight: 400;
+
+      &:hover, &:focus {
+        background-color: rgba(0, 0, 0, .1);
+      }
+    }
+  }
+}

--- a/packages/shared-components/src/components/onto-user-menu/onto-user-menu.tsx
+++ b/packages/shared-components/src/components/onto-user-menu/onto-user-menu.tsx
@@ -1,0 +1,61 @@
+import {Component, h, Prop, State} from '@stencil/core';
+import {AuthenticatedUser} from '@ontotext/workbench-api';
+import {navigateTo} from '../../utils/routing-utils';
+
+/**
+ * This component displays the current user's name and provides options
+ * for navigating to settings and logging out.
+ */
+@Component({
+  tag: 'onto-user-menu',
+  styleUrl: 'onto-user-menu.scss'
+})
+export class OntoUserMenu {
+  /** Whether the dropdown menu is open or closed */
+  @State() private isOpen: boolean;
+
+  /** Currently authenticated user */
+  @Prop() user: AuthenticatedUser;
+
+  render() {
+    return (
+      <section class={`onto-user-menu`} onClick={this.toggleDropdown()}>
+        <button class={`${this.isOpen ? 'open' : ''}`}>
+          <i class="fa-solid fa-user"></i>
+          <span class="username">{this.user.username}</span>
+          <i class={`fa-regular fa-angle-down ${this.isOpen ? 'fa-rotate-180' : ''}`}></i>
+        </button>
+        {this.isOpen ?
+          <section class="onto-user-menu-dropdown">
+              <translate-label onClick={navigateTo('/settings')}
+                               labelKey={'user_menu.my_settings'}></translate-label>
+            {!this.user.external ?
+                <translate-label onClick={this.logout()}
+                                 labelKey={'user_menu.logout'}></translate-label> : ''}
+          </section> : ''}
+      </section>
+    );
+  }
+
+  /**
+   * Log out the current user.
+   *
+   * @returns A function that executes the logout logic.
+   */
+  private logout(): () => void {
+    return () => {
+      // TODO
+    }
+  }
+
+  /**
+   * Toggles the dropdown menu's open state.
+   *
+   * @returns A function that toggles the `isOpen` state between true and false.
+   */
+  private toggleDropdown(): () => void {
+    return () => {
+      this.isOpen = !this.isOpen;
+    };
+  }
+}

--- a/packages/shared-components/src/components/onto-user-menu/readme.md
+++ b/packages/shared-components/src/components/onto-user-menu/readme.md
@@ -1,0 +1,40 @@
+# onto-user-menu
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+This component displays the current user's name and provides options
+for navigating to settings and logging out.
+
+## Properties
+
+| Property | Attribute | Description                  | Type                | Default     |
+| -------- | --------- | ---------------------------- | ------------------- | ----------- |
+| `user`   | --        | Currently authenticated user | `AuthenticatedUser` | `undefined` |
+
+
+## Dependencies
+
+### Used by
+
+ - [onto-header](../onto-header)
+
+### Depends on
+
+- [translate-label](../translate-label)
+
+### Graph
+```mermaid
+graph TD;
+  onto-user-menu --> translate-label
+  onto-header --> onto-user-menu
+  style onto-user-menu fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/shared-components/src/components/translate-label/readme.md
+++ b/packages/shared-components/src/components/translate-label/readme.md
@@ -37,6 +37,7 @@ Example of usage:
  - [onto-operations-notification](../onto-operations-notification)
  - [onto-permission-banner](../onto-permission-banner)
  - [onto-toggle-switch](../onto-toggle-switch)
+ - [onto-user-menu](../onto-user-menu)
 
 ### Graph
 ```mermaid
@@ -50,6 +51,7 @@ graph TD;
   onto-operations-notification --> translate-label
   onto-permission-banner --> translate-label
   onto-toggle-switch --> translate-label
+  onto-user-menu --> translate-label
   style translate-label fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/shared-components/src/index.html
+++ b/packages/shared-components/src/index.html
@@ -26,6 +26,7 @@
       <li><a href="/pages/cookie-consent">Cookie Consent</a></li>
       <li><a href="/pages/operations-notification/index.html">Operations notification</a></li>
       <li><a href="/pages/toastr/index.html">Toastr</a></li>
+      <li><a href="/pages/user-menu/index.html">User menu</a></li>
     </ul>
   </body>
 </html>

--- a/packages/shared-components/src/models/single-spa/single-spa.ts
+++ b/packages/shared-components/src/models/single-spa/single-spa.ts
@@ -1,0 +1,8 @@
+export interface SingleSpa {
+  /**
+   * Navigates the single-spa application to the specified URL.
+   *
+   * @param url - The URL to navigate to
+   */
+  navigateToUrl: (url: string) => void;
+}

--- a/packages/shared-components/src/pages/header/index.html
+++ b/packages/shared-components/src/pages/header/index.html
@@ -25,6 +25,9 @@
 <button id="valid-license" onclick="setValidLicense()">set valid license</button>
 <button id="invalid-license" onclick="setInvalidLicense()">set invalid license</button>
 <button id="load-repositories" onclick="loadRepositories()">load repositories</button>
+<button id="enable-security" onclick="setSecurityConfig({enabled: true})">enable security</button>
+<button id="disable-security" onclick="setSecurityConfig({enabled: false})">disable security</button>
+<button id="set-authenticated-user" onclick="setAuthUser({external: true, username: 'john.doe'})">set authenticated user</button>
 <onto-header></onto-header>
 <onto-tooltip></onto-tooltip>
 </body>

--- a/packages/shared-components/src/pages/user-menu/index.html
+++ b/packages/shared-components/src/pages/user-menu/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <base href="/pages/user-menu/"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"/>
+    <title>Stencil Component Starter</title>
+
+    <script type="importmap">
+        {
+          "imports": {
+            "@ontotext/workbench-api": "/resources/ontotext-workbench-api.js"
+          }
+        }
+    </script>
+
+    <script type="module" src="/build/shared-components.esm.js"></script>
+    <script nomodule src="/build/shared-components.js"></script>
+    <script src="./main.js" defer></script>
+    <script src="../js/main.js" defer></script>
+    <link rel="stylesheet" href="../css/bootstrap.min.css">
+    <link rel="stylesheet" href="/pages/css/fontawesome.min.css">
+    <link rel="stylesheet" href="/pages/css/regular.min.css">
+</head>
+<body>
+<button id="set-external-user" onclick="setExternalUser()">set external user</button>
+<onto-user-menu></onto-user-menu>
+</body>
+</html>

--- a/packages/shared-components/src/pages/user-menu/main.js
+++ b/packages/shared-components/src/pages/user-menu/main.js
@@ -1,0 +1,12 @@
+const userMenu = document.querySelector('onto-user-menu');
+
+userMenu.user = {
+  username: 'john.doe'
+}
+
+const setExternalUser = () => {
+  userMenu.user = {
+    ...userMenu.user,
+    external: true
+  }
+}

--- a/packages/shared-components/src/utils/routing-utils.ts
+++ b/packages/shared-components/src/utils/routing-utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Redirects the current page to a specified URL using the single-spa framework.
+ *
+ * @param url - The target URL to which the page should be redirected.
+ */
+export function navigateTo(url: string): (event: Event) => void {
+  return (event: Event): void => {
+    event.preventDefault();
+    window.singleSpa.navigateToUrl(url);
+  }
+}


### PR DESCRIPTION
## What
Implement user menu component inside the header

## Why
To have visibility of logged-in user, as well as settings and logout

## How
Created `onto-user-menu` component, which displays a button with the currently logged-in user. The component will be displayed, when security is on, and there is an authenticated user When clicked, it shows a dropdown with `My-settings` and `Logout` options. The logout is currently not implemented When an external user is logged, there is no logout option The header is subscribed to changes for user and security configuration, and determines, weather to display the new component

## Testing
cypress


## Screenshots
![image](https://github.com/user-attachments/assets/1a371c4e-3cdd-4ae8-a820-26728d75559e)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
