### PR TITLE
GDB-11469: UI visualization of LLM response tokens used

### DIFF
--- a/src/css/ttyg/chat-item-details.css
+++ b/src/css/ttyg/chat-item-details.css
@@ -156,3 +156,30 @@
     -webkit-box-orient: vertical;
     max-height: 4.5rem; /* fallback if line-clamp doesn't work */
 }
+
+.chat-detail .token-usage-info-btn {
+    margin-top: 2px;
+}
+
+/*********************************************************
+* Styling the popover displaying token usage information.
+**********************************************************/
+
+.token-usage-info {
+    max-width: 500px;
+    color: var(--text-color);
+    font-size: 1rem;
+    line-height: 1.7em;
+    margin-top: -1.4em;
+    margin-left: 0.7em;
+}
+
+.token-usage-info .description {
+    font-weight: 300;
+    margin-bottom: 0.3em;
+    line-height: 1.2em;
+}
+
+.token-info-number {
+    color: var(--primary-color);
+}

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -422,6 +422,13 @@
             "dialog": {
                 "confirm_repository_change": {
                     "body": "If you proceed with executing of SPARQL query, GraphDB will open in a new tab and switch to the <b>{{repositoryId}}</b> repository."
+                },
+                "token_usage_info": {
+                    "title": "Tokens usage",
+                    "prompt_tokens_info": "{{promptTokens}} prompt tokens",
+                    "prompt_tokens_info_description": "Tokens used to process instructions, chat history and user input.",
+                    "completion_tokens_info": "{{completionTokens}} completion tokens",
+                    "completion_tokens_info_description": "Tokens used to generate the response"
                 }
             },
             "messages": {

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -421,6 +421,13 @@
             "dialog": {
                 "confirm_repository_change": {
                     "body": "Si vous continuez l'exécution de la requête SPARQL, GraphDB s'ouvrira dans un nouvel onglet et passera au dépôt <b>{{repositoryId}}</b>."
+                },
+                "token_usage_info": {
+                    "title": "Utilisation des jetons",
+                    "prompt_tokens_info": "{{promptTokens}} jetons de requête",
+                    "prompt_tokens_info_description": "Jetons utilisés pour traiter les instructions, l'historique de la conversation et les saisies de l'utilisateur.",
+                    "completion_tokens_info": "{{completionTokens}} jetons de réponse",
+                    "completion_tokens_info_description": "Jetons utilisés pour générer la réponse"
                 }
             },
             "messages": {

--- a/src/js/angular/models/ttyg/chat-answer.js
+++ b/src/js/angular/models/ttyg/chat-answer.js
@@ -24,6 +24,13 @@ export class ChatAnswerModel {
          * @type {string}
          */
         this._continueRunId = data.continueRunId;
+
+        /**
+         * Holds information about the number of tokens used for this answer, including prompt and completion tokens.
+         *
+         * @type {TokenUsageInfo}
+         */
+        this.tokenUsageInfo = data.tokenUsageInfo;
     }
 
     get chatId() {

--- a/src/js/angular/models/ttyg/chat-message.js
+++ b/src/js/angular/models/ttyg/chat-message.js
@@ -20,6 +20,14 @@ export class ChatMessageModel {
          * @type {number}
          */
         this._timestamp = data.timestamp * 1000;
+
+        /**
+         * Holds information about the number of tokens used for this answer, including prompt and completion tokens.
+         * It is applicable only to the assistant role ({@link CHAT_MESSAGE_ROLE#ASSISTANT}).
+         *
+         * @type {TokenUsageInfo}
+         */
+        this.tokenUsageInfo = data.tokenUsageInfo;
     }
 
     get id() {

--- a/src/js/angular/models/ttyg/token-usage-info.js
+++ b/src/js/angular/models/ttyg/token-usage-info.js
@@ -1,0 +1,42 @@
+/**
+ * Represents token usage details for an AI interaction.
+ * This class tracks the number of tokens used in the prompt (input), the completion (output),
+ * and the total number of tokens consumed.
+ */
+export class TokenUsageInfo {
+    /**
+     * @param {Object} data - The data object containing token usage information.
+     * @param {number} data.promptTokens - The number of tokens in the input prompt (i.e., the conversation history, user query, and system instructions).
+     * @param {number} data.completionTokens - The number of tokens used in the model's response.
+     * @param {number} data.totalTokens - data.totalTokens - The sum of both (completionTokens + promptTokens).
+     */
+    constructor(data) {
+        this._totalTokens = data.totalTokens;
+        this._promptTokens = data.promptTokens;
+        this._completionTokens = data.completionTokens;
+    }
+
+    /**
+     * Gets the number of tokens in the input prompt (i.e., the conversation history, user query, and system instructions).
+     * @return {number}
+     */
+    get promptTokens() {
+        return this._promptTokens;
+    }
+
+    /**
+     * Gets the number of tokens used in the model's response.
+     * @return {number}
+     */
+    get completionTokens() {
+        return this._completionTokens;
+    }
+
+    /**
+     * Gets the total number of tokens used (the sum of completionTokens and promptTokens).
+     * @return {number}
+     */
+    get totalTokens() {
+        return this._totalTokens;
+    }
+}

--- a/src/js/angular/ttyg/directives/chat-item-detail.directive.js
+++ b/src/js/angular/ttyg/directives/chat-item-detail.directive.js
@@ -105,6 +105,18 @@ function ChatItemDetailComponent(toastr, $translate, TTYGContextService, TTYGSer
             };
 
             /**
+             * Handles the click event on the token usage info button.
+             * No additional actions are needed at this time; the handler simply prevents
+             * the default button behavior and stops the event from bubbling up.
+             *
+             * @param {Event} event - The click event object.
+             */
+            $scope.onTokenUsageInfo = (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+            };
+
+            /**
              * Opens <code>query</code> in sparql editor.
              * @param {string} query
              */

--- a/src/js/angular/ttyg/services/chat-message.mapper.js
+++ b/src/js/angular/ttyg/services/chat-message.mapper.js
@@ -87,6 +87,7 @@ export const chatMessageModelMapper = (data) => {
         role: data.role,
         message: data.message,
         timestamp: data.timestamp,
+        tokenUsageInfo: data.usage,
         data: data
     });
 };
@@ -105,6 +106,7 @@ export const chatAnswerModelMapper = (data) => {
         chatName: data.name,
         timestamp: data.timestamp,
         messages: chatMessageModelListMapper(data.messages),
-        continueRunId: data.continueRunId
+        continueRunId: data.continueRunId,
+        tokenUsageInfo: data.usage
     });
 };

