### PR TITLE
(cherry-pick) GDB-12146 - Prevent namespace API call when GQL RO rights

### DIFF
--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -124,7 +124,8 @@ function homeCtrl($scope,
     const subscriptions = [];
 
     const onSelectedRepositoryIdUpdated = (repositoryId) => {
-        if (!repositoryId) {
+        // Don't call API, if no repo ID or if GQL read only or write rights
+        if (!repositoryId || $jwtAuth.hasGraphqlRightsOverCurrentRepo()) {
             $scope.repositoryNamespaces = new NamespacesListModel();
             return;
         }


### PR DESCRIPTION
## What
When a GQL Read only user opens the homepage, there will be no toast message with a Namespace error.

![image](https://github.com/user-attachments/assets/64d85d6f-ca3a-41a3-90b7-466c696a15c8)

## Why
The error would appear, because the user does not have rights to call the API. This is expected. The message causes confusion.

## How
I added a GQL RO check before the API is called.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
