### PR TITLE
(cherry-pick) GDB-12015 - Hide autocomplete IRI discovery method in TTYG

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -397,7 +397,8 @@
                 "similarity_search": "Similarity search",
                 "retrieval_search": "ChatGPT Retrieval",
                 "iri_discovery": "FTS for IRI discovery",
-                "now": "the Now function"
+                "now": "the Now function",
+                "autocomplete_iri_discovery_search": "Autocomplete for IRI discovery"
             },
             "query_colon": ":",
             "query_desc": {
@@ -406,7 +407,8 @@
                 "similarity_search": "Similarity search via SPARQL",
                 "retrieval_search": "Direct JSON query",
                 "iri_discovery": "Full-text search via SPARQL",
-                "now": "returns the system time"
+                "now": "returns the system time",
+                "autocomplete_iri_discovery_search": "Autocomplete search via SPARQL"
             },
             "dialog": {
                 "confirm_repository_change": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -396,7 +396,8 @@
                 "similarity_search": "Recherche de similarité",
                 "retrieval_search": "ChatGPT Retrieval",
                 "iri_discovery": "FTS pour la découverte IRI",
-                "now": "La fonction \"Maintenant\""
+                "now": "La fonction \"Maintenant\"",
+                "autocomplete_iri_discovery_search": "Autocomplétion pour la découverte d'IRI"
             },
             "query_colon": " :",
             "query_desc": {
@@ -405,7 +406,8 @@
                 "similarity_search": "Recherche de similarité via SPARQL",
                 "retrieval_search": "Requête JSON directe",
                 "iri_discovery": "Recherche en texte intégral via SPARQL",
-                "now": "Renvoie l'heure système"
+                "now": "Renvoie l'heure système",
+                "autocomplete_iri_discovery_search": "Recherche en autocomplétion via SPARQL"
             },
             "dialog": {
                 "confirm_repository_change": {

--- a/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -20,7 +20,8 @@ angular
     ])
     .constant('ExtractionMethodTemplates', {
     'iri_discovery_search': 'iri-discovery-search',
-    'autocomplete_iri_discovery_search': 'autocomplete-iri-discovery-search'
+        // Temporarily hidden template until the feature is fine-tuned
+    //'autocomplete_iri_discovery_search': 'autocomplete-iri-discovery-search'
     })
     .controller('AgentSettingsModalController', AgentSettingsModalController);
 

--- a/src/js/angular/ttyg/templates/autocomplete-iri-discovery-search.html
+++ b/src/js/angular/ttyg/templates/autocomplete-iri-discovery-search.html
@@ -44,23 +44,6 @@
                               ng-model="extractionMethod.maxNumberOfResultsPerCall"
                               placeholder="{{'ttyg.agent.create_agent_modal.form.additional_query_methods.autocomplete_max_number_of_results_per_call.placeholder' | translate}}">
                    </div>
-                   <div class="autocomplete-predicate-tags">
-                       <label uib-popover="{{'ttyg.agent.create_agent_modal.form.additional_query_methods.autocomplete_search_predicates.tooltip' | translate}}"
-                              popover-trigger="mouseenter">
-                           {{'ttyg.agent.create_agent_modal.form.additional_query_methods.autocomplete_search_predicates.label' | translate}}</label>
-                       <tags-input id="autocompletePredicateField" class="wb-tags-input" ng-model="extractionMethod.searchLabelPredicates" min-length="1"
-                                   ng-disabled="!extractionMethod.selected"
-                                   use-strings="true"
-                                   add-on-space="true"
-                                   add-on-comma="true"
-                                   add-on-paste="true"
-                                   replace-spaces-with-dashes="false"
-                                   paste-split-pattern="[\s+]"
-                                   ng-keydown="getSuggestions($event)"
-                                   placeholder="{{'ttyg.agent.create_agent_modal.form.additional_query_methods.autocomplete_search_predicates.placeholder' | translate}}">
-                           <auto-complete source="autocompleteSuggestions"></auto-complete>
-                       </tags-input>
-                   </div>
                </div>
         </div>
     </div>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -397,7 +397,8 @@
                 "similarity_search": "Similarity search",
                 "retrieval_search": "ChatGPT Retrieval",
                 "iri_discovery": "FTS for IRI discovery",
-                "now": "the Now function"
+                "now": "the Now function",
+                "autocomplete_iri_discovery_search": "Autocomplete for IRI discovery"
             },
             "query_colon": ":",
             "query_desc": {
@@ -406,7 +407,8 @@
                 "similarity_search": "Similarity search via SPARQL",
                 "retrieval_search": "Direct JSON query",
                 "iri_discovery": "Full-text search via SPARQL",
-                "now": "returns the system time"
+                "now": "returns the system time",
+                "autocomplete_iri_discovery_search": "Autocomplete search via SPARQL"
             },
             "dialog": {
                 "confirm_repository_change": {

--- a/test-cypress/integration/ttyg/edit-agent.spec.js
+++ b/test-cypress/integration/ttyg/edit-agent.spec.js
@@ -52,7 +52,7 @@ describe('TTYG edit an agent', () => {
     });
 
 
-    it('should be able to edit Autocomplete extraction method option', {
+    it.skip('should be able to edit Autocomplete extraction method option', {
         retries: {
             runMode: 1,
             openMode: 0


### PR DESCRIPTION
## What
The `Autocomplete IRI method` in TTYG will be hidden. A missing label has been added. The `Search predicates` field was removed.

## Why
The method is not finalized for release.

## How
I commented out the template from `ExtractionMethodTemplates`.

## Testing
One test for the method skipped.

## Screenshots
![image](https://github.com/user-attachments/assets/acd204ab-1446-4a27-888b-2dfc1ebdc92e)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