--- a/src/js/angular/ttyg/templates/chat-item-detail.html
+++ b/src/js/angular/ttyg/templates/chat-item-detail.html
@@ -24,6 +24,15 @@
                     </button>
                     <copy-to-clipboard tooltip-text="ttyg.chat_panel.btn.copy_answer.tooltip"
                                        text-to-copy="{{answer.message}}"></copy-to-clipboard>
+                    <button ng-if="answer.tokenUsageInfo"
+                         class="btn btn-link btn-sm token-usage-info-btn"
+                         uib-popover-template="'token-usage-info.html'"
+                         ng-click="onTokenUsageInfo($event)"
+                         popover-class="token-usage-info"
+                         popover-placement="bottom-right"
+                         popover-trigger="mouseenter">
+                        <i class="fa fa-message-question"></i>
+                    </button>
                     <button class="btn btn-link btn-link-only-icons btn-sm explain-response-btn" guide-selector="explain-response-btn"
                             ng-click="explainResponse(answer.id)"
                             ng-disabled="disabled && !explainResponseModel[answer.id]"
@@ -95,3 +104,22 @@
     <div ng-if="asking" onto-loader-new size="40" guide-selector="question-loader"></div>
 </div>
 
+<script type="text/ng-template" id="token-usage-info.html">
+    <h4 class="title">{{'ttyg.chat_panel.dialog.token_usage_info.title' | translate}}</h4>
+
+    <span class="token-info-number">
+            {{answer.tokenUsageInfo.promptTokens | formatNumberToLocaleString}}
+    </span>
+    {{'ttyg.chat_panel.dialog.token_usage_info.prompt_tokens_info' | translate}}
+    <div class="description">
+        {{'ttyg.chat_panel.dialog.token_usage_info.prompt_tokens_info_description' | translate }}
+    </div>
+
+    <span class="token-info-number">
+            {{answer.tokenUsageInfo.completionTokens | formatNumberToLocaleString}}
+    </span>
+    {{'ttyg.chat_panel.dialog.token_usage_info.completion_tokens_info' | translate}}
+    <div class="description">
+        {{'ttyg.chat_panel.dialog.token_usage_info.completion_tokens_info_description' | translate }}
+    </div>
+</script>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -422,6 +422,13 @@
             "dialog": {
                 "confirm_repository_change": {
                     "body": "If you proceed with executing of SPARQL query, GraphDB will open in a new tab and switch to the <b>{{repositoryId}}</b> repository."
+                },
+                "token_usage_info": {
+                    "title": "Tokens usage",
+                    "prompt_tokens_info": "{{promptTokens}} prompt tokens",
+                    "prompt_tokens_info_description": "Tokens used to process instructions, chat history and user input.",
+                    "completion_tokens_info": "{{completionTokens}} completion tokens",
+                    "completion_tokens_info_description": "Tokens used to generate the response"
                 }
             },
             "messages": {

--- a/test-cypress/fixtures/ttyg/chats/ask-question.json
+++ b/test-cypress/fixtures/ttyg/chats/ask-question.json
@@ -10,7 +10,12 @@
             "agentId": "requestBody.agentId",
             "message": "Reply to '${requestBody.question}' Second`",
             "timestamp": 53425243523,
-            "name": null
+            "name": null,
+            "usage": {
+                "completionTokens": 82,
+                "promptTokens": 10246,
+                "totalTokens": 10328
+            }
         },
         {
             "id": "msg_Bn07kVDCYT1qmgu1G7Zw0KNe_",
@@ -19,7 +24,12 @@
             "agentId": "requestBody.agentId",
             "message": "Reply to '${requestBody.question}",
             "timestamp": 23432424242,
-            "name": null
+            "name": null,
+            "usage": {
+                "completionTokens": 80,
+                "promptTokens": 10244,
+                "totalTokens": 10324
+            }
         }
     ]
 }

