### PR TITLE
GDB-11314 Add autocomplete and filter to RDF search

### DIFF
--- a/packages/api/src/models/rdf-search/api/autocomplete-search-result-response.ts
+++ b/packages/api/src/models/rdf-search/api/autocomplete-search-result-response.ts
@@ -1,0 +1,9 @@
+import {SuggestionResponse} from './suggestion-response';
+import {SuggestionList} from '../suggestion-list';
+
+export interface AutocompleteSearchResultResponse {
+  suggestions: SuggestionResponse[];
+
+  // internal
+  suggestionList: SuggestionList;
+}

--- a/packages/api/src/models/rdf-search/api/suggestion-response.ts
+++ b/packages/api/src/models/rdf-search/api/suggestion-response.ts
@@ -1,0 +1,16 @@
+import {SuggestionType} from '../suggestion-type';
+
+export interface SuggestionResponse {
+  /** The type of the suggestion. */
+  type: SuggestionType;
+
+  /** The value of the suggestion. */
+  value: string;
+
+  /** A description of the suggestion. */
+  description: string;
+
+  // internal
+  /** Unique identifier for the suggestion. */
+  id: number;
+}

--- a/packages/api/src/models/rdf-search/autocomplete-search-result.ts
+++ b/packages/api/src/models/rdf-search/autocomplete-search-result.ts
@@ -1,0 +1,51 @@
+import {Model} from '../common';
+import {SuggestionList} from './suggestion-list';
+import {AutocompleteSearchResultResponse} from './api/autocomplete-search-result-response';
+import {Suggestion} from './suggestion';
+
+/**
+ * Represents an RDF search result containing suggestions.
+ */
+export class AutocompleteSearchResult extends Model<AutocompleteSearchResult> {
+  /** The list of suggestions associated with this search result. */
+  private _suggestions!: SuggestionList;
+
+  constructor(searchResult: AutocompleteSearchResultResponse) {
+    super();
+    this.setSuggestions(searchResult.suggestionList);
+  }
+
+  getSuggestions(): SuggestionList {
+    return this._suggestions;
+  }
+
+  setSuggestions(suggestions: SuggestionList) {
+    this._suggestions = suggestions;
+  }
+
+  /**
+   * Sets the hovered state of the first suggestion to true, if present.
+   */
+  hoverFirstSuggestion() {
+    this.hoverSuggestion(this.getSuggestions().getItems()[0]);
+  }
+
+  /**
+   * Sets the hovered state of the specified suggestion to true.
+   * @param suggestion - The suggestion to be highlighted.
+   */
+  hoverSuggestion(suggestion: Suggestion) {
+    if (!suggestion || suggestion.isHovered()) {
+      return;
+    }
+    this.clearHoveredState();
+    suggestion.setHovered(true);
+  }
+
+  /**
+   * Sets the hovered state of all suggestions to false.
+   */
+  clearHoveredState() {
+    this.getSuggestions().getItems().forEach((suggestion) => suggestion.setHovered(false));
+  }
+}

--- a/packages/api/src/models/rdf-search/index.ts
+++ b/packages/api/src/models/rdf-search/index.ts
@@ -2,3 +2,7 @@ export {SearchButtonConfig} from './search-button-config';
 export {SearchButtonList} from './search-button-list';
 export {SearchButton} from './search-button';
 export {SearchViewType} from './search-view-type';
+export {AutocompleteSearchResult} from './autocomplete-search-result';
+export {SuggestionList} from './suggestion-list';
+export {Suggestion} from './suggestion';
+export {SuggestionType} from './suggestion-type';

--- a/packages/api/src/models/rdf-search/suggestion-list.ts
+++ b/packages/api/src/models/rdf-search/suggestion-list.ts
@@ -1,0 +1,11 @@
+import {Suggestion} from './suggestion';
+import {ModelList} from '../common';
+
+/**
+ * Represents a list of suggestions, returned from an RDF search query.
+ */
+export class SuggestionList extends ModelList<Suggestion> {
+  constructor(suggestions?: Suggestion[]) {
+    super(suggestions);
+  }
+}

--- a/packages/api/src/models/rdf-search/suggestion-type.ts
+++ b/packages/api/src/models/rdf-search/suggestion-type.ts
@@ -1,0 +1,4 @@
+export enum SuggestionType {
+  URI = 'uri',
+  PREFIX = 'prefix',
+}

