### PR TITLE
GDB-11267 destroy tooltip on node removal

### DIFF
--- a/packages/shared-components/cypress/e2e/tooltip/tooltip.cy.js
+++ b/packages/shared-components/cypress/e2e/tooltip/tooltip.cy.js
@@ -1,4 +1,4 @@
-import { TooltipSteps } from "../../steps/tooltip-steps";
+import {TooltipSteps} from "../../steps/tooltip-steps";
 
 describe('Tooltip', () => {
   it('Should handle various tooltip behaviors and styles correctly', () => {
@@ -45,5 +45,24 @@ describe('Tooltip', () => {
     TooltipSteps.getElementWithCustomThemeTooltip().trigger('mouseover');
     // Then I expect the tooltip to be colored according to the custom theme.
     TooltipSteps.getTooltip('custom-theme').should('have.css', 'background-color', 'rgb(252, 255, 205)');
+  });
+
+  it('Should remove tooltip, when the element is removed from the DOM', () => {
+    // Given, I visit the page with an element that has a tooltip
+    TooltipSteps.visit();
+
+    // When, I hover over the removable element
+    TooltipSteps.hoverOnRemovableButton();
+
+    // Then, I expect the tooltip to be visible
+    TooltipSteps.getTooltipContent()
+      .should('be.visible')
+      .and('contain', 'Remove me');
+
+    // When, I remove the element from the DOM
+    TooltipSteps.clickOnRemovableButton();
+
+    // Then, I expect the tooltip to be removed along with the element
+    TooltipSteps.getTooltip().should('not.exist');
   });
 });

--- a/packages/shared-components/cypress/steps/tooltip-steps.js
+++ b/packages/shared-components/cypress/steps/tooltip-steps.js
@@ -53,4 +53,17 @@ export class TooltipSteps extends BaseSteps {
   static verifyBottomTooltipPlacement() {
     TooltipSteps.getTooltip().should('have.attr', 'data-placement', 'bottom')
   }
+
+  static getRemovableButton() {
+    return cy.get('#remove-me');
+  }
+
+  static hoverOnRemovableButton() {
+    return this.getRemovableButton().trigger('mouseover');
+  }
+
+  static clickOnRemovableButton() {
+    return this.getRemovableButton().click();
+  }
+
 }

--- a/packages/shared-components/src/pages/tooltip/index.html
+++ b/packages/shared-components/src/pages/tooltip/index.html
@@ -86,6 +86,13 @@
       <span class="button-label">Button</span>
     </button>
   </div>
+
+  <button onclick="removeElement()"
+          id="remove-me"
+          tooltip-content="Remove me"
+          tooltip-placement="bottom">
+    Click to remove me
+  </button>
 </div>
 
 <onto-tooltip></onto-tooltip>

--- a/packages/shared-components/src/pages/tooltip/main.js
+++ b/packages/shared-components/src/pages/tooltip/main.js
@@ -1,1 +1,6 @@
-let headerElement = document.querySelector("onto-header");
+const removeElement = () => {
+  const button = document.getElementById('remove-me');
+  if (button) {
+    button.remove();
+  }
+}


### PR DESCRIPTION
## What
Add functionality to remove existing tooltip, when its target element has been removed from the dom

## Why
Because currently, when an element, which has a tooltip is removed, the tooltip stays visible

## How
Added a mutation observer, which listens to changes in the body and monitors removed nodes. When a node is removed, it is checked to see, if it has a tooltip. If a tooltip is present, it is destroyed.

## Testing
cypress

## Screenshots
before: 
![before-fix](https://github.com/user-attachments/assets/d0b7a302-981a-44e1-866f-28475ea41564)


after:
![after-fix](https://github.com/user-attachments/assets/25d6d1d9-aeff-4ca9-880f-58c0ce9252e6)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
