### PR TITLE
(cherry-pick) GDB-11287 - Reposition Entity pool chart axis label to make it more visible

### DIFF
--- a/src/js/angular/resources/chart-models/performance/epool-chart.js
+++ b/src/js/angular/resources/chart-models/performance/epool-chart.js
@@ -16,15 +16,15 @@ export class EpoolChart extends ChartData {
                     name: this.translateService.instant('resource.epool.reads'),
                     nameLocation: 'middle',
                     type: 'value',
-                    nameGap: 50,
+                    nameGap: 40
                 },
                 {
                     name: this.translateService.instant('resource.epool.writes'),
                     nameLocation: 'middle',
                     type: 'value',
-                    nameGap: 50,
+                    nameGap: 40
                 }
-            ],
+            ]
         };
         _.merge(chartOptions, epoolChartOptions);
     }


### PR DESCRIPTION
## What
The "Reads" label in the Entity pool chart will be closer to the axis.

## Why
It was cut off slightly by the navigation menu.

## How
I edited the gap in the configuration.

## Testing
N/A

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/718c0a35-05bb-4f58-8370-9955a8fc7dd0)

After:
![image](https://github.com/user-attachments/assets/65331412-81e3-46a9-83d0-97c74c120627)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
