### PR TITLE
GDB-10684: Saved queries are not displayed in Yasgui

### DIFF
--- a/packages/legacy-workbench/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/packages/legacy-workbench/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -196,7 +196,7 @@ function yasguiComponentDirective(
                 $scope.savedQueryConfig = {
                     savedQueries: []
                 };
-                Promise.all([$jwtAuth.getPrincipal(), SparqlRestService.getSavedQueries()])
+                $q.all([$jwtAuth.getPrincipal(), SparqlRestService.getSavedQueries()])
                     .then(([principal, savedQueries]) => {
                         $scope.savedQueryConfig = {
                             savedQueries: savedQueriesResponseMapper(savedQueries, principal.username)


### PR DESCRIPTION
## What
The saved queries are loaded successfully but are not displayed in the Yasgui dialog.

## Why
The saved queries are passed to Yasgui through the bound property savedQueryConfig. After the queries are loaded, the object is updated, but Yasgui not triggered to re-render.

## How
The queries were previously loaded using Promise.all. This has been changed to use AngularJS $q service, which triggers Angular's digest cycle.

## Testing
N/A

## Screenshots
<img src="https://github.com/user-attachments/assets/6da5fca0-f371-486d-a86a-4216cf199a7a" width="320"/>
<span>&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp</span>
<img src="https://github.com/user-attachments/assets/45ceb192-ae5c-405f-a8bb-74c0829385c2" width="320"/>

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
