### PR TITLE
Gdb 11320 fix flaky tests in dropdown and cookie

### DIFF
--- a/packages/shared-components/src/components/dialogs/onto-cookie-policy-dialog/onto-cookie-policy-dialog.tsx
+++ b/packages/shared-components/src/components/dialogs/onto-cookie-policy-dialog/onto-cookie-policy-dialog.tsx
@@ -25,7 +25,8 @@ export class OntoCookiePolicyDialog implements OntoDialog {
   @Listen('toggleChanged')
   toggleChanged(event: CustomEvent<ToggleEventPayload>) {
     this.setUserCookieConsent(this.updateCookieConsent(event.detail));
-    this.securityService.updateUserData(this.user);
+    this.securityService.updateUserData(this.user)
+      .catch(console.error);
   }
 
   render() {

--- a/packages/shared-components/src/components/onto-dropdown/onto-dropdown.tsx
+++ b/packages/shared-components/src/components/onto-dropdown/onto-dropdown.tsx
@@ -143,7 +143,7 @@ export class OntoDropdown {
     return async (event: MouseEvent) => {
       const target = event.currentTarget as HTMLElement;
       if (typeof this.dropdownButtonTooltip === 'function') {
-        const tooltipContent = await this.dropdownButtonTooltip();
+        const tooltipContent = await this.getTooltipContent(this.dropdownButtonTooltip);
         target.setAttribute('tooltip-content', tooltipContent);
       } else {
         target.setAttribute(
@@ -158,7 +158,7 @@ export class OntoDropdown {
     return async (event: MouseEvent) => {
       const target = event.currentTarget as HTMLElement;
       if (typeof item.tooltip === 'function') {
-        const tooltipContent = await item.tooltip();
+        let tooltipContent =  await this.getTooltipContent(item.tooltip);
         target.setAttribute('tooltip-content', tooltipContent);
       } else {
         target.setAttribute(
@@ -192,5 +192,15 @@ export class OntoDropdown {
 
   private closeMenu(): void {
     this.open = false;
+  }
+
+  private async getTooltipContent(tooltipFunction: () => Promise<string>): Promise<string> {
+    let tooltipContent = '';
+    try {
+      tooltipContent = await tooltipFunction();
+    } catch (error) {
+      console.error(error);
+    }
+    return tooltipContent;
   }
 }


### PR DESCRIPTION
## What
Fix flaky tests in dropdown and cookie-consent components

## Why
They are flaky

## How
Added catch clauses to promises in those components. When the tests fail, the error which is reported from cypress, points to a non-handled rejected promise. Catch clauses are added to the promises in those components, which should stop the flakiness

## Testing
cypress

## Screenshots
none

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