--- a/packages/api/src/models/rdf-search/suggestion.ts
+++ b/packages/api/src/models/rdf-search/suggestion.ts
@@ -1,0 +1,71 @@
+import {Model} from '../common';
+import {SuggestionType} from './suggestion-type';
+import {SuggestionResponse} from './api/suggestion-response';
+
+/**
+ * Represents a suggestion in the RDF search functionality.
+ */
+export class Suggestion extends Model<Suggestion> {
+  /** Unique identifier for the suggestion. */
+  private _id!: number;
+
+  /** The type of the suggestion. */
+  private _type!: SuggestionType;
+
+  /** The value of the suggestion. */
+  private _value!: string;
+
+  /** A description of the suggestion. */
+  private _description!: string;
+
+  /** Whether the suggestion is hovered. The hovered suggestion is the subject of action on key press */
+  private _hovered?: boolean;
+
+  constructor(data: SuggestionResponse) {
+    super();
+    this.setId(data.id);
+    this.setType(data.type);
+    this.setValue(data.value);
+    this.setDescription(data.description);
+  }
+
+  getId(): number {
+    return this._id;
+  }
+
+  setId(id: number): void {
+    this._id = id;
+  }
+
+  getType(): SuggestionType {
+    return this._type;
+  }
+
+  setType(type: SuggestionType): void {
+    this._type = type;
+  }
+
+  getValue(): string {
+    return this._value;
+  }
+
+  setValue(value: string): void {
+    this._value = value;
+  }
+
+  getDescription(): string {
+    return this._description;
+  }
+
+  setDescription(description: string): void {
+    this._description = description;
+  }
+
+  isHovered(): boolean | undefined {
+    return this._hovered;
+  }
+
+  setHovered(hovered: boolean): void {
+    this._hovered = hovered;
+  }
+}

--- a/packages/api/src/models/toastr/toast-config.ts
+++ b/packages/api/src/models/toastr/toast-config.ts
@@ -6,9 +6,21 @@ export class ToastConfig {
   /**
    * The duration in milliseconds for which the toast notification will be displayed.
    */
-  timeout: number;
+  timeout?: number;
+
+  /**
+   * A function to be called when the toast notification is clicked.
+   */
+  onClick?: (event: Event) => void;
+
+  /**
+   * Remove the toast notification when it is clicked.
+   */
+  removeOnClick?: boolean;
 
   constructor(data?: Partial<ToastConfig>) {
     this.timeout = data?.timeout || 5000;
+    this.onClick = data?.onClick;
+    this.removeOnClick = data?.removeOnClick || false;
   }
 }

--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -33,6 +33,7 @@ export * from './services/event-service';
 export * from './services/cookie';
 export * from './services/monitoring';
 export * from './services/toastr';
+export * from './services/autocomplete';
 
 // Export utils for external usages.
 export * from './services/utils';

--- a/packages/api/src/services/autocomplete/autocomplete-context.service.ts
+++ b/packages/api/src/services/autocomplete/autocomplete-context.service.ts
@@ -1,0 +1,43 @@
+import {ContextService} from '../context';
+import {DeriveContextServiceContract} from '../../models/context/update-context-method';
+import {ValueChangeCallback} from '../../models/context/value-change-callback';
+import {ServiceProvider} from '../../providers';
+import {AutocompleteStorageService} from './autocomplete-storage.service';
+
+type AutocompleteContextFields = {
+  readonly AUTOCOMPLETE_ENABLED: string;
+}
+
+type AutocompleteContextFieldParams = {
+  readonly AUTOCOMPLETE_ENABLED: boolean;
+};
+
+/**
+ * Service for managing autocomplete context state across the application.
+ */
+export class AutocompleteContextService extends ContextService<AutocompleteContextFields> implements DeriveContextServiceContract<AutocompleteContextFields, AutocompleteContextFieldParams> {
+  /**
+   * Context property key for the autocomplete enabled state.
+   */
+  readonly AUTOCOMPLETE_ENABLED = 'isAutocompleteEnabled';
+
+  /**
+   * Updates the autocomplete enabled state in the context and in the local store
+   *
+   * @param enabled - Boolean value indicating whether autocomplete is enabled
+   */
+  updateAutocompleteEnabled(enabled: boolean): void {
+    this.updateContextProperty(this.AUTOCOMPLETE_ENABLED, enabled);
+    ServiceProvider.get(AutocompleteStorageService).setEnabled(enabled);
+  }
+
+  /**
+   * Subscribes to changes in the autocomplete enabled state.
+   *
+   * @param callbackFn - Callback function that will be invoked when the autocomplete enabled state changes
+   * @returns A function that can be called to unsubscribe from the changes
+   */
+  onAutocompleteEnabledChanged(callbackFn: ValueChangeCallback<boolean | undefined>): () => void {
+    return this.subscribe(this.AUTOCOMPLETE_ENABLED, callbackFn);
+  }
+}

