### PR TITLE
GDB-12152 Fix confirmation dialog for repository changes with unsaved data

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "description": "The web application for GraphDB APIs",
     "scripts": {
         "clean": "sh scripts/clean.sh",
+        "clean-install": "sh scripts/clean.sh && npm run install:local",
         "install:ci": "sh scripts/install.sh && sh scripts/postinstall.sh",
+        "install:local": "sh scripts/install-local.sh && sh scripts/postinstall.sh",
         "prebuild": "npm run license-report-api && npm run license-report-root-config && npm run license-report-legacy-workbench && npm run license-report-shared-components && npm run license-report-workbench",
         "build": "npm run build-dev",
         "postbuild": "webpack --env BUILD_MODE=production --config=webpack.config.prod.js",

--- a/packages/api/src/services/context/context.service.ts
+++ b/packages/api/src/services/context/context.service.ts
@@ -30,24 +30,18 @@ export abstract class ContextService<TFields extends Record<string, unknown>> im
   }
 
   /**
-   * Validates and updates the value of a specific property if validation passes.
-   * This method first checks if the value can be updated and only updates the value if the validation succeeds.
+   * Checks if validation passes for a value of a specific property.
    *
    * @param propertyName The name of the property to be validated and updated.
    * @param value The new value to be validated and potentially assigned to the property.
    *
-   * @returns A promise that resolves to a boolean indicating whether the validation passed and the update was performed.
-   *          Returns true if the value was successfully updated, false otherwise.
+   * @returns A promise that resolves to a boolean indicating whether the validation passed.
    *
    * @template T The type of the value to be validated and set.
    */
