### PR TITLE
fix(GDB-12088) Correct SHACL property label key to match API contract 3.0

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1138,7 +1138,7 @@
                                 "label": "Default Maximum Cardinality",
                                 "tooltip": "Sets the default maximum cardinality for all values, defining whether properties without explicit cardinality are multi or single valued by default."
                             },
-                            "readShaclPropertiesLabels": {
+                            "readShaclPropertyLabels": {
                                 "label": "Use SHACL Property Labels",
                                 "tooltip": "Defines whether labels and descriptions for sh:PropertyShape should be used instead of sh:path labels and descriptions."
                             },

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1137,7 +1137,7 @@
                                 "label": "Cardinalité Maximale par Défaut",
                                 "tooltip": "Définit la cardinalité maximale par défaut pour toutes les valeurs, en définissant si les propriétés sans configuration explicite de cardinalité sont par défaut multi ou mono valeurs."
                             },
-                            "readShaclPropertiesLabels": {
+                            "readShaclPropertyLabels": {
                                 "label": "Utiliser les Libellés des Propriétés SHACL",
                                 "tooltip": "Définit si les libellés et descriptions pour sh:PropertyShape doivent être utilisés à la place des libellés et descriptions de sh:path."
                             },

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -1138,7 +1138,7 @@
                                 "label": "Default Maximum Cardinality",
                                 "tooltip": "Sets the default maximum cardinality for all values, defining whether properties without explicit cardinality are multi or single valued by default."
                             },
-                            "readShaclPropertiesLabels": {
+                            "readShaclPropertyLabels": {
                                 "label": "Use SHACL Property Labels",
                                 "tooltip": "Defines whether labels and descriptions for sh:PropertyShape should be used instead of sh:path labels and descriptions."
                             },


### PR DESCRIPTION
## WHAT:
Fixes a typo in the property key readShaclPropertiesLabels → readShaclPropertyLabels in English and French i18n files and test fixtures.

## WHY:
The incorrect property name readShaclPropertiesLabels was being used in the i18n files. However, the correct property used in the public REST API and the SomlOntology is readShaclPropertyLabels.

## HOW:
Renamed all occurrences of readShaclPropertiesLabels to readShaclPropertyLabels

cherry-pick from 124f49e8d6f12ffd4d7b6a04576f2bba6966ea16


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