--- a/packages/api/src/services/autocomplete/autocomplete-rest.service.ts
+++ b/packages/api/src/services/autocomplete/autocomplete-rest.service.ts
@@ -1,0 +1,46 @@
+import {AutocompleteSearchResult} from '../../models/rdf-search/autocomplete-search-result';
+import {HttpService} from '../http/http.service';
+import {ServiceProvider} from '../../providers';
+import {RepositoryStorageService} from '../repository';
+import {AuthenticationStorageService} from '../security';
+
+/**
+ * Service for handling autocomplete REST operations.
+ */
+export class AutocompleteRestService extends HttpService {
+  private readonly autocompleteRestPrefix = '/rest/autocomplete';
+
+  /**
+   * Performs an autocomplete search based on the provided search term.
+   *
+   * @param searchTerm - The string to use for autocomplete search.
+   * @returns A Promise that resolves to an AutocompleteSearchResult object containing search suggestions.
+   */
+  search(searchTerm: string): Promise<AutocompleteSearchResult> {
+    return this.get(`${this.autocompleteRestPrefix}/query?q=${searchTerm}`, {}, this.createHeaders());
+  }
+
+  /**
+   * Checks if the autocomplete feature is enabled.
+   *
+   * @returns A Promise that resolves to a boolean indicating whether autocomplete is enabled.
+   */
+  enabled(): Promise<boolean> {
+    return this.get(`${this.autocompleteRestPrefix}/enabled`, {}, this.createHeaders());
+  }
+
+  // TODO: remove this, when the auth http interceptor is implemented,
+  private createHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {};
+    const token = ServiceProvider.get(AuthenticationStorageService).getAuthToken().getValue();
+    if (token) {
+      headers['Authorization'] = token;
+    }
+
+    const repositoryId = ServiceProvider.get(RepositoryStorageService).get('selectedRepositoryId').getValue();
+    if (repositoryId) {
+      headers['X-Graphdb-Repository'] = repositoryId;
+    }
+    return headers;
+  }
+}

--- a/packages/api/src/services/autocomplete/autocomplete-storage.service.ts
+++ b/packages/api/src/services/autocomplete/autocomplete-storage.service.ts
@@ -1,0 +1,29 @@
+import {LocalStorageService} from '../storage';
+
+/**
+ * Service for managing autocomplete-related storage operations.
+ */
+export class AutocompleteStorageService extends LocalStorageService {
+  private readonly autocompleteEnabledKey = 'enabled';
+  readonly NAMESPACE = 'autocomplete';
+
+  set(key: string, value: string): void {
+    this.storeValue(key, value);
+  }
+
+  /**
+   * Checks if autocomplete is enabled.
+   * @returns {boolean} True if autocomplete is enabled, false otherwise.
+   */
+  isEnabled(): boolean {
+    return this.get(this.autocompleteEnabledKey).value === 'true';
+  }
+
+  /**
+   * Sets the value of 'autocomplete.enabled' in the local store.
+   * @param value - The value to set for 'autocomplete.enabled'.
+   */
+  setEnabled(value: boolean): void {
+    this.set(this.autocompleteEnabledKey, value.toString());
+  }
+}

--- a/packages/api/src/services/autocomplete/autocomplete.service.ts
+++ b/packages/api/src/services/autocomplete/autocomplete.service.ts
@@ -1,0 +1,35 @@
+import {Service} from '../../providers/service/service';
+import {AutocompleteSearchResult} from '../../models/rdf-search/autocomplete-search-result';
+import {MapperProvider, ServiceProvider} from '../../providers';
+import {AutocompleteRestService} from './autocomplete-rest.service';
+import {AutocompleteSearchResultMapper} from './mapper/autocomplete-search-result.mapper';
+
+/**
+ * Service responsible for handling autocomplete functionality in the RDF search.
+ */
+export class AutocompleteService implements Service {
+  /**
+   * Performs an autocomplete search based on the provided search term.
+   * This method fetches autocomplete suggestions from the REST service and maps
+   * the results to the AutocompleteSearchResult.
+   *
+   * @param searchTerm - The string to use as the basis for autocomplete suggestions
+   * @returns A promise that resolves to an AutocompleteSearchResult containing the matching suggestions
+   */
+  search(searchTerm: string): Promise<AutocompleteSearchResult> {
+    return ServiceProvider.get(AutocompleteRestService).search(searchTerm)
+      .then((searchResult: AutocompleteSearchResult) => MapperProvider.get(AutocompleteSearchResultMapper).mapToModel(searchResult));
+  }
+
+  /**
+   * Checks if the autocomplete functionality is enabled.
+   *
+   * This method queries the AutocompleteRestService to determine
+   * whether the autocomplete feature is currently enabled.
+   *
+   * @returns A promise that resolves to a boolean value.
+   */
+  isAutocompleteEnabled(): Promise<boolean> {
+    return ServiceProvider.get(AutocompleteRestService).enabled();
+  }
+}

--- a/packages/api/src/services/autocomplete/index.ts
+++ b/packages/api/src/services/autocomplete/index.ts
@@ -1,0 +1,4 @@
+export {AutocompleteService} from './autocomplete.service';
+export {SuggestionListMapper} from '../rdf-search/mapper/suggestion-list.mapper';
+export {AutocompleteContextService} from './autocomplete-context.service';
+export {AutocompleteStorageService} from './autocomplete-storage.service';

