### PR TITLE
(cherry-pick) GDB-7796 - Stop key press propagation from modal to graph

### DIFF
--- a/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -398,12 +398,26 @@ function GraphsVisualizationsCtrl(
     };
     subscriptions.push($scope.$watch('propertiesObj.items', propertiesItemsChangeHandler));
 
+    // ========================= Save graph modal =========================
+    let modalIsOpen = false;
+    // When restarting the modal ("Save as new..." button press) opens a new modal and closes the old one
+    let openModalCount = 0;
+
+    function handleKeyDown(e) {
+        if (modalIsOpen) {
+            e.stopPropagation();
+        }
+    }
+
+    document.addEventListener('keydown', handleKeyDown, true);
+
     const removeAllListeners = () => {
         subscriptions.forEach((subscription) => subscription());
     };
 
     const destroyHandler = () => {
         removeAllListeners();
+        document.removeEventListener('keydown', handleKeyDown, true);
     };
 
     // Deregister the watcher when the scope/directive is destroyed
@@ -2912,6 +2926,8 @@ function GraphsVisualizationsCtrl(
                 }
             }
         });
+        openModalCount++;
+        modalIsOpen = true;
 
         modalInstance.result.then(function (data) {
             if (data.restart) {
@@ -2928,6 +2944,13 @@ function GraphsVisualizationsCtrl(
                 case 'rename':
                     editSavedGraphHttp(data.graph);
                     break;
+            }
+        }).finally(() => {
+            openModalCount--;
+            // Ensure that all modals are closed before resetting the flag
+            if (openModalCount <= 0) {
+                modalIsOpen = false;
+                openModalCount = 0;
             }
         });
     };


### PR DESCRIPTION
## What
Pressing the arrow keys, while in the Save Graph modal, will not cause the graph in the background to rotate.
![image](https://github.com/user-attachments/assets/916921a3-885d-465e-a724-474ba9a267cc)


## Why
The event was propagated and while the cursor moved in the Name input field, the graph in the background also rotated.

## How
I check if the modal is open and stop the event propagation. I added a modal counter to handle the case when the existing instance is restarted and the close flag is reset too early.


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
