### PR TITLE
GDB-10684: WB Migration: resolve issues with the ontotext-yasgui custom component

### DIFF
--- a/packages/root-config/src/index.ejs
+++ b/packages/root-config/src/index.ejs
@@ -21,10 +21,10 @@
     -->
     <meta http-equiv="Content-Security-Policy"
           content=" default-src 'self' <%= microFrontEndsUrls %>;
-                    script-src 'self' 'unsafe-inline' 'unsafe-eval' <%= microFrontEndsUrls %> https://cdn.jsdelivr.net https://www.googletagmanager.com;
+                    script-src 'self' 'unsafe-inline' 'unsafe-eval' <%= microFrontEndsUrls %> <%= externalJavaScripts %>;
                     connect-src 'self' <%= microFrontEndsUrls %> https://www.googletagmanager.com https://region1.google-analytics.com;
-                    style-src 'self' 'unsafe-inline' <%= microFrontEndsUrls %>;
-                    img-src 'self' data: <%= microFrontEndsUrls %> https://www.googletagmanager.com;
+                    style-src 'self' 'unsafe-inline' <%= microFrontEndsUrls %> <%= externalCSSs %>;
+                    img-src 'self' data: <%= microFrontEndsUrls %>  <%= externalImages %>;
                     font-src 'self' <%= microFrontEndsUrls %>;
                     base-uri 'self';">
     <meta name="importmap-type" use-injector />

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -19,6 +19,31 @@ const languagesConfig = JSON.stringify(
     JSON.parse(fs.readFileSync(path.resolve(__dirname, 'packages/legacy-workbench/src/i18n/languages.json'), 'utf8'))
 );
 
+const externalCSSs = [
+    // pivot table
+    'https://pivottable.js.org',
+    // Google Charts
+    'https://www.gstatic.com'
+];
+
+const externalJavaScripts = [
+    'https://www.googletagmanager.com',
+    'https://cdn.jsdelivr.net',
+    // pivot table
+    'https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js',
+    'https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.min.js',
+    'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js',
+    'https://pivottable.js.org',
+    // Google Charts
+    'https://www.gstatic.com',
+];
+
+const externalImages = [
+    // Google Charts
+    'https://ssl.gstatic.com',
+    'https://www.googletagmanager.com'
+];
+
 const host = 'localhost';
 const portHere = 9000;
 const portThere = 7200;
@@ -73,7 +98,10 @@ module.exports = (webpackConfigEnv, argv) => {
                         workbenchAppBundle: Object.keys(compilation.assets).find(asset => asset.includes('workbenchApp') && asset.endsWith('.js')),
                         contentHash: assets.contentHash,
                         buildVersion: PACKAGE.version,
-                        microFrontEndsUrls: 'http://localhost:9002 http://localhost:9003 ws://localhost:9003 ws://localhost:9002'
+                        microFrontEndsUrls: 'http://localhost:9002 http://localhost:9003 ws://localhost:9003 ws://localhost:9002',
+                        externalCSSs: externalCSSs.join(' '),
+                        externalJavaScripts: externalJavaScripts.join(' '),
+                        externalImages: externalImages.join(' ')
                     };
                 },
                 chunks: ['main'],


### PR DESCRIPTION
## What
The "Pivot table" and "Google Chart" plugins in the "SPARQL Query & Update" view are not working.

## Why
Both plugins fail to load because they require external resources that were blocked by the current Content Security Policy (CSP).

## How
Updated the Content-Security-Policy directive to include the required external resources for both plugins.

## Testing
N/A

## Screenshots
<p>

<img src="https://github.com/user-attachments/assets/91fcd69d-d215-484c-b860-e8eb0ed26190" width="320"/>
<img src="https://github.com/user-attachments/assets/51eb687f-501b-465e-bdc4-0600b76e6d6a" width="320"/>
</p>
<p>
<img src="https://github.com/user-attachments/assets/bde11566-c0f0-4d10-939f-74d7cb2ba7cc" width="320"/>
<img src="https://github.com/user-attachments/assets/2184b771-dd05-4ec9-a3cc-1de0db874d5f" width="320"/>
</p>

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
