### PR TITLE
(cherry pick) GDB-11955 - Increase error text size in create/edit cluster info

### DIFF
--- a/src/css/clustermanagement.css
+++ b/src/css/clustermanagement.css
@@ -302,7 +302,7 @@ div.nodetooltip {
 }
 
 .error-message {
-    font-size: x-small;
+    font-size: small;
     color: var(--color-warning-dark);
 }
 
@@ -339,11 +339,6 @@ div.nodetooltip {
 
 .autocomplete-dropdown li:hover {
     background-color: #f0f0f0;
-}
-
-.error-message {
-    font-size: x-small;
-    color: var(--color-warning-dark);
 }
 
 .alert-save {


### PR DESCRIPTION
## What
The error text in the Cluster create/edit dialog will be slightly larger.

## Why
QA reported error message was too small.

## How
Font size changed and duplicate declaration was removed.

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/9cf55dc8-5bf9-4851-8a26-8308c80c53a4)


After:
![image](https://github.com/user-attachments/assets/695defa9-502b-428f-8126-056fb36a4336)


## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
