### PR TITLE
GDB-10490 Fix header buttons scaling

### DIFF
--- a/packages/shared-components/src/components/onto-dropdown/onto-dropdown.scss
+++ b/packages/shared-components/src/components/onto-dropdown/onto-dropdown.scss
@@ -52,6 +52,7 @@
     height: fit-content;
     color: var(--onto-dropdown-color);
     background-color: var(--onto-dropdown-button-background-color);
+    transition: all 0.15s ease-out;
 
     .button-icon {
       font-size: 1.4em;
@@ -104,16 +105,5 @@
   .onto-dropdown-right-item-alignment {
     right: 0;
     left: auto;
-  }
-
-  @media (max-width: 1440px) {
-    .onto-dropdown-button, .onto-dropdown.open {
-      font-size: 0.9rem;
-      min-height: 2rem;
-    }
-
-    .selector-button, .button-name {
-      font-size: 0.9rem;
-    }
   }
 }

--- a/packages/shared-components/src/components/onto-dropdown/onto-dropdown.tsx
+++ b/packages/shared-components/src/components/onto-dropdown/onto-dropdown.tsx
@@ -115,7 +115,7 @@ export class OntoDropdown {
                 {...(this.tooltipTheme ? { 'tooltip-theme': this.tooltipTheme } : {})}
                 onMouseEnter={this.setDropdownButtonTooltip()}
                 onClick={this.toggleButtonClickHandler()}>
-          {this.iconClass ? <span class={'button-icon ' + this.iconClass}></span> : ''}
+          {this.iconClass ? <i class={'button-icon ' + this.iconClass}></i> : ''}
           <span class='button-name'>
                       {this.dropdownButtonName ?? this.translate(this.dropdownButtonNameLabelKey)}
                     </span>

--- a/packages/shared-components/src/components/onto-language-selector/onto-language-selector.scss
+++ b/packages/shared-components/src/components/onto-language-selector/onto-language-selector.scss
@@ -26,13 +26,3 @@ onto-language-selector {
     }
   }
 }
-
-@media (max-width: 1440px) {
-  .onto-dropdown-button {
-    font-size: 0.9rem;
-  }
-
-  .selector-button, .button-name, .onto-dropdown-menu-item > * {
-    font-size: 0.9rem;
-  }
-}

--- a/packages/shared-components/src/components/onto-operations-notification/onto-operations-notification.scss
+++ b/packages/shared-components/src/components/onto-operations-notification/onto-operations-notification.scss
@@ -16,6 +16,7 @@ $hover-color: #d4d4d4;
     padding: .4rem 1rem;
     font-size: 1rem;
     gap: 0.75em;
+    transition: all 0.15s ease-out;
 
     &:hover {
       background-color: $hover-color;


### PR DESCRIPTION
## What
Fix the scaling of buttons inside the header, whenever the screen width is less than 1439px.
This doesn't include making the header entirely responsive. There are still issues with that

## Why
It wasn't working correct for all buttons

## How
Removed @media queries from the language selector and repository selectors. They will use the global one. Added smooth transition for the scaling to all buttons Changed `span` to `i` tag in `onto-dropdown` as it was styling the button icon slightly differently

## Testing
nont, as it is only styling

## Screenshots
![header-buttons-scale](https://github.com/user-attachments/assets/28b9de69-c91f-4af2-9c71-5371beda03ca)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
