### PR TITLE
fix(GDB-12315): Fix language selector not updating after route change

### DIFF
--- a/packages/shared-components/src/components/onto-language-selector/onto-language-selector.tsx
+++ b/packages/shared-components/src/components/onto-language-selector/onto-language-selector.tsx
@@ -4,7 +4,6 @@ import {
   ServiceProvider,
   LanguageService,
   LanguageContextService,
-  LanguageStorageService
 } from "@ontotext/workbench-api";
 import {DropdownItemAlignment} from '../../models/dropdown/dropdown-item-alignment';
 
@@ -14,8 +13,8 @@ import {DropdownItemAlignment} from '../../models/dropdown/dropdown-item-alignme
   shadow: false,
 })
 export class OntoLanguageSelector {
-  private languageService: LanguageService;
-  private languageContextService: LanguageContextService;
+  private readonly languageService = ServiceProvider.get(LanguageService);
+  private readonly languageContextService = ServiceProvider.get(LanguageContextService);
   private items: DropdownItem<string>[] = [];
   private onLanguageChangeSubscription: () => void;
 
@@ -30,11 +29,7 @@ export class OntoLanguageSelector {
    */
   @State() currentLanguage: string;
 
-  constructor() {
-    this.languageService = ServiceProvider.get(LanguageService);
-    this.languageContextService = ServiceProvider.get(LanguageContextService);
-    const selectedLanguage = ServiceProvider.get(LanguageStorageService).get(this.languageContextService.SELECTED_LANGUAGE);
-    this.changeLanguage(selectedLanguage?.getValueOrDefault(this.languageService.getDefaultLanguage()));
+  connectedCallback() {
     this.onLanguageChangeSubscription = this.languageContextService.onSelectedLanguageChanged((newLanguage) => this.changeLanguage(newLanguage));
     this.items = this.getLanguageDropdownOptions();
   }
@@ -68,7 +63,12 @@ export class OntoLanguageSelector {
   }
 
   private changeLanguage(newLanguage: string): void {
-    this.currentLanguage = newLanguage;
+    let selectedLanguage = newLanguage;
+    if (!selectedLanguage) {
+      selectedLanguage = this.languageService.getDefaultLanguage();
+    }
+
+    this.currentLanguage = selectedLanguage;
     this.items = this.getLanguageDropdownOptions();
   }
 

--- a/packages/shared-components/src/components/translate-label/translate-label.tsx
+++ b/packages/shared-components/src/components/translate-label/translate-label.tsx
@@ -18,7 +18,7 @@ import {TranslationService} from '../../services/translation.service';
 })
 export class TranslateLabel {
 
-  private readonly unsubscribeTranslationChanged: Function;
+  private unsubscribeTranslationChanged: Function;
 
   /**
    * Represents a label key.
@@ -32,7 +32,7 @@ export class TranslateLabel {
 
   @State() translatedLabel: string;
 
-  constructor() {
+  connectedCallback() {
     this.unsubscribeTranslationChanged = TranslationService.onTranslate(this.labelKey, this.translationParameters, (translatedLabel) => this.translatedLabel = translatedLabel);
   }
 


### PR DESCRIPTION
## What
Fixes an issue where the language selector does not reflect the selected language after navigating to a new route.

## Why
Previously, the language selector’s internal state was initialized only in the constructor, which is not re-invoked on route changes. As a result, when the language was changed post-routing, the selector did not update

## How
- Moved initialization logic from the constructor to connectedCallback() in both TranslateLabel and OntoLanguageSelector components to ensure proper setup on each mount.
- Replaced redundant service retrieval with readonly properties directly initialized from ServiceProvider.
- Ensured fallback to default language when no language is selected.

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
