### PR TITLE
GDB-12117 Define HTTP interceptor structure

### DIFF
--- a/packages/api/src/interceptor/auth/auth-request-interceptor.ts
+++ b/packages/api/src/interceptor/auth/auth-request-interceptor.ts
@@ -1,0 +1,54 @@
+import {HttpRequest} from '../../models/http/http-request';
+import {HttpInterceptor} from '../../models/interceptor/http-interceptor';
+import {AuthenticationStorageService} from '../../services/security/authentication-storage.service';
+import {ServiceProvider} from '../../providers/service/service.provider';
+import {RepositoryContextService} from '../../services/repository/repository-context.service';
+import {RepositoryStorageService} from '../../services/repository/repository-storage.service';
+
+/**
+ * AuthRequestInterceptor is responsible for intercepting HTTP requests and adding authentication
+ * and repository information to the request headers.
+ */
+export class AuthRequestInterceptor extends HttpInterceptor<HttpRequest> {
+
+  private readonly authStorage = ServiceProvider.get(AuthenticationStorageService);
+  private readonly repositoryStorageService = ServiceProvider.get(RepositoryStorageService);
+  private readonly repositoryContextService = ServiceProvider.get(RepositoryContextService);
+
+  /**
+   * Preprocesses the HTTP request by adding authentication and repository information to the headers.
+   *
+   * This method performs the following tasks:
+   * 1. Adds an authorization token to the request headers if available.
+   * 2. Adds repository ID and location to the headers if available.
+   *
+   * @param request - The HTTP request to be processed.
+   * @returns A Promise that resolves to the modified HTTP request.
+   */
+  process(request: HttpRequest): Promise<HttpRequest> {
+    request.headers['X-Requested-With'] = 'XMLHttpRequest';
+
+    const authToken = this.authStorage.getAuthToken().getValue();
+    if (authToken) {
+      request.headers.Authorization = authToken;
+    }
+
+    const repositoryId = this.repositoryStorageService.get(this.repositoryContextService.SELECTED_REPOSITORY_ID).getValue();
+    if (repositoryId) {
+      request.headers['X-GraphDB-Repository'] = repositoryId;
+    }
+
+    const repositoryLocation = this.repositoryStorageService.get(this.repositoryContextService.REPOSITORY_LOCATION).getValue();
+
+    if (repositoryLocation) {
+      request.headers['X-GraphDB-Repository-Location'] = repositoryLocation;
+    }
+
+    return Promise.resolve(request);
+  }
+
+  shouldProcess(): boolean {
+    //TODO: when using OpenId this should be skipped
+    return true;
+  }
+}

