### PR TITLE
GDB-12029: Fix grammar of sentence on GraphQL endpoint creation screen

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -1046,7 +1046,7 @@
                         "messages": {
                             "loading_graphql_shapes": "Loading GraphQL schema shapes...",
                             "no_schemas": "No GraphQL schema shapes were found in the selected repository. You can browse other repositories or change the source.",
-                            "endpoint_per_shape": "Each GraphQL schema shape results in one endpoint"
+                            "endpoint_per_shape": "Each GraphQL schema shape results in one endpoint."
                         }
                     },
                     "shacl_shapes": {
@@ -1166,7 +1166,7 @@
                     "overview": {
                         "title": "Overview",
                         "for_shapes": {
-                            "info": "GraphDB will attempt to create {{endpointsCount}} GraphQL endpoints in the \"{{activeRepoId}}\" based on the selected resources. To modify the selection, go back to Step 1 (Select schema source).",
+                            "info": "GraphDB will attempt to create {{endpointsCount}} GraphQL endpoints in the \"{{activeRepoId}}\" repository based on the selected resources. To modify the selection, go back to Step 1 (Select schema source).",
                             "included_endpoints": "Included GraphQL schema shapes",
                             "generated_endpoints": "GraphQL endpoints",
                             "explore_in_playground_link_tooltip": "Explore in Playground (opens in a new tab)",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -1045,7 +1045,7 @@
                         "messages": {
                             "loading_graphql_shapes": "Chargement des formes de schéma GraphQL...",
                             "no_schemas": "Aucune forme de schéma GraphQL n'a été trouvée dans le référentiel sélectionné. Vous pouvez parcourir d'autres référentiels ou modifier la source.",
-                            "endpoint_per_shape": "Chaque forme de schéma GraphQL génère un point de terminaison"
+                            "endpoint_per_shape": "Chaque forme de schéma GraphQL génère un point de terminaison."
                         }
                     },
                     "shacl_shapes": {

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -1046,7 +1046,7 @@
                         "messages": {
                             "loading_graphql_shapes": "Loading GraphQL schema shapes...",
                             "no_schemas": "No GraphQL schema shapes were found in the selected repository. You can browse other repositories or change the source.",
-                            "endpoint_per_shape": "Each GraphQL schema shape results in one endpoint"
+                            "endpoint_per_shape": "Each GraphQL schema shape results in one endpoint."
                         }
                     },
                     "shacl_shapes": {
@@ -1166,7 +1166,7 @@
                     "overview": {
                         "title": "Overview",
                         "for_shapes": {
-                            "info": "GraphDB will attempt to create {{endpointsCount}} GraphQL endpoints in the \"{{activeRepoId}}\" based on the selected resources. To modify the selection, go back to Step 1 (Select schema source).",
+                            "info": "GraphDB will attempt to create {{endpointsCount}} GraphQL endpoints in the \"{{activeRepoId}}\" repository based on the selected resources. To modify the selection, go back to Step 1 (Select schema source).",
                             "included_endpoints": "Included GraphQL schema shapes",
                             "generated_endpoints": "GraphQL endpoints",
                             "explore_in_playground_link_tooltip": "Explore in Playground (opens in a new tab)",

--- a/test-cypress/integration/explore/visual-graph/visual.graph.spec.js
+++ b/test-cypress/integration/explore/visual-graph/visual.graph.spec.js
@@ -54,7 +54,12 @@ describe('Visual graph screen validation', () => {
             ApplicationSteps.getErrorNotifications().should('be.visible').and('contain', 'Invalid IRI');
         });
 
-        it('Test search for a valid resource', () => {
+        it('Test search for a valid resource', {
+            retries: {
+                openMode: 0,
+                runMode: 1
+            }
+        }, () => {
             AutocompleteStubs.spyAutocompleteStatus();
             VisualGraphSteps.visit();
             // Verify autocomplete is ON, because sometimes in CI it is OFF and fails when searching for Resource


### PR DESCRIPTION
## What
Improve the grammar of the overview sentences displayed before creating a GraphQL endpoint.

## Why

## How

## Testing
N/A

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