--- a/test-cypress/fixtures/ttyg/chats/get-chat.json
+++ b/test-cypress/fixtures/ttyg/chats/get-chat.json
@@ -37,7 +37,12 @@
                 "role": "assistant",
                 "message": "Han Solo is a fictional character in the Star ",
                 "timestamp": "1725875332",
-                "name": null
+                "name": null,
+                "usage": {
+                    "completionTokens": 81,
+                    "promptTokens": 10245,
+                    "totalTokens": 10326
+                }
             }
         ],
         "timestamp": "1725875483"

--- a/test-cypress/integration/ttyg/chat-panel.spec.js
+++ b/test-cypress/integration/ttyg/chat-panel.spec.js
@@ -76,6 +76,15 @@ describe('Ttyg ChatPanel', () => {
         // and only the actions for the last message are visible.
         ChatPanelSteps.getChatDetailActions(2, 0).should('not.be.visible');
         ChatPanelSteps.getChatDetailActions(2, 1).should('be.visible');
+        // When: I hover over the token usage info button
+        TTYGViewSteps.hoverTokenUsageInfoButton(0);
+        // Then: I expect the token usage info popover to be displayed.
+        TTYGViewSteps.getTokenUsageInfoPopover()
+            .should("exist")
+            .and('contain', '10,246')
+            .and('contain', 'prompt tokens')
+            .and('contain', '82')
+            .and('contain', 'completion tokens');
 
         // When I click on regenerate button on the last response => +2 messages
         TTYGStubs.stubAnswerQuestion();
@@ -163,6 +172,22 @@ describe('Ttyg ChatPanel', () => {
         TTYGViewSteps.getQueryMethodElement(1, 2).should('contain', "FTS for IRI discovery");
         TTYGViewSteps.getQueryMethodDetailsElement(1, 2).should('contain', "via SPARQL");
         TTYGViewSteps.getExplainQueryQueryElement(1, 2).contains("PREFIX rdfs: <http://www.w3.org/2000/01/rdf-sch");
+    });
+
+    it('Should display info about used tokens for response', () => {
+        // Given: I visit the TTYG page, a chat with two questions and answers is loaded.
+        // Wait to chat be loaded
+        ChatPanelSteps.getChatDetailsElements().should('have.length', 2);
+
+        // When: I hover over the token usage info button
+        TTYGViewSteps.hoverTokenUsageInfoButton(0);
+        // Then: I expect the token usage info popover to be displayed.
+        TTYGViewSteps.getTokenUsageInfoPopover()
+            .should("exist")
+            .and('contain', '10,245')
+            .and('contain', 'prompt tokens')
+            .and('contain', '81')
+            .and('contain', 'completion tokens');
     });
 
     // Can't test this on CI

--- a/test-cypress/steps/ttyg/ttyg-view-steps.js
+++ b/test-cypress/steps/ttyg/ttyg-view-steps.js
@@ -316,6 +316,18 @@ export class TTYGViewSteps {
         this.getExplainResponseButton(index).click();
     }
 
+    static getTokenUsageInfoButton(index) {
+        return this.getTtygView().find('.token-usage-info-btn').eq(index);
+    }
+
+    static hoverTokenUsageInfoButton(index) {
+        return this.getTokenUsageInfoButton(index).realHover();
+    }
+
+    static getTokenUsageInfoPopover() {
+        return cy.get('.token-usage-info');
+    }
+
     static getHowDeliverAnswerButton() {
         return this.getTtygView().find('.deliver-answer-btn');
     }


### PR DESCRIPTION
## What
Added a visualisation showing the number of response tokens used by the LLM.

## Why
Users need to know how many response tokens were consumed to better understand the cost of the response.

## How
A new button was added between the "Copy answer" and "Explain response" buttons. When the user hovers over this button, a popup appears displaying information about the tokens used in the response.

## Screenshots
![image](https://github.com/user-attachments/assets/b467d8f7-1d47-471e-bb1d-363133def3e7)
##
![image](https://github.com/user-attachments/assets/4a28966f-e5c4-4430-abc3-492aafbd6d65)



## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
