### PR TITLE
(Cherry-pick) GDB-12146 - Prevent Namespace error appearing, if there's no active repo

### DIFF
--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -75,6 +75,7 @@ homeCtrl.$inject = ['$scope',
     'RepositoriesRestService',
     'WorkbenchContextService',
     'RDF4JRepositoriesService',
+    'RepositoryStorage',
     'toastr'];
 
 function homeCtrl($scope,
@@ -89,6 +90,7 @@ function homeCtrl($scope,
                   RepositoriesRestService,
                   WorkbenchContextService,
                   RDF4JRepositoriesService,
+                  RepositoryStorage,
                   toastr) {
 
     // =========================
@@ -124,8 +126,8 @@ function homeCtrl($scope,
     const subscriptions = [];
 
     const onSelectedRepositoryIdUpdated = (repositoryId) => {
-        // Don't call API, if no repo ID or if GQL read only or write rights
-        if (!repositoryId || $jwtAuth.hasGraphqlRightsOverCurrentRepo()) {
+        // Don't call API, if no repo ID, or with GQL read-only or write rights
+        if (!repositoryId || !RepositoryStorage.getActiveRepositoryObject().id || $jwtAuth.hasGraphqlRightsOverCurrentRepo()) {
             $scope.repositoryNamespaces = new NamespacesListModel();
             return;
         }


### PR DESCRIPTION
## What
If there's no active repository selected, the namespaces won't be fetched.

## Why
On login, the `onSelectedRepositoryIdUpdated` call is triggered twice. Once is when the old (before logout) repo is set. The second time happens a second or two after, and the repo is correctly set to what it is, or as not selected. The first call triggers an error toastr to appear in the following scenario:

1. Admin selects a repo to which a GQL read-only user doesn't have rights.
2. Admin logs out.
3. GQL read-only user logs in.
4. Sees toastr error, because the repo selected by the Admin is updated, before the active repo is correctly set on the second call.

## How
Due to the many flows and complexity of these services, I opted for checking if there is an `active repository object`, before the API call for the namespaces is made.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
