### PR TITLE
GDB-12152 Display confirmation dialog when changing the language on in SPARQL view

### DIFF
--- a/packages/api/src/models/context/before-change-validation-promise.ts
+++ b/packages/api/src/models/context/before-change-validation-promise.ts
@@ -1,0 +1,9 @@
+/**
+ * Type definition for a callback function that is triggered before the value of the context changes.
+ * Should return a boolean indicating whether the change should be allowed.
+ *
+ * @template T - The type of the value passed to the callback function.
+ * @param value - A value of type T.
+ * @return Promise<boolean> - A promise that resolves to a boolean indicating whether the change should be allowed.
+ */
+export type BeforeChangeValidationPromise<T> = (value: T | undefined) => Promise<boolean>;

--- a/packages/api/src/models/context/test/value-context.spec.ts
+++ b/packages/api/src/models/context/test/value-context.spec.ts
@@ -37,6 +37,14 @@ describe('ValueContext', () => {
     expect(valueContext.getValue()).toEqual({ a: 1 });
   });
 
+  it('setValue should return undefined if value is null', () => {
+    valueContext.setValue(5);
+    expect(valueContext.getValue()).toBe(5);
+
+    valueContext.setValue(null as unknown as number);
+    expect(valueContext.getValue()).toBeUndefined();
+  });
+
   it('should unsubscribe callback correctly', () => {
     const unsubscribe = valueContext.subscribe(callback);
     unsubscribe();
@@ -51,12 +59,84 @@ describe('ValueContext', () => {
         return new CopyableValue(this.a);
       }
     }
-
+    const copyableValueContext = new ValueContext<CopyableValue>();
     const copyableValue = new CopyableValue(1);
-    valueContext.setValue(copyableValue as unknown as number);
-    const result = valueContext.getValue() as unknown as CopyableValue;
-    expect(result).toEqual(copyableValue);
+    jest.spyOn(copyableValue, 'copy');
+
+    copyableValueContext.setValue(copyableValue);
+    const result = copyableValueContext.getValue();
+    expect(result?.a).toEqual(copyableValue.a);
     // Ensure it's a copy, not the same instance
     expect(result).not.toBe(copyableValue);
+    expect(copyableValue.copy).toHaveBeenCalled();
+  });
+
+  it('canUpdate should return true when no validation promises are set', async () => {
+    // First test: validation that returns false
+    const valueContext = new ValueContext<number>();
+
+    // Setting a value should fail and return false
+    const result = await valueContext.canUpdate(42);
+    expect(result).toBe(true);
+  });
+
+  it('canUpdate should return true when all validation promises resolve to true', async () => {
+    // Create multiple validation promises that all return true
+    const validation1 = jest.fn().mockImplementation(() => Promise.resolve(true));
+    const validation2 = jest.fn().mockImplementation(() => Promise.resolve(true));
+
+    // Subscribe with multiple validations
+    valueContext.subscribe(callback, validation1);
+    valueContext.subscribe(callback, validation2);
+
+    // Setting a value should return true
+    const result = await valueContext.canUpdate(42);
+
+    // Verify all validations were called
+    expect(validation1).toHaveBeenCalledWith(42);
+    expect(validation2).toHaveBeenCalledWith(42);
+
+    // Verify the value was updated and callback was called
+    expect(result).toBe(true);
+  });
+
+  it('canUpdate should return false when some validation promises resolve to false', async () => {
+    // Create multiple validation promises where one resolves to false
+    const validation1 = jest.fn().mockImplementation(() => Promise.resolve(true));
+    const validation2 = jest.fn().mockImplementation(() => Promise.resolve(false));
+
+    // Subscribe with multiple validations
+    valueContext.subscribe(callback, validation1);
+    valueContext.subscribe(callback, validation2);
+
+    // Setting a value should return false
+    const result = await valueContext.canUpdate(42);
+
+    // Verify all validations were called
+    expect(validation1).toHaveBeenCalledWith(42);
+    expect(validation2).toHaveBeenCalledWith(42);
+
+    // Verify the value was not updated and callback was not called
+    expect(result).toBe(false);
+  });
+
+  it('canUpdate should return false when some validation promises rejects', async () => {
+    // Create multiple validation promises where one rejects
+    const validation1 = jest.fn().mockImplementation(() => Promise.resolve(true));
+    const validation2 = jest.fn().mockImplementation(() => Promise.reject());
+
+    // Subscribe with multiple validations
+    valueContext.subscribe(callback, validation1);
+    valueContext.subscribe(callback, validation2);
+
+    // Setting a value should return false
+    const result = await valueContext.canUpdate(42);
+
+    // Verify all validations were called
+    expect(validation1).toHaveBeenCalledWith(42);
+    expect(validation2).toHaveBeenCalledWith(42);
+
+    // Verify the value was not updated and callback was not called
+    expect(result).toBe(false);
   });
 });

--- a/packages/api/src/services/language/language-context.service.ts
+++ b/packages/api/src/services/language/language-context.service.ts
@@ -5,6 +5,7 @@ import {LanguageStorageService} from './language-storage.service';
 import {LanguageService} from './language.service';
 import {DeriveContextServiceContract} from '../../models/context/update-context-method';
 import {LanguageConfig, TranslationBundle} from '../../models/language';
