### PR TITLE
GDB-12247 Fix navigation link not updating

### DIFF
--- a/packages/api/src/services/utils/routing-utils.ts
+++ b/packages/api/src/services/utils/routing-utils.ts
@@ -37,3 +37,13 @@ export function isHomePage(): boolean {
 export function getPathName(): string {
   return window.location.pathname;
 }
+
+/**
+ * Retrieves the current route from the URL, removing the leading <code>/</code>.
+ * For example:<br>
+ * Calling <code>getCurrentRoute()</code> while on http://localhost:9000/sparql will return <code>"sparql"</code><br>
+ * Calling <code>getCurrentRoute()</code> while on http://localhost:9000/graphql/endpoints will return <code>"graphql/endpoints"<code>
+ */
+export function getCurrentRoute(): string {
+  return getPathName().substring(1);
+}

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -13,7 +13,7 @@ import {
   AuthenticatedUser,
   SecurityConfig,
   Authority,
-  AuthenticationService
+  AuthenticationService, getCurrentRoute
 } from '@ontotext/workbench-api';
 import {ExternalMenuItemModel} from '../onto-navbar/external-menu-model';
 
@@ -176,8 +176,7 @@ export class OntoLayout {
   }
 
   componentWillLoad() {
-    let route = window.location.pathname;
-    this.currentRoute  = route.replace('/', '').split('/')[0];
+    this.currentRoute = getCurrentRoute();
     window.addEventListener("storage", this.handleStorageChange);
     this.onSecurityChanged();
   }


### PR DESCRIPTION
## What
Fix navigation links not updating upon certain navigations

## Why
They are not updated, when a non-reloading navigation is triggered inside the app

## How
- Added a subscription to `navigation-end` inside `onto-navbar`. Whenever a navigation ends, the current route is taken from the URL. It is then used to match the corresponding menu item and select it. If the navigation is towards the home page, then all navbar links are closed and cleared.
- Added `getCurrentRoute` to get the current pathname with removed leading `/`. This is used to match the menu items via href

## Testing
existing

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