--- a/packages/api/src/interceptor/auth/test/auth-request-interceptor.spec.ts
+++ b/packages/api/src/interceptor/auth/test/auth-request-interceptor.spec.ts
@@ -1,0 +1,90 @@
+import {AuthRequestInterceptor} from '../auth-request-interceptor';
+import {ServiceProvider} from '../../../providers/service/service.provider';
+import {AuthenticationStorageService} from '../../../services/security/authentication-storage.service';
+import {RepositoryStorageService} from '../../../services/repository/repository-storage.service';
+import {StorageData} from '../../../models/storage';
+
+describe('AuthHttpInterceptor', () => {
+  let authHttpInterceptor: AuthRequestInterceptor;
+  const authStorage = ServiceProvider.get(AuthenticationStorageService);
+  const repositoryStorage = ServiceProvider.get(RepositoryStorageService);
+
+  beforeEach(() => {
+    authHttpInterceptor = new AuthRequestInterceptor();
+  });
+
+  test('Should add Authorization header when auth token is available', async () => {
+    // Given, I have a mock auth token
+    const mockAuthToken = 'mock-auth-token';
+    const mockRequest = {
+      headers: {},
+      url: 'http://example.com/api/endpoint',
+      method: 'GET',
+      body: {}
+    };
+
+    // And I have mocked the auth storage service to return the mock auth token
+    jest.spyOn(authStorage, 'getAuthToken').mockImplementation(() => {
+      return new StorageData(mockAuthToken);
+    });
+
+    // When I preprocess the request
+    const result = await authHttpInterceptor.process(mockRequest);
+
+    // Then, the authorization header should be added to the request
+    expect(result.headers['X-Requested-With']).toEqual('XMLHttpRequest');
+    expect(result.headers['Authorization']).toEqual(mockAuthToken);
+    expect(result.headers['X-GraphDB-Repository']).toBeUndefined();
+    expect(result.headers['X-GraphDB-Repository-Location']).toBeUndefined();
+  });
+
+  test('Should add X-GraphDB-Repository header when repository context is available', async () => {
+    const mockRequest = {
+      headers: {},
+      url: 'http://example.com/api/endpoint',
+      method: 'GET',
+      body: {}
+    };
+    // Given, I have a mock selected repository ID
+    const mockRepositoryId = '1';
+    // And I have mocked the repository storage service to return the mock selected repository ID
+    jest.spyOn(repositoryStorage, 'get').mockImplementation((param) => {
+      const value = param === 'selectedRepositoryId' ? mockRepositoryId : null;
+      return new StorageData(value);
+    });
+
+    // When I preprocess the request
+    const result = await authHttpInterceptor.process(mockRequest);
+
+    // Then, the X-GraphDB-Repository header should be added to the request
+    expect(result.headers['X-Requested-With']).toEqual('XMLHttpRequest');
+    expect(result.headers['Authorization']).toBeUndefined();
+    expect(result.headers['X-GraphDB-Repository']).toEqual(mockRepositoryId);
+    expect(result.headers['X-GraphDB-Repository-Location']).toBeUndefined();
+  });
+
+  test('Should add X-GraphDB-Repository-Location header when repository context is available', async () => {
+    const mockRequest = {
+      headers: {},
+      url: 'http://example.com/api/endpoint',
+      method: 'GET',
+      body: {}
+    };
+    // Given, I have a mock selected repository location
+    const mockRepositoryLocation = 'repo-location-uri';
+    // And I have mocked the repository storage service to return the mock selected repository location
+    jest.spyOn(repositoryStorage, 'get').mockImplementation((param) => {
+      const value = param === 'repositoryLocation' ? mockRepositoryLocation : null;
+      return new StorageData(value);
+    });
+
+    // When I preprocess the request
+    const result = await authHttpInterceptor.process(mockRequest);
+
+    // Then, the X-GraphDB-Repository-Location header should be added to the request
+    expect(result.headers['X-Requested-With']).toEqual('XMLHttpRequest');
+    expect(result.headers['Authorization']).toBeUndefined();
+    expect(result.headers['X-GraphDB-Repository']).toBeUndefined();
+    expect(result.headers['X-GraphDB-Repository-Location']).toEqual(mockRepositoryLocation);
+  });
+});

--- a/packages/api/src/interceptor/interceptors.ts
+++ b/packages/api/src/interceptor/interceptors.ts
@@ -1,0 +1,18 @@
+import {HttpInterceptor} from '../models/interceptor/http-interceptor';
+import {HttpRequest} from '../models/http/http-request';
+import {ModelList} from '../models/common';
+
+/**
+ * An array of HTTP request interceptors to be used in the application.
+ */
+export const REQUEST_INTERCEPTORS = new ModelList<HttpInterceptor<HttpRequest>>([
+  // Request interceptors go here
+  // new AuthRequestInterceptor()
+]);
+
+/**
+ * An array of HTTP response interceptors to be used in the application.
+ */
+export const RESPONSE_INTERCEPTORS = new ModelList<HttpInterceptor<Response>> ([
+  // Response interceptors go here
+]);

--- a/packages/api/src/models/common/model-list.ts
+++ b/packages/api/src/models/common/model-list.ts
@@ -9,7 +9,7 @@ import { Model } from './model';
  *
  * @template T - The type of items in the list.
  */
