### PR TITLE
(cherry-pick) GDB-12032 - Remove old repo rename warning

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -2353,7 +2353,6 @@
     "edit.repo.restart.requested.msg": "<span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>The repository will be restarted.",
     "edit.repo.restart.needed.msg": "<span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>Repository restart required for changes to take effect.",
     "edit.repo.id.warning.msg": "<p>Changing the repository ID is a dangerous operation since it renames the repository folder and enforces repository shutdown.</p>",
-    "edit.repo.id.cluster.warning.msg": "<p>If your repository is in a cluster, it is your responsibility to update the cluster after renaming.</p>",
     "confirm.enable.edit": "Confirm enable edit",
     "repo.description": "Repository description",
     "repo.indexing.section": "Indexing",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -2351,7 +2351,6 @@
     "edit.repo.restart.requested.msg": "<span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>Le dépôt sera redémarré.",
     "edit.repo.restart.needed.msg": "<span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>Le redémarrage du dépôt est nécessaire pour que les changements prennent effet.",
     "edit.repo.id.warning.msg": "<p>Changer l'ID du dépôt est une opération dangereuse puisqu'elle renomme le dossier du dépôt et impose l'arrêt du dépôt.</p>",
-    "edit.repo.id.cluster.warning.msg": "<p>Si votre dépôt est dans un cluster, il est de votre responsabilité de mettre à jour le cluster après le renommage.</p>",
     "confirm.enable.edit": "Confirmation de l'activation de l'édition",
     "repo.description": "Description du dépôt",
     "repo.indexing.section": "Indexage",

--- a/src/js/angular/repositories/controllers.js
+++ b/src/js/angular/repositories/controllers.js
@@ -937,9 +937,7 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
 
     $scope.editRepositoryId = function () {
         let msg = decodeHTML($translate.instant('edit.repo.id.warning.msg'));
-        if ($scope.isEnterprise()) {
-            msg += decodeHTML($translate.instant('edit.repo.id.cluster.warning.msg'));
-        }
+
         ModalService.openSimpleModal({
             title: $translate.instant('confirm.enable.edit'),
             message: msg,

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -2353,7 +2353,6 @@
     "edit.repo.restart.requested.msg": "<span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>The repository will be restarted.",
     "edit.repo.restart.needed.msg": "<span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>Repository restart required for changes to take effect.",
     "edit.repo.id.warning.msg": "<p>Changing the repository ID is a dangerous operation since it renames the repository folder and enforces repository shutdown.</p>",
-    "edit.repo.id.cluster.warning.msg": "<p>If your repository is in a cluster, it is your responsibility to update the cluster after renaming.</p>",
     "confirm.enable.edit": "Confirm enable edit",
     "repo.description": "Repository description",
     "repo.indexing.section": "Indexing",


### PR DESCRIPTION
## What
When renaming a repo, the user won't see the cluster renaming part of the warning.

## Why
Necessary changes were made in the BE for repo renaming in cluster to happen without user interaction.

## How
I removed the label from the language files and the controller.

## Testing
N/A

## Screenshots
Old

![image](https://github.com/user-attachments/assets/e7349506-ebc6-47a7-ae10-e0b9bf1f78d9)

New:

![image](https://github.com/user-attachments/assets/843d5b29-f547-415d-9cae-c45db3bf4dc6)
![image](https://github.com/user-attachments/assets/b5673bbd-bc43-4dd4-95d5-6af24dce0880)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
