### PR TITLE
(cherry-pick) GDB-11955 - Introduce cluster Create dialog improvements

### DIFF
--- a/src/css/clustermanagement.css
+++ b/src/css/clustermanagement.css
@@ -225,10 +225,18 @@ div.nodetooltip {
     -webkit-user-select: none;
     user-select: none;
     word-break: break-all;
-
     display: flex;
     align-items: center;
     justify-content: flex-start;
+}
+
+.location-item .text-only:hover {
+    text-decoration: 1px underline dashed var(--color-success-dark);
+    text-underline-offset: 4px;
+}
+
+.location-item:hover .custom-link-icon {
+    opacity: 1;
 }
 
 .location-item.hoverable:not(.list-group-item-danger):hover {

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -194,7 +194,8 @@
             "actions": {
                 "replace_node": "Replace node",
                 "delete_node": "Delete node",
-                "cannot_delete_node": "You cannot remove more than half of the healthy nodes at the same time",
+                "cannot_delete_node": "The current node cannot be removed",
+                "cannot_replace_node": "You cannot replace this node",
                 "add_node": "Add node",
                 "add_node_tooltip": "Add node to current cluster",
                 "cancel": "Cancel",
@@ -208,6 +209,11 @@
             },
             "field_placeholders": {
                 "location": "http://my-hostname:7200"
+            },
+            "copy_to_clipboard": {
+                "copied": {
+                    "tooltip": "IRI copied"
+                }
             }
         }
     },
@@ -2467,6 +2473,9 @@
         "dates": {
             "today": "Today",
             "yesterday": "Yesterday"
+        },
+        "messages": {
+            "copied_to_clipboard": "Copied to clipboard"
         }
     },
     "common.confirm.delete": "Confirm delete",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -193,7 +193,8 @@
             "actions": {
                 "replace_node": "Remplacer le nœud",
                 "delete_node": "Supprimer le nœud",
-                "cannot_delete_node": "Vous ne pouvez pas supprimer plus de la moitié des nœuds sains en même temps",
+                "cannot_delete_node": "Le nœud actuel ne peut pas être supprimé",
+                "cannot_replace_node": "Vous ne pouvez pas remplacer ce nœud",
                 "add_node": "Ajouter un nœud",
                 "add_node_tooltip": "Ajouter un nœud au cluster actuel",
                 "cancel": "Annuler",
@@ -207,6 +208,11 @@
             },
             "field_placeholders": {
                 "location": "http://my-hostname:7200"
+            },
+            "copy_to_clipboard": {
+                "copied": {
+                    "tooltip": "IRI copié"
+                }
             }
         }
     },
@@ -2465,6 +2471,9 @@
         "dates": {
             "today": "Aujourd'hui",
             "yesterday": "Hier"
+        },
+        "messages": {
+            "copied_to_clipboard": "Copié dans le presse-papier"
         }
     },
     "common.confirm.delete": "Confirmation de la suppression",