+import {BeforeChangeValidationPromise} from '../../models/context/before-change-validation-promise';
 
 type LanguageContextFields = {
   readonly SELECTED_LANGUAGE: string;
@@ -25,22 +26,27 @@ export class LanguageContextService extends ContextService<LanguageContextFields
    *
    * @param {string} locale - The new language code to set (e.g., 'en', 'fr', 'de').
    */
-  updateSelectedLanguage(locale?: string): void {
+  updateSelectedLanguage(locale?: string): Promise<boolean> {
     const selectedLanguage = locale || ServiceProvider.get(LanguageService).getDefaultLanguage();
     const storageService = ServiceProvider.get(LanguageStorageService);
     storageService.set(this.SELECTED_LANGUAGE, selectedLanguage);
-    this.updateContextProperty(this.SELECTED_LANGUAGE, locale);
+    return this.validateAndUpdateContextProperty(this.SELECTED_LANGUAGE, locale);
   }
 
   /**
+   * Registers a <code>callbackFunction</code> to be called whenever the selected language changes.
    *
-   * Registers the <code>callbackFunction</code> to be called whenever the selected language changes.
+   * This method allows components to react to language changes in the application.
+   * The callback will be triggered with the new language value whenever it changes.
    *
    * @param callbackFunction - The function to call when the selected language changes.
+   * @param beforeChangeValidationPromise - Optional. A promise that will be resolved before
+   *        the language change is applied. This can be used to validate or prepare for the
+   *        language change. If the promise is resolved with false or rejects, the language change will be canceled.
    * @returns A function to unsubscribe from updates.
    */
-  onSelectedLanguageChanged(callbackFunction: ValueChangeCallback<string | undefined>): () => void {
-    return this.subscribe(this.SELECTED_LANGUAGE, callbackFunction);
+  onSelectedLanguageChanged(callbackFunction: ValueChangeCallback<string | undefined>, beforeChangeValidationPromise?: BeforeChangeValidationPromise<string | undefined>): () => void {
+    return this.subscribe(this.SELECTED_LANGUAGE, callbackFunction, beforeChangeValidationPromise);
   }
 
   /**

--- a/packages/legacy-workbench/.editorconfig
+++ b/packages/legacy-workbench/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+
+indent_style = space
+indent_size = 4
+
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.txt]
+insert_final_newline = false

--- a/packages/legacy-workbench/src/js/angular/sparql-template/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/sparql-template/controllers.js
@@ -405,7 +405,7 @@ function SparqlTemplateCreateCtrl(
         updateTitle();
     };
 
-    const repositoryWillChangedHandler = (eventData) => {
+    const repositoryWillChangeHandler = (eventData) => {
         return new Promise(function (resolve) {
 
             if ($scope.sparqlTemplateInfo.isNewTemplate) {
@@ -488,7 +488,7 @@ function SparqlTemplateCreateCtrl(
     subscriptions.push($scope.$on('queryChanged', queryChangeHandler));
     subscriptions.push($rootScope.$on('$translateChangeSuccess', languageChangedHandler));
     subscriptions.push($scope.$on('$locationChangeStart', locationChangedHandler));
-    subscriptions.push(eventEmitterService.subscribe('repositoryWillChangeEvent', repositoryWillChangedHandler));
+    subscriptions.push(eventEmitterService.subscribe('repositoryWillChangeEvent', repositoryWillChangeHandler));
     subscriptions.push($scope.$on('$destroy', removeAllListeners));
     // Prevent go out of the current page? check
     window.addEventListener('beforeunload', beforeunloadHandler);


### PR DESCRIPTION
## What
Display confirmation dialog when changing the language on the SPARQL view

## Why
Since the page must be reloaded in order to change the language, the user might lose data about running queries in the SPARQL editor

## How
- defined a new `BeforeChangeValidationPromise` function which takes a value and returns a Promise which resolves to a boolean
- added an array of `BeforeChangeValidationPromise` in `ValueContext` to hold validation functions
- refactored `subscribe` method of `ValueContext` to accept validation functions and also to remove them in the unsubscribe function
- added a new async method `canUpdate` in `ValueContext` which calls the validation functions and returns true if they all resolve to true or false if some resolves to false or if the promise is rejected
- added a new method `validateAndUpdateContextProperty` in `ContextService` to be used to set a context property only after it is validated by the validation functions of the context
- refactored `updateSelectedLanguage` in `LanguageContextService` to use the new `validateAndUpdateContextProperty`
- refactored logic in the  `SparqlEditorCtrl` to listen to `LanguageContextService` language change trigger and add a validation function to show a modal for user confirmation

## Also in this MR
- added a `.editorconfig` to the legacy workbench package because of different formatting
- fixed a typo in `SparqlTemplateCreateCtrl`

## Testing
- added tests for better coverage

## Screenshots
![image](https://github.com/user-attachments/assets/7e9c87e3-2de8-45c8-b8b9-03a3ef17939a)


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [X] Tests
