### PR TITLE
GDB-12107 Fix guide autostart when security is on

### DIFF
--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -182,18 +182,18 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
     $scope.embedded = $location.search().embedded;
     $scope.productInfo = productInfo;
     $scope.guidePaused = 'true' === LocalStorageAdapter.get(GUIDE_PAUSE);
+    $scope.startGuideAfterSecurityInit = true;
 
     $scope.hideRdfResourceSearch = false;
     $scope.showRdfResourceSearch = () => {
         return !$scope.hideRdfResourceSearch && !!$scope.getActiveRepository() && $scope.hasActiveLocation() && (!$scope.isLoadingLocation() || $scope.isLoadingLocation() && $location.url() === '/repository');
     };
 
-    const queryParams = $location.search();
-    if (queryParams.autostartGuide) {
+    const startGuide = (guideId) => {
         // Check to see if $translate service is ready with the language before starting the guide as the steps are translated ahead on time. Will retry 20 times (1 second).
         const timer = $interval(function () {
             if ($translate.use()) {
-                GuidesService.autoStartGuide(queryParams.autostartGuide)
+                GuidesService.autoStartGuide(guideId)
                 $interval.cancel(timer);
             }
         }, 50, 20);
@@ -977,6 +977,12 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
                     const msg = getError(error.data, error.status);
                     toastr.error(msg, $translate.instant('common.error'));
                 });
+
+            const queryParams = $location.search();
+            if ($jwtAuth.isRepoManager() && $scope.startGuideAfterSecurityInit && queryParams.autostartGuide) {
+                startGuide(queryParams.autostartGuide);
+                $scope.startGuideAfterSecurityInit = false;
+            }
         }
     });
 


### PR DESCRIPTION
## What
Start the guide if the security is off or if the security is on, start the guide if the user is at least a Repository Manager as guides need to create repositories. The guide will autostart once the user has logged in.

## Why
The guides autostart wes not implemented to take into account if security is turned on.

## How
- moved the autostart logic in the on `securityInit` callback. It is called after login or ono load if security is off
- added check if user is Repository manager
- added check to not double start the guide if callback is applied multiple times

## Testing

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
