### PR TITLE
GDB-12134 - Create a new payload for saved query updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
                 "ontotext-graphql-playground-component": "^0.0.8",
-                "ontotext-yasgui-web-component": "1.3.21",
+                "ontotext-yasgui-web-component": "1.3.23",
                 "shepherd.js": "^11.2.0"
             },
             "devDependencies": {
@@ -10805,9 +10805,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.21",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.21.tgz",
-            "integrity": "sha512-hX6tB0D2jgu2UKkaLmGVGEv/WS7CqPrvR9heFFs9nT24pvjnccMAPrkOKbR4BQghskT70XI0/GqWaz0V2DWArA==",
+            "version": "1.3.23",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.23.tgz",
+            "integrity": "sha512-p2h6vaAXYvQXYm22zabW42042j/j2P1QYOxnOzhOnY0GtA6HJzuIxIrUWw1/EPvgEgjpFwWjxJ7Q8+4vON+A1w==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
         "ontotext-graphql-playground-component": "^0.0.8",
-        "ontotext-yasgui-web-component": "1.3.21",
+        "ontotext-yasgui-web-component": "1.3.23",
         "shepherd.js": "^11.2.0"
     },
     "resolutions": {

--- a/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -1,6 +1,9 @@
 import 'angular/core/services/translation.service';
 import 'angular/sparql-editor/share-query-link.service';
-import {queryPayloadFromEvent, savedQueriesResponseMapper} from "../../../rest/mappers/saved-query-mapper";
+import {
+    queryPayloadFromEvent,
+    savedQueriesResponseMapper
+} from "../../../rest/mappers/saved-query-mapper";
 import {isFunction, merge} from "lodash";
 import {saveAs} from 'lib/FileSaver-patch';
 import {toYasguiOutputModel} from "../../../utils/yasgui-utils";
@@ -136,7 +139,7 @@ function yasguiComponentDirective(
              */
             $scope.updateSavedQuery = (event) => {
                 const payload = queryPayloadFromEvent(event);
-                SparqlRestService.editSavedQuery(payload)
+                SparqlRestService.editSavedQuery(event.detail.originalQueryName, payload)
                     .then(() => queryUpdatedHandler(payload))
                     .catch(querySaveErrorHandler);
             };

--- a/src/js/angular/rest/mappers/saved-query-mapper.js
+++ b/src/js/angular/rest/mappers/saved-query-mapper.js
@@ -41,6 +41,12 @@ export const savedQueryResponseMapper = (response, currentUsername) => {
     return null;
 };
 
+/**
+ * Extracts and constructs a payload object from the provided event.
+ *
+ * @param {Object} event - The event object containing query details.
+ * @returns {Object} Returns an object containing query details: `name`, `body`, and `shared`.
+ */
 export const queryPayloadFromEvent = (event) => {
     return {
         name: event.detail.queryName,

--- a/src/js/angular/rest/sparql.rest.service.js
+++ b/src/js/angular/rest/sparql.rest.service.js
@@ -88,18 +88,19 @@ function SparqlRestService($http) {
     /**
      * Updates an existing saved query.
      *
+     * @param oldQueryName The name of the query before user edit.
      * @param {object} payload A payload object in format
      * <pre>
-     *  {
-     *      body: string,
-     *      name: string,
-     *      shared: boolean
-     *  }
+     *     {
+     *     body: string,
+     *     name: string,
+     *     shared: boolean
+     *     }
      * </pre>
      * @return {Promise} a promise which resolves with the result from the save query request or an error message.
      */
-    function editSavedQuery(payload) {
-        return $http.put(SAVED_QUERIES_ENDPOINT, payload);
+    function editSavedQuery(oldQueryName, payload) {
+        return $http.put(`${SAVED_QUERIES_ENDPOINT}?oldQueryName=${encodeURIComponent(oldQueryName)}`, payload);
     }
 
     /**

--- a/test-cypress/support/sparql-commands.js
+++ b/test-cypress/support/sparql-commands.js
@@ -1,3 +1,5 @@
+const DELETE_SAVED_QUERY_URL = '/rest/sparql/saved-queries';
+
 Cypress.Commands.add('pasteQuery', (query) => {
     // Setting the textarea and the calling setValue seems to work
     // more reliably then other strategies (see history)
@@ -10,6 +12,24 @@ Cypress.Commands.add('pasteQuery', (query) => {
 Cypress.Commands.add('executeQuery', () => {
     getRunQueryButton().click();
     getLoader().should('not.exist');
+});
+
+Cypress.Commands.add('deleteSavedQuery', (savedQueryName, secured = false) => {
+    const url = DELETE_SAVED_QUERY_URL + '?name=' + savedQueryName;
+    let headers = {'Content-Type': 'application/json'};
+    if (secured) {
+        const authHeader = Cypress.env('adminToken');
+        headers = {...headers,
+            'Authorization': authHeader
+        }
+    }
+    return cy.request({
+        method: 'DELETE',
+        url: url,
+        headers,
+        // Prevent Cypress from failing the test on non-2xx status codes
+        failOnStatusCode: false
+    });
 });
 
 Cypress.Commands.add('verifyResultsPageLength', (resultLength) => {


### PR DESCRIPTION
## What
When a user edits a saved query, they will be able to edit the name without getting an error.

## Why
Previously, only editing the body of the query was possible, because the BE searches for them by name.

## How
I added the original query name in the payload, so the BE can process it.  

**Merge should be synced with BE**

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
