### PR TITLE
Cherry-pick GDB-12006: GraphiQL pop-up menu's text is much too large

### DIFF
--- a/src/css/graphql/graphql-playground.css
+++ b/src/css/graphql/graphql-playground.css
@@ -58,7 +58,7 @@ graphql-playground {
 
 .graphql-playground-view #graphiql * {
     border-radius: 0;
-    font-size: 1rem;
+    font-size: 1rem !important;
     font-family: var(--main-font);
 }
 
@@ -337,6 +337,102 @@ div[data-radix-popper-content-wrapper] * {
 
 .graphql-playground-view #graphiql .docExplorerWrap .doc-explorer-title {
     color: var(--base-text-color);
+}
+
+/*
+    Removes the scroll from the GraphiQL Explorer plugin, since the parent container
+    with the class "graphiql-plugin" already provides vertical (y-axis) scrolling.
+    For horizontal (x-axis) scrolling, each GraphQL queries/mutations container will handle its own scroll.
+*/
+.graphql-playground-view #graphiql .docExplorerWrap .graphiql-explorer-root > div {
+    overflow: hidden !important;
+}
+
+/*
+  Adds horizontal (x-axis) scrolling to each GraphQL queries/mutations container.
+*/
+.graphql-playground-view #graphiql .docExplorerWrap .graphiql-explorer-root > div:first-child > div,
+.graphql-playground-view #graphiql .docExplorerWrap .graphiql-explorer-root > div:has(.variable-editor-title) {
+    overflow-x: auto !important;
+}
+
+/* Added a separation line between the container with queries/mutations and the container with the form for adding a new query/mutation. */
+.graphql-playground-view #graphiql .docExplorerWrap .graphiql-explorer-root > div:first-child {
+    border-bottom: 1px solid rgb(214, 214, 214);
+}
+
+/* Removes the top border from the form for adding a new query/mutation,
+   which was used as a visual horizontal separator between the queries/mutations and the form. */
+.graphql-playground-view #graphiql .docExplorerWrap .graphiql-explorer-root > div:last-child .variable-editor-title {
+    border: none !important;
+    padding: 0 !important;
+}
+
+.graphql-playground-view #graphiql .docExplorerWrap .graphiql-explorer-root > div:has(.variable-editor-title) {
+    margin-top: 16px;
+}
+
+/* =========================*/
+/*     Button overrides     */
+/* =========================*/
+.graphql-playground-view #graphiql .docExplorerWrap .toolbar-button {
+    background-color: var(--base-background-hover-color);
+    border: none;
+    outline: none;
+    cursor: pointer;
+}
+
+.graphql-playground-view #graphiql .docExplorerWrap .variable-editor-title .toolbar-button,
+.graphql-playground-view #graphiql .docExplorerWrap .graphiql-operation-title-bar .toolbar-button {
+    height: 100% !important;
+    width: auto !important;
+    aspect-ratio: 1 / 1;
+}
+
+/**
+  Make the span resizable. This allows the icon/text inside the button to become larger on mouseover.
+ */
+.graphql-playground-view #graphiql .docExplorerWrap .toolbar-button span {
+    display: block;
+}
+
+.graphql-playground-view #graphiql .docExplorerWrap .toolbar-button:hover span {
+    transform: scale(1.2);
+    color: var(--primary-color) !important;
+}
+
+
+/* Make the button's size match the dropdown in the 'Add New Fragment' form */
+.graphql-playground-view #graphiql .docExplorerWrap .variable-editor-title .toolbar-button {
+    padding: var(--px-4) var(--px-10);
+}
+
+/* =========================*/
+/*     Dropdown overrides     */
+/* =========================*/
+.graphql-playground-view #graphiql .docExplorerWrap select {
+    font-size: 1rem !important;
+    height: calc(2rem - 2px);
+    line-height: 1.25;
+    color: #55595c !important;
+    background-color: #fff !important;
+    background-image: none !important;
+    border: 1px solid rgba(0, 0, 0, .15);
+    border-radius: 0;
+    font-weight: 400;
+    margin: 1px 8px;
+    outline: 0;
+}
+
+.graphql-playground-view #graphiql .docExplorerWrap select:focus {
+    color: #55595c;
+    background-color: #fff;
+    border-color: hsla(var(--secondary-color-hsl), 0.5);
+}
+
+.graphql-playground-view #graphiql .docExplorerWrap select option {
+    background-color: var(--html-background) !important;
+    color: var(--gray-color) !important;
 }
 
 /* =============================================== */


