### PR TITLE
(cherry pick) GDB-12078 - Update text snippet correctly after Edit

### DIFF
--- a/src/js/angular/import/controllers/import-view.controller.js
+++ b/src/js/angular/import/controllers/import-view.controller.js
@@ -708,14 +708,20 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
                 }
                 importResource.data = data.text;
                 importResource.format = data.format;
-                updateTextImport(importResource);
+                updateTextImport(importResource)
+                    .then(() => $scope.updateListHttp(true))
+                    .then(() => {
+                        if (data.startImport) {
+                            $scope.setSettingsFor(importResource.name, false, importResource.format, Operation.IMPORT_SNIPPET);
+                        }
+                    })
             } else {
                 importResource = {type: 'text', name: 'Text snippet ' + DateUtils.formatCurrentDateTime(), format: data.format, data: data.text};
                 $scope.files.unshift(importResource);
                 $scope.updateImport(importResource.name, false, false);
-            }
-            if (data.startImport) {
-                $scope.setSettingsFor(importResource.name, false, importResource.format, Operation.IMPORT_SNIPPET);
+                if (data.startImport) {
+                    $scope.setSettingsFor(importResource.name, false, importResource.format, Operation.IMPORT_SNIPPET);
+                }
             }
         });
     };
@@ -780,8 +786,8 @@ importViewModule.controller('UploadCtrl', ['$scope', 'toastr', '$controller', '$
 
     const updateTextImport = (settings) => {
         $scope.updating = true;
-        ImportRestService.updateTextSnippet($repositories.getActiveRepository(), settings).success(function (data) {
-            // its updated
+        return ImportRestService.updateTextSnippet($repositories.getActiveRepository(), settings).success(function (data) {
+            // it's updated
         }).error(function (data) {
             toastr.error($translate.instant('import.could.not.update.text', {data: getError(data)}));
         }).finally(function () {


### PR DESCRIPTION
## What
When editing and updating an imported `text snipped`, the changes will not be lost.

## Why
The update call and the import call sometimes happened before the list updates. This meant that the old file was used and any new changes the user made to the snippet would be lost.

## How
This was a little hard to reproduce, because the update and import actions had to be done very quickly. The solution was to add a list update call after the successful update.

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
