### PR TITLE
GDB-12002 - add replaceVersion for cluster management templates

### DIFF
--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -122,7 +122,8 @@ module.exports = {
             },
             {
                 from: 'src/js/angular/clustermanagement/templates',
-                to: 'js/angular/clustermanagement/templates'
+                to: 'js/angular/clustermanagement/templates',
+                transform: replaceVersion
             },
             {
                 from: 'src/js/angular/core/templates',


### PR DESCRIPTION
## What
When creating a Cluster or editing its nodes, the styles in the dialog will load correctly.

## Why
Some styles in the Cluster create/edit dialog were not loaded correctly. This was due to one of the stylesheets not resolving its version correctly.
![Screenshot from 2025-03-26 15-50-20](https://github.com/user-attachments/assets/18cf83b8-d2fa-4c30-88c1-e9c09c9eb6ec)

## How
I updated the webpack config.

## Testing
N/A

## Screenshots
N/A


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