--- a/src/js/angular/clustermanagement/directives/cluster-nodes-configuration.directive.js
+++ b/src/js/angular/clustermanagement/directives/cluster-nodes-configuration.directive.js
@@ -33,6 +33,13 @@ function ClusterNodesConfigurationComponent($translate, $timeout, productInfo, t
             $scope.addNode = () => {
                 $scope.addNewLocation = true;
                 $scope.newLocation = new Location();
+                // Timeout used because field is added dynamically on "Add Node" and needs to render before it can be focused
+                $timeout(function () {
+                    const input = document.querySelector("input[name='location']");
+                    if (input) {
+                        input.focus();
+                    }
+                }, 0);
             };
 
             /**

--- a/src/js/angular/clustermanagement/templates/cluster-nodes-configuration.html
+++ b/src/js/angular/clustermanagement/templates/cluster-nodes-configuration.html
@@ -43,8 +43,13 @@
                 ng-class="{'selected': $index === selectedNode || $index === editedNodeIndex}">
                 <td class="index-cell"><span ng-if="!node.isDeleted">{{node.index + 1}}</span></td>
                 <td class="location-cell data"  ng-class="{'deleting': node.isDeleted, 'adding': !node.item.address}">
-                    <div class="location-item">
-                        {{node.item.endpoint}}
+                    <div class="location-item" id="endpoint-{{::node.index}}">
+                        <span class="text-only">{{node.item.endpoint}}</span>
+                        <copy-to-clipboard
+                        text-to-copy="{{node.item.endpoint}}"
+                        custom-tooltip-style="true"
+                        ng-attr-target-selector="#endpoint-{{::node.index}}"
+                        custom-tooltip-text="{{'cluster_management.update_cluster_group_dialog.copy_to_clipboard.copied.tooltip' | translate}}"></copy-to-clipboard>
                     </div>
                 </td>
                 <td class="info-cell data">
@@ -70,14 +75,18 @@
                 <td class="empty-cell"></td>
                 <td class="actions-cell">
                     <div ng-if="editedNodeIndex === undefined && !node.isDeleted" class="actions-group">
-                        <button ng-click="deleteNode($index, node)" ng-disabled="!canDeleteNode"
+                        <button ng-click="deleteNode($index, node)" ng-disabled="(hasCluster && !canDeleteNode) || (!hasCluster && node.isLocal)"
                                 class="btn btn-link delete-node-btn secondary"
-                                gdb-tooltip="{{ canDeleteNode ? ('cluster_management.update_cluster_group_dialog.actions.delete_node' | translate) : ('cluster_management.update_cluster_group_dialog.actions.cannot_delete_node' | translate) }}"
+                                gdb-tooltip="{{ (hasCluster && canDeleteNode) || (!hasCluster && !node.isLocal) ?
+                                ('cluster_management.update_cluster_group_dialog.actions.delete_node' | translate) :
+                                ('cluster_management.update_cluster_group_dialog.actions.cannot_delete_node' | translate) }}"
                                 title-class="delete-node-tooltip">
                             <i class="fa fa-xmark"></i>
                         </button>
-                        <button ng-click="replaceNode($index, node)" class="btn btn-link replace-node-btn"
-                                gdb-tooltip="{{'cluster_management.update_cluster_group_dialog.actions.replace_node' | translate}}">
+                        <button ng-click="replaceNode($index, node)" class="btn btn-link replace-node-btn" ng-disabled="!hasCluster && node.isLocal"
+                                gdb-tooltip="{{hasCluster || !node.isLocal ?
+                                ('cluster_management.update_cluster_group_dialog.actions.replace_node' | translate) :
+                                ('cluster_management.update_cluster_group_dialog.actions.cannot_replace_node' | translate) }}">
                             <i class="fa fa-arrow-right-arrow-left"></i>
                         </button>
                     </div>

--- a/src/js/angular/core/directives/copy-to-clipboard/copy-to-clipboard.directive.js
+++ b/src/js/angular/core/directives/copy-to-clipboard/copy-to-clipboard.directive.js
@@ -6,17 +6,36 @@
  *
  * @description
  * `copyToClipboard` is a directive that creates a button which, when clicked, copies a specific text to the clipboard.
- * The directive uses an isolated scope with a single property, `tooltipText`, which is bound to the `tooltipText` attribute of the element where the directive is used.
- * The tooltip text is translated using the `$translate` service.
- * The button also has an `ng-click` directive that triggers the `copyToClipboard` function when the button is clicked.
+ * The directive uses an isolated scope with multiple properties to support both default and custom styling behaviors.
  *
- * @param {string} tooltipText - The text to be displayed as a tooltip when hovering over the button.
- * @param {string} textToCopy - (optional) The text to be copied. If not passed, searching by the class 'copyable'
- *                                         will be used, and the search will be executed within the scope of
- *                                         the directive's parent element.
+ * - By default, the button shows a translated tooltip on hover and triggers a copy to clipboard operation.
+ * - In a custom behavior mode (enabled via `customTooltipStyle`), the directive suppresses the tooltip and instead displays a styled inline tooltip on click.
+ * - The copy operation can be targeted to a specific element using `targetSelector`, useful when triggering the directive indirectly (e.g. clicking on a container).
+ * - The success message via `toastr` can also be disabled if custom feedback is handled separately.
+ *
+ * @param {string} tooltipText - The text to be displayed as a tooltip when hovering over the button. One-time bound by default.
+ * @param {string} textToCopy - (optional) The text to be copied. If not passed, the directive will search for an element with class `copyable` within the parent element.
+ * @param {boolean} customTooltipStyle - (optional) If true, suppresses the default tooltip and shows a custom-styled tooltip near the icon on click.
+ * @param {string} targetSelector - (optional) A CSS selector used to locate an external DOM element to which the tooltip should be anchored.
+ * @param {string} customTooltipText - (optional) The text to display in the custom tooltip.
  *
  * @example
+ * <!-- Default usage -->
  * <copy-to-clipboard tooltip-text="Your tooltip text here"></copy-to-clipboard>
+ *
+ * @example
+ * <!-- With custom copy text -->
+ * <copy-to-clipboard tooltip-text="'Click to copy'" text-to-copy="{{valueToCopy}}"></copy-to-clipboard>
+ *
+ * @example
+ * <!-- With custom tooltip behavior and external target -->
+ * <div class="item" id="itemId">
+ *   <copy-to-clipboard
+ *     text-to-copy="{{valueToCopy}}"
+ *     custom-tooltip-style="true"
+ *     ng-attr-target-selector="#itemId">
+ *   </copy-to-clipboard>
+ * </div>
  */
 angular
     .module('graphdb.framework.core.directives.copytoclipboard.copytoclipboard', [])
@@ -41,42 +60,111 @@ copyToClipboard.$inject = ['$translate', 'toastr'];
  */
 function copyToClipboard($translate, toastr) {
     return {
-        // Note: the line-height of the element must match the line-height of the icon
         template: `
             <style>
                 .copy-btn {
                     line-height: 0.75;
+                    position: relative;
+                }
+
+                .custom-link-icon {
+                    opacity: 0;
+                    margin-left: 5px;
+                    transition: opacity 0.2s ease-in-out;
+                    color: var(--secondary-color);
+                }
+
+                .copy-btn:hover .custom-link-icon {
+                    opacity: 1;
+                }
+
+                 .copy-btn:hover .custom-link-icon {
+                    opacity: 1;
+                }
+
+                .custom-tooltip-popup {
+                    font-family: Arial, sans-serif;
+                    position: absolute;
+                    background: #000000;
+                    color: #FFFFFF;
+                    padding: 5px 8px;
+                    margin: 0 5px;
+                    border-radius: 4px;
+                    font-size: 12px;
+                    z-index: 9999;
+                    opacity: 0;
+                    transition: opacity 0.2s ease-in-out;
+                    line-height: 0.75;
+                }
+
+                .custom-tooltip-popup.show {
+                    opacity: 1;
                 }
             </style>
-            <button class="btn btn-link btn-sm copy-btn" gdb-tooltip="{{tooltipText | translate}}" ng-click="copyToClipboard()"><i class="fa fa-clone"></i></button>
+            <button
+                class="btn btn-link btn-sm copy-btn"
+                ng-if="!customTooltipStyle"
+                gdb-tooltip="{{tooltipText | translate}}"
+                ng-click="copyToClipboard($event)">
+                <i class="fa fa-clone link-icon" aria-hidden="true"></i>
+            </button>
+            <button
+                class="btn btn-link btn-sm copy-btn"
+                ng-if="customTooltipStyle"
+                ng-click="copyToClipboard($event)">
+                <i class="fa fa-clone custom-link-icon" aria-hidden="true"></i>
+            </button>
         `,
         restrict: 'E',
         scope: {
             tooltipText: '@',
-            textToCopy: '@'
+            textToCopy: '@',
+            customTooltipStyle: '@?',
+            targetSelector: '@?',
+            customTooltipText: '@?'
         },
         link: function ($scope, element) {
             $scope.copyToClipboard = function() {
                 const textToCopy = $scope.textToCopy ? $scope.textToCopy : element.parent().find('.copyable').text();
 
-                if (navigator.clipboard) {
-                    navigator.clipboard.writeText(textToCopy).then(() => {
-                        toastr.success($translate.instant('import.help.messages.copied_to_clipboard'));
-                    }).catch((err) => {
-                        console.error('Could not copy text: ', err);
+                function showCustomTooltip() {
+                    const tooltip = document.createElement("span");
+                    tooltip.innerText = $scope.customTooltipText;
+                    tooltip.className = "custom-tooltip-popup";
+                    const iconElement = element[0].querySelector('.custom-link-icon');
+
+                    iconElement.appendChild(tooltip);
+
+                    requestAnimationFrame(() => {
+                        tooltip.classList.add("show");
                     });
-                } else {
+
+                    setTimeout(() => {
+                        tooltip.classList.remove("show");
+                        setTimeout(() => tooltip.remove(), 200);
+                    }, 1500);
+                }
+
+                function showSuccessFeedback() {
+                    if ($scope.customTooltipStyle) {
+                        showCustomTooltip();
+                    } else {
+                        toastr.success($translate.instant('common.messages.copied_to_clipboard'));
+                    }
+                }
+
+                function fallbackCopy(text) {
                     // document.execCommand('copy') can only copy text that is selected. The browser requires a selected
                     // text range to perform the copy operation. So the string is temporarily placed into a selectable form.
                     const tempTextArea = document.createElement('textarea');
-                    tempTextArea.value = textToCopy;
+                    tempTextArea.value = text;
                     document.body.appendChild(tempTextArea);
                     tempTextArea.select();
 
                     try {
                         const successful = document.execCommand('copy');
                         if (successful) {
-                            toastr.success($translate.instant('import.help.messages.copied_to_clipboard'));
+                            showSuccessFeedback();
                         } else {
                             console.error('Unable to copy text');
                         }
@@ -86,7 +174,39 @@ function copyToClipboard($translate, toastr) {
                         document.body.removeChild(tempTextArea);
                     }
                 }
+
+                if (navigator.clipboard) {
+                    navigator.clipboard.writeText(textToCopy).then(() => {
+                        showSuccessFeedback();
+                    }).catch(err => {
+                        console.error('Could not copy text: ', err);
+                        fallbackCopy(textToCopy);
+                    });
+                } else {
+                    fallbackCopy(textToCopy);
+                }
             };
+
+            // Clicking the targetSelector will trigger copy
+            if ($scope.customTooltipStyle && $scope.targetSelector) {
+                // Delay to ensure DOM is fully loaded when dynamically rendering
+                setTimeout(() => {
+                    const target = document.querySelector($scope.targetSelector);
+                    if (target) {
+                        const clickHandler = function (e) {
+                            e.stopPropagation();
+                            $scope.copyToClipboard();
+                        };
+                        target.addEventListener('click', clickHandler);
+
+                        $scope.$on('$destroy', () => {
+                            target.removeEventListener('click', clickHandler);
+                        });
+                    } else {
+                        console.warn('copyToClipboard: targetSelector not found:', $scope.targetSelector);
+                    }
+                }, 0);
+            }
         }
     };
 }

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -194,7 +194,8 @@
             "actions": {
                 "replace_node": "Replace node",
                 "delete_node": "Delete node",
-                "cannot_delete_node": "You cannot remove more than half of the healthy nodes at the same time",
+                "cannot_delete_node": "The current node cannot be removed",
+                "cannot_replace_node": "You cannot replace this node",
                 "add_node": "Add node",
                 "add_node_tooltip": "Add node to current cluster",
                 "cancel": "Cancel",
@@ -208,6 +209,11 @@
             },
             "field_placeholders": {
                 "location": "http://my-hostname:7200"
+            },
+            "copy_to_clipboard": {
+                "copied": {
+                    "tooltip": "IRI copied"
+                }
             }
         }
     },
@@ -2467,6 +2473,9 @@
         "dates": {
             "today": "Today",
             "yesterday": "Yesterday"
+        },
+        "messages": {
+            "copied_to_clipboard": "Copied to clipboard"
         }
     },
     "common.confirm.delete": "Confirm delete",


### PR DESCRIPTION
## What
Several improvements added to cluster create dialog:

- field for new node gets auto-focused;
- current node replace is not allowed;
- added new locations can be removed during cluster creation (exception is the Current node);
- copy functionality added for locations.

## Why
The changes improve the user experience.

## How
I extended the existing copy-to-clipboard directive with a custom tooltip for the copy action notification. I added the necessary logic for input focus of the dynamic fields.

## Testing
N/A

## Screenshots
Video in MR for Master branch - https://github.com/Ontotext-AD/graphdb-workbench/pull/1926

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
