### PR TITLE
GDB-11393: Shift+Enter to go to a new line without prompting the LLM should be supported

### DIFF
--- a/src/css/editable-content.css
+++ b/src/css/editable-content.css
@@ -1,0 +1,19 @@
+editable-content .contenteditable {
+    height: 100%;
+    width: 100%;
+    outline: none;
+    min-height: 2rem;
+    max-height: 7rem;
+    overflow-y: auto;
+}
+
+editable-content .contenteditable[disabled] {
+    cursor: not-allowed;
+}
+
+editable-content [placeholder]:empty:before {
+    content: attr(placeholder);
+    position: absolute;
+    color: gray;
+    background-color: transparent;
+}

--- a/src/css/markdown-content.css
+++ b/src/css/markdown-content.css
@@ -1,0 +1,3 @@
+markdown-content {
+    overflow-wrap: break-word;
+}

--- a/src/css/ttyg/chat-panel.css
+++ b/src/css/ttyg/chat-panel.css
@@ -64,6 +64,11 @@
     line-height: var(--line-height);
 }
 
+.chat-panel .user-message .question .question-text {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
 .chat-panel .messages-hint {
     padding-top: 1rem;
     text-align: center;
@@ -132,9 +137,21 @@
     padding-left: 1rem;
 }
 
+.chat-panel .new-question .form-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.chat-panel .new-question .new-question-actions {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
 .chat-panel .new-question .question-input {
-    background-color: #EFF3F8;
-    color: var(--text-color);
+    width: 100%;
 }
 
 .chat-panel .chat-loading {
@@ -144,3 +161,5 @@
 .chat-panel .text-warning {
     font-weight: 300;
 }
+
+

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -397,6 +397,9 @@
                 "called": "Called {{('ttyg.chat_panel.query_name.' + name) | translate}}",
                 "no_query": "There is no query."
             },
+            "placeholder": {
+                "ask-input": "Ask anything"
+            },
             "query_name": {
                 "sparql_query":"SPARQL",
                 "fts_search": "Full-text search",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -396,6 +396,9 @@
                 "called": "{{('ttyg.chat_panel.query_name.' + name) | translate}} a été appelé",
                 "no_query": "Il n'y a pas de requête."
             },
+            "placeholder": {
+                "ask-input": "Posez une question"
+            },
             "query_name": {
                 "sparql_query": "SPARQL",
                 "fts_search": "Recherche en texte intégral",

--- a/src/js/angular/core/directives/editable-content/editable-content.js
+++ b/src/js/angular/core/directives/editable-content/editable-content.js
@@ -1,0 +1,81 @@
+/**
+ * @ngdoc directive
+ * @name editableContent
+ * @module graphdb.framework.core.directives.editable-content
+ * @restrict E
+ * @description
+ * A reusable contenteditable directive bound to an ngModel. It allows editable plain-text input and supports disabling and placeholder text.
+ *
+ * @param {string} ngModel - The model to bind contenteditable input to.
+ * @param {boolean=} ngDisabled - Disables the contenteditable field when true.
+ * @param {string=} placeholder - Placeholder text to show when input is empty.
+ */
+const modules = [];
+
+angular
+    .module('graphdb.framework.core.directives.editable-content', modules)
+    .directive('editableContent', editableContent);
+
+editableContent.$inject = [];
+
+function editableContent() {
+    return {
+        restrict: 'E',
+        require: 'ngModel',
+        scope: {
+            ngModel: '=',
+            ngDisabled: '=',
+            placeholder: '@'
+        },
+        templateUrl: 'js/angular/core/templates/editable-content/editable-content.html',
+        link: function(scope, element, attrs, ngModelCtrl) {
+
+            // =========================
+            // Private variables
+            // =========================
+
+            const editableDiv = element.find('div');
+
+            // =========================
+            // Private functions
+            // =========================
+
+            /**
+             * Updates the bound ngModel with the current contenteditable value.
+             * Also clears invalid HTML when only whitespace remains.
+             */
+            const updateModelValue = () => {
+                if (!scope.ngDisabled) {
+                    scope.$apply(() => {
+                        if (editableDiv.html().length && !editableDiv.text().trim().length) {
+                            // Fixes a problem with the placeholder when type some word and delete it.
+                            editableDiv.empty();
+                        }
+                        ngModelCtrl.$setViewValue(editableDiv[0].innerText);
+                    });
+                }
+            };
+
+            /**
+             * Renders the model value into the contenteditable element.
+             */
+            ngModelCtrl.$render = () => {
+                editableDiv.html(ngModelCtrl.$viewValue || '');
+            };
+
+            // =========================
+            // Subscriptions
+            // =========================
+
+            /**
+             * Unsubscribes from all watchers and event listeners to prevent memory leaks.
+             */
+            const removeAllSubscribers = () => {
+                editableDiv.off('blur keyup change input', updateModelValue);
+            };
+
+            scope.$on('$destroy', removeAllSubscribers);
+            editableDiv.on('blur keyup change input', updateModelValue);
+        }
+    };
+}

--- a/src/js/angular/core/directives/markdown-content/markdown-content.js
+++ b/src/js/angular/core/directives/markdown-content/markdown-content.js
@@ -30,7 +30,7 @@ markdownContentDirective.$inject = ['$compile', 'MarkdownService'];
 
 function markdownContentDirective($compile, MarkdownService) {
     return {
-        template: '<div class="markdown-content" ng-bind-html="markdownContent"></div>',
+        templateUrl: 'js/angular/core/templates/markdown-content/markdown-content.html',
         restrict: 'E',
         scope: {
             content: '@',

--- a/src/js/angular/core/templates/editable-content/editable-content.html
+++ b/src/js/angular/core/templates/editable-content/editable-content.html
@@ -1,0 +1,8 @@
+<link href="css/editable-content.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+<div
+        ng-attr-contenteditable="{{!ngDisabled}}"
+        ng-attr-disabled="{{ngDisabled ? true : undefined}}"
+        placeholder="{{placeholder}}"
+        guide-selector="contenteditable"
+        class="contenteditable">
+</div>

--- a/src/js/angular/core/templates/markdown-content/markdown-content.html
+++ b/src/js/angular/core/templates/markdown-content/markdown-content.html
@@ -1,0 +1,2 @@
+<link href="css/markdown-content.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+<div class="markdown-content" ng-bind-html="markdownContent"></div>

--- a/src/js/angular/guides/steps/complex/ttyg/ask-ttyg-agent/plugin.js
+++ b/src/js/angular/guides/steps/complex/ttyg/ask-ttyg-agent/plugin.js
@@ -21,12 +21,12 @@ PluginRegistry.add('guide.step', [
                         url: '/ttyg',
                         elementSelector: GuideUtils.getGuideElementSelector('question-input'),
                         show: (guide) => () => {
-                            const elementSelector = GuideUtils.getGuideElementSelector('question-input');
+                            const elementSelector = GuideUtils.getGuideElementSelector('contenteditable');
 
                             // Add "keydown" listener to the element. The question-input directive listens for keypress of enter to trigger question asking.
                             // When enter is pressed, proceed with next step. Using 'keydown' to trigger before the directive 'keypress', which clears the value.
                             $(elementSelector).on('keydown', (event) => {
-                                const value = $(elementSelector).val();
+                                const value = $(elementSelector).text();
 
                                 if (value && event.key === 'Enter' && !event.shiftKey && !event.ctrlKey) {
                                     guide.next();
@@ -34,7 +34,7 @@ PluginRegistry.add('guide.step', [
                             });
                         },
                         hide: () => () => {
-                            const elementSelector = GuideUtils.getGuideElementSelector('question-input');
+                            const elementSelector = GuideUtils.getGuideElementSelector('contenteditable');
                             // Remove the "keydown" listener of element. It is important when step is hidden.
                             $(elementSelector).off('keydown');
                         },

--- a/src/js/angular/ttyg/directives/chat-panel.directive.js
+++ b/src/js/angular/ttyg/directives/chat-panel.directive.js
@@ -1,4 +1,5 @@
 import './chat-item-detail.directive';
+import 'angular/core/directives/editable-content/editable-content';
 import {TTYGEventName} from "../services/ttyg-context.service";
 import {CHAT_MESSAGE_ROLE, ChatMessageModel} from "../../models/ttyg/chat-message";
 import {ChatItemModel} from "../../models/ttyg/chat-item";
@@ -7,7 +8,8 @@ import {decodeHTML} from "../../../../app";
 import {ChatModel} from "../../models/ttyg/chats";
 
 const modules = [
-    'graphdb.framework.ttyg.directives.chat-item-detail'
+    'graphdb.framework.ttyg.directives.chat-item-detail',
+    'graphdb.framework.core.directives.editable-content'
 ];
 
 angular

--- a/src/js/angular/ttyg/templates/chat-item-detail.html
+++ b/src/js/angular/ttyg/templates/chat-item-detail.html
@@ -4,7 +4,7 @@
     <div class="user-message" ng-if="chatItemDetail.question">
         <div class="question alert-help"
              gdb-tooltip="{{ 'ttyg.chat_panel.labels.question_asked' | translate : { date: getHumanReadableQuestionTimestamp(chatItemDetail.question.timestamp), time: (chatItemDetail.question.timestamp | date:'HH:mm') } }}">
-            {{ chatItemDetail.question.message }}
+            <div class="question-text">{{chatItemDetail.question.message}}</div>
         </div>
     </div>
     <div class="answers" ng-repeat="answer in chatItemDetail.answers">

--- a/src/js/angular/ttyg/templates/chat-panel.html
+++ b/src/js/angular/ttyg/templates/chat-panel.html
@@ -37,16 +37,26 @@
         <chat-item-detail ng-if="askingChatItem" chat-item-detail="askingChatItem"
                           asking="!!askingChatItem"></chat-item-detail>
     </div>
-    <div class="new-question mt-3 d-flex" ng-if="!loadingChat" guide-selector="question-box">
-        <input class="form-control question-input" ng-model="chatItem.question.message" type="text" guide-selector="question-input"
-               ng-disabled="loadingChat || !selectedAgent || selectedAgent.isDeleted"
-               ng-keypress="onKeypressOnInput($event)">
-        <button class="btn btn-primary ask-button" guide-selector="question-ask"
-                ng-disabled="!chatItem.question.message || !selectedAgent || selectedAgent.isDeleted || waitingForLastMessage || loadingChat"
-                ng-click="ask()">
-            <i class="fa fa-arrow-turn-left-up"></i>
-            {{ 'ttyg.chat_panel.btn.ask.label ' | translate }}
-        </button>
+    <div class="new-question mt-3" ng-if="!loadingChat" guide-selector="question-box">
+        <div class="form-control">
+            <editable-content
+                    placeholder="{{'ttyg.chat_panel.placeholder.ask-input' | translate}}"
+                    ng-model="chatItem.question.message"
+                    guide-selector="question-input"
+                    ng-disabled="loadingChat || !selectedAgent || selectedAgent.isDeleted"
+                    ng-keypress="onKeypressOnInput($event)"
+                    class="question-input"></editable-content>
+            <div class="new-question-actions">
+                <div class="left-side-actions"></div>
+                <div class="right-side-actions">
+                    <button class="btn btn-primary ask-button" guide-selector="question-ask"
+                            ng-disabled="!chatItem.question.message || !selectedAgent || selectedAgent.isDeleted || waitingForLastMessage || loadingChat"
+                            ng-click="ask()">
+                        <i class="fa fa-arrow-up"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
     </div>
 
     <div class="messages-hint text-muted" ng-if="!loadingChat && chat.chatHistory.isEmpty() && !waitingForLastMessage" ng-cloak>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -397,6 +397,9 @@
                 "called": "Called {{('ttyg.chat_panel.query_name.' + name) | translate}}",
                 "no_query": "There is no query."
             },
+            "placeholder": {
+                "ask-input": "Ask anything"
+            },
             "query_name": {
                 "sparql_query":"SPARQL",
                 "fts_search": "Full-text search",

--- a/test-cypress/integration/ttyg/chat-panel.spec.js
+++ b/test-cypress/integration/ttyg/chat-panel.spec.js
@@ -42,7 +42,7 @@ describe('Ttyg ChatPanel', () => {
         // When the new question input is empty.
         // The "Ask" button must be disabled.
         ChatPanelSteps.getAskButtonElement().should('be.disabled');
-        ChatPanelSteps.getQuestionInputElement().should('be.disabled');
+        ChatPanelSteps.getQuestionInputElement().should('have.attr', 'disabled');
 
         // Then I expect the "Ask" button be not active because agent is not selected
         ChatPanelSteps.getAskButtonElement().should('not.be.enabled');
@@ -54,7 +54,8 @@ describe('Ttyg ChatPanel', () => {
         // When I type a question
         ChatPanelSteps.getQuestionInputElement()
             .should('be.visible')
-            .and('not.be.disabled')
+            .and('not.have.attr', 'disabled');
+        ChatPanelSteps.getQuestionInputElement()
             .type('Who is Han Solo?');
 
         // Then I expect the "Ask" button be active.
@@ -68,7 +69,7 @@ describe('Ttyg ChatPanel', () => {
         ChatPanelSteps.getChatDetailsElements().should('have.length', 3);
         ChatPanelSteps.getChatDetailQuestionElement(2).contains('Who is Han Solo?');
         // and input field be empty,
-        ChatPanelSteps.getQuestionInputElement().should('be.enabled');
+        ChatPanelSteps.getQuestionInputElement().should('not.have.attr', 'disabled');
         ChatPanelSteps.getQuestionInputElement().should('have.value', '');
         // and "Ask" button be disabled.
         ChatPanelSteps.getAskButtonElement().should('be.disabled');

--- a/test-cypress/integration/ttyg/create-chat.spec.js
+++ b/test-cypress/integration/ttyg/create-chat.spec.js
@@ -38,8 +38,10 @@ describe('TTYG create chat', () => {
         // When I type a question
         ChatPanelSteps.getQuestionInputElement()
             .should('be.visible')
-            .and('not.be.disabled')
+            .and('not.have.attr', 'disabled');
+        ChatPanelSteps.getQuestionInputElement()
             .type('Who is Han Solo?');
+
 
         // Then I expect the "Ask" button be active.
         ChatPanelSteps.getAskButtonElement().should('be.enabled');

--- a/test-cypress/steps/ttyg/chat-panel-steps.js
+++ b/test-cypress/steps/ttyg/chat-panel-steps.js
@@ -17,7 +17,7 @@ export class ChatPanelSteps {
     }
 
     static getQuestionInputElement() {
-        return ChatPanelSteps.getChatPanel().find('.question-input');
+        return ChatPanelSteps.getChatPanel().find('.question-input .contenteditable');
     }
 
     static getAskButtonElement() {


### PR DESCRIPTION
## What
Extend the question input to support inserting a new line when pressing Shift+Enter.

## Why
Users want to be able to insert a new line character in the prompt using Shift+Enter, without triggering the LLM.

## How
- Implement a new editable-content directive that provides this functionality using the contenteditable attribute;
- Update the new question input to use the editable-content directive.


## Screenshots
<img src="https://github.com/user-attachments/assets/d5e16909-09a4-4c3b-9b8c-b049afbf15d3" width="320">
<img src="https://github.com/user-attachments/assets/34a38054-e97e-457a-8bbf-9c214d03e2db" width="320">


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
