### PR TITLE
GDB-11955 - Increase error text size in create/edit cluster info

### DIFF
--- a/src/css/clustermanagement.css
+++ b/src/css/clustermanagement.css
@@ -302,7 +302,7 @@ div.nodetooltip {
 }
 
 .error-message {
-    font-size: x-small;
+    font-size: small;
     color: var(--color-warning-dark);
 }
 
@@ -339,11 +339,6 @@ div.nodetooltip {
 
 .autocomplete-dropdown li:hover {
     background-color: #f0f0f0;
-}
-
-.error-message {
-    font-size: x-small;
-    color: var(--color-warning-dark);
 }
 
 .alert-save {


### PR DESCRIPTION
## What
The error text in the Cluster create/edit dialog will be slightly larger.

## Why
QA reported error message was too small.

## How
Font size changed and duplicate declaration was removed.

## Testing
N/A

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/b4429735-f9af-4a9d-b984-cf17fa24e062)


Now:
![image](https://github.com/user-attachments/assets/98ecd746-3a05-466b-92a8-2dfb344f303d)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
