### PR TITLE
GDB-10684: Cannot navigate away from the SPARQL editor page

### DIFF
--- a/packages/api/src/services/utils/routing-utils.ts
+++ b/packages/api/src/services/utils/routing-utils.ts
@@ -5,7 +5,9 @@
  */
 export function navigateTo(url: string): (event: Event) => void {
   return (event: Event): void => {
-    event.preventDefault();
+    if (event) {
+      event.preventDefault();
+    }
     window.singleSpa.navigateToUrl(url);
   };
 }

--- a/packages/legacy-workbench/src/js/angular/sparql-editor/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/sparql-editor/controllers.js
@@ -15,6 +15,7 @@ import {VIEW_SPARQL_EDITOR} from "../models/sparql/constants";
 import {CancelAbortingQuery} from "../models/sparql/cancel-aborting-query";
 import {QueryMode} from "../models/ontotext-yasgui/query-mode";
 import 'angular/core/services/event-emitter-service';
+import {navigateTo} from '@ontotext/workbench-api';
 
 const modules = [
     'ui.bootstrap',
@@ -517,8 +518,7 @@ function SparqlEditorCtrl($rootScope,
             return;
         }
         event.preventDefault();
-        const newPath = $location.path();
-        const searches = $location.search();
+        const newUrl = $location.url();
         // First, we check if there are any ongoing requests initiated by the user.
         // If the user has ongoing requests, we request confirmation to abort them.
         // If the user confirms or there are no ongoing requests, we call the "abortAllRequests" method. This method will abort all requests.
@@ -528,11 +528,13 @@ function SparqlEditorCtrl($rootScope,
             .then(() => ontotextYasguiElement.abortAllRequests())
             .then(() => {
                 queriesAreCanceled = true;
-                $location.path(newPath).search(searches);
+                navigateTo(newUrl)();
             })
             .catch((error) => {
                 if (!(error instanceof CancelAbortingQuery)) {
-                    throw error;
+                    console.error(error)
+                    queriesAreCanceled = true;
+                    navigateTo(newUrl)();
                 }
             });
     };

--- a/packages/legacy-workbench/src/pages/sparql-editor.html
+++ b/packages/legacy-workbench/src/pages/sparql-editor.html
@@ -9,6 +9,5 @@
     <div core-errors></div>
 
     <yasgui-component id="query-editor" yasgui-config="yasguiConfig"
-                      ng-if="yasguiConfig && getActiveRepositoryNoError()"
-                      after-init="initViewFromUrlParams()"></yasgui-component>
+                      ng-if="yasguiConfig && getActiveRepositoryNoError()"></yasgui-component>
 </div>


### PR DESCRIPTION
## What
When the "SPARQL Query & Update" view is loaded and the user tries to navigate to another view, the navigation does not occur.

## Why
The "SPARQL Query & Update" view includes functionality that displays a confirmation dialog if there are running queries. If the user confirms, those queries are aborted. This functionality relies on methods from the ontotext-yasgui-web-component, which are asynchronous. Because of this, the original navigation event is prevented, and navigation is manually triggered using the $location service after user confirmation. However, this approach does not work in a single-spa environment—after the user confirms, the navigation is not performed.

## How
Replaced navigation using the $location service with the navigateToUrl method provided by single-spa.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