-  async validateAndUpdateContextProperty<T>(propertyName: string, value: T): Promise<boolean> {
+  validatePropertyChange<T>(propertyName: string, value: T): Promise<boolean> {
     const valueContext = this.getOrCreateValueContext(propertyName);
-    const canUpdate = await valueContext.canUpdate(value);
-    if (canUpdate) {
-      valueContext.setValue(value);
-    }
-    return canUpdate;
+    return valueContext.canUpdate(value);
   }
 
   /**
@@ -65,18 +59,18 @@ export abstract class ContextService<TFields extends Record<string, unknown>> im
   }
 
   /**
- * Registers a <code>callbackFunction</code> function that will be called when the value of a property with <code>propertyName</code> changes.
- * It immediately calls the callback with the current value and then subscribes the callback for future changes to the property.
- *
- * @param propertyName The name of the property to subscribe to.
- * @param callbackFunction The callback function to be called when the property value changes.
- *                         It will receive the current value of the property as its argument.
- * @param beforeChangeValidationPromise Optional promise that can be used to validate the new value before it is set.
- *                                     If the promise resolves to false, the value change will be rejected.
- *
- * @returns A function that can be called to unsubscribe from the property updates.
- *
- * @template T The type of the value that the callback function will receive.
+   * Registers a <code>callbackFunction</code> function that will be called when the value of a property with <code>propertyName</code> changes.
+   * It immediately calls the callback with the current value and then subscribes the callback for future changes to the property.
+   *
+   * @param propertyName The name of the property to subscribe to.
+   * @param callbackFunction The callback function to be called when the property value changes.
+   *                         It will receive the current value of the property as its argument.
+   * @param beforeChangeValidationPromise Optional promise that can be used to validate the new value before it is set.
+   *                                     If the promise resolves to false, the value change will be rejected.
+   *
+   * @returns A function that can be called to unsubscribe from the property updates.
+   *
+   * @template T The type of the value that the callback function will receive.
    */
   protected subscribe<T>(propertyName: string, callbackFunction: ValueChangeCallback<T | undefined>, beforeChangeValidationPromise?: BeforeChangeValidationPromise<T>): () => void {
     if (callbackFunction) {

--- a/packages/api/src/services/context/test/context.servce.spec.ts
+++ b/packages/api/src/services/context/test/context.servce.spec.ts
@@ -111,7 +111,7 @@ describe('ContextService', () => {
     expect(result).toBe(true);
   });
 
-  test('Should validate and update a property successfully when validation returns true', async () => {
+  test('Should validate a property successfully when validation returns true', async () => {
     const valueOfTestProperty = {a: 1, b: [1, 2]};
     const propertyName = 'testProperty';
 
@@ -119,19 +119,15 @@ describe('ContextService', () => {
     const validation = jest.fn().mockImplementation(() => Promise.resolve(true));
     contextService.subscribeToProperty(propertyName, callBackFunction, validation);
 
-    // When validating and updating a property
-    const result = await contextService.validateAndUpdateContextProperty(propertyName, valueOfTestProperty);
-
-    const newValue = contextService.getProperty(propertyName);
+    // When validating a property
+    const result = await contextService.validatePropertyChange(propertyName, valueOfTestProperty);
 
     // Then the result should be true
     expect(result).toBe(true);
     // And canUpdate should have been called with the value
     expect(validation).toHaveBeenCalledWith(valueOfTestProperty);
-    // And setValue should have been called to update the value
-    expect(callBackFunction).toHaveBeenCalledWith(valueOfTestProperty);
-    // And value should be set
-    expect(newValue).toEqual(valueOfTestProperty);
+    // And callback should have been called once on initial subscription
+    expect(callBackFunction).toHaveBeenCalledTimes(1);
   });
 
   test('Should not update a property when canUpdate returns false', async () => {
@@ -146,18 +142,14 @@ describe('ContextService', () => {
     contextService.subscribeToProperty(propertyName, callBackFunction, validation);
 
     // When validating and updating a property
-    const result = await contextService.validateAndUpdateContextProperty(propertyName, newValue);
-
-    const newProperty = contextService.getProperty(propertyName);
+    const result = await contextService.validatePropertyChange(propertyName, newValue);
 
     // Then the result should be false
     expect(result).toBe(false);
     // And canUpdate should have been called with the value
     expect(validation).toHaveBeenCalledWith(newValue);
-    // And setValue should not have been called to update the value
+    // And callback should have been called once on initial subscription
     expect(callBackFunction).toHaveBeenCalledTimes(1);
-    // And value should be set
-    expect(newProperty).toEqual(initialValue);
   });
 });
 

--- a/packages/api/src/services/language/language-context.service.ts
+++ b/packages/api/src/services/language/language-context.service.ts
@@ -26,11 +26,16 @@ export class LanguageContextService extends ContextService<LanguageContextFields
    *
    * @param {string} locale - The new language code to set (e.g., 'en', 'fr', 'de').
    */
-  updateSelectedLanguage(locale?: string): Promise<boolean> {
-    const selectedLanguage = locale || ServiceProvider.get(LanguageService).getDefaultLanguage();
-    const storageService = ServiceProvider.get(LanguageStorageService);
-    storageService.set(this.SELECTED_LANGUAGE, selectedLanguage);
-    return this.validateAndUpdateContextProperty(this.SELECTED_LANGUAGE, locale);
+  updateSelectedLanguage(locale?: string): void {
+    this.validatePropertyChange(this.SELECTED_LANGUAGE, locale)
+      .then((shouldSet) => {
+        if (shouldSet) {
+          const selectedLanguage = locale || ServiceProvider.get(LanguageService).getDefaultLanguage();
+          const storageService = ServiceProvider.get(LanguageStorageService);
+          storageService.set(this.SELECTED_LANGUAGE, selectedLanguage);
+          this.updateContextProperty(this.SELECTED_LANGUAGE, locale);
+        }
+      });
   }
 
   /**

--- a/packages/api/src/services/language/test/language-context.service.spec.ts
+++ b/packages/api/src/services/language/test/language-context.service.spec.ts
@@ -36,7 +36,7 @@ describe('LanguageContextService', () => {
 
   test('updateSelectedLanguage should update selected language and notify subscribers', async () => {
     const locale = 'fr';
-    const validateAndUpdateContextPropertySpy = jest.spyOn(languageContextService, 'validateAndUpdateContextProperty');
+    const validateAndUpdateContextPropertySpy = jest.spyOn(languageContextService, 'validatePropertyChange');
 
     await languageContextService.updateSelectedLanguage(locale);
 
@@ -45,7 +45,7 @@ describe('LanguageContextService', () => {
   });
 
   test('updateSelectedLanguage should use default language if locale is undefined', async () => {
-    const validateAndUpdateContextPropertySpy = jest.spyOn(languageContextService, 'validateAndUpdateContextProperty');
+    const validateAndUpdateContextPropertySpy = jest.spyOn(languageContextService, 'validatePropertyChange');
 
     await languageContextService.updateSelectedLanguage(undefined);
 

--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -2505,6 +2505,7 @@
     "common.show_all": "Show all",
     "common.hide": "Hide",
     "common.learn_more_in_documentation": "Learn more in the GraphDB documentation",
+    "common.unsaved.changes": "You have unsaved changes. Are you sure that you want to exit?",
     "paginator.first.page.label": "First",
     "paginator.last.page.label": "Last",
     "deactivate": "deactivate",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -2503,6 +2503,7 @@
     "common.show_all": "Afficher tout",
     "common.hide": "Masquer",
     "common.learn_more_in_documentation": "Pour en savoir plus, consultez la documentation GraphDB",
+    "common.unsaved.changes": "Vous avez des modifications non sauvegardées. Etes-vous sûr de vouloir quitter?",
     "paginator.first.page.label": "Premier",
     "paginator.last.page.label": "Dernier",
     "deactivate": "désactiver",

--- a/packages/legacy-workbench/src/js/angular/core/services/repositories.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/repositories.service.js
@@ -409,8 +409,7 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
                         repositoryStorageService.set(repositoryContextService.SELECTED_REPOSITORY_ID, repo.id);
                         repositoryStorageService.set(repositoryContextService.REPOSITORY_LOCATION, repo.location);
                         // trigger context change for the current tab
-                        repositoryContextService.updateSelectedRepositoryId(repo.id);
-                        repositoryContextService.updateRepositoryLocation(repo.location);
+                        repositoryContextService.updateRepositoryIdAndLocation(repo.id, repo.location);
                     } else {
                         repositoryStorageService.remove(repositoryContextService.SELECTED_REPOSITORY_ID);
                         repositoryStorageService.remove(repositoryContextService.REPOSITORY_LOCATION);

--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
@@ -1,12 +1,15 @@
-import {Component, Host, h, State} from '@stencil/core';
+import {Component, h, Host, State} from '@stencil/core';
 import {
+  LanguageContextService,
+  LanguageService,
   Repository,
+  RepositoryContextService,
+  RepositoryList,
+  RepositoryService,
+  RepositorySizeInfo,
   RepositoryStorageService,
   ServiceProvider,
-  RepositoryService,
-  RepositoryList,
-  RepositoryContextService,
-  UriUtil, RepositorySizeInfo, LanguageService, LanguageContextService
+  UriUtil
 } from "@ontotext/workbench-api";
 import {DropdownItem} from '../../models/dropdown/dropdown-item';
 import {DropdownItemAlignment} from '../../models/dropdown/dropdown-item-alignment';
@@ -28,9 +31,9 @@ import {TranslationService} from '../../services/translation.service';
  * <onto-repository-selector></onto-repository-selector>
  */
 export class OntoRepositorySelector {
-  private repositoryService = ServiceProvider.get(RepositoryService);
-  private repositoryContextService = ServiceProvider.get(RepositoryContextService);
-  private repositoryStorageService = ServiceProvider.get(RepositoryStorageService);
+  private readonly repositoryService = ServiceProvider.get(RepositoryService);
+  private readonly repositoryContextService = ServiceProvider.get(RepositoryContextService);
+  private readonly repositoryStorageService = ServiceProvider.get(RepositoryStorageService);
   private readonly languageService: LanguageService = ServiceProvider.get(LanguageService);
   private totalTripletsFormatter: Intl.NumberFormat;
   private currentRepositoryId: string;
@@ -108,10 +111,8 @@ export class OntoRepositorySelector {
   private initOnRepositoryListChanged(repositories: RepositoryList): void {
     this.repositoryList = repositories;
     const location = '';
-    const repository = repositories.findRepository(this.currentRepositoryId, location);
     // currently selected repository could be deleted and not in the list at this point
-    this.currentRepository = repository;
-    this.repositoryContextService.updateSelectedRepository(repository);
+    this.currentRepository = repositories.findRepository(this.currentRepositoryId, location);
     this.repositoryContextService.updateSelectedRepositoryId(this.currentRepositoryId);
     this.items = this.getRepositoriesDropdownItems();
   }
@@ -167,11 +168,11 @@ export class OntoRepositorySelector {
   }
 
   private onRepositoryChanged(selectedRepository: Repository): void {
-    this.repositoryContextService.updateSelectedRepository(selectedRepository);
+    this.repositoryContextService.updateRepositoryIdAndLocation(selectedRepository.id, this.getLocation());
   }
 
   private getLocation() {
-    if (this.currentRepository && this.currentRepository.location) {
+    if (this.currentRepository?.location) {
       return `@${UriUtil.shortenIri(this.currentRepository.location)}`;
     }
     return ``;

--- a/scripts/clean-locks.sh
+++ b/scripts/clean-locks.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script should be run from the root directory of the project.
+
+# Source the error handling script
+. scripts/error-handling.sh
+
+remove_lock() {
+    local path=$1
+    local description
+    description=$(echo "$path" | sed 's/\// -- /g')
+
+    echo "########################   DELETE -- ${description} --   ###########################"
+    rm -rf "${path}"
+
+    handle_error "Removing ${description}"
+}
+
+# Clean
+remove_lock "packages/shared-components/package-lock.json"
+remove_lock "packages/api/package-lock.json"
+remove_lock "packages/workbench/package-lock.json"
+remove_lock "packages/legacy-workbench/package-lock.json"
+remove_lock "packages/root-config/package-lock.json"
+
+echo '########################   All package locks are deleted successfully!   ###########################'
+echo ''

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -22,25 +22,20 @@ clean_directory "packages/shared-components/dist"
 clean_directory "packages/shared-components/loader"
 clean_directory "packages/shared-components/node_modules"
 clean_directory "packages/shared-components/www"
-clean_directory "packages/shared-components/package-lock.json"
 
 clean_directory "packages/api/dist"
 clean_directory "packages/api/node_modules"
 clean_directory "packages/api/coverage"
-clean_directory "packages/api/package-lock.json"
 
 clean_directory "packages/workbench/dist"
 clean_directory "packages/workbench/node_modules"
 clean_directory "packages/workbench/.angular"
-clean_directory "packages/workbench/package-lock.json"
 
 clean_directory "packages/legacy-workbench/dist"
 clean_directory "packages/legacy-workbench/node_modules"
-clean_directory "packages/legacy-workbench/package-lock.json"
 
 clean_directory "packages/root-config/dist"
 clean_directory "packages/root-config/node_modules"
-clean_directory "packages/root-config/package-lock.json"
 
 clean_directory "e2e-tests/node_modules"
 clean_directory "e2e-tests/report"

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This script should be run from the root directory of the project.
+
+# Source the error handling script
+. scripts/error-handling.sh
+
+install_package() {
+    local package=$1
+    local description
+    description=$(echo "$package" | sed 's/\// -- /g')
+
+    echo ''
+    echo "########################   Installing -- ${description} --   ###########################"
+    echo ''
+
+    npm install --prefix "${package}"
+
+    handle_error "Installing ${description}"
+}
+
+# Install package dependencies
+install_package "packages/legacy-workbench"
+install_package "packages/root-config"
+install_package "packages/workbench"
+install_package "packages/api"
+install_package "packages/shared-components"
+install_package "e2e-tests"
+
+echo ''
+echo '########################   Installing main project dependencies   ###########################'
+echo ''
+npm install
+
+echo ''
+echo '########################   All packages installed successfully!   ###########################'
+echo ''


### PR DESCRIPTION
## What
Fixed showing confirmation dialog when changing repositories with unsaved data in edit views, replacing the legacy event system with the new RepositoryContextService.

## Why
Users need to be warned before losing unsaved changes when switching repositories. This migration restores critical functionality from the old Workbench to prevent accidental data loss in edit modes for SPARQL Templates, SQL Table Configuration, and Similarity Index views.

## How
- Replaced `EventEmitterService`'s `repositoryWillChangeEvent` with `RepositoryContextService`'s `onSelectedRepositoryIdChanged`
- Added validation callbacks to repository change handlers that return a confirmation modal which resolves to true if ok and false if not ok to change repository
- updated context service to separate validation from update operations
- refactored affected controllers (similarity, JDBC, SPARQL template) to use the new approach

## Also in this MR
- added an `install-local.sh` script to run `npm install` on packages
- added a `clean-locks.sh` script to remove all package-lock files
- added scripts to `package.json` - `clean-install` and `install-local`

## Testing

## Screenshots
![image](https://github.com/user-attachments/assets/923cb5e6-4801-4be0-996b-9f66a7b2c46d)

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
