### PR TITLE
feat(GDB-11897) Migrate pipelines to new Jenkins 2.8

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## What
+
+
+## Why
+
+
+## How
+
+
+## Testing
+
+
+## Screenshots
+
+
+## Checklist
+- [ ] Branch name
+- [ ] Target branch
+- [ ] Commit messages
+- [ ] Squash commits
+- [ ] MR name
+- [ ] MR Description
+- [ ] Tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,113 +1,133 @@
+@Library('ontotext-platform@v0.1.49') _
 pipeline {
-
-  agent {
-    label 'graphdb-jenkins-node'
-  }
-
-  tools {
-    nodejs 'nodejs-20.11.1'
-  }
-
-  environment {
-    CI = "true"
-    NEXUS_CREDENTIALS = credentials('nexus-kim-user')
-    // Needed for our version of webpack + newer nodejs
-    NODE_OPTIONS = "--openssl-legacy-provider"
-    // Tells NPM and co. not to use color output (looks like garbage in Jenkins)
-    NO_COLOR = "1"
-  }
-
-  stages {
-
-    stage('Install') {
-      steps {
-        sh "npm install"
-      }
+    agent {
+        label 'aws-large'
     }
 
-    stage('Validate translations') {
-     steps {
-       sh 'node scripts/validate-translations.js || exit 1'
-     }
+    tools {
+        nodejs 'nodejs-18.9.0'
     }
 
-    stage('Print Branch Name') {
-      steps {
-        script {
-          echo "Building branch: ${env.BRANCH_NAME}"
-        }
-      }
+    environment {
+        // Needed for our version of webpack + newer nodejs
+        NODE_OPTIONS = "--openssl-legacy-provider"
+        // Tells NPM and co. not to use color output (looks like garbage in Jenkins)
+        NO_COLOR = "1"
+        SONAR_ENVIRONMENT = "SonarCloud"
     }
 
-    stage('Build') {
-      steps {
-        sh "npm run build"
-      }
-    }
-
-    stage('Sonar') {
-      steps {
-        withSonarQubeEnv('SonarCloud') {
-          script {
-            if (env.BRANCH_NAME == 'master') {
-              sh "node sonar-project.js --branch='${env.BRANCH_NAME}'"
-            } else {
-              sh "node sonar-project.js --branch='${env.ghprbSourceBranch}' --target-branch='${env.ghprbTargetBranch}' --pull-request-id='${env.ghprbPullId}'"
+    stages {
+        stage('Install, Validate translations, Build') {
+            steps {
+                script {
+                    try {
+                        npm.install(scripts: ['validate-translations', 'build'])
+                    } catch (e) {
+                        archiveValidationArtifacts()
+                    }
+                }
             }
-          }
         }
-      }
-    }
 
-
-    stage('Acceptance') {
-      when {
-        expression {
-          return env.BRANCH_NAME != 'master'
+        stage('Sonar') {
+            steps {
+                withSonarQubeEnv(SONAR_ENVIRONMENT) {
+                    script {
+                        try {
+                            if (scmUtil.isMaster()) {
+                                sh "node sonar-project.js --branch='${scmUtil.getCurrentBranch()}'"
+                            } else {
+                                sh "node sonar-project.js --branch='${scmUtil.getSourceBranch()}' --target-branch='${scmUtil.getTargetBranch()}' --pull-request-id='${scmUtil.getMergeRequestId()}'"
+                            }
+                        } catch (e) {
+                            echo "Sonar analysis failed, but continuing the pipeline. Error: ${e.getMessage()}"
+                        }
+                    }
+                }
+            }
         }
-      }
-      steps {
-        configFileProvider(
-                [configFile(fileId: 'ceb7e555-a3d9-47c7-9afe-d008fd9efb14', targetLocation: 'graphdb.license')]) {
-          sh 'cp graphdb.license ./test-cypress/fixtures/'
+
+        stage('Acceptance') {
+            steps {
+                script {
+                    if (!scmUtil.isMaster()) {
+                        withKsm(application: [[
+                            credentialsId: 'ksm-jenkins',
+                            secrets: [
+                                [
+                                    destination: 'file',
+                                    filePath: 'graphdb.license',
+                                    notation: 'keeper://AByA4tIDmeN7RmqnQYGY0A/file/graphdb.license'
+                                ]
+                            ]
+                        ]]) {
+                            sh 'cp graphdb.license ./test-cypress/fixtures/'
+                            archiveArtifacts allowEmptyArchive: true, artifacts: 'graphdb.license'
+
+                            sh "ls ./test-cypress/fixtures/"
+                            dockerCompose.buildCmd(options: ["--force-rm"])
+                            try {
+                                dockerCompose.upCmd(options: ["--abort-on-container-exit", "--exit-code-from cypress-tests"])
+                            } finally {
+                                cleanup()
+                            }
+                        }
+                    }
+                }
+            }
         }
-          sh "ls ./test-cypress/fixtures/"
-          // --no-ansi suppresses color output that shows as garbage in Jenkins
-          sh "docker-compose --no-ansi build --force-rm --no-cache --parallel"
-          sh "docker-compose --no-ansi up --abort-on-container-exit --exit-code-from cypress-tests"
-
-          // Fix coverage permissions
-          sh "sudo chown -R \$(id -u):\$(id -g) coverage/"
-          sh "sudo chown -R \$(id -u):\$(id -g) cypress/"
-          sh "sudo chown -R \$(id -u):\$(id -g) report/"
-
-          // Move up to be picked by Sonar
-//           sh "mv test-cypress/coverage/ cypress-coverage/"
-//           sh "sync"
-//
-//           // Update relative paths to absolute path
-//           sh "sed -i.backup \"s@^SF:..@SF:\$(pwd)@\" cypress-coverage/lcov.info"
-      }
-    }
-  }
-
-  post {
-    always {
-      // upload failed tests report and artifacts
-      junit allowEmptyResults: true, testResults: 'cypress/results/**/*.xml'
-      archiveArtifacts allowEmptyArchive: true, artifacts: 'report/screenshots/**/*.png, report/videos/**/*.mp4, cypress/logs/*.log'
-
-      // --no-ansi suppresses color output that shows as garbage in Jenkins
-      sh "docker-compose --no-ansi down -v --remove-orphans --rmi=local || true"
-      // clean root owned resources from docker volumes, just in case
-      sh "sudo rm -rf ./coverage"
-      sh "sudo rm -rf ./cypress"
-      sh "sudo rm -rf ./report"
     }
 
-    failure {
-      archiveArtifacts artifacts: 'translation-validation-result.json', onlyIfSuccessful: false
+    post {
+        always {
+            script {
+                cleanup()
+                workspaceCleanup()
+            }
+        }
     }
-  }
 }
 
+def cleanup() {
+    // upload failed tests report and artifacts
+    try {
+        junit allowEmptyResults: true, testResults: 'cypress/results/**/*.xml'
+    } catch (e) {
+        echo "Test results not found: ${e.getMessage()}"
+    }
+
+    try {
+        archiveArtifacts allowEmptyArchive: true, artifacts: 'report/screenshots/**/*.png, report/videos/**/*.mp4, cypress/logs/*.log'
+    } catch (e) {
+        echo "Artifacts not found: ${e.getMessage()}"
+    }
+
+    try {
+        dockerCompose.downCmd(
+            options: ['--volumes', '--remove-orphans', '--rmi', 'local'],
+            ignoreErrors: true
+        )
+    } catch (e) {
+        echo "dockerCompose downCmd failed: ${e.getMessage()}"
+    }
+
+    // clean root owned resources from docker volumes, just in case
+    sh "sudo rm -rf ./coverage || true"
+    sh "sudo rm -rf ./cypress || true"
+    sh "sudo rm -rf ./report || true"
+}
+
+def archiveValidationArtifacts() {
+    try {
+        archiveArtifacts artifacts: 'translation-validation-result.json', onlyIfSuccessful: false
+    } catch (e) {
+        echo "Artifacts not found: ${e.getMessage()}"
+    }
+}
+
+def workspaceCleanup() {
+    configFileProvider([configFile(fileId: 'cleanup-script', variable: 'CLEANUP_SCRIPT')]) {
+        def scriptContent = readFile(env.CLEANUP_SCRIPT)
+        evaluate(scriptContent)
+    }
+}

--- a/docker-rootfs/etc/nginx/conf.d/default.conf
+++ b/docker-rootfs/etc/nginx/conf.d/default.conf
@@ -2,6 +2,8 @@ server {
   listen 80;
   server_name _;
 
+  client_body_buffer_size 512k;
+
   root /usr/share/nginx/html;
   index index.html index.htm;
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
         "lint": "eslint ./src",
         "less:watch": "less-watch-compiler --config=./less-watch-compiler.config.json",
         "less:preprocess": "less-watch-compiler --config=./less-compiler.config.json",
-        "license-report": "license-checker --production --json --customPath license-checker-format.json --out dist/license-checker.json",
-        "postbuild": "npm run license-report && copyfiles -V -f license-checker/license-checker-static.json dist/"
+        "license-report": "node scripts/license-report.js",
+        "postbuild": "npm run license-report && node scripts/copyfiles.js",
+        "validate-translations": "node scripts/validate-translations.js"
     },
     "files": [
         "dist/"
@@ -18,6 +19,9 @@
     "repository": {
         "type": "git",
         "url": "git+https://github.com/Ontotext-AD/graphdb-workbench.git"
+    },
+    "publishConfig": {
+        "registry": "https://registry.npmjs.org/"
     },
     "keywords": [
         "graphdb",

--- a/release.Jenkinsfile
+++ b/release.Jenkinsfile
@@ -1,0 +1,143 @@
+@Library('ontotext-platform@v0.1.49') _
+
+def performCleanup = {
+    dir("${env.WORKSPACE}") {
+        sh "git restore .npmrc || git checkout HEAD -- .npmrc"
+        dir("test-cypress") {
+            sh "rm -f .npmrc"
+        }
+    }
+}
+
+pipeline {
+    agent {
+        label 'aws-small'
+    }
+
+    environment {
+        // Required for our version of webpack + newer Node.js
+        NODE_OPTIONS = "--openssl-legacy-provider"
+        NODE_IMAGE = 'node:18.20.2-bullseye'
+    }
+
+    parameters {
+        gitParameter name: 'GIT_BRANCH',
+            description: 'The Git branch to build',
+            branchFilter: 'origin/(.*)',
+            defaultValue: 'master',
+            selectedValue: 'DEFAULT',
+            type: 'PT_BRANCH',
+            listSize: '0',
+            quickFilterEnabled: true
+
+        string name: 'RELEASE_VERSION',
+            description: 'Version to release',
+            defaultValue: ''
+
+        booleanParam(
+            name: 'NOTIFY_SLACK',
+            defaultValue: false,
+            description: 'Send Slack notification after successful build'
+        )
+
+        string(
+            name: 'SLACK_CHANNEL',
+            defaultValue: '#graphdb-team',
+            description: 'Slack channel for notification (only used if checkbox above is selected)'
+        )
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timeout(time: 15, unit: 'MINUTES')
+        timestamps()
+    }
+
+    stages {
+        stage ('Prepare & Publish') {
+            agent {
+                docker {
+                    image "${env.NODE_IMAGE}"
+                    label 'aws-small'
+                    reuseNode true
+                    args '-v $WORKSPACE/.npmrc:/home/node/.npmrc --entrypoint=""'
+                }
+            }
+            steps {
+                script {
+                    git_cmd.checkout(branch: params.GIT_BRANCH)
+                    npm.prepareRelease(version: params.RELEASE_VERSION, scripts: ['build'])
+                    npm.prepareRelease(version: params.RELEASE_VERSION, dir: "test-cypress/")
+
+                    withKsm(application: [
+                        [
+                            credentialsId: 'ksm-jenkins',
+                            secrets: [
+                                [destination: 'env', envVar: 'NPM_TOKEN', filePath: '', notation: 'keeper://FcbEgbi287PN2yx_3uCz4Q/field/note'],
+                            ]
+                        ]
+                    ]) {
+                        sh "echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc"
+                        sh "npm whoami || echo 'whoami failed'"
+                        sh "npm publish"
+                        dir("test-cypress/") {
+                            sh "echo //registry.npmjs.org/:_authToken=\${NPM_TOKEN} > .npmrc"
+                            sh "npm publish"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        success {
+            script {
+                performCleanup()
+
+                // Commit and tag the release
+                sh "git commit -a -m 'Release ${params.RELEASE_VERSION}'"
+                sh "git tag -a v${params.RELEASE_VERSION} -m 'Release v${params.RELEASE_VERSION}'"
+
+                withKsm(application: [
+                    [
+                        credentialsId: 'ksm-jenkins',
+                        secrets: [
+                            [destination: 'env', envVar: 'GIT_USER', filePath: '', notation: 'keeper://8hm1g9HCfBPgoWAmpiHn6w/field/login'],
+                            [destination: 'env', envVar: 'GIT_TOKEN', filePath: '', notation: 'keeper://8hm1g9HCfBPgoWAmpiHn6w/field/password']
+                        ]
+                    ]
+                ]) {
+                    sh 'mkdir -p ~/.ssh'
+                    sh 'ssh-keyscan github.com >> ~/.ssh/known_hosts'
+
+                    sh 'git config --global user.name "$GIT_USER"'
+                    sh 'git config --global user.email "$GIT_USER@users.noreply.github.com"'
+
+                    sh 'git remote set-url origin git@github.com:Ontotext-AD/graphdb-workbench.git'
+                    sh "git push --set-upstream origin ${params.GIT_BRANCH}"
+                    sh 'git push --tags'
+                }
+
+                // Optional Slack notification if enabled and channel is provided
+                if (params.NOTIFY_SLACK && params.SLACK_CHANNEL?.trim()) {
+                    try {
+                        slack.notifyResult(channel: params.SLACK_CHANNEL, color:'good', message:"Released graphdb-workbench v${params.RELEASE_VERSION}")
+                    } catch (e) {
+                        echo "Slack notification failed: ${e.getMessage()}"
+                    }
+                }
+            }
+        }
+
+        failure {
+            wrap([$class: 'BuildUser']) {
+                sendMail(env.BUILD_USER_EMAIL)
+            }
+
+            script {
+                performCleanup()
+            }
+        }
+    }
+}

--- a/scripts/copyfiles.js
+++ b/scripts/copyfiles.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+const sourceFile = path.join(__dirname, '../license-checker/license-checker-static.json');
+const targetDir = path.join(__dirname, '../dist');
+const targetFile = path.join(targetDir, 'license-checker-static.json');
+
+function copyFiles() {
+    if (!fs.existsSync(targetDir)) {
+        fs.mkdirSync(targetDir, { recursive: true });
+    }
+
+    fs.copyFileSync(sourceFile, targetFile);
+    console.log(`Copied ${sourceFile} to ${targetFile}`);
+}
+copyFiles();

--- a/scripts/license-report.js
+++ b/scripts/license-report.js
@@ -1,0 +1,25 @@
+// scripts/license-report.js
+const { spawnSync } = require('child_process');
+
+function runLicenseCheck() {
+    const result = spawnSync(
+        'license-checker',
+        [
+            '--production',
+            '--json',
+            '--customPath',
+            'license-checker-format.json',
+            '--out',
+            'dist/license-checker.json',
+        ],
+        {
+            stdio: 'inherit',
+            shell: true
+        }
+    );
+    if (result.status !== 0) {
+        process.exit(result.status);
+    }
+}
+
+runLicenseCheck();

--- a/test-cypress/cypress.config.js
+++ b/test-cypress/cypress.config.js
@@ -9,6 +9,10 @@ module.exports = defineConfig({
     defaultCommandTimeout: 25000,
     numTestsKeptInMemory: 10,
     e2e: {
+        retries: {
+            runMode: 2,
+            openMode: 0
+        },
         // We've imported your old cypress plugins here.
         // You may want to clean this up later by importing these.
         setupNodeEvents(on, config) {

--- a/test-cypress/integration/home/cookie-policy.spec.js
+++ b/test-cypress/integration/home/cookie-policy.spec.js
@@ -2,6 +2,7 @@ import HomeSteps from '../../steps/home-steps';
 import {EnvironmentStubs} from "../../stubs/environment-stubs";
 import {SecurityStubs} from "../../stubs/security-stubs";
 import {SettingsSteps} from "../../steps/setup/settings-steps";
+import {LicenseStubs} from "../../stubs/license-stubs";
 
 Cypress.env('set_default_user_data', false);
 
@@ -9,6 +10,7 @@ describe('Cookie policy', () => {
     beforeEach(() => {
         cy.setDefaultUserData(false);
         cy.viewport(1280, 1000);
+        LicenseStubs.stubFreeLicense();
     });
 
     afterEach(() => cy.setDefaultUserData());

--- a/test-cypress/integration/setup/user-and-access.spec.js
+++ b/test-cypress/integration/setup/user-and-access.spec.js
@@ -1,4 +1,11 @@
 import {UserAndAccessSteps} from "../../steps/setup/user-and-access-steps";
+import {RepositoriesStubs} from "../../stubs/repositories/repositories-stubs";
+import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";
+import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
+import {ToasterSteps} from "../../steps/toaster-steps";
+import HomeSteps from "../../steps/home-steps";
+import {LoginSteps} from "../../steps/login-steps";
+
 
 describe('User and Access', () => {
 
@@ -8,132 +15,318 @@ describe('User and Access', () => {
     const ROLE_CUSTOM_ADMIN = "#roleAdmin";
     const DEFAULT_ADMIN_PASSWORD = "root";
 
-    beforeEach(() => {
-        UserAndAccessSteps.visit();
-        cy.window();
-        // Users table should be visible
-        UserAndAccessSteps.getUsersTable().should('be.visible');
-    });
+    context('', () => {
+        const user = "user";
 
-    after(() => {
-        UserAndAccessSteps.visit();
-        UserAndAccessSteps.getUsersTable().should('be.visible');
-        UserAndAccessSteps.getUsersTableRow().then((table) => {
-            UserAndAccessSteps.getTableRow().each(($el, index, $list) => {
-                UserAndAccessSteps.getUsersTable().should('be.visible');
-                const username = $el.find('.username').text();
-                if (username !=='admin') {
-                    UserAndAccessSteps.deleteUser(username);
+        beforeEach(() => {
+            UserAndAccessSteps.visit();
+            cy.window();
+            // Users table should be visible
+            UserAndAccessSteps.getUsersTable().should('be.visible');
+        });
+
+        afterEach(() => {
+            cy.loginAsAdmin().then(()=> {
+                cy.deleteUser(user, true);
+                cy.switchOffSecurity(true);
+            });
+        });
+
+        it('Initial state', () => {
+            // Create new user button should be visible
+            UserAndAccessSteps.getCreateNewUserButton().should('be.visible');
+            // Security should be disabled
+            UserAndAccessSteps.getSecuritySwitchLabel().should('be.visible').and('contain', 'Security is OFF');
+            UserAndAccessSteps.getSecurityCheckbox().should('not.be.checked');
+            // Only admin user should be created by default
+            UserAndAccessSteps.getTableRow().should('have.length', 1);
+            UserAndAccessSteps.findUserInTable('admin');
+            UserAndAccessSteps.getUserType().should('be.visible').and('contain', 'Administrator');
+            // The admin should have unrestricted rights
+            UserAndAccessSteps.getRepositoryRights().should('be.visible').and('contain', 'Unrestricted');
+            // And can be edited
+            UserAndAccessSteps.getEditUserButton().should('be.visible').and('not.be.disabled');
+            // And cannot be deleted
+            UserAndAccessSteps.getDeleteUserButton().should('not.exist');
+            // Date created should be visible
+            UserAndAccessSteps.getDateCreated().should('be.visible');
+        });
+
+        it('Create user', () => {
+            //create a normal read/write user
+            createUser(user, PASSWORD, ROLE_USER, {readWrite: true});
+            testForUser(user, false);
+        });
+
+        it('Create repo-manager', () => {
+            //create a repo-manager
+            createUser(user, PASSWORD, ROLE_REPO_MANAGER);
+            testForUser(user, false);
+        });
+
+        it('Create second admin', () => {
+            //create a custom admin
+            createUser(user, PASSWORD, ROLE_CUSTOM_ADMIN);
+            testForUser(user, true);
+        });
+
+        it('Create user with custom role', () => {
+            // When I create a read/write user
+            UserAndAccessSteps.clickCreateNewUserButton();
+            UserAndAccessSteps.typeUsername(user);
+            UserAndAccessSteps.typePassword(PASSWORD);
+            UserAndAccessSteps.typeConfirmPasswordField(PASSWORD);
+            UserAndAccessSteps.selectRoleRadioButton(ROLE_USER);
+            // And add a custom role of 1 letter
+            UserAndAccessSteps.addTextToCustomRoleField('A');
+            clickWriteAccessForRepo('*');
+
+            // Then the 'create' button should be disabled
+            UserAndAccessSteps.getConfirmUserCreateButton().should('be.disabled');
+            // And the field should show an error
+            UserAndAccessSteps.getFieldError().should('contain.text', 'Must be at least 2 symbols long');
+            // When I add more text to the custom role tag
+            UserAndAccessSteps.addTextToCustomRoleField('A{enter}');
+            // Then the 'create' button should be enabled
+            UserAndAccessSteps.getConfirmUserCreateButton().should('be.enabled');
+            // And the field error should not exist
+            UserAndAccessSteps.getFieldError().should('not.be.visible');
+
+            // When I type an invalid tag
+            UserAndAccessSteps.addTextToCustomRoleField('B{enter}');
+            // And the field shows an error
+            UserAndAccessSteps.getFieldError().should('contain.text', 'Must be at least 2 symbols long');
+            // When I delete the invalid text
+            UserAndAccessSteps.addTextToCustomRoleField('{backspace}');
+            // Then the error should not be visible
+            UserAndAccessSteps.getFieldError().should('not.be.visible');
+        });
+
+        it('Adding a role with a CUSTOM_ prefix shows a warning message', () => {
+            // When I create a user
+            UserAndAccessSteps.clickCreateNewUserButton();
+            // And I add a custom role tag with prefix CUSTOM_
+            UserAndAccessSteps.addTextToCustomRoleField('CUSTOM_USER{Enter}');
+            // There should be a warning text
+            UserAndAccessSteps.getPrefixWarning(0).should('contain', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
+        });
+
+        it('Warn users when setting no password when creating new user admin', () => {
+            UserAndAccessSteps.getUsersTable().should('be.visible');
+            createUser(user, PASSWORD, ROLE_CUSTOM_ADMIN, {noPassword: true});
+            UserAndAccessSteps.getUsersTable().should('be.visible');
+            UserAndAccessSteps.getSplashLoader().should('not.be.visible');
+        });
+    })
+
+    context('GraphQL only', () => {
+        let repositoryId1;
+        let repositoryId2;
+        let repositoryId3;
+        const graphqlUser = 'graphqlUser';
+
+        beforeEach(() => {
+            cy.viewport(1280, 1000);
+            RepositoriesStubs.spyGetRepositories();
+            repositoryId1 = 'user-access-repo1-' + Date.now();
+            repositoryId2 = 'user-access-repo2-' + Date.now();
+            repositoryId3 = 'user-access-repo3-' + Date.now();
+            cy.createRepository({id: repositoryId1});
+            cy.createRepository({id: repositoryId2});
+            cy.createRepository({id: repositoryId3});
+            cy.presetRepository(repositoryId1);
+            UserAndAccessSteps.visit();
+            // Users table should be visible
+            UserAndAccessSteps.getUsersTable().should('be.visible');
+        });
+
+        afterEach(() => {
+            cy.loginAsAdmin().then(() => {
+                cy.deleteRepository(repositoryId1, true);
+                cy.deleteRepository(repositoryId2, true);
+                cy.deleteRepository(repositoryId3, true);
+                cy.deleteUser(graphqlUser, true);
+                cy.switchOffSecurity(true);
+            });
+
+        });
+
+        it('Create user with GraphQL-only access', () => {
+            cy.wait('@getRepositories');
+            createUser(graphqlUser, PASSWORD, ROLE_USER, {read: true, graphql: true, repoName: repositoryId2});
+        });
+
+        it('Can create user with different auth combinations', () => {
+            cy.wait('@getRepositories');
+            // WHEN I create a user with read + GraphQL for repository #2
+            createUser(graphqlUser, PASSWORD, ROLE_USER, {read: true, graphql: true, repoName: repositoryId2});
+            // THEN the user should have read + GraphQL on that repo
+            assertUserAuths(graphqlUser, {repo: repositoryId2, read: true, graphql: true});
+            // WHEN I open the edit page for that user
+            UserAndAccessSteps.openEditUserPage(graphqlUser);
+            // THEN for repository #1, the GraphQL checkbox should be disabled initially
+            UserAndAccessSteps.getGraphqlAccessForRepo(repositoryId1).should('be.disabled');
+            // WHEN I enable "read" for repository #1
+            editUserAuths({repo: repositoryId1, read: true});
+            // THEN GraphQL for repository #1 should become enabled
+            UserAndAccessSteps.getGraphqlAccessForRepo(repositoryId1).should('be.enabled');
+            // WHEN I enable GraphQL and read
+            editUserAuths({repo: repositoryId1, graphql: true});
+            editUserAuths({repo: repositoryId1, read: true});
+            // THEN GraphQL should be checked and disabled
+            UserAndAccessSteps.getGraphqlAccessForRepo(repositoryId1).should('be.checked').and('be.disabled');
+            // THEN for repository #3, GraphQL should be disabled initially
+            UserAndAccessSteps.getGraphqlAccessForRepo(repositoryId3).should('be.disabled');
+            // WHEN I enable "write" for repository #3
+            editUserAuths({repo: repositoryId3, write: true});
+            // THEN GraphQL for repository #3 should become enabled
+            UserAndAccessSteps.getGraphqlAccessForRepo(repositoryId3).should('be.enabled');
+            // And I expect "read" to be checked and disabled
+            UserAndAccessSteps.getReadAccessForRepo(repositoryId3).should('be.checked').and('be.disabled');
+            // I enable GraphQL for repository #3
+            editUserAuths({repo: repositoryId3, graphql: true});
+
+            // WHEN I confirm the user edit
+            UserAndAccessSteps.confirmUserEdit();
+            // THEN verify the final rights:
+            //  - repo #1 has no read/write/graphql
+            //  - repo #2 has read + graphql
+            //  - repo #3 has write + graphql (and read was auto-checked but disabled)
+            assertUserAuths(graphqlUser, {repo: repositoryId1, read: false, write: false, graphql: false});
+            assertUserAuths(graphqlUser, {repo: repositoryId2, read: true, write: false, graphql: true});
+            assertUserAuths(graphqlUser, {repo: repositoryId3, read: false, write: true, graphql: true});
+        });
+
+        it('Should have access to 5 pages when have graphql only rights', () => {
+            cy.wait('@getRepositories');
+            // WHEN I create a user with read + GraphQL for repository #2
+            createUser(graphqlUser, PASSWORD, ROLE_USER, {readWrite: true, graphql: true, repoName: repositoryId1});
+            //enable security
+            UserAndAccessSteps.toggleSecurity();
+            //login new user
+            LoginSteps.loginWithUser(graphqlUser, PASSWORD);
+            RepositorySelectorSteps.selectRepository(repositoryId1);
+
+            MENU_ITEMS_WITHOUT_GRAPHQL.forEach(({path, expectedUrl, checks, expectedTitle}) => {
+                navigateMenuPath(path, expectedUrl, expectedTitle);
+                if (checks) {
+                    runChecks(checks);
                 }
+            });
+        });
+
+        it('Should not have access endpoints management when have read graphql only rights', () => {
+            cy.wait('@getRepositories');
+            // WHEN I create a user with read + GraphQL for repository #2
+            createUser(graphqlUser, PASSWORD, ROLE_USER, {read: true, graphql: true, repoName: repositoryId1});
+            //enable security
+            UserAndAccessSteps.toggleSecurity();
+            //login new user
+            LoginSteps.loginWithUser(graphqlUser, PASSWORD);
+            RepositorySelectorSteps.selectRepository(repositoryId1);
+
+            GRAPHQL_READ_MENU_ITEMS.forEach(({path, expectedUrl, checks, expectedTitle}) => {
+                navigateMenuPath(path, expectedUrl, expectedTitle);
+                if (checks) {
+                    runChecks(checks);
+                }
+            });
+        });
+
+        it('Should have all access to endpoints management when have REPO_MANAGER role', () => {
+            cy.wait('@getRepositories');
+            createUser(graphqlUser, PASSWORD, ROLE_REPO_MANAGER);
+            //enable security
+            UserAndAccessSteps.toggleSecurity();
+            HomeSteps.visit();
+            //login new user
+            LoginSteps.loginWithUser(graphqlUser, PASSWORD);
+            GRAPHQL_REPO_MANAGER_MENU_ITEMS.forEach(({path, expectedUrl, checks, expectedTitle}) => {
+                navigateMenuPath(path, expectedUrl, expectedTitle);
+                if (checks) {
+                    runChecks(checks);
+                }
+            });
+        });
+
+        it('Can have Free Access and GraphQL working together', () => {
+            cy.wait('@getRepositories');
+            //enable security
+            UserAndAccessSteps.toggleSecurity();
+            //login with the admin
+            LoginSteps.loginWithUser("admin", DEFAULT_ADMIN_PASSWORD);
+            // The Free Access toggle should be OFF
+            UserAndAccessSteps.getFreeAccessSwitchInput().should('not.be.checked');
+            // When I toggle Free Access ON
+            UserAndAccessSteps.toggleFreeAccess();
+            // Then I set repo auths
+            UserAndAccessSteps.clickFreeReadAccessRepo(repositoryId1);
+            UserAndAccessSteps.clickFreeWriteAccessRepo(repositoryId2);
+            UserAndAccessSteps.clickFreeWriteAccessRepo(repositoryId3);
+            UserAndAccessSteps.clickFreeGraphqlAccessRepo(repositoryId3);
+            // Then I click OK in the modal
+            ModalDialogSteps.clickOKButton();
+            // Then the toggle button should be ON
+            UserAndAccessSteps.getFreeAccessSwitchInput().should('be.checked');
+            // And I should see a success message
+            ToasterSteps.verifySuccess('Free access has been enabled.');
+            UserAndAccessSteps.getUsersTable().should('be.visible');
+
+            // Then I logout
+            LoginSteps.logout();
+            HomeSteps.visit();
+            //  I change the repository to this with GraphQL only rights
+            RepositorySelectorSteps.selectRepository(repositoryId3);
+            // Then I should have GraphQL only rights
+            FREE_ACCESS_MENU_ITEMS_WITHOUT_GRAPHQL.forEach(({path, expectedUrl,  checks, expectedTitle}) => {
+                navigateMenuPath(path, expectedUrl, expectedTitle);
+                if (checks) {
+                    runChecks(checks);
+                }
+            });
+            // Turn free access off
+            cy.loginAsAdmin().then(()=> {
+                cy.switchOffFreeAccess(true);
             });
         });
     });
 
-    it('Initial state', () => {
-        // Create new user button should be visible
-        UserAndAccessSteps.getCreateNewUserButton().should('be.visible');
-        // Security should be disabled
-        UserAndAccessSteps.getSecuritySwitchLabel().should('be.visible').and('contain', 'Security is OFF');
-        UserAndAccessSteps.getSecurityCheckbox().should('not.be.checked');
-        // Only admin user should be created by default
-        UserAndAccessSteps.getTableRow().should('have.length', 1);
-        UserAndAccessSteps.findUserInTable('admin');
-        UserAndAccessSteps.getUserType().should('be.visible').and('contain', 'Administrator');
-        // The admin should have unrestricted rights
-        UserAndAccessSteps.getRepositoryRights().should('be.visible').and('contain', 'Unrestricted');
-        // And can be edited
-        UserAndAccessSteps.getEditUserButton().should('be.visible').and('not.be.disabled');
-        // And cannot be deleted
-        UserAndAccessSteps.getDeleteUserButton().should('not.exist');
-        // Date created should be visible
-        UserAndAccessSteps.getDateCreated().should('be.visible');
-    });
+    function clickGraphqlAccessForRepo(repoName) {
+        if (repoName === '*') {
+            UserAndAccessSteps.clickGraphqlAccessAny();
+        } else {
+           UserAndAccessSteps.clickGraphqlAccessRepo(repoName);
+        }
+    }
 
-    it('Create user', () => {
-        const name = "user";
-        //create a normal read/write user
-        createUser(name, PASSWORD, ROLE_USER);
-        testForUser(name, false);
-    });
+    function clickReadAccessForRepo(repoName) {
+        if (repoName === '*') {
+            UserAndAccessSteps.clickReadAccessAny();
+        } else {
+            UserAndAccessSteps.clickReadAccessRepo(repoName);
+        }
+    }
 
-    it('Create repo-manager', () => {
-        const name = "repo-manager";
-        //create a repo-manager
-        createUser(name, PASSWORD, ROLE_REPO_MANAGER);
-        testForUser(name, false);
-    });
+    function clickWriteAccessForRepo(repoName) {
+        if (repoName === '*') {
+            UserAndAccessSteps.clickWriteAccessAny();
+        } else {
+            UserAndAccessSteps.clickWriteAccessRepo(repoName);
+        }
+    }
 
-    it('Create second admin', () => {
-        const name = "second-admin";
-        //create a custom admin
-        createUser(name, PASSWORD, ROLE_CUSTOM_ADMIN);
-        testForUser(name, true);
-    });
-
-    it('Create user with custom role', () => {
-        const name = "user";
-        // When I create a read/write user
-        UserAndAccessSteps.clickCreateNewUserButton();
-        UserAndAccessSteps.typeUsername(name);
-        UserAndAccessSteps.typePassword(PASSWORD);
-        UserAndAccessSteps.typeConfirmPasswordField(PASSWORD);
-        UserAndAccessSteps.selectRoleRadioButton(ROLE_USER);
-        // And add a custom role of 1 letter
-        UserAndAccessSteps.addTextToCustomRoleField('A');
-        UserAndAccessSteps.getRepositoryRightsList().contains('Any data repository').nextUntil('.write').eq(1).within(() => {
-            UserAndAccessSteps.clickWriteAccess();
-        });
-
-        // Then the 'create' button should be disabled
-        UserAndAccessSteps.getConfirmUserCreateButton().should('be.disabled');
-        // And the field should show an error
-        UserAndAccessSteps.getFieldError().should('contain.text', 'Must be at least 2 symbols long');
-        // When I add more text to the custom role tag
-        UserAndAccessSteps.addTextToCustomRoleField('A{enter}');
-        // Then the 'create' button should be enabled
-        UserAndAccessSteps.getConfirmUserCreateButton().should('be.enabled');
-        // And the field error should not exist
-        UserAndAccessSteps.getFieldError().should('not.be.visible');
-
-        // When I type an invalid tag
-        UserAndAccessSteps.addTextToCustomRoleField('B{enter}');
-        // And the field shows an error
-        UserAndAccessSteps.getFieldError().should('contain.text', 'Must be at least 2 symbols long');
-        // When I delete the invalid text
-        UserAndAccessSteps.addTextToCustomRoleField('{backspace}');
-        // Then the error should not be visible
-        UserAndAccessSteps.getFieldError().should('not.be.visible');
-    });
-
-    it('Adding a role with a CUSTOM_ prefix shows a warning message', () => {
-        // When I create a user
-        UserAndAccessSteps.clickCreateNewUserButton();
-        // And I add a custom role tag with prefix CUSTOM_
-        UserAndAccessSteps.addTextToCustomRoleField('CUSTOM_USER{Enter}');
-        // There should be a warning text
-        UserAndAccessSteps.getPrefixWarning(0).should('contain', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
-    });
-
-    it('Warn users when setting no password when creating new user admin', () => {
-        UserAndAccessSteps.getUsersTable().should('be.visible');
-        createUser("adminWithNoPassword", PASSWORD, ROLE_CUSTOM_ADMIN);
-        UserAndAccessSteps.getUsersTable().should('be.visible');
-        UserAndAccessSteps.getSplashLoader().should('not.be.visible');
-        UserAndAccessSteps.deleteUser("adminWithNoPassword");
-    });
-
-    function createUser(username, password, role) {
+    function createUser(username, password, role, opts = {}) {
         UserAndAccessSteps.clickCreateNewUserButton();
         UserAndAccessSteps.typeUsername(username);
         UserAndAccessSteps.typePassword(password);
         UserAndAccessSteps.typeConfirmPasswordField(password);
         UserAndAccessSteps.selectRoleRadioButton(role);
+        UserAndAccessSteps.getRoleRadioButton(role).should('be.checked');
+
         if (role === "#roleUser") {
-            UserAndAccessSteps.getRepositoryRightsList().contains('Any data repository').nextUntil('.write').eq(1).within(() => {
-                UserAndAccessSteps.clickWriteAccess();
-            });
+            setRoles(opts);
             UserAndAccessSteps.confirmUserCreate();
-        } else if (role === "#roleAdmin" && username === "adminWithNoPassword") {
+        } else if (role === ROLE_CUSTOM_ADMIN && opts.noPassword) {
             UserAndAccessSteps.getNoPasswordCheckbox().check()
                 .then(() => {
                     UserAndAccessSteps.getNoPasswordCheckbox()
@@ -152,11 +345,24 @@ describe('User and Access', () => {
         UserAndAccessSteps.getUsersTable().should('contain', username);
     }
 
+    function setRoles(opts = {}) {
+        const {read = false, readWrite = false, graphql = false, repoName = '*'} = opts;
+        if (read) {
+            clickReadAccessForRepo(repoName);
+        }
+        if (readWrite) {
+            clickWriteAccessForRepo(repoName);
+        }
+        if (graphql) {
+            clickGraphqlAccessForRepo(repoName);
+        }
+    }
+
     function testForUser(name, isAdmin) {
         //enable security
         UserAndAccessSteps.toggleSecurity();
         //login new user
-        UserAndAccessSteps.loginWithUser(name, PASSWORD);
+        LoginSteps.loginWithUser(name, PASSWORD);
         //verify permissions
         UserAndAccessSteps.getUrl().should('include', '/users');
         if (isAdmin) {
@@ -165,16 +371,358 @@ describe('User and Access', () => {
             UserAndAccessSteps.getError().should('contain',
                 'You have no permission to access this functionality with your current credentials.');
         }
-        UserAndAccessSteps.logout();
-        //login with the admin
-        UserAndAccessSteps.loginWithUser("admin", DEFAULT_ADMIN_PASSWORD);
-        UserAndAccessSteps.getSplashLoader().should('not.be.visible');
-        UserAndAccessSteps.getUsersTable().should('be.visible');
-        //delete new-user
-        UserAndAccessSteps.deleteUser(name);
-        //disable security
-        UserAndAccessSteps.toggleSecurity();//.click({force: true});
-        UserAndAccessSteps.getSecuritySwitchLabel().should('be.visible').and('contain', 'Security is OFF');
-        UserAndAccessSteps.getUsersTable().should('be.visible');
     }
+
+    function assertUserAuths(username, {repo, read = false, write = false, graphql = false} = {}) {
+        UserAndAccessSteps.findUserRowAlias(username, 'userRow');
+
+        if(!read && !write) {
+            return UserAndAccessSteps.getRepoLine('@userRow', repo).should('not.exist');
+        }
+
+        UserAndAccessSteps.findRepoLineAlias('@userRow', repo, 'repoLine');
+
+        if (read) {
+            UserAndAccessSteps.findReadIconAlias('@repoLine').should('be.visible');
+        } else {
+            UserAndAccessSteps.findReadIconAlias('@repoLine').should('not.exist');
+
+        }
+
+        if (write) {
+            UserAndAccessSteps.findWriteIconAlias('@repoLine').should('be.visible');
+        } else {
+            UserAndAccessSteps.findWriteIconAlias('@repoLine').should('not.exist');
+        }
+
+        if (graphql) {
+            UserAndAccessSteps.findGraphqlIconAlias('@repoLine').should('exist');
+        } else {
+            UserAndAccessSteps.findGraphqlIconAlias('@repoLine').should('not.exist');
+        }
+    }
+
+    function editUserAuths({repo, read = false, write = false, graphql = false} = {}) {
+        if (read === true) {
+            UserAndAccessSteps.toggleReadAccessForRepo(repo);
+        }
+
+        if (write === true) {
+            UserAndAccessSteps.toggleWriteAccessForRepo(repo);
+        }
+
+        if (graphql === true) {
+            UserAndAccessSteps.toggleGraphqlAccessForRepo(repo);
+        }
+    }
+
+    function navigateMenuPath(pathArray, expectedUrl, expectedTitle) {
+        pathArray.forEach((label, index) => {
+            if (index === 0) {
+                UserAndAccessSteps.clickMenuItem(label);
+            } else {
+                UserAndAccessSteps.clickSubmenuItem(label);
+                const title = expectedTitle ? expectedTitle : label;
+                cy.get('h1').should('contain', title);
+            }
+        });
+
+        if (expectedUrl) {
+            cy.url().should('include', expectedUrl);
+        }
+    }
+
+    function runChecks(checks = {}) {
+        Object.entries(checks).forEach(([selector, assertions]) => {
+            let chain = cy.get(selector);
+
+            // assertions is an array, e.g. ["exist", ["contain.text", "Hello"], "be.visible"]
+            assertions.forEach((assertion, index) => {
+                if (index === 0) {
+                    // First assertion = .should(...)
+                    if (Array.isArray(assertion)) {
+                        // e.g. ["contain.text", "Hello"]
+                        chain = chain.should(...assertion);
+                    } else {
+                        // e.g. "exist"
+                        chain = chain.should(assertion);
+                    }
+                } else {
+                    // Subsequent assertions = .and(...)
+                    if (Array.isArray(assertion)) {
+                        chain = chain.and(...assertion);
+                    } else {
+                        chain = chain.and(assertion);
+                    }
+                }
+            });
+        });
+    }
+
+    const noAuthChecks = {
+        'div[role="main]': [
+            'not.exist'
+        ],
+        '.no-authority-panel .alert-warning': [
+            'be.visible',
+            ['contains.text', 'Some functionalities are not available because'],
+            ['contains.text', 'you do not have the required repository permissions.']
+        ]
+    }
+
+    const hasAuthChecks = {
+        'div[role="main"]': [
+            'exist',
+            'be.visible'
+        ],
+        '.no-authority-panel .alert-warning': [
+            'not.exist'
+        ]
+    }
+
+    const MENU_ITEMS_WITHOUT_GRAPHQL = [
+        // 1) Import
+        {
+            path: ['Import'],
+            expectedUrl: '/import',
+            checks: noAuthChecks
+        },
+
+        // 2) Explore
+        {
+            path: ['Explore', 'Graphs overview'],
+            expectedUrl: '/graphs',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Explore', 'Class hierarchy'],
+            expectedUrl: '/hierarchy',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Explore', 'Class relationships'],
+            expectedUrl: '/relationships',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Explore', 'Visual graph'],
+            expectedUrl: '/graphs-visualizations',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Explore', 'Similarity'],
+            expectedTitle: 'Similarity indexes',
+            expectedUrl: '/similarity',
+            checks: noAuthChecks
+        },
+
+        // 3) SPARQL
+        {
+            path: ['SPARQL'],
+            expectedTitle: 'SPARQL Query & Update',
+            expectedUrl: '/sparql',
+            checks: noAuthChecks
+        },
+
+        // 4) GraphQL
+
+        // 5) Monitor
+        {
+            path: ['Monitor', 'Queries and Updates'],
+            expectedUrl: '/monitor/queries',
+            expectedTitle: 'Query and Update monitoring',
+            checks: noAuthChecks
+        },
+
+        // 6) Setup
+        {
+            path: ['Setup', 'My Settings'],
+            expectedUrl: '/settings',
+            expectedTitle: 'Settings',
+            checks: hasAuthChecks
+        },
+        {
+            path: ['Setup', 'Connectors'],
+            expectedUrl: '/connectors',
+            expectedTitle: 'Connector management',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Setup', 'Cluster'],
+            expectedUrl: '/cluster',
+            expectedTitle: 'Cluster management',
+            checks: hasAuthChecks
+        },
+        {
+            path: ['Setup', 'Plugins'],
+            expectedUrl: '/plugins',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Setup', 'Namespaces'],
+            expectedUrl: '/namespaces',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Setup', 'Autocomplete'],
+            expectedUrl: '/autocomplete',
+            expectedTitle: 'Autocomplete index',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Setup', 'RDF Rank'],
+            expectedUrl: '/rdfrank',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Setup', 'JDBC'],
+            expectedUrl: '/jdbc',
+            expectedTitle: 'JDBC configuration',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Setup', 'SPARQL Templates'],
+            expectedUrl: '/sparql-templates',
+            checks: noAuthChecks
+        },
+
+        // 7) Lab
+        {
+            path: ['Lab', 'Talk to Your Graph'],
+            expectedUrl: '/ttyg',
+            checks: noAuthChecks
+        },
+
+        // 8) Help
+        {
+            path: ['Help', 'REST API'],
+            expectedUrl: '/webapi',
+            expectedTitle: 'REST API documentation',
+            checks: hasAuthChecks
+        }
+    ];
+
+    const GRAPHQL_READ_MENU_ITEMS = [
+        {
+            path: ['GraphQL', 'GraphQL Playground'],
+            expectedUrl: '/graphql/playground',
+            checks: hasAuthChecks
+        }
+    ];
+    const GRAPHQL_REPO_MANAGER_MENU_ITEMS = [
+        {
+            path: ['GraphQL', 'Endpoint Management'],
+            expectedUrl: '/graphql/endpoints',
+            checks: hasAuthChecks
+        },
+        {
+            path: ['GraphQL', 'GraphQL Playground'],
+            expectedUrl: '/graphql/playground',
+            checks: hasAuthChecks
+        },
+        {
+            path: ['Monitor', 'Backup and Restore'],
+            expectedUrl: '/monitor/backup-and-restore',
+            checks: hasAuthChecks
+        },
+        {
+            path: ['Help', 'Interactive guides'],
+            expectedUrl: '/guides',
+            checks: hasAuthChecks
+        }
+    ];
+
+    const FREE_ACCESS_MENU_ITEMS_WITHOUT_GRAPHQL = [
+        // 1) Import
+        {
+            path: ['Import'],
+            expectedUrl: '/import',
+            checks: noAuthChecks
+        },
+
+        // 2) Explore
+        {
+            path: ['Explore', 'Graphs overview'],
+            expectedUrl: '/graphs',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Explore', 'Class hierarchy'],
+            expectedUrl: '/hierarchy',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Explore', 'Class relationships'],
+            expectedUrl: '/relationships',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Explore', 'Visual graph'],
+            expectedUrl: '/graphs-visualizations',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Explore', 'Similarity'],
+            expectedTitle: 'Similarity indexes',
+            expectedUrl: '/similarity',
+            checks: noAuthChecks
+        },
+
+        // 3) SPARQL
+        {
+            path: ['SPARQL'],
+            expectedTitle: 'SPARQL Query & Update',
+            expectedUrl: '/sparql',
+            checks: noAuthChecks
+        },
+
+
+        // 6) Setup
+        {
+            path: ['Setup', 'Connectors'],
+            expectedUrl: '/connectors',
+            expectedTitle: 'Connector management',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Setup', 'Plugins'],
+            expectedUrl: '/plugins',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Setup', 'Namespaces'],
+            expectedUrl: '/namespaces',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Setup', 'Autocomplete'],
+            expectedUrl: '/autocomplete',
+            expectedTitle: 'Autocomplete index',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Setup', 'RDF Rank'],
+            expectedUrl: '/rdfrank',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Setup', 'JDBC'],
+            expectedUrl: '/jdbc',
+            expectedTitle: 'JDBC configuration',
+            checks: noAuthChecks
+        },
+        {
+            path: ['Setup', 'SPARQL Templates'],
+            expectedUrl: '/sparql-templates',
+            checks: noAuthChecks
+        },
+
+        // 7) Help
+        {
+            path: ['Help', 'REST API'],
+            expectedUrl: '/webapi',
+            expectedTitle: 'REST API documentation',
+            checks: hasAuthChecks
+        }
+    ];
 });

--- a/test-cypress/plugins/index.js
+++ b/test-cypress/plugins/index.js
@@ -12,6 +12,7 @@
 // the project's config changing)
 
 const del = require('del');
+const retryTracker = {};
 
 module.exports = (on, config) => {
     // `on` is used to hook into various events Cypress emits
@@ -29,17 +30,69 @@ module.exports = (on, config) => {
         }
     });
 
-    // keep only the videos for the failed specs
     on('after:spec', (spec, results) => {
+        // Retry tracking
+        if (!retryTracker.flaky) {
+            retryTracker.flaky = {};
+        }
+
+        if (!retryTracker.broken) {
+            retryTracker.broken = {};
+        }
+
+        results.tests.forEach((test) => {
+            const title = test.title.join(' ');
+            const attempts = test.attempts.length;
+            const retries = attempts - 1;
+
+            if (retries < 1) {
+                return;
+            }
+
+            if (test.state === 'passed') {
+                retryTracker.flaky[title] = retries;
+            }
+
+            if (test.state === 'failed') {
+                retryTracker.broken[title] = retries;
+            }
+        });
+
+        // Video cleanup
         if (results && results.video) {
-            // Do we have failures for any retry attempts?
-            const failures = results.tests.some((test) => {
-                return test.attempts.some((attempt) => attempt.state === 'failed');
-            });
+            const failures = results.tests.some((test) =>
+                test.attempts.some((attempt) => attempt.state === 'failed')
+            );
             if (!failures) {
-                // delete the video if the spec passed and no tests retried
                 return del(results.video);
             }
         }
+    });
+
+    on('after:run', () => {
+        const { flaky = {}, broken = {} } = retryTracker;
+
+        const printGroup = (label, group) => {
+            const entries = Object.entries(group);
+            if (entries.length === 0) {
+                return;
+            }
+
+            console.log(`\n ${label} (${entries.length}):`);
+            entries.forEach(([name, retry]) => {
+                console.log(`  * ${name}`);
+                console.log(`    ↪ retried ${retry} time(s), total runs: ${retry + 1}`);
+            });
+        };
+
+        if (Object.keys(flaky).length === 0 && Object.keys(broken).length === 0) {
+            console.log('\n========================================   Retry  Summary   ========================================\n️ [PASS] No retried tests!\n====================================================================================================\n');
+            return;
+        }
+
+        console.log('\n========================================   Retry  Summary   ========================================');
+        printGroup('[WARNING] Flaky tests', flaky);
+        printGroup('[FAIL] Broken tests', broken);
+        console.log('====================================================================================================\n');
     });
 };


### PR DESCRIPTION
## WHAT:
- Migrated the main Jenkinsfile to run on the new Jenkins
- Migrated the main Jenkinsfile to use the shared ontotext-platform@v0.1.49 library
- Introduced a new release.Jenkinsfile for handling npm package publishing
- Moved pull_request_template.md to .github/ for proper GitHub PR template support
- Replaced external license-checker CLI usage with custom scripts/license-report.js and scripts/copyfiles.js
- Added validate-translations as an npm script

## WHY:
To unify and standardize CI/CD pipelines across Ontotext projects

## HOW:
- Rewrote the Jenkinsfile to use new structure: shared ontotext-platform library, declarative stages, dockerCompose helpers, Sonar error handling, secrets via KSM
- Introduced a new release.Jenkinsfile that builds, tags, and publishes npm packages, with optional Slack notification
- Optimised JS scripts
- Applied structural improvements and pipeline logic`

(cherry picked from commit 67a78611a06b246a6328b1437e6e6d0ecc4a7d4f)


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
