### PR TITLE
(cherry-pick) GDB-11287 - Reposition Entity pool chart axis label to make it more visible

### DIFF
--- a/src/js/angular/resources/chart-models/performance/epool-chart.js
+++ b/src/js/angular/resources/chart-models/performance/epool-chart.js
@@ -16,15 +16,15 @@ export class EpoolChart extends ChartData {
                     name: this.translateService.instant('resource.epool.reads'),
                     nameLocation: 'middle',
                     type: 'value',
-                    nameGap: 50,
+                    nameGap: 40
                 },
                 {
                     name: this.translateService.instant('resource.epool.writes'),
                     nameLocation: 'middle',
                     type: 'value',
-                    nameGap: 50,
+                    nameGap: 40
                 }
-            ],
+            ]
         };
         _.merge(chartOptions, epoolChartOptions);
     }


### PR DESCRIPTION
## What
The "Reads" label in the Entity pool chart will be closer to the axis.

## Why
It was cut off slightly by the navigation menu.

## How
I edited the gap in the configuration.

## Testing
N/A

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/ce129d22-31ea-4165-9870-eb63febea1e0)

After:
![image](https://github.com/user-attachments/assets/f564617d-e3e6-4c14-b526-24d1eef9b0ea)


## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
