### PR TITLE
GDB-12302: List and disable agents incompatible with TTYG version

### DIFF
--- a/src/css/ttyg/agent-list.css
+++ b/src/css/ttyg/agent-list.css
@@ -116,3 +116,7 @@
     color: var(--secondary-color);
     font-weight: 400;
 }
+
+.agent-list-component .agent-name.incompatible-agent {
+    color: var(--gray-color-dark);
+}

--- a/src/css/ttyg/agent-select-menu.css
+++ b/src/css/ttyg/agent-select-menu.css
@@ -25,16 +25,23 @@
 
 .agent-select-menu .dropdown-menu li {
     white-space: nowrap;
-    padding: 4px 10px;
+    padding-top: 4px;
+    padding-bottom: 4px;
 }
 
-.agent-select-menu .dropdown-menu li.selected {
-    background-color: #f0f0f0;
-}
-
+.agent-select-menu .dropdown-menu li.selected,
 .agent-select-menu .dropdown-menu li:hover {
     background-color: #f0f0f0;
-    cursor: pointer;
+}
+
+.agent-select-menu .incompatible-agent .agent-option,
+.agent-select-menu .incompatible-agent .agent-option .agent-name,
+.agent-select-menu .incompatible-agent .agent-option .repository-id {
+    color: var(--gray-color-dark);
+}
+
+.agent-select-menu .dropdown-menu li.incompatible-agent .agent-option {
+    cursor: not-allowed;
 }
 
 .agent-select-menu .dropdown-menu li a {
@@ -48,6 +55,11 @@
     align-items: center;
     gap: 0.2em;
     width: 100%;
+}
+
+.agent-select-menu .agent-option {
+    padding-left: 10px;
+    padding-right: 10px;
 }
 
 .agent-select-menu .agent-option .agent-name,

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -430,6 +430,7 @@
             "loading_agents": "Loading agents...",
             "deleting_agent": "Deleting agent...",
             "deleted_repository": "Deleted repository",
