### PR TITLE
GDB-7797 - Remove extra whitespaces from new visual graph names

### DIFF
--- a/src/js/angular/graphexplore/controllers/graphs-config.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-config.controller.js
@@ -258,6 +258,11 @@ function GraphConfigCtrl(
         $scope.newConfig.startQueryIncludeInferred = $scope.tabConfig.inference;
         $scope.newConfig.startQuerySameAs = $scope.tabConfig.sameAs;
 
+        if ($scope.newConfig.name) {
+            // remove whitespace
+            $scope.newConfig.name = $scope.newConfig.name.replace(/\s+/g, ' ').trim();
+        }
+
         validateCurrentPage(() => {
             if (!$scope.newConfig.name) {
                 showInvalidMsg($translate.instant('graphexplore.provide.config.name'));


### PR DESCRIPTION
## What
When creating a Visual Graph, typed extra spaces will be removed.

## Why
Saving two graphs with names "foo bar" (one space) and "foo  bar" (two spaces), created two graphs called "foo bar", when the second one should have been invalid and rejected.

## How
I clean up the name input from extra spaces when the form is submitted.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
