### PR TITLE
Saved queries are not displayed in Yasgui immediately

### DIFF
--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -196,7 +196,7 @@ function yasguiComponentDirective(
                 $scope.savedQueryConfig = {
                     savedQueries: []
                 };
-                Promise.all([$jwtAuth.getPrincipal(), SparqlRestService.getSavedQueries()])
+                $q.all([$jwtAuth.getPrincipal(), SparqlRestService.getSavedQueries()])
                     .then(([principal, savedQueries]) => {
                         $scope.savedQueryConfig = {
                             savedQueries: savedQueriesResponseMapper(savedQueries, principal.username)


### PR DESCRIPTION
What
The saved queries are loaded successfully but appear with a noticeable delay in the Yasgui dialog.

Why
The saved queries are passed to Yasgui through the bound property savedQueryConfig. Although the object is updated after loading, Yasgui's re-render is delayed because the AngularJS digest cycle is not triggered immediately. Instead, it's triggered later by a different component, causing the queries to appear slowly.

How
The loading logic was initially implemented using Promise.all, which does not trigger AngularJS’s digest cycle. It has been updated to use Angular's $q service, ensuring the digest cycle runs at the right time and the Yasgui dialog updates promptly.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