+            "incompatible_agent": "Incompatible with the current GraphDB version",
             "create_agent_modal": {
                 "title": {
                     "create": "Create Agent",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -429,6 +429,7 @@
             "loading_agents": "Chargement des agents...",
             "deleting_agent": "Suppression de l'agent...",
             "deleted_repository": "Dépôt supprimé",
+            "incompatible_agent": "Incompatible avec la version actuelle de GraphDB",
             "create_agent_modal": {
                 "title": {
                     "create": "Créer un agent",

--- a/src/js/angular/models/ttyg/agents.js
+++ b/src/js/angular/models/ttyg/agents.js
@@ -63,6 +63,20 @@ export class AgentModel {
          * @private
          */
         this._additionalExtractionMethods = data.additionalExtractionMethods;
+
+        /**
+         *
+         * @type {AgentCompatibility.COMPATIBLE | AgentCompatibility.INCOMPATIBLE}
+         * @private
+         */
+        this._compatibility = data.compatibility || AgentCompatibility.COMPATIBLE;
+
+        /**
+         * Indicates whether the agent is compatible with the currently running version of GraphDb.
+         * @type {boolean} true if compatible otherwise false.
+         * @private
+         */
+        this._isCompatible = this._compatibility === AgentCompatibility.COMPATIBLE;
     }
 
     get isDeleted() {
@@ -151,6 +165,13 @@ export class AgentModel {
 
     set additionalExtractionMethods(value) {
         this._additionalExtractionMethods = value;
+    }
+    get compatibility() {
+        return this._compatibility;
+    }
+
+    get isCompatible() {
+        return this._isCompatible;
     }
 }
 
@@ -498,3 +519,24 @@ export class AgentListFilterModel {
         this._selected = value;
     }
 }
+
+/**
+ * Represents the compatibility status of an agent with the current version of the GraphDB.
+ *
+ * Compatibility is determined based on the versions of the agent and the GraphDB application.
+ * For example, an agent created with a newer version of GraphDB may not be compatible
+ * with an older version of the GraphDB due to differences in features or protocol changes.
+ *
+ * @type {{COMPATIBLE: string, INCOMPATIBLE: string}}
+ */
+export const AgentCompatibility = {
+    /** The agent is compatible with the current version of the GraphDB. */
+    'COMPATIBLE': 'COMPATIBLE',
+
+    /**
+     * The agent is incompatible with the current version of the GraphDB.
+     * This may occur when the agent was created using a newer GraphDB version
+     * than the one currently running.
+     */
+    'INCOMPATIBLE': 'INCOMPATIBLE'
+};

--- a/src/js/angular/ttyg/directives/agent-select-menu.directive.js
+++ b/src/js/angular/ttyg/directives/agent-select-menu.directive.js
@@ -40,9 +40,17 @@ function AgentSelectMenuComponent(TTYGContextService, $translate, $sce, ModalSer
 
             /**
              * Handles the agent selection.
-             * @param {AgentModel} agent
+             * @param {Event} $event - The DOM event triggered by the selection.
+             * @param {AgentModel} agent - The selected agent instance.
              */
-            $scope.onAgentSelected = (agent) => {
+            $scope.onAgentSelected = ($event, agent) => {
+                if (!agent.isCompatible) {
+                    // Prevents the dropdown from closing if the selected agent is not compatible
+                    // by stopping event propagation and preventing the default action.
+                    $event.stopPropagation();
+                    $event.preventDefault();
+                    return;
+                }
                 markAsSelected(agent);
                 $scope.selectedAgent = agent;
                 TTYGContextService.selectAgent(agent);

--- a/src/js/angular/ttyg/services/agents.mapper.js
+++ b/src/js/angular/ttyg/services/agents.mapper.js
@@ -177,7 +177,8 @@ export const agentModelMapper = (data, localRepositoryIds) => {
         seed: data.seed,
         instructions: agentInstructionsMapper(data.instructions),
         assistantExtractionMethods: extractionMethodsMapper(data.assistantExtractionMethods),
-        additionalExtractionMethods: additionalExtractionMethodsMapper(data.additionalExtractionMethods)
+        additionalExtractionMethods: additionalExtractionMethodsMapper(data.additionalExtractionMethods),
+        compatibility: data.compatibility,
     }, hashGenerator);
 };
 

--- a/src/js/angular/ttyg/templates/agent-list.html
+++ b/src/js/angular/ttyg/templates/agent-list.html
@@ -25,8 +25,14 @@
         <div ng-repeat="agent in agentList.filterableAgents">
             <div ng-if="!deletingAgent || deletingAgent.agentId !== agent.id" class="agent-item"
                  ng-class="{'selected': agent.id === selectedAgent.id}">
-                <div class="agent-info">
-                    <div class="agent-name">{{agent.name}}</div>
+                <div class="agent-info"
+                     ng-attr-gdb-tooltip="{{!agent.isCompatible ? ('ttyg.agent.incompatible_agent' | translate) : undefined}}">
+                    <div class="agent-name" ng-class="{'incompatible-agent': !agent.isCompatible}">
+                        <i ng-if="!agent.isCompatible"
+                           class="fa fa-triangle-exclamation text-warning">
+                        </i>
+                        {{agent.name}}
+                    </div>
                     <div class="related-repository">
                         <i ng-if="!agent.isRepositoryDeleted" class="fa-kit fa-gdb-repo-graphdb"></i>
                         <i ng-if="agent.isRepositoryDeleted"
@@ -45,15 +51,22 @@
                         <i class="fa fa-ellipsis"></i>
                     </button>
                     <div class="dropdown-menu dropdown-menu-right agent-actions-menu">
-                        <button class="dropdown-item edit-agent-btn" type="button" ng-click="onEditAgent(agent)">
+                        <button ng-if="agent.isCompatible"
+                                class="dropdown-item edit-agent-btn"
+                                type="button"
+                                ng-click="onEditAgent(agent)">
                             <i class="fa fa-gear"></i>
                             <span>{{'ttyg.agent.btn.edit_agent.label' | translate}}</span>
                         </button>
-                        <button class="dropdown-item clone-agent-btn" type="button" ng-click="onCloneAgent(agent)">
+                        <button ng-if="agent.isCompatible"
+                                class="dropdown-item clone-agent-btn"
+                                type="button"
+                                ng-click="onCloneAgent(agent)">
                             <i class="fa fa-clone"></i>
                             <span>{{'ttyg.agent.btn.clone_agent.label' | translate}}</span>
                         </button>
-                        <div class="dropdown-divider"></div>
+                        <div ng-if="agent.isCompatible"
+                             class="dropdown-divider"></div>
                         <button class="dropdown-item delete-agent-btn" type="button" ng-click="onDeleteAgent(agent)">
                             <i class="fa fa-trash-can"></i>
                             <span>{{'ttyg.agent.btn.delete_agent.label' | translate}}</span>

--- a/src/js/angular/ttyg/templates/agent-select-menu.html
+++ b/src/js/angular/ttyg/templates/agent-select-menu.html
@@ -21,11 +21,14 @@
     </button>
     <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="single-button" guide-selector="select-agent-panel">
         <li ng-repeat="agentOption in agentOptionsList" role="menuitem" class="agent-menu-item"
-            ng-class="{'selected': agentOption.selected}"
-            ng-attr-title="{{agentOption.label}}  &middot; {{agentOption.data.agent.repositoryId}}">
+            ng-class="{'selected': agentOption.selected, 'incompatible-agent': !agentOption.data.agent.isCompatible}"
+            ng-attr-title="{{!agentOption.data.agent.isCompatible ? ('ttyg.agent.incompatible_agent' | translate) : agentOption.label + ' · ' + agentOption.data.agent.repositoryId}}">
             <a href="#"
                class="agent-option"
-               ng-click="onAgentSelected(agentOption.data.agent)">
+               ng-click="onAgentSelected($event, agentOption.data.agent)">
+               <i ng-if="!agentOption.data.agent.isCompatible"
+                   class="fa fa-triangle-exclamation text-warning">
+                </i>
                 <span class="agent-name">{{agentOption.label}}</span> &middot;
                 <i ng-if="!agentOption.data.agent.isRepositoryDeleted" class="fa-kit fa-gdb-repo-graphdb"></i>
                 <i ng-if="agentOption.data.agent.isRepositoryDeleted"

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -430,6 +430,7 @@
             "loading_agents": "Loading agents...",
             "deleting_agent": "Deleting agent...",
             "deleted_repository": "Deleted repository",
+            "incompatible_agent": "Incompatible with the current GraphDB version",
             "create_agent_modal": {
                 "title": {
                     "create": "Create Agent",

--- a/test-cypress/fixtures/ttyg/agent/get-agent-list-with-incompatible-agents.json
+++ b/test-cypress/fixtures/ttyg/agent/get-agent-list-with-incompatible-agents.json
@@ -1,0 +1,79 @@
+[
+    {
+        "id": "asst_gAPcrHQQ9ZIxD5eXWH2BNFfo",
+        "name": "agent-1",
+        "model": "gpt-4o",
+        "temperature": 0.0,
+        "topP": 0.0,
+        "seed": null,
+        "repositoryId": "starwars",
+        "compatibility": "INCOMPATIBLE",
+        "instructions": {
+            "systemInstruction": "",
+            "userInstruction": ""
+        },
+        "assistantExtractionMethods": [
+            {
+                "method": "fts_search",
+                "maxNumberOfTriplesPerCall": 44
+            }
+        ]
+    },
+    {
+        "id": "asst_qMyCpCBmqxV9I2B8UoMfFzc5",
+        "name": "agent-2",
+        "model": "gpt-4o",
+        "temperature": 0.0,
+        "topP": 0.0,
+        "seed": null,
+        "repositoryId": "Not existing repo",
+        "compatibility": "COMPATIBLE",
+        "instructions": {
+            "systemInstruction": "string\n\nstring",
+            "userInstruction": "string"
+        },
+        "assistantExtractionMethods": [
+            {
+                "method": "fts_search"
+            }
+        ]
+    },
+    {
+        "id": "asst_Cr0RxobrY07WpOvvyQilEWMI",
+        "name": "Databricks-general-unbiased",
+        "model": "gpt-4o-2024-08-06",
+        "temperature": 1.0,
+        "topP": 1.0,
+        "seed": null,
+        "repositoryId": "starwars",
+        "instructions": {
+            "systemInstruction": "You are helpful assistant in discovering information regarding diagnostic biomarkers.",
+            "userInstruction": null
+        },
+        "assistantExtractionMethods": [
+            {
+                "method": "fts_search",
+                "maxNumberOfTriplesPerCall": 44
+            }
+        ]
+    },
+    {
+        "id": "asst_5GxNYTdaOh7Tl6lLl6Pya2aH",
+        "name": "Databricks-biomarkers",
+        "model": "gpt-3.5-turbo-0125",
+        "temperature": 1.0,
+        "topP": 1.0,
+        "seed": null,
+        "repositoryId": "biomarkers",
+        "instructions": {
+            "systemInstruction": "You're a helpful assistant in discovering new diagnostic biomarkers for given diseases. I'll submit a set of publication abstracts discussing given disease and your task is to find in the abstracts any potential new biomarkers which are not yet listed in the appropriate databases. Each abstract is preceded by identifier - its PubMed id called for short PMID. \n\nReturn the set of biomarkers listed one per row, each marker followed by the | and PMID of the respective abstract if was mentioned in.\n\nExample: \nInput: 36418457\t[Amyotrophic lateral sclerosis (ALS) is a genetically and phenotypically heterogeneous disease results in the loss of motor neurons. Mounting information points to involvement of other systems including cognitive impairment. However, neither the valid biomarker for diagnosis nor effective therapeutic intervention is available for ALS. The present study is aimed at identifying potentially genetic biomarker that improves the diagnosis and treatment of ALS patients based on the data of the Gene Expression Omnibus. We retrieved datasets and conducted a weighted gene co-expression network analysis (WGCNA) to identify ALS-related co-expression genes. Functional enrichment analysis was performed to determine the features and pathways of the main modules. We then constructed an ALS-related model using the least absolute shrinkage and selection operator (LASSO) regression analysis and verified the model by the receiver operating characteristic (ROC) curve. Besides we screened the non-preserved gene modules in FTD and ALS-mimic disorders to distinct ALS-related genes from disorders with overlapping genes and features. Altogether, 4198 common genes between datasets with the most variation were analyzed and 16 distinct modules were identified through WGCNA. Blue module had the most correlation with ALS and functionally enriched in pathways of neurodegeneration-multiple diseases', 'amyotrophic lateral sclerosis', and 'endocytosis' KEGG terms. Further, some of other modules related to ALS were enriched in 'autophagy' and 'amyotrophic lateral sclerosis'. The 30 top of hub genes were recruited to a LASSO regression model and 5 genes (BCLAF1, GNA13, ARL6IP5, ARGLU1, and YPEL5) were identified as potentially diagnostic ALS biomarkers with validating of the ROC curve and AUC value.]\n\nYour response: BCLAF1|36418457\nGNA13|36418457\nARL6IP5|36418457\nARGLU1|36418457\nYPEL5|36418457",
+            "userInstruction": null
+        },
+        "assistantExtractionMethods": [
+            {
+                "method": "fts_search",
+                "maxNumberOfTriplesPerCall": 44
+            }
+        ]
+    }
+]

--- a/test-cypress/integration/ttyg/agent-list.spec.js
+++ b/test-cypress/integration/ttyg/agent-list.spec.js
@@ -73,4 +73,21 @@ describe('TTYG agent list', () => {
             {name: 'Databricks-biomarkers', repositoryId: 'biomarkers', isRepositoryDeleted: false}
         ]);
     });
+
+    it('should filter agent actions based on compatibility', () => {
+        TTYGStubs.stubAgentListWithIncompatibleGet();
+        // When: I visit the ttyg page with incompatible agents
+        TTYGViewSteps.visit();
+        // Then: Only the delete action should be available for incompatible agents
+        TTYGViewSteps.expandAgentsSidebar();
+        TTYGViewSteps.openAgentActionMenu(0);
+        TTYGViewSteps.getDeleteAgentButton(0).should('be.visible');
+        TTYGViewSteps.getCloneAgentButton(0).should('not.exist');
+        TTYGViewSteps.getEditAgentButton(0).should('not.exist');
+        // And: All actions should be available for compatible agents
+        TTYGViewSteps.openAgentActionMenu(1);
+        TTYGViewSteps.getDeleteAgentButton(1).should('be.visible');
+        TTYGViewSteps.getCloneAgentButton(1).should('be.visible');
+        TTYGViewSteps.getEditAgentButton(1).should('be.visible');
+    });
 });

--- a/test-cypress/integration/ttyg/agent-select-menu.spec.js
+++ b/test-cypress/integration/ttyg/agent-select-menu.spec.js
@@ -29,6 +29,30 @@ describe('TTYG agent select menu', () => {
         ]);
     });
 
+    it('should not allow selecting an incompatible agent from the menu', () => {
+        TTYGStubs.stubAgentListWithIncompatibleGet();
+        // Given: I have opened the ttyg page
+        TTYGViewSteps.visit();
+        // And: The agent dropdown menu is not visible
+        TTYGViewSteps.getAgentsDropdownMenu().should('not.be.visible');
+        // And: No agent is currently selected
+        TTYGViewSteps.getAgentsMenuToggleButton().should('contain', 'Select an agent');
+
+        // When: I open the agent selection menu
+        TTYGViewSteps.openAgentsMenu();
+        // Then: I should see that the first agent is marked as incompatible
+        TTYGViewSteps.getAgentFromMenu(0)
+            .trigger('mouseover')
+            .should('have.css', 'cursor', 'not-allowed');
+
+        // When: I attempt to select an incompatible agent from the menu
+        TTYGViewSteps.selectAgent(0);
+        // Then: The incompatible agent should not be selected
+        TTYGViewSteps.getAgentsMenuToggleButton().should('contain', 'Select an agent');
+        // And: The dropdown menu should remain open
+        TTYGViewSteps.getAgentsDropdownMenu().should('be.visible');
+    });
+
     it('Should be able to select agent from the menu', () => {
         TTYGStubs.stubAgentListGet();
         // Given I have opened the ttyg page

--- a/test-cypress/steps/ttyg/ttyg-view-steps.js
+++ b/test-cypress/steps/ttyg/ttyg-view-steps.js
@@ -221,14 +221,31 @@ export class TTYGViewSteps {
         this.getOpenAgentActionsButton(index).click();
     }
 
+    static triggerEditAgentActionMenu(index) {
+        this.openAgentActionMenu(index);
+        this.getEditAgentButton(index).click();
+    }
+
+    static getEditAgentButton(index) {
+        return this.getAgent(index).find('.agent-actions-menu .edit-agent-btn');
+    }
+
     static triggerCloneAgentActionMenu(index) {
         this.openAgentActionMenu(index);
-        this.getAgent(index).find('.agent-actions-menu .clone-agent-btn').click();
+        this.getCloneAgentButton(index).click();
+    }
+
+    static getCloneAgentButton(index) {
+        return this.getAgent(index).find('.agent-actions-menu .clone-agent-btn');
     }
 
     static triggerDeleteAgentActionMenu(index) {
         this.openAgentActionMenu(index);
-        this.getAgent(index).find('.agent-actions-menu .delete-agent-btn').click();
+        this.getDeleteAgentButton(index).click();
+    }
+
+    static getDeleteAgentButton(index) {
+        return this.getAgent(index).find('.agent-actions-menu .delete-agent-btn');
     }
 
     static getAgentDeletingLoader() {
@@ -254,6 +271,10 @@ export class TTYGViewSteps {
         return this.getTtygView().find('.agent-select-menu');
     }
 
+    static getAgentsDropdownMenu() {
+        return this.getAgentsMenu().find('.dropdown-menu');
+    }
+
     static getAgentsMenuToggleButton() {
         return this.getAgentsMenu().find('.dropdown-toggle-btn');
     }
@@ -263,7 +284,7 @@ export class TTYGViewSteps {
     }
 
     static getAgentsFromMenu() {
-        return this.getAgentsMenu().find('.agent-menu-item');
+        return this.getAgentsMenu().find('.agent-menu-item a');
     }
 
     static getAgentFromMenu(index) {

--- a/test-cypress/stubs/ttyg/ttyg-stubs.js
+++ b/test-cypress/stubs/ttyg/ttyg-stubs.js
@@ -86,6 +86,10 @@ export class TTYGStubs extends Stubs {
         }).as('get-agent-list');
     }
 
+    static stubAgentListWithIncompatibleGet(delay = 0) {
+        this.stubAgentListGet('/ttyg/agent/get-agent-list-with-incompatible-agents.json');
+    }
+
     static stubAgentGet(fixture = '/ttyg/agent/get-agent.json', delay = 0) {
         cy.intercept('GET', '/rest/chat/agents/*', {
             fixture: fixture,


### PR DESCRIPTION
## What
Added restrictions on interactions with agents:
 - Restricted actions for incompatible agents: If an agent is not compatible with the currently running version of GraphDB, it can only be deleted;
 - Restricted agent selection: Incompatible agents cannot be selected or used.

## Why
Agent implementations can vary between GraphDB versions, which may lead to issues due to differences in features or protocol changes. The agent model returned from the backend is now extended with a new field, compatibility, which determines whether a given agent is compatible with the currently running instance of GraphDB.

## How
- Restricted the available actions in the agent action menu. For incompatible agents, only the Delete button is displayed;
- Disabled the ability to select incompatible agents as active. Such agents are visually disabled and cannot be interacted with.

## Screenshots
<img src="https://github.com/user-attachments/assets/a546f6ba-0986-4a42-af03-c181a39c59c4" width="320"/>
<br>
<img src="https://github.com/user-attachments/assets/f742fc73-06fc-49a9-9244-f4893100be78" width="320"/>
<br>
<img src="https://github.com/user-attachments/assets/e5bb12ed-3db8-4d44-955a-a39960f0fa4a" width="320"/>

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