--- a/packages/api/src/services/autocomplete/mapper/autocomplete-search-result.mapper.ts
+++ b/packages/api/src/services/autocomplete/mapper/autocomplete-search-result.mapper.ts
@@ -1,0 +1,24 @@
+import {AutocompleteSearchResult} from '../../../models/rdf-search/autocomplete-search-result';
+import {Mapper} from '../../../providers/mapper/mapper';
+import {MapperProvider} from '../../../providers';
+import {SuggestionListMapper} from '../../rdf-search/mapper/suggestion-list.mapper';
+import {AutocompleteSearchResultResponse} from '../../../models/rdf-search/api/autocomplete-search-result-response';
+
+/**
+ * Mapper class for AutocompleteSearchResult objects.
+ */
+export class AutocompleteSearchResultMapper extends Mapper<AutocompleteSearchResult> {
+  /**
+   * Maps the input AutocompleteSearchResultResponse data to a new AutocompleteSearchResult model.
+   *
+   * @param data - The input AutocompleteSearchResultResponse data to be mapped.
+   * @returns A new AutocompleteSearchResult instance with mapped suggestions.
+   */
+  mapToModel(data: AutocompleteSearchResultResponse): AutocompleteSearchResult {
+    return new AutocompleteSearchResult(
+      {
+        ...data,
+        suggestionList: MapperProvider.get(SuggestionListMapper).mapToModel(data.suggestions)
+      });
+  }
+}

--- a/packages/api/src/services/autocomplete/mapper/test/autocomplete-search-result.mapper.spec.ts
+++ b/packages/api/src/services/autocomplete/mapper/test/autocomplete-search-result.mapper.spec.ts
@@ -1,0 +1,31 @@
+import {AutocompleteSearchResultMapper} from '../autocomplete-search-result.mapper';
+import {Suggestion, SuggestionList, SuggestionType} from '../../../../models/rdf-search';
+import {AutocompleteSearchResultResponse} from '../../../../models/rdf-search/api/autocomplete-search-result-response';
+
+describe('Autocomplete search result mapper', () => {
+  let mapper: AutocompleteSearchResultMapper;
+
+  beforeEach(() => {
+    mapper = new AutocompleteSearchResultMapper();
+  });
+
+  test('should correctly map an autocomplete search result', () => {
+    // Given, I have an autocomplete search result.
+    const searchResultJson = {
+      suggestions: [
+        {
+          value: 'suggestion1',
+          description: 'description1',
+          type: SuggestionType.URI,
+          id: -241098730,
+        }
+      ]
+    };
+
+    // When, I map the autocomplete search result to a model.
+    const result = mapper.mapToModel(searchResultJson as AutocompleteSearchResultResponse);
+
+    // Then, I should get a model containing the same data.
+    expect(result.getSuggestions()).toEqual(new SuggestionList(searchResultJson.suggestions.map(suggestion => new Suggestion(suggestion))));
+  });
+});