-export abstract class ModelList<T> extends Model<T> {
+export class ModelList<T> extends Model<T> {
   /**
    * The list of items managed by this class.
    */
@@ -21,7 +21,7 @@ export abstract class ModelList<T> extends Model<T> {
    * @param items - An optional array of items to initialize the list. If no items are provided,
    *                an empty array is used by default.
    */
-  protected constructor(items: T[] = []) {
+  constructor(items: T[] = []) {
     super();
     this.items = items;
   }
@@ -83,6 +83,15 @@ export abstract class ModelList<T> extends Model<T> {
    */
   addToStart(item: T): void {
     this.items.unshift(item);
+  }
+
+  /**
+   * Adds an array of items to the end of the list.
+   *
+   * @param items the items to add
+   */
+  addItems(items: T[]): void {
+    this.items.push(...items);
   }
 
   /**

--- a/packages/api/src/models/http/http-request.ts
+++ b/packages/api/src/models/http/http-request.ts
@@ -1,0 +1,23 @@
+/**
+ * Represents an HTTP request with its essential properties.
+ */
+export class HttpRequest {
+  /** The URL of the request. */
+  url: string;
+
+  /** The HTTP method of the request (e.g., GET, POST, PUT, DELETE). */
+  method: string;
+
+  /** A key-value pair object representing the headers of the request. */
+  headers: Record<string, string | undefined>;
+
+  /** The body of the request. Can be of any type or undefined. */
+  body?: unknown;
+
+  constructor(data: HttpRequest) {
+    this.url = data.url;
+    this.method = data.method;
+    this.headers = {...data.headers};
+    this.body = data.body;
+  }
+}

--- a/packages/api/src/models/interceptor/http-interceptor.ts
+++ b/packages/api/src/models/interceptor/http-interceptor.ts
@@ -1,0 +1,30 @@
+import {HttpRequest} from '../http/http-request';
+
+/**
+ * Defines the structure for an HTTP interceptor.
+ * This class allows for processing of HTTP requests or responses.
+ * A class extending this can override the `process` and `shouldProcess` methods to customize the HTTP
+ * request and response flow.
+ */
+export abstract class HttpInterceptor<T extends HttpRequest | Response> {
+  /** Priority of the interceptor. Higher values indicate earlier execution. */
+  priority = 0;
+
+  /**
+   * Processes an HTTP request or response.
+   * This method can be used to modify or enhance the request or response.
+   *
+   * @param data - The original HTTP request or response to be processed.
+   * @returns A promise that resolves to the processed HTTP request or response.
+   */
+  abstract process(data: T): Promise<T>
+
+  /**
+   * Determines whether the processing step should be applied to the given HTTP request or response.
+   * This method allows for conditional processing based on the request's or response's properties.
+   *
+   * @param data - The HTTP request or response to be evaluated.
+   * @returns A boolean indicating whether the processing should be applied (true) or skipped (false).
+   */
+  abstract shouldProcess(data: T): boolean;
+}

--- a/packages/api/src/services/interceptor/interceptor.service.ts
+++ b/packages/api/src/services/interceptor/interceptor.service.ts
@@ -1,0 +1,81 @@
+import {HttpRequest} from '../../models/http/http-request';
+import {RESPONSE_INTERCEPTORS, REQUEST_INTERCEPTORS} from '../../interceptor/interceptors';
+import {HttpInterceptor} from '../../models/interceptor/http-interceptor';
+import {ModelList} from '../../models/common';
+
+/**
+ * Service responsible for managing and executing HTTP interceptors.
+ */
+export class InterceptorService {
+  private preProcessors = new ModelList<HttpInterceptor<HttpRequest>>();
+  private postProcessors = new ModelList<HttpInterceptor<Response>>();
+
+  /**
+   * Initializes a new instance of the InterceptorService class.
+   * This constructor sets up the default pre-processors and post-processors, defined in
+   * {@link RESPONSE_INTERCEPTORS} and {@link REQUEST_INTERCEPTORS} lists.
+   * It sorts the interceptors based on their priority using the sortInterceptors method.
+   */
+  constructor() {
+    this.registerRequestInterceptors(REQUEST_INTERCEPTORS);
+    this.registerResponseInterceptors(RESPONSE_INTERCEPTORS);
+  }
+
+  /**
+   * Chains all interceptors, which {@link HttpInterceptor#shouldPreProcess should pre-process} the request.
+   * @param request The initial HTTP request.
+   * @returns A promise that resolves to the final processed HTTP request.
+   */
+  async preProcess(request: HttpRequest): Promise<HttpRequest> {
+    let processedRequest = request;
+    for (const interceptor of this.preProcessors.getItems()) {
+      if (interceptor.shouldProcess(processedRequest)) {
+        processedRequest = await interceptor.process(processedRequest);
+      }
+    }
+    return processedRequest;
+  }
+
+  /**
+   * Chains all interceptors, which {@link HttpInterceptor#shouldPostProcess should post process} the response.
+   * @param response The initial HTTP response.
+   * @returns A promise that resolves to the final processed HTTP response.
+   */
+  async postProcess(response: Response): Promise<Response> {
+    let processedResponse = response;
+    for (const interceptor of this.postProcessors.getItems()) {
+      if (interceptor.shouldProcess(processedResponse)) {
+        processedResponse = await interceptor.process(processedResponse);
+      }
+    }
+    return processedResponse;
+  }
+
+  /**
+   * Registers new pre-processors for HTTP requests.
+   * Adds the provided elements to the existing pre-processors and sorts all elements again.
+   *
+   * @param preProcessors - A ModelList containing HttpInterceptor instances for HttpRequest objects.
+   *                        These interceptors will be used to pre-process HTTP requests.
+   */
+  registerRequestInterceptors(preProcessors: ModelList<HttpInterceptor<HttpRequest>>): void {
+    this.preProcessors.addItems(preProcessors.getItems());
+    this.sortInterceptors(this.preProcessors);
+  }
+
+  /**
+   * Registers new post-processors for HTTP responses.
+   * Adds the provided elements to the existing postProcessors and sorts all elements again.
+   *
+   * @param postProcessors - An array containing HttpInterceptor instances for Response objects.
+   *                         These interceptors will be used to post-process HTTP responses.
+   */
+  registerResponseInterceptors(postProcessors: ModelList<HttpInterceptor<Response>>): void {
+    this.postProcessors.addItems(postProcessors.getItems());
+    this.sortInterceptors(this.postProcessors);
+  }
+
+  private sortInterceptors<T extends HttpRequest | Response>(interceptors: ModelList<HttpInterceptor<T>>) {
+    interceptors.sort((a, b) => b.priority - a.priority);
+  }
+}

--- a/packages/api/src/services/interceptor/test/interceptor.service.spec.ts
+++ b/packages/api/src/services/interceptor/test/interceptor.service.spec.ts
@@ -1,0 +1,128 @@
+import {InterceptorService} from '../interceptor.service';
+import {HttpInterceptor} from '../../../models/interceptor/http-interceptor';
+import {HttpRequest} from '../../../models/http/http-request';
+import {ModelList} from '../../../models/common';
+
+class PriorityPreInterceptor extends HttpInterceptor<HttpRequest> {
+  priority = 1;
+
+  shouldProcess(): boolean {
+    return true;
+  }
+
+  process(request: HttpRequest): Promise<HttpRequest> {
+    request.url += 'priorityPre';
+    return Promise.resolve(request);
+  }
+}
+
+class NoPriorityPreInterceptor extends HttpInterceptor<HttpRequest> {
+  shouldProcess(): boolean {
+    return true;
+  }
+
+  process(request: HttpRequest): Promise<HttpRequest> {
+    request.url += 'noPriority';
+    return Promise.resolve(request);
+  }
+}
+
+class NoPriorityPostInterceptor extends HttpInterceptor<Response> {
+  process(response: Response): Promise<Response> {
+    return Promise.resolve({...response, url: 'modifiedInPostProcess'});
+  }
+
+  shouldProcess(): boolean {
+    return true;
+  }
+}
+
+describe('Interceptor Service', () => {
+  let interceptorService: InterceptorService;
+  let priorityRequestInterceptor: PriorityPreInterceptor;
+  let noPriorityPreInterceptor: NoPriorityPreInterceptor;
+
+  beforeEach(() => {
+    interceptorService = new InterceptorService();
+    priorityRequestInterceptor = new PriorityPreInterceptor();
+    noPriorityPreInterceptor = new NoPriorityPreInterceptor();
+    interceptorService.registerRequestInterceptors(new ModelList([
+      priorityRequestInterceptor,
+      noPriorityPreInterceptor
+    ]));
+    interceptorService.registerResponseInterceptors(new ModelList([
+      new NoPriorityPostInterceptor()
+    ]));
+  });
+
+  test('should post-process interceptors, which shouldPostProcess the response', async () => {
+    //Given I post-process a response
+    const response = await interceptorService.postProcess({url: '/original'} as Response);
+    // Then, I expect the response to have been modified only by NoPriorityHttpInterceptor, because it shouldPostProcess
+    expect(response.url).toEqual('modifiedInPostProcess');
+  });
+
+  test('should prioritise interceptors', async () => {
+    // Given, I pre-process a request with two interceptors, which have different priority
+    const result = await interceptorService.preProcess(new HttpRequest(
+      {
+        url: '/original',
+        method: 'GET',
+        headers: {},
+        body: null
+      }));
+    // Then, I expect the interceptor with higher priority to be executed first
+    // Because both interceptors shouldPreProcess the request and the PriorityHttpInterceptor has higher priority
+    expect(result.url).toEqual('/originalpriorityPrenoPriority');
+  });
+
+  test('should stop interceptors, when promise is rejected', async () => {
+    // Given, I have a pre-process interceptor that rejects
+    jest.spyOn(priorityRequestInterceptor, 'process').mockRejectedValue('rejected error');
+    const secondInterceptorProcess = jest.spyOn(noPriorityPreInterceptor, 'process');
+
+    // When, I try to process a request
+    try {
+      await interceptorService.preProcess(new HttpRequest(
+        {
+          url: '/original',
+          method: 'GET',
+          headers: {},
+          body: null
+        }));
+      fail('Expected an error to be thrown');
+    } catch (error) {
+      // Then, I expect the error to be thrown by the interceptor
+      expect(error).toBe('rejected error');
+      // And the second interceptor should not have been executed
+      expect(secondInterceptorProcess).not.toHaveBeenCalled();
+    }
+  });
+
+  test('should stop interceptors, when error is thrown', async () => {
+    // Given, I have a pre-process interceptor that throws an error
+    jest.spyOn(priorityRequestInterceptor, 'process').mockImplementation(() => {
+      throw new Error('error during processing');
+    });
+    const secondInterceptorProcess = jest.spyOn(noPriorityPreInterceptor, 'process');
+
+    // When, I try to process a request
+    try {
+      await interceptorService.preProcess(new HttpRequest(
+        {
+          url: '/original',
+          method: 'GET',
+          headers: {},
+          body: null
+        }));
+      // We shouldn't get to here, as we expect an error to be thrown
+      fail('Expected an error to be thrown');
+      // @ts-expect-error error should be thrown from process
+    } catch (error: Error) {
+      // Then, I expect the error to be thrown by the interceptor
+      expect(error.message).toEqual('error during processing');
+      // And the second interceptor should not have been executed
+      expect(secondInterceptorProcess).not.toHaveBeenCalled();
+    }
+  });
+});


### PR DESCRIPTION
## What
Define a structure for HTTP interceptors

## Why
To have the ability to pre- and post-process HTTP requests

## How
Created an abstract class, which holds the contract methods of an HTTP interceptor. An interceptor can pre- and post-process a request. To do that, it needs to implement the `preProcess` and/or `postProcess` methods. For those methods to be considered, the interceptor must implement `shouldPreProcess` and `shouldPostProcess`, which will determine, what must be intercepted

Added `interceptor.service`, which chains all `preProcess` and `postProcess`

Interceptors have a priority (number). If an interceptor needs to be executed in a specific order, this can be done, by modifying that property. Interceptors with higher priority are executed first

Modified `http-service` to call the `preProcess` chain, before making the request, and `postProcess`, after receiving the response.

Created `auth-http-interceptor`, which adds security headers to each request. This hasn't been attached, however, since some security features are missing

## Testing
jest

## Screenshots
none, as the functionality is not active yet

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
