### PR TITLE
GDB-12319 - Class hierarchy visual inconsistency and side panel bug

### DIFF
--- a/src/css/rdf-class-hierarchy.css
+++ b/src/css/rdf-class-hierarchy.css
@@ -153,7 +153,7 @@
 }
 
 #graphsBtnGroup[aria-expanded="true"] {
-    color: inherit;
+    color: #FFFFFF;
 }
 
 ::-webkit-scrollbar {

--- a/src/js/angular/graphexplore/controllers/rdf-class-hierarchy.controller.js
+++ b/src/js/angular/graphexplore/controllers/rdf-class-hierarchy.controller.js
@@ -145,6 +145,7 @@ function RdfClassHierarchyCtlr($scope, $rootScope, $location, $repositories, $li
     // functions
     $scope.goToDomainRangeGraphView = goToDomainRangeGraphView;
     $scope.toggleClassInfoSidePanel = toggleClassInfoSidePanel;
+    $scope.toggleHidePrefixes = toggleHidePrefixes;
     $scope.getActiveRepositoryNoError = getActiveRepositoryNoError;
     $scope.isSystemRepository = isSystemRepository;
     $scope.confirmReloadClassHierarchy = confirmReloadClassHierarchy;
@@ -377,6 +378,10 @@ function RdfClassHierarchyCtlr($scope, $rootScope, $location, $repositories, $li
     function toggleClassInfoSidePanel() {
         $scope.showClassInfoPanel = !$scope.showClassInfoPanel;
         $rootScope.$broadcast('sidePanelClosed');
+    }
+
+    function toggleHidePrefixes() {
+        $scope.hidePrefixes = !$scope.hidePrefixes;
     }
 
     function getActiveRepositoryNoError() {

--- a/src/js/angular/graphexplore/directives/rdf-class-hierarchy.directive.js
+++ b/src/js/angular/graphexplore/directives/rdf-class-hierarchy.directive.js
@@ -37,6 +37,11 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
     }
 
     function renderCirclePacking(scope, element) {
+        /**
+         * A boolean flag that determines whether the opening of the side info panel
+         * should be suppressed when focusing on the chart while a class is selected.
+         */
+        let suppressPanelOpen = false;
 
         var width = 800,
             height = 800,
@@ -271,7 +276,9 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
                     d3.selectAll(".selected").classed("selected", false);
                 } else {
                     getCurrentClassDataAndMarkSelected(obj);
-                    showClassInfoPanel();
+                    if (!suppressPanelOpen) {
+                        showClassInfoPanel();
+                    }
 
                     // FIXME: is it ok to bind this event handler every time and not just once?
                     scope.$on('sidePanelClosed', function (event) {
@@ -722,10 +729,13 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
                         drawDiagram(currentRootData, prefixesConfig, focus, true);
                     }
 
-                    $timeout(function () {
+                    $timeout(() => {
                         LocalStorageAdapter.set(LSKeys.CLASS_HIERARCHY_SWITCH_PREFIXES, switchPrefixes);
                         autoZoomToPreviousState();
-                    }, 70);
+                        // Need to set this to false to enable the info panel to work when selecting a class.
+                        // The panel opening will be suppressed only when the prefixes are toggled.
+                        suppressPanelOpen = false;
+                        }, 70);
                 }
 
                 function redrawFilteredDiagram(currentSliderValue, sortedChildrenArray, useSlider) {
@@ -808,6 +818,7 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
                     }
                     // if digest overflows a possible fix might be wrapping this in $timeout
                     $timeout(function () {
+                        suppressPanelOpen = true;
                         savePrefixesState(hidePrefixes);
                         restoreDiagramState(rootData, true);
                     }, 50);

--- a/src/pages/rdfClassHierarchyInfo.html
+++ b/src/pages/rdfClassHierarchyInfo.html
@@ -12,16 +12,14 @@
 	ng-class="{ 'pushed-toolbar': showClassInfoPanel }"
 	ng-show="hasClassHierarchy() && !loader || !isAllGraphsSelected()">
     <div id="selectGraphDropdown" class="btn-group" role="group" ng-show="graphsInRepo.length > 2">
-        <button id="graphsBtnGroup" type="button" class="btn btn-lg btn-secondary"
+        <button id="graphsBtnGroup" type="button" class="btn btn-lg btn-secondary dropdown-toggle"
                 data-toggle="dropdown"
 				uib-dropdown
 				on-toggle="graphsDropdownToggled(open)"
                 aria-expanded="false">
-            <a uib-dropdown-toggle>
 				<span tooltip-placement="bottom" gdb-tooltip="{{'select.graph.label' | translate}}">
 					{{getSelGraphValue() | translate}}
 				</span>
-            </a>
         </button>
         <ul class="dropdown-menu dropdown-menu-right pre-scrollable" aria-labelledby="dropdownMenuButton">
             <li ng-repeat="graph in graphsInRepo" ng-if="graph.contextID.value !== getSelGraphValue()">
@@ -43,7 +41,7 @@
 	</search-icon-input>
 
 	<button class="btn btn-link p-0 prefix-toggle-btn" type="button"
-		ng-click="hidePrefixes = !hidePrefixes"
+		ng-click="toggleHidePrefixes()"
 		gdb-tooltip="{{hidePrefixes ? 'show.prefixes.btn' : 'hide.prefixes.btn' | translate}}"
 		tooltip-placement="bottom">
 		<em class="fa fa-2x"


### PR DESCRIPTION
## What
The active state of the "All graphs" dropdown will be styled like the other dropdowns.
The side panel will not be toggled when a class is selected and the "hide prefixes" toggle clicked.

## Why
There was a mismatch in the button styling.
The "hide prefixes" toggle would open and close the info panel, when a class was focused.

## How
I edited the styling and added a flag to track when the panel shouldn't be opened.

## Testing
N/A

## Screenshots
Dropdown style, when open, matches the other dropdowns in the app.
![image](https://github.com/user-attachments/assets/5f9429a8-853c-43b3-bb39-06dc19ee92f9)

Dropdown closed:
![image](https://github.com/user-attachments/assets/f9898db5-3757-4d33-a737-a87b315c27a1)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