--- a/packages/api/src/services/autocomplete/test/autocomplete-context.service.spec.ts
+++ b/packages/api/src/services/autocomplete/test/autocomplete-context.service.spec.ts
@@ -1,0 +1,38 @@
+import {AutocompleteContextService} from '../autocomplete-context.service';
+
+describe('Autocomplete context service', () => {
+  let autocompleteService: AutocompleteContextService;
+
+  beforeEach(() => {
+    autocompleteService = new AutocompleteContextService();
+  });
+
+  test('should update autocomplete enabled state and notify subscribers', () => {
+    // Given a new autocomplete enabled state
+    const enabled = true;
+    const mockCallback = jest.fn();
+    autocompleteService.onAutocompleteEnabledChanged(mockCallback);
+
+    // When updating the autocomplete enabled state
+    autocompleteService.updateAutocompleteEnabled(enabled);
+
+    // Then the context should be updated and subscribers notified
+    expect(mockCallback).toHaveBeenCalledWith(enabled);
+  });
+
+  test('should stop receiving updates, after unsubscribe', () => {
+    // Given a new autocomplete enabled state
+    const enabled = true;
+    const mockCallback = jest.fn();
+    const unsubscribe = autocompleteService.onAutocompleteEnabledChanged(mockCallback);
+    // Clear the callback call when the callback function is registered.
+    mockCallback.mockClear();
+
+    // When unsubscribed
+    unsubscribe();
+
+    // Then the context should not receive updates
+    autocompleteService.updateAutocompleteEnabled(enabled);
+    expect(mockCallback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/autocomplete/test/autocomplete-storage.service.spec.ts
+++ b/packages/api/src/services/autocomplete/test/autocomplete-storage.service.spec.ts
@@ -1,0 +1,18 @@
+import {AutocompleteStorageService} from '../autocomplete-storage.service';
+
+describe('Autocomplete storage service', () => {
+  let service: AutocompleteStorageService;
+
+  beforeEach(() => {
+    service = new AutocompleteStorageService();
+  });
+
+  test('Should set and determine the enabled state', () => {
+    service.setEnabled(true);
+    expect(service.isEnabled()).toEqual(true);
+
+    service.setEnabled(false);
+    expect(service.isEnabled()).toEqual(false);
+  });
+
+});

--- a/packages/api/src/services/autocomplete/test/autocomplete.service.spec.ts
+++ b/packages/api/src/services/autocomplete/test/autocomplete.service.spec.ts
@@ -1,0 +1,42 @@
+import {AutocompleteService} from '../autocomplete.service';
+import {AutocompleteSearchResult, Suggestion, SuggestionList, SuggestionType} from '../../../models/rdf-search';
+import {TestUtil} from '../../utils/test/test-util';
+import {ResponseMock} from '../../http/test/response-mock';
+
+describe('Autocomplete service', () => {
+  let autocompleteService: AutocompleteService;
+
+  beforeEach(() => {
+    autocompleteService = new AutocompleteService();
+  });
+
+  test('should return a list of suggestions when searching', async() => {
+    // Given, I have mocked the autocomplete search result
+    const mockSearchResult = {
+      suggestions: [
+        {
+          value: 'suggestion1',
+          description: 'description1',
+          type: SuggestionType.URI,
+          id: -241098730,
+        },
+        {
+          value: 'suggestion2',
+          description: 'description2',
+          type: SuggestionType.PREFIX,
+          id: -1906117808,
+        },
+      ],
+    };
+    const searchTerm = 'test';
+    TestUtil.mockResponse(new ResponseMock(`/rest/autocomplete/query?q=${searchTerm}`).setResponse(mockSearchResult));
+
+    // When, I call the search method
+    const result = await autocompleteService.search(searchTerm);
+
+    // Then, I expect the result to be an instance of AutocompleteSearchResult
+    expect(result).toBeInstanceOf(AutocompleteSearchResult);
+    // And, it should contain the expected suggestions
+    expect(result.getSuggestions()).toEqual(new SuggestionList(mockSearchResult.suggestions.map((suggestion) => new Suggestion(suggestion))));
+  });
+});

--- a/packages/api/src/services/rdf-search/mapper/suggestion-list.mapper.ts
+++ b/packages/api/src/services/rdf-search/mapper/suggestion-list.mapper.ts
@@ -1,0 +1,23 @@
+import {SuggestionList} from '../../../models/rdf-search/suggestion-list';
+import {Mapper} from '../../../providers/mapper/mapper';
+import {Suggestion} from '../../../models/rdf-search/suggestion';
+import {GeneratorUtils} from '../../utils/generator-utils';
+import {SuggestionResponse} from '../../../models/rdf-search/api/suggestion-response';
+
+/**
+ * Mapper class for converting an array of Suggestion objects to a SuggestionList model.
+ */
+export class SuggestionListMapper extends Mapper<SuggestionList> {
+  /**
+   * Maps an array of SuggestionResponse objects to a SuggestionList model.
+   *
+   * @param data - An array of SuggestionResponse objects to be converted into a SuggestionList.
+   * @returns A new SuggestionList instance containing the provided Suggestion objects.
+   */
+  mapToModel(data: SuggestionResponse[]): SuggestionList {
+    return new SuggestionList(data.map(suggestion => new Suggestion({
+      ...suggestion,
+      id: GeneratorUtils.hashCode(`${suggestion.type}-${suggestion.value}-${suggestion.description}`)
+    })));
+  }
+}

--- a/packages/api/src/services/rdf-search/mapper/test/suggestion-list.mapper.spec.ts
+++ b/packages/api/src/services/rdf-search/mapper/test/suggestion-list.mapper.spec.ts
@@ -1,0 +1,42 @@
+import {SuggestionListMapper} from '../suggestion-list.mapper';
+import {SuggestionList} from '../../../../models/rdf-search/suggestion-list';
+import {Suggestion} from '../../../../models/rdf-search/suggestion';
+import {SuggestionType} from '../../../../models/rdf-search/suggestion-type';
+
+describe('SuggestionListMapper', () => {
+  let mapper: SuggestionListMapper;
+
+  beforeEach(() => {
+    mapper = new SuggestionListMapper();
+  });
+
+  test('should correctly map an array of Suggestion objects', () => {
+    // Given, I have an array of Suggestion objects.
+    const suggestionsJson = [
+      {
+        value: 'suggestion1',
+        description: 'description1',
+        type: SuggestionType.URI,
+        id: -241098730,
+      },
+      {
+        value: 'suggestion2',
+        description: 'description2',
+        type: SuggestionType.PREFIX,
+        id: -1906117808,
+      }
+    ];
+
+    // When, I map the array of Suggestion objects to a SuggestionList.
+    const result = mapper.mapToModel(suggestionsJson);
+
+    // Then, I should get suggestion list containing the same data.
+    expect(result).toBeInstanceOf(SuggestionList);
+
+    // And each suggestion should be an instance of Suggestion and contain the correct data.
+    result.getItems().forEach(((suggestion, index) => {
+      expect(suggestion).toBeInstanceOf(Suggestion);
+      expect(suggestion).toEqual(new Suggestion(suggestionsJson[index]));
+    }));
+  });
+});

--- a/packages/api/src/services/utils/generator-utils.ts
+++ b/packages/api/src/services/utils/generator-utils.ts
@@ -15,4 +15,19 @@ export class GeneratorUtils {
   static uuid(): string {
     return window.crypto.randomUUID();
   }
+
+  /**
+   * Returns a hash code from a string
+   * @param  {String} str The string to hash.
+   * @return {Number}    A 32bit integer
+   */
+  static hashCode(str: string): number {
+    let hash = 0;
+    for (let i = 0, len = str.length; i < len; i++) {
+      const chr = str.charCodeAt(i);
+      hash = (hash << 5) - hash + chr;
+      hash |= 0; // Convert to 32bit integer
+    }
+    return hash;
+  }
 }

--- a/packages/api/src/services/utils/test/generator-utils.spec.ts
+++ b/packages/api/src/services/utils/test/generator-utils.spec.ts
@@ -1,0 +1,15 @@
+import {GeneratorUtils} from '../generator-utils';
+
+describe('Generator Utils', () => {
+  test('should generate same hash code for equal strings', () => {
+    const str = 'hello world';
+    const concatenatedStr = 'hello ' + 'world';
+    expect(GeneratorUtils.hashCode(str)).toEqual(GeneratorUtils.hashCode(concatenatedStr));
+  });
+
+  test('should generate different hash codes for different strings', () => {
+    const str1 = 'hello world';
+    const str2 = 'hello universe';
+    expect(GeneratorUtils.hashCode(str1)).not.toEqual(GeneratorUtils.hashCode(str2));
+  });
+});

--- a/packages/legacy-workbench/src/js/angular/autocomplete/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/autocomplete/controllers.js
@@ -1,6 +1,7 @@
 import 'angular/rest/autocomplete.rest.service';
 import {mapNamespacesResponse} from "../rest/mappers/namespaces-mapper";
 import {decodeHTML} from "../../../app";
+import {AutocompleteContextService, ServiceProvider} from "@ontotext/workbench-api";
 
 const modules = [
     'toastr',
@@ -204,6 +205,7 @@ function AutocompleteCtrl(
             .success(function () {
                 refreshEnabledStatus();
                 refreshIndexStatus();
+                ServiceProvider.get(AutocompleteContextService).updateAutocompleteEnabled(newValue);
             }).error(function (data) {
             toastr.error(getError(data));
         }).finally(function () {

--- a/packages/legacy-workbench/src/js/angular/core/services/autocomplete.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/autocomplete.service.js
@@ -1,4 +1,5 @@
 import 'angular/rest/autocomplete.rest.service';
+import {AutocompleteContextService, ServiceProvider} from "@ontotext/workbench-api";
 
 angular
     .module('graphdb.framework.core.services.autocomplete', ['graphdb.framework.rest.autocomplete.service'])
@@ -17,6 +18,7 @@ function AutocompleteService(AutocompleteRestService, LSKeys, LocalStorageAdapte
         return AutocompleteRestService.checkAutocompleteStatus()
             .then((response) => {
                 LocalStorageAdapter.set(LSKeys.AUTOCOMPLETE_ENABLED, response.data);
+                ServiceProvider.get(AutocompleteContextService).updateAutocompleteEnabled(response.data);
                 return response.data;
             });
     };

--- a/packages/root-config/src/bootstrap/autocomplete/autocomplete.js
+++ b/packages/root-config/src/bootstrap/autocomplete/autocomplete.js
@@ -1,0 +1,19 @@
+import {ServiceProvider, AutocompleteService, AutocompleteContextService, RepositoryStorageService} from '@ontotext/workbench-api';
+
+/**
+ * Check if autocomplete is enabled, when loading(reloading) the application.
+ * Gets the current autocomplete status from the backend and updates the context with the value.
+ * If there is no selected repository, the request will not be made.
+ */
+const isAutocompleteEnabled = () => {
+  const currentRepository = ServiceProvider.get(RepositoryStorageService).get('selecterRepositoryId').getValue();
+  if (!currentRepository) {
+    return Promise.resolve();
+  }
+  return ServiceProvider.get(AutocompleteService).isAutocompleteEnabled()
+    .then((enabled) => {
+      ServiceProvider.get(AutocompleteContextService).updateAutocompleteEnabled(enabled);
+    });
+};
+
+export const autoCompleteBootstrap = [isAutocompleteEnabled];

--- a/packages/root-config/src/bootstrap/bootstrap.js
+++ b/packages/root-config/src/bootstrap/bootstrap.js
@@ -2,10 +2,12 @@ import {languageBootstrap} from './language/language-bootstrap';
 import {licenseBootstrap} from './license/license-bootstrap';
 import {productInfoBootstrap} from './product-info/product-info-bootstrap';
 import {repositoryBootstrap} from './repository/repository-bootstrap';
+import {autoCompleteBootstrap} from './autocomplete/autocomplete';
 
 export const bootstrapPromises = [
   ...languageBootstrap,
   ...licenseBootstrap,
   ...productInfoBootstrap,
-  ...repositoryBootstrap
+  ...repositoryBootstrap,
+  ...autoCompleteBootstrap
 ];

--- a/packages/root-config/src/styles/partials/_core.scss
+++ b/packages/root-config/src/styles/partials/_core.scss
@@ -2,3 +2,4 @@
 @forward './alert/alert';
 @forward './animations/fade-button';
 @forward './responsive/responsive';
+@forward './anchor/anchor';

--- a/packages/root-config/src/styles/partials/anchor/_anchor.scss
+++ b/packages/root-config/src/styles/partials/anchor/_anchor.scss
@@ -1,0 +1,12 @@
+a {
+  &:hover,
+  &:active,
+  &[href^="http"],
+  &[href^="http"]:hover,
+  &[href^="http"]:active {
+    text-decoration-line: underline !important;
+    text-decoration-style: solid !important;
+    text-decoration-thickness: var(--link-decoration-thickness) !important;
+    text-underline-offset: var(--link-underline-offset) !important;
+  }
+}

--- a/packages/shared-components/cypress/e2e/rdf-search/rdf-search.cy.js
+++ b/packages/shared-components/cypress/e2e/rdf-search/rdf-search.cy.js
@@ -1,0 +1,45 @@
+import {RdfSearchSteps} from "../../steps/rdf-search/rdf-search-steps";
+
+describe('RDF Search', () => {
+  it('should display RDF search', () => {
+    // Given, I visit the RDF search page
+    RdfSearchSteps.visit();
+
+    // Then, I expect the RDF search icon to be visible
+    RdfSearchSteps.getSearchIcon()
+      .should('exist')
+      .and('be.visible');
+    // And it should not be opened
+    RdfSearchSteps.getSearchArea().should('not.be.visible');
+
+    // When, I hover over the search icon
+    RdfSearchSteps.hoverSearchIcon();
+    // Then, I expect a tooltip to appear
+    RdfSearchSteps.getTooltip()
+      .should('be.visible')
+      .and('have.text', 'Search RDF resources');
+
+    // When, I click on the search icon
+    RdfSearchSteps.clickSearchIcon();
+    // Then, I expect the RDF search area to be visible
+    RdfSearchSteps.getSearchArea().should('be.visible');
+    // And the search icon should not be visible
+    RdfSearchSteps.getSearchIcon().should('not.exist');
+    // And I should see 2 radio buttons for Table and Visual display
+    const buttons = ['Table', 'Visual'];
+    // And the Table button should be selected
+    const classes = ['selected', ''];
+    RdfSearchSteps.getSearchAreaButtons().each(($button, index) => {
+      cy.wrap($button)
+        .should('have.text', buttons[index])
+        .and('have.class', classes[index]);
+    });
+
+    // When, I close the search area
+    RdfSearchSteps.closeSearchArea();
+    // Then, I expect the RDF search area to be hidden
+    RdfSearchSteps.getSearchArea().should('not.be.visible');
+    // And the search icon should be visible
+    RdfSearchSteps.getSearchIcon().should('be.visible');
+  });
+});

--- a/packages/shared-components/cypress/steps/rdf-search/rdf-search-steps.js
+++ b/packages/shared-components/cypress/steps/rdf-search/rdf-search-steps.js
@@ -1,0 +1,39 @@
+import {BaseSteps} from "../base-steps";
+
+export class RdfSearchSteps extends BaseSteps {
+  static visit() {
+    super.visit('rdf-search');
+  }
+
+  static getSearch() {
+    return cy.get('onto-rdf-search');
+  }
+
+  static getSearchIcon() {
+    return this.getSearch().find('onto-search-icon');
+  }
+
+  static clickSearchIcon() {
+    return this.getSearchIcon().click();
+  }
+
+  static hoverSearchIcon() {
+    return this.getSearchIcon().trigger('mouseover');
+  }
+
+  static getSearchArea() {
+    return this.getSearch().find('.search-area');
+  }
+
+  static closeSearchArea() {
+    return this.getSearchArea().find('.close-btn').click();
+  }
+
+  static getTooltip() {
+    return cy.get('[data-tippy-root]');
+  }
+
+  static getSearchAreaButtons() {
+    return this.getSearchArea().find('button');
+  }
+}

--- a/packages/shared-components/src/assets/i18n/en.json
+++ b/packages/shared-components/src/assets/i18n/en.json
@@ -177,7 +177,8 @@
       "clear": "Clear"
     },
     "toasts": {
-      "use_view_resource": "<b>Search RDF resources</b></br>Use <b>View resource</b> on this page"
+      "use_view_resource": "<b>Search RDF resources</b></br>Use <b>View resource</b> on this page",
+      "autocomplete_is_off": "Autocomplete is OFF<br>Go to Setup -> Autocomplete"
     }
   }
 }

--- a/packages/shared-components/src/assets/i18n/fr.json
+++ b/packages/shared-components/src/assets/i18n/fr.json
@@ -180,7 +180,8 @@
       "clear": "Clair"
     },
     "toasts": {
-      "use_view_resource": "<b>Rechercher des ressources RDF</b></br>Utilisez <b>Voir la ressource</b> sur cette page"
+      "use_view_resource": "<b>Rechercher des ressources RDF</b></br>Utilisez <b>Voir la ressource</b> sur cette page",
+      "autocomplete_is_off": "L'autocomplétion est désactivée<br>Aller à Configuration -> Autocomplétion"
     }
   }
 }

--- a/packages/shared-components/src/components/onto-search-resource-input/onto-search-resource-input.scss
+++ b/packages/shared-components/src/components/onto-search-resource-input/onto-search-resource-input.scss
@@ -79,4 +79,28 @@
     font-size: 0.8rem;
     color: #818a91;
   }
+
+  & .autocomplete-results-wrapper {
+    margin-top: 6px;
+    max-height: 204px;
+    overflow: auto;
+
+    & p {
+      font-size: 1.1rem;
+      line-height: 1.5;
+      color: #373a3c;
+      background-color: #fff;
+      margin-bottom: 0;
+      padding: 5px 25px;
+      cursor: pointer;
+
+      & b {
+        color: var(--secondary-color, #003663);
+      }
+
+      &.hovered {
+        background-color: var(--autocomplete-background, #02a98f4d);
+      }
+    }
+  }
 }

--- a/packages/shared-components/src/components/onto-toastr/onto-toastr.scss
+++ b/packages/shared-components/src/components/onto-toastr/onto-toastr.scss
@@ -49,8 +49,13 @@
     }
 
     & i {
-      font-size: 1.5rem;
+      font-size: 1.8rem;
       padding: 0 20px;
+      color: inherit;
+
+      &:hover {
+        transform: none;
+      }
     }
 
     & .toast-message {

--- a/packages/shared-components/src/components/onto-toastr/onto-toastr.tsx
+++ b/packages/shared-components/src/components/onto-toastr/onto-toastr.tsx
@@ -52,7 +52,9 @@ export class OntoToastr {
                 onMouseEnter={() => this.clearToastTimeout(toast)}
                 onMouseLeave={() => this.setTimeoutForToast(toast)}>
               <i class={`fa-regular ${toastTypeToIconMap[toast.type]}`}></i>
-              <span class="toast-message" innerHTML={sanitizeHTML(toast.message)}></span>
+              <span onClick={this.handleToastClick(toast)}
+                    class="toast-message"
+                    innerHTML={sanitizeHTML(toast.message)}></span>
           </div>
         ))}
       </section>
@@ -106,5 +108,26 @@ export class OntoToastr {
     clearTimeout(timeoutId);
     this.toastToTimeout.delete(toast);
     this.updateToastrReference();
+  }
+
+  /**
+   * Handle click events on toast messages.
+   * Executes the configured onClick callback for the toast message, if provided.
+   * Removes the toast message, if the removeOnClick configuration is enabled.
+   *
+   * @param toast - The clicked toast message
+   * @returns An event handler function that processes click events on the toast
+   */
+  private handleToastClick(toast: ToastMessage) {
+    return (event: Event) => {
+      if (toast.config?.onClick) {
+        toast.config.onClick(event);
+      }
+
+      if (toast.config?.removeOnClick) {
+        this.toasts.remove(toast);
+        this.clearToastTimeout(toast);
+      }
+    }
   }
 }

