### PR TITLE
GDB-11944: Support Different File Types for Downloading Running GraphQL Queries

### DIFF
--- a/src/js/angular/models/monitoring/query-and-update/monitoring-track-record-state.js
+++ b/src/js/angular/models/monitoring/query-and-update/monitoring-track-record-state.js
@@ -1,0 +1,38 @@
+export const MonitoringTrackRecordState = {
+    /**
+     * Initial state before a permit has been acquired.
+     */
+    'PENDING': 'PENDING',
+
+    /**
+     * state between IN_NEXT and IN_HAS_NEXT
+     */
+    'ACTIVE': 'ACTIVE',
+
+    // =====================
+    // = Iterators' states =
+    // =====================
+    'IN_NEXT': 'IN_NEXT',
+    'IN_HAS_NEXT': 'IN_HAS_NEXT',
+
+    // ======================================
+    // = SE/Free/Worker transaction states =
+    // ======================================
+    'COMMIT_PENDING': 'COMMIT_PENDING',
+    'IN_COMMIT': 'IN_COMMIT',
+    'IN_COMMIT_PLUGIN': 'IN_COMMIT_PLUGIN',
+    'PARALLEL_BEGIN': 'PARALLEL_BEGIN',
+    'IN_PARALLEL_IMPORT': 'IN_PARALLEL_IMPORT',
+    'IN_PARALLEL_COMMIT': 'IN_PARALLEL_COMMIT',
+
+    // =================
+    // = Master states =
+    // =================
+    'ENQUEUED': 'ENQUEUED',
+    'IN_TESTING': 'IN_TESTING',
+
+    /**
+     * final state
+     */
+    'CLOSED': 'CLOSED'
+}

--- a/src/js/angular/models/monitoring/query-and-update/monitoring-track-record-type.js
+++ b/src/js/angular/models/monitoring/query-and-update/monitoring-track-record-type.js
@@ -1,0 +1,18 @@
+export const MonitoringTrackRecordType = {
+    /**
+     * Evaluating a SPARQL query (e.g., SELECT statements, or checking if statements exist)
+     */
+    'QUERY': 'QUERY',
+
+    /**
+     * Executing a SPARQL update (e.g., adding or removing statements)
+     */
+    'UPDATE': 'UPDATE',
+
+    /**
+     * Executing a SPARQL query in a GraphQL context
+     */
+    'GRAPHQL': 'GRAPHQL',
+
+    'ANY': 'ANY'
+};

--- a/src/js/angular/models/monitoring/query-and-update/monitoring-track-record.js
+++ b/src/js/angular/models/monitoring/query-and-update/monitoring-track-record.js
@@ -1,0 +1,48 @@
+export class MonitoringTrackRecord {
+    constructor(rawData = {}) {
+        /**
+         * @type {string}
+         */
+        this.trackId = rawData.trackId;
+        /**
+         * @type {string}
+         */
+        this.trackAlias = rawData.trackAlias;
+        /**
+         * @type {string}
+         */
+        this.username = rawData.username;
+        /**
+         * @type {string}
+         */
+        this.node = rawData.node;
+        /**
+         * @type {boolean}
+         */
+        this.isRequestedToStop  = rawData.isRequestedToStop;
+        /**
+         * @type {string}
+         */
+        this.sparqlString = rawData.sparqlString;
+        /**
+         * @type {string} - the value have to be one of the {@link MonitoringTrackRecordState} options.
+         */
+        this.state = rawData.state; // create model
+        /**
+         * @type {string} - the value have to be one of the {@link MonitoringTrackRecordType} options.
+         */
+        this.type = rawData.type; // create model
+        /**
+         * @type {number}
+         */
+        this.numberOfOperations = rawData.numberOfOperations || 0;
+        /**
+         * @type {number}
+         */
+        this.msSinceCreated = rawData.msSinceCreated || 0;
+        /**
+         * @type {string}
+         */
+        this.humanLifetime = rawData.humanLifetime;
+    }
+}

--- a/src/js/angular/queries/controllers.js
+++ b/src/js/angular/queries/controllers.js
@@ -1,5 +1,7 @@
 import 'angular/core/services';
 import 'angular/rest/monitoring.rest.service';
+import {MonitoringTrackRecord} from "../models/monitoring/query-and-update/monitoring-track-record";
+import {MonitoringTrackRecordType} from "../models/monitoring/query-and-update/monitoring-track-record-type";
 
 const queriesCtrl = angular.module('graphdb.framework.jmx.queries.controllers', [
     'ui.bootstrap',
@@ -76,7 +78,7 @@ queriesCtrl.controller('QueriesCtrl', ['$scope', '$uibModal', 'toastr', '$interv
                 $scope.queries = {};
                 for (let i = 0; i < newQueries.length; i++) {
                     newQueries[i].parsedNode = $scope.parseNode(newQueries[i].node);
-                    $scope.queries[newQueries[i].trackId] = newQueries[i];
+                    $scope.queries[newQueries[i].trackId] = new MonitoringTrackRecord(newQueries[i]);
                 }
 
                 $scope.noActiveRepository = false;
@@ -125,10 +127,15 @@ queriesCtrl.controller('QueriesCtrl', ['$scope', '$uibModal', 'toastr', '$interv
             });
         };
 
-        $scope.downloadQuery = function (queryId) {
-            const filename = 'query_' + queryId + '.rq';
+        /**
+         * Downloads the executed query.
+         * @param record {MonitoringTrackRecord} The monitoring track record whose query will be downloaded.
+         */
+        $scope.downloadQuery = function (record) {
+            const trackId = record.trackId;
+            const filename = 'query_' + trackId + (record.type === MonitoringTrackRecordType.GRAPHQL ? '.json' : '.rq');
             let link = 'rest/monitor/repository/' + $repositories.getActiveRepository()
-                + '/query/download?query=' + encodeURIComponent(queryId)
+                + '/query/download?query=' + encodeURIComponent(trackId)
                 + '&filename=' + encodeURIComponent(filename);
             if ($jwtAuth.isAuthenticated()) {
                 link = link + '&authToken=' + encodeURIComponent(AuthTokenService.getAuthToken());

--- a/src/pages/monitor/queries.html
+++ b/src/pages/monitor/queries.html
@@ -59,7 +59,7 @@
                                 <td>{{query.username}}</td>
 								<td>{{query.type}}</td>
 								<td>
-									<button class="pull-left btn btn-primary btn-sm" ng-click="downloadQuery(query.trackId)">{{'download.btn' | translate}}</button>
+									<button class="pull-left btn btn-primary btn-sm" ng-click="downloadQuery(query)">{{'download.btn' | translate}}</button>
 									<div ng-if="query.sparqlString.length > stringLimit" class="pull-right">
 										<button class="btn btn-link small px-0" ng-click="toggleQueryExpanded(query.trackId)">
 											<span ng-show="!expanded[query.trackId]">{{'show.remaining' | translate}} {{query.sparqlString.length - stringLimit}} {{'characters.label' | translate}}</span>


### PR DESCRIPTION
## What
Enhanced the GraphDB Workbench to support appropriate file extensions when downloading running queries from the Queries Monitoring tab.

## Why
With the introduction of GraphQL functionality, the list of possible query types has expanded to include "GRAPHQL". When the download button is clicked for such queries, the downloaded file should have a .json extension. Currently, all files are downloaded with a .rq extension, which is incorrect for GraphQL queries.

## How
Updated the logic to dynamically determine the file extension based on the type of the executed query.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
