### PR TITLE
GDB-11287 - Reposition Entity pool chart axis label to make it more visible

### DIFF
--- a/src/js/angular/resources/chart-models/performance/epool-chart.js
+++ b/src/js/angular/resources/chart-models/performance/epool-chart.js
@@ -16,15 +16,15 @@ export class EpoolChart extends ChartData {
                     name: this.translateService.instant('resource.epool.reads'),
                     nameLocation: 'middle',
                     type: 'value',
-                    nameGap: 50,
+                    nameGap: 40
                 },
                 {
                     name: this.translateService.instant('resource.epool.writes'),
                     nameLocation: 'middle',
                     type: 'value',
-                    nameGap: 50,
+                    nameGap: 40
                 }
-            ],
+            ]
         };
         _.merge(chartOptions, epoolChartOptions);
     }


### PR DESCRIPTION
## What
The "Reads" label in the Entity pool chart will be closer to the axis.

## Why
It was cut off slightly by the navigation menu.

## How
I edited the gap in the configuration.

## Testing
N/A

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/fcf3d87a-3569-404e-9a2e-24488f975f18)

After:
![image](https://github.com/user-attachments/assets/f6232043-cccc-4434-8171-a915d0b03401)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
