### PR TITLE
GDB-11287 - Fix chart axis resetting when using chart filters

### DIFF
--- a/src/js/angular/resources/chart-models/performance/connections-chart.js
+++ b/src/js/angular/resources/chart-models/performance/connections-chart.js
@@ -46,7 +46,7 @@ export class ConnectionsChart extends ChartData {
     }
 
     updateRange(dataHolder, multiplier) {
-        const [max, minInterval] = ChartData.getIntegerRangeForValues(dataHolder, this.selectedSeries)
+        const [max, minInterval] = ChartData.getIntegerRangeForValues(dataHolder, multiplier, this.selectedSeries)
         this.chartOptions.yAxis.max = max;
         this.chartOptions.yAxis.minInterval = minInterval;
     }

--- a/src/js/angular/resources/chart-models/performance/epool-chart.js
+++ b/src/js/angular/resources/chart-models/performance/epool-chart.js
@@ -16,15 +16,13 @@ export class EpoolChart extends ChartData {
                     name: this.translateService.instant('resource.epool.reads'),
                     nameLocation: 'middle',
                     type: 'value',
-                    nameGap: 40,
-
+                    nameGap: 50,
                 },
                 {
                     name: this.translateService.instant('resource.epool.writes'),
                     nameLocation: 'middle',
                     type: 'value',
-                    nameGap: 40,
-
+                    nameGap: 50,
                 }
             ],
         };
@@ -91,7 +89,7 @@ export class EpoolChart extends ChartData {
 
     updateRange(dataHolder) {
         dataHolder.forEach((data, i) => {
-            const [max, minInterval] = ChartData.getIntegerRangeForValues(data, this.selectedSeries)
+            const [max, minInterval] = ChartData.getIntegerRangeForValues(data, 0, this.selectedSeries)
             this.chartOptions.yAxis[i].max = max;
             this.chartOptions.yAxis[i].minInterval = minInterval;
         })

--- a/src/js/angular/resources/chart-models/performance/queries-chart.js
+++ b/src/js/angular/resources/chart-models/performance/queries-chart.js
@@ -42,7 +42,7 @@ export class QueriesChart extends ChartData {
     }
 
     updateRange(dataHolder, multiplier) {
-        const [max, minInterval] = ChartData.getIntegerRangeForValues(dataHolder, this.selectedSeries)
+        const [max, minInterval] = ChartData.getIntegerRangeForValues(dataHolder, multiplier, this.selectedSeries)
         this.chartOptions.yAxis.max = max;
         this.chartOptions.yAxis.minInterval = minInterval;
     }


### PR DESCRIPTION
## What
When filtering the `Monitoring` charts, the axis will show the correct ranges, without cutting off a part of the data.
The y-axis names will not overlap long tick labels.

## Why
No value was passed in for the `multiplier` and the wrong function parameter was used to calculate the y-axis max value. Hence, the y-axis max value would reset to 1 when the chart data was toggled.

## How
I made sure the function receives the `multiplier` value where it is expected.
I added a bigger gap between the axis name and the tick label.

## Testing
N/A

## Screenshots
After the fix. The y-axis values won't reset to 0 and 1 when the charts are toggled.

https://github.com/user-attachments/assets/34e77904-df0f-4e32-ba3f-4ef297aa0d6e


## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