--- a/packages/shared-components/src/index.html
+++ b/packages/shared-components/src/index.html
@@ -27,6 +27,7 @@
       <li><a href="/pages/operations-notification/index.html">Operations notification</a></li>
       <li><a href="/pages/toastr/index.html">Toastr</a></li>
       <li><a href="/pages/user-menu/index.html">User menu</a></li>
+      <li><a href="/pages/rdf-search/index.html">RDF search</a></li>
     </ul>
   </body>
 </html>

--- a/packages/shared-components/src/pages/rdf-search/index.html
+++ b/packages/shared-components/src/pages/rdf-search/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <base href="/pages/rdf-search/"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"/>
+    <title>Stencil Component Starter</title>
+
+    <script type="importmap">
+        {
+          "imports": {
+            "@ontotext/workbench-api": "/resources/ontotext-workbench-api.js"
+          }
+        }
+    </script>
+
+    <script type="module" src="/build/shared-components.esm.js"></script>
+    <script nomodule src="/build/shared-components.js"></script>
+    <script src="./main.js" defer></script>
+    <script src="../js/main.js" defer></script>
+    <link rel="stylesheet" href="../css/bootstrap.min.css">
+    <link rel="stylesheet" href="/pages/css/fontawesome.min.css">
+    <link rel="stylesheet" href="/pages/css/light.min.css">
+</head>
+<body>
+<onto-rdf-search></onto-rdf-search>
+<onto-tooltip></onto-tooltip>
+</body>
+</html>

--- a/packages/shared-components/src/pages/rdf-search/main.js
+++ b/packages/shared-components/src/pages/rdf-search/main.js
@@ -1,0 +1,1 @@
+const rdfSearch = document.querySelector('onto-rdf-search');


### PR DESCRIPTION
## What
Add autocomplete check and filtering, upon typing in the RDF search component

## Why
As part of the step by step migration of the component to the new workbench

## How
- Added request to check the state of the autocomplete on startup. Also added an event to update the context of the autocomplete state, on repository change

- Added toast notification, whenever a user starts typing in the search component, without turning on autocomplete. The warning appears only once and contains a link, which redirects to the autocomplete page

- Added requests, when autocomplete is enabled and the user is typing. The filtered results are then displayed in the component.

- Enhanced the toast config to include an `onClick` function and a `removeOnClick` boolean property. The first is currently used to navigate to the autocomplete page, when the toast notification is clicked. The second is to close the toast upon click, as this is the current behavior in the legacy workbench

## Testing
jest/cypress


## Screenshots
![image](https://github.com/user-attachments/assets/7c841e42-64fd-4bff-bf2a-4738818c5b20)

![image](https://github.com/user-attachments/assets/8b7d8de4-9ccc-467c-ba24-8fe252d85113)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