### PR DESCRIPTION
## What
- Removes the inner scroll from the GraphiQL Explorer plugin, since the parent container with the class "graphiql-plugin" already provides scrolling;
- Styled the buttons and dropdowns to align with the Workbench design.
- Added a separate horizontal scroll for all containers that hold queries/mutations.

## Why
- The parent container already has vertical scroll enabled, which made the inner scroll unnecessary and created visual issues (e.g., a scroll area with no visible scrollbar);
- The buttons and dropdowns looked inconsistent with those used in the Workbench.

## How
 - Set overflow: hidden on the container to remove the unnecessary scroll.
 - Applied styling consistent with the Workbench. Some CSS declarations use !important due to inline styles applied by GraphiQL Playground.

(cherry picked from commit 0e818ff01f952cd0fe1654310368dd7236ecf6a9)

## Testing
N/A

## Screenshots
<p>
   <div>Remove unnecessary scroll</div>
   <img src="https://github.com/user-attachments/assets/ef0c371c-fc05-4790-aee4-030ad04cdbd4" width="320">
   <span>&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;<span>
   <img src="https://github.com/user-attachments/assets/9a4d0aa5-e668-45db-81a1-34f704c00583" width="320" >
</p>
<p>
   <div>Added a scroll to the add query/mutation form.</div>
   <img src="https://github.com/user-attachments/assets/d0b70a33-edbc-4c42-9d95-c3b63bf5e4bd" width="320">
   <span>&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;<span>
   <img src="https://github.com/user-attachments/assets/10620ecf-92ff-45fc-a491-a33739f9bd71" width="320" >
</p>
<p>
   <div>Fixing the styling of buttons.</div>
  <p>
     <img src="https://github.com/user-attachments/assets/df807e26-b7bf-4df6-b640-4bee28fdb5b0" width="320">
    <span>&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;<span>
      <img src="https://github.com/user-attachments/assets/c9df0213-279c-4788-b3eb-aa889cee5543" width="320" >
   </p>
    <p>
       <img src="https://github.com/user-attachments/assets/6d887fe7-0814-4c0e-8270-b2fb2d8f54f2" width="320">
      <span>&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;<span>
      <img src="https://github.com/user-attachments/assets/0704783a-0227-4036-bdc8-f18b6eedf5f9" width="320" >
   </p>

   <p>
      <img src="https://github.com/user-attachments/assets/10146df7-3ec8-4e33-bc30-a9f3a7b21663" width="320">
      <span>&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;<span>
      <img src="https://github.com/user-attachments/assets/fdf833f0-7ff3-4909-b35b-f885d5ee7163" width="320" >
   </p>
   
</p>

<p>
   <div>Fixing the styling of dropdowns.</div>
   <p>
     <img src="https://github.com/user-attachments/assets/abe4cd68-1a56-4e6d-99b4-676db69f2719" width="320">
     <span>&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;<span>
     <img src="https://github.com/user-attachments/assets/e0b12491-7826-4037-a758-8f86aab0a0b8" width="320" >
  </p>
<p>
     <img src="https://github.com/user-attachments/assets/2a84019a-f99f-4ddd-bd7c-cb21a5131f71" width="320">
     <span>&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;<span>
     <img src="https://github.com/user-attachments/assets/cf9e755a-6eee-4f66-bdf8-5f8e1053a95a" width="320" >
  </p>
</p>


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
