### PR TITLE
GDB-10684: Fixes issue with the confirmation dialog

### DIFF
--- a/e2e-tests/e2e-legacy/sparql-editor/actions/execute-query.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/execute-query.spec.js
@@ -3,10 +3,7 @@ import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
 import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
 import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
 
-/**
- * TODO: Fix me. Broken due to migration (Error: beforeEach)
- */
-describe.skip('Execute query', () => {
+describe('Execute query', () => {
 
     let repositoryId;
 

--- a/e2e-tests/e2e-legacy/sparql-editor/actions/expand-results-over-sameas.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/expand-results-over-sameas.spec.js
@@ -3,10 +3,7 @@ import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
 import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
 import {QueryStubDescription, QueryStubs} from "../../../stubs/yasgui/query-stubs";
 
-/**
- * TODO: Fix me. Broken due to migration (Error: beforeEach)
- */
-describe.skip('Expand results over owl:sameAs', () => {
+describe('Expand results over owl:sameAs', () => {
 
     let repositoryId;
 

--- a/e2e-tests/e2e-legacy/sparql-editor/actions/include-inferred-statements.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/include-inferred-statements.spec.js
@@ -3,10 +3,7 @@ import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
 import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
 import {QueryStubDescription, QueryStubs} from "../../../stubs/yasgui/query-stubs";
 
-/**
- * TODO: Fix me. Broken due to migration (Error: beforeEach)
- */
-describe.skip('Include inferred statements', () => {
+describe('Include inferred statements', () => {
 
     let repositoryId;
 

--- a/e2e-tests/e2e-legacy/sparql-editor/actions/inferred-sameas.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/inferred-sameas.spec.js
@@ -2,16 +2,13 @@ import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
 import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
 import {RepositoriesStub} from "../../../stubs/repositories-stub";
 
-/**
- * TODO: Fix me. Broken due to migration (Error: beforeEach)
- */
-describe.skip('Expand results over owl:sameAs', () => {
+describe('Expand results over owl:sameAs', () => {
 
     let repositoryId;
 
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();
-        cy.setLocalStorage("ls.repository-id", repositoryId);
+        cy.setLocalStorage("ontotext.gdb.repository.selectedRepositoryId", repositoryId);
         RepositoriesStub.stubOntopRepository(repositoryId);
         RepositoriesStub.stubNameSpaces(repositoryId);
     });

--- a/e2e-tests/e2e-legacy/sparql-editor/actions/save-query.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/save-query.spec.js
@@ -6,8 +6,7 @@ import {SaveQueryDialog} from "../../../steps/yasgui/save-query-dialog";
 import {SavedQuery} from "../../../steps/yasgui/saved-query";
 import {SavedQueriesDialog} from "../../../steps/yasgui/saved-queries-dialog";
 
-//TODO: Fix me. Broken due to migration (Error: beforeEach)
-describe.skip('Save query', () => {
+describe('Save query', () => {
 
     let repositoryId;
 

--- a/e2e-tests/e2e-legacy/sparql-editor/actions/show-saved-queries.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/show-saved-queries.spec.js
@@ -3,11 +3,7 @@ import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
 import {SavedQueriesDialog} from "../../../steps/yasgui/saved-queries-dialog";
 import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
 
-
-/**
- * TODO: Fix me. Broken due to migration (Error: beforeEach)
- */
-describe.skip('Show saved queries', () => {
+describe('Show saved queries', () => {
 
     let repositoryId;
 

--- a/e2e-tests/e2e-legacy/sparql-editor/saved-query/delete-query.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/saved-query/delete-query.spec.js
@@ -6,10 +6,7 @@ import {SavedQuery} from "../../../steps/yasgui/saved-query";
 import {SavedQueriesDialog} from "../../../steps/yasgui/saved-queries-dialog";
 import {SaveQueryDialog} from "../../../steps/yasgui/save-query-dialog";
 
-/**
- * TODO: Fix me. Broken due to migration (Error: beforeEach)
- */
-describe.skip('Delete saved queries', () => {
+describe('Delete saved queries', () => {
 
     let repositoryId;
 

--- a/e2e-tests/e2e-legacy/sparql-editor/saved-query/edit-query.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/saved-query/edit-query.spec.js
@@ -8,7 +8,7 @@ import {SaveQueryDialog} from "../../../steps/yasgui/save-query-dialog";
 /**
  * TODO: Fix me. Broken due to migration (Error: beforeEach)
  */
-describe.skip('Edit saved queries', () => {
+describe('Edit saved queries', () => {
 
     let repositoryId;
 

--- a/e2e-tests/e2e-legacy/sparql-editor/sparql-editor.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/sparql-editor.spec.js
@@ -4,8 +4,7 @@ import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
 import {YasrSteps} from "../../steps/yasgui/yasr-steps";
 import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";
 
-// TODO: Fix me. Broken due to migration (Error: beforeEach)
-describe.skip('Sparql editor', () => {
+describe('Sparql editor', () => {
     let repositoryId;
     let secondRepositoryId;
 

--- a/e2e-tests/e2e-legacy/sparql-editor/yasgui-tabs.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/yasgui-tabs.spec.js
@@ -6,8 +6,7 @@ import {QueryStubs} from "../../stubs/yasgui/query-stubs";
 import {MainMenuSteps} from "../../steps/main-menu-steps";
 import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
 
-// TODO: Fix me. Broken due to migration (Error: beforeEach)
-describe.skip('Yasgui tabs', () => {
+describe('Yasgui tabs', () => {
 
     let repositoryId;
     beforeEach(() => {

--- a/e2e-tests/e2e-legacy/sparql-editor/yasr/download-as.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/yasr/download-as.spec.js
@@ -5,10 +5,7 @@ import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
 import {JsonLdModalSteps} from "../../../steps/json-ld-modal-steps";
 import {GraphsOverviewSteps} from "../../../steps/explore/graphs-overview-steps";
 
-/**
- * TODO: Fix me. Broken due to migration (Error: beforeEach)
- */
-describe.skip('Download results', () => {
+describe('Download results', () => {
     let repositoryId;
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();

--- a/e2e-tests/e2e-legacy/sparql-editor/yasr/pagination.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/yasr/pagination.spec.js
@@ -5,9 +5,7 @@ import {YasrSteps} from "../../../steps/yasgui/yasr-steps";
 import {PaginationSteps} from "../../../steps/yasgui/pagination-steps";
 import {NamespaceStubs} from "../../../stubs/namespace-stubs";
 
-
-// TODO: Fix me. Broken due to migration (Error: unknown)
-describe.skip('Yasr result pagination', () => {
+describe('Yasr result pagination', () => {
     let repositoryId;
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();

--- a/e2e-tests/e2e-legacy/sparql-editor/yasr/table-plugin.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/yasr/table-plugin.spec.js
@@ -3,9 +3,7 @@ import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
 import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
 import {YasrSteps} from "../../../steps/yasgui/yasr-steps";
 
-
-//TODO: Fix me. Broken due to migration (Error: beforeEach)
-describe.skip('Yasr Table plugin', () => {
+describe('Yasr Table plugin', () => {
     let repositoryId;
     beforeEach(() => {
         repositoryId = 'sparql-editor-' + Date.now();

--- a/e2e-tests/e2e-legacy/sparql-editor/yasr/toolbar/visual-graph-button.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/yasr/toolbar/visual-graph-button.spec.js
@@ -3,10 +3,7 @@ import {YasqeSteps} from "../../../../steps/yasgui/yasqe-steps";
 import {YasrSteps} from "../../../../steps/yasgui/yasr-steps";
 import {QueryStubs} from "../../../../stubs/yasgui/query-stubs";
 
-/**
- * TODO: Fix me. Broken due to migration (Error: beforeEach)
- */
-describe.skip('Visual graph button when user execute a CONSTRUCT query', () => {
+describe('Visual graph button when user execute a CONSTRUCT query', () => {
     let repositoryId;
 
     beforeEach(() => {

--- a/packages/api/src/models/events/event-name.ts
+++ b/packages/api/src/models/events/event-name.ts
@@ -6,5 +6,6 @@
  *
  */
 export const EventName = {
-  NAVIGATION_END: 'navigationEnd'
+  NAVIGATION_END: 'navigationEnd',
+  NAVIGATION_START: 'navigationStart'
 };

--- a/packages/api/src/models/events/index.ts
+++ b/packages/api/src/models/events/index.ts
@@ -2,3 +2,4 @@ export * from './event';
 export * from './event-name';
 export * from './navigation/navigation-end';
 export * from './navigation/navigation-end-payload';
+export * from './navigation/navigation-start';

--- a/packages/api/src/models/events/navigation/navigation-start-payload.ts
+++ b/packages/api/src/models/events/navigation/navigation-start-payload.ts
@@ -1,0 +1,28 @@
+/**
+ * Represents the payload for a navigation start event.
+ */
+export interface NavigationStartPayload {
+  
+  /**
+   * The URL from which the navigation originated.
+   *
+   * @type {string | undefined}
+   */
+  oldUrl: string | undefined;
+  
+  /**
+   * The URL to which the navigation ended.
+   *
+   * @type {string | undefined}
+   */
+  newUrl: string | undefined;
+  
+  /**
+   * Cancels the ongoing navigation.
+   *
+   * @param cancellationPayload - The payload required to cancel the navigation.
+   * This depends on the navigation implementation. For example, in Angular it can be a native or custom event,
+   * while in single-spa it can be boolean or a Promise whose result determines whether the navigation is canceled.
+   */
+  cancelNavigation: (cancellationPayload: unknown) => void
+}

--- a/packages/api/src/models/events/navigation/navigation-start.ts
+++ b/packages/api/src/models/events/navigation/navigation-start.ts
@@ -1,0 +1,21 @@
+import {Event} from '../event';
+import {EventName} from '../event-name';
+import {NavigationStartPayload} from './navigation-start-payload';
+
+/**
+ * Represents a "navigationStart" event.
+ *
+ * This event is triggered when navigation starts and contains information about the previous and current URLs.
+ */
+export class NavigationStart extends Event<NavigationStartPayload> {
+  /**
+   * Creates an instance of the NavigationStart event.
+   *
+   * @param oldUrl - The URL from which the navigation originated.
+   * @param newUrl - The URL to which the navigation ended.
+   * @param cancelNavigation - A function to cancel the ongoing navigation.
+   */
+  constructor(oldUrl: string, newUrl: string, cancelNavigation: (cancellationPayload: unknown) => void) {
+    super(EventName.NAVIGATION_START, {oldUrl, newUrl, cancelNavigation});
+  }
+}

--- a/packages/legacy-workbench/src/js/angular/sparql-editor/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/sparql-editor/controllers.js
@@ -15,7 +15,7 @@ import {VIEW_SPARQL_EDITOR} from "../models/sparql/constants";
 import {CancelAbortingQuery} from "../models/sparql/cancel-aborting-query";
 import {QueryMode} from "../models/ontotext-yasgui/query-mode";
 import 'angular/core/services/event-emitter-service';
-import {navigateTo} from '@ontotext/workbench-api';
+import {navigateTo, ServiceProvider, EventService, EventName} from "@ontotext/workbench-api";
 
 const modules = [
     'ui.bootstrap',
@@ -444,7 +444,7 @@ function SparqlEditorCtrl($rootScope,
                 return;
             }
         }
-        Promise.all([$jwtAuth.getPrincipal(), $repositories.getPrefixes(activeRepository)])
+        $q.all([$jwtAuth.getPrincipal(), $repositories.getPrefixes(activeRepository)])
             .then(([principal, usedPrefixes]) => {
                 $scope.prefixes = usedPrefixes;
                 setInferAndSameAs(principal);
@@ -508,7 +508,7 @@ function SparqlEditorCtrl($rootScope,
         });
     });
     let queriesAreCanceled = undefined;
-    const locationChangeHandler = (event) => {
+    const locationChangeHandler = (eventPayload) => {
         if (internallyReloaded) {
             internallyReloaded = false;
             return;
@@ -517,8 +517,10 @@ function SparqlEditorCtrl($rootScope,
         if (!ontotextYasguiElement || queriesAreCanceled) {
             return;
         }
-        event.preventDefault();
-        const newUrl = $location.url();
+
+        const url = new URL(eventPayload.newUrl);
+        const newUrl = url.pathname + url.search + url.hash;
+        eventPayload.cancelNavigation();
         // First, we check if there are any ongoing requests initiated by the user.
         // If the user has ongoing requests, we request confirmation to abort them.
         // If the user confirms or there are no ongoing requests, we call the "abortAllRequests" method. This method will abort all requests.
@@ -539,7 +541,9 @@ function SparqlEditorCtrl($rootScope,
             });
     };
 
-    subscriptions.push($rootScope.$on('$locationChangeStart', locationChangeHandler));
+    subscriptions.push(
+        ServiceProvider.get(EventService).subscribe(EventName.NAVIGATION_START, (eventPayload) => locationChangeHandler(eventPayload))
+    );
 
     const removeAllListeners = () => {
         subscriptions.forEach((subscription) => subscription());

--- a/packages/root-config/src/ontotext-root-config.js
+++ b/packages/root-config/src/ontotext-root-config.js
@@ -21,7 +21,8 @@ import {bootstrapPromises} from './bootstrap/bootstrap';
 import {
   ServiceProvider,
   EventService,
-  NavigationEnd
+  NavigationEnd,
+  NavigationStart
 } from '@ontotext/workbench-api';
 
 const showSplashScreen = (show) => {
@@ -78,9 +79,12 @@ const layoutEngine = constructLayoutEngine({routes, applications});
 applications.forEach(registerApplication);
 layoutEngine.activate();
 
-const registerSingleSpaRouterListener = () => {
-  if (!window.singleSingleSpaRouterListenerRegistered) {
-    window.singleSingleSpaRouterListenerRegistered = true;
+const registerSingleSpaRouterListeners = () => {
+  if (!window.singleSingleSpaRouterListenersRegistered) {
+    window.singleSingleSpaRouterListenersRegistered = true;
+    window.addEventListener('single-spa:before-routing-event', (evt) => {
+      ServiceProvider.get(EventService).emit(new NavigationStart(evt.detail.oldUrl, evt.detail.newUrl, evt.detail.cancelNavigation));
+    });
     window.addEventListener('single-spa:routing-event', (evt) => {
       ServiceProvider.get(EventService).emit(new NavigationEnd(evt.detail.oldUrl, evt.detail.newUrl));
     });
@@ -101,7 +105,7 @@ const bootstrapApplication = () => {
     });
 };
 
-registerSingleSpaRouterListener();
+registerSingleSpaRouterListeners();
 bootstrapApplication();
 
 // window.addEventListener("single-spa:routing-event", (evt) => {


### PR DESCRIPTION
## What
The old workbench has functionality to ask the user for confirmation when attempting to leave the "SPARQL Query & Update" view while at least one query or update is still running. This functionality works when navigating to the view via the main menu, but it stops working if the page is refreshed while on the view.

## Why
When leaving the view, the Yasgui component instance is used to check for ongoing queries or updates. Yasgui is a web component built using the Stencil framework and uses the disconnectedCallback lifecycle hook to clean up when destroyed. In the failing scenario, there's a difference in the order of event listeners — the disconnectedCallback is triggered before AngularJS's $locationChangeStart, which means Yasgui is already destroyed before the check for ongoing queries/updates can occur.

## How
Single-spa provides a custom event called single-spa:before-routing-event, which is fired before the component's disconnectedCallback is called. The confirmation logic has been updated to use this event, ensuring that the Yasgui instance is still available when checking for active queries or updates.

## Testing
- Replaced usages of Promise.all with AngularJS’s $q.all, as Promise.all was breaking some tests.
- Unskipped all "SPARQL Query & Update" view tests.

## Screenshots
![image](https://github.com/user-attachments/assets/251d2758-4533-4152-ac09-a26b7ac68baf)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
