### PR TITLE
(cherry-pick) GDB-11916 - Fix nq.gz file not visible on macOS

### DIFF
--- a/src/js/angular/models/import/file-formats.js
+++ b/src/js/angular/models/import/file-formats.js
@@ -11,7 +11,13 @@ export class FileFormats {
     }
 
     static getFileFormatsExtended() {
-        return [...this.getGZS(), ...this.getBasics(), '.zip'].join(', ');
+        return [
+            ...this.getGZS(),
+            ...this.getBasics(),
+            '.zip',
+            '.gz',
+            'application/gzip',
+            'application/x-gzip'].join(', ');
     }
 
     static getFileFormatsHuman() {


### PR DESCRIPTION
## What
macOS users will be able to select `.nq.gz` archives from the Import page.

## Why
macOS users couldn't select the `.nq.gz` archives from the Import page.

## How
I added the `mime types` and `.gz` extension explicitly.

## Testing
Tested on Sequoia 15.3.2. Bug observed before fix. Bug not present after fix.


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
