### PR TITLE
GDB-12249: Arrows are missing from dropdown menus in the page header

### DIFF
--- a/packages/shared-components/src/components/onto-dropdown/onto-dropdown.scss
+++ b/packages/shared-components/src/components/onto-dropdown/onto-dropdown.scss
@@ -42,21 +42,28 @@
   }
 
   .onto-dropdown-button {
+    display: flex;
+    flex-direction: row;
+    gap: 0.3em;
+    align-items: center;
     font-size: 1rem;
     font-weight: 400;
     padding: 0.4em 1rem;
     line-height: 1.5;
     border: 1px solid transparent;
     outline: none;
-    width: fit-content;
-    height: fit-content;
     color: var(--onto-dropdown-color);
     background-color: var(--onto-dropdown-button-background-color);
     transition: all 0.15s ease-out;
 
     .button-icon {
       font-size: 1.4em;
-      padding-right: 0.2em;
+    }
+
+    .fa-angle-down {
+      color: rgba(0, 0, 0, 0.35);
+      font-size: 1.1em;
+      transition: all 0.2s ease-in;
     }
   }
 

--- a/packages/shared-components/src/components/onto-dropdown/onto-dropdown.tsx
+++ b/packages/shared-components/src/components/onto-dropdown/onto-dropdown.tsx
@@ -136,11 +136,11 @@ export class OntoDropdown {
                 onClick={this.toggleButtonClickHandler()}>
           {this.iconClass ? <i class={'button-icon ' + this.iconClass}></i> : ''}
           <span class='button-name'>
-                      {this.dropdownButtonName ?? this.translate(this.dropdownButtonNameLabelKey)}
-                    </span>
-          {/* TODO: Add dropdown toggle button. This depends on GDB-10490 */}
+            {this.dropdownButtonName ?? this.translate(this.dropdownButtonNameLabelKey)}
+          </span>
+          <i class={`fa-regular fa-angle-down ${this.open ? 'fa-rotate-180' : ''}`}></i>
         </button>
-
+        
         <div
           class={'onto-dropdown-menu ' + dropdownAlignmentClass}>
           {this.items && this.items.map(item =>

--- a/packages/shared-components/src/components/onto-header/onto-header.scss
+++ b/packages/shared-components/src/components/onto-header/onto-header.scss
@@ -11,6 +11,6 @@
   justify-content: flex-end;
   align-items: stretch;
   gap: 0.25em;
-  padding: 0 2rem .5em 0;
+  margin-right: 2em;
   font-size: 1.1em;
 }

--- a/packages/shared-components/src/components/onto-language-selector/onto-language-selector.scss
+++ b/packages/shared-components/src/components/onto-language-selector/onto-language-selector.scss
@@ -18,6 +18,10 @@ onto-language-selector {
 
       .onto-dropdown-button {
         background-color: transparent;
+
+        .icon-translation {
+          font-size: 1.5em;
+        }
       }
 
       .onto-dropdown-button:hover {


### PR DESCRIPTION
## What
Arrows were missing from the dropdown menus in the page header.

## Why
They were not implemented initially because the necessary icons were not available when the components were first introduced.

## How
Arrows have been added to the dropdown menus.

## Testing
N/A

## Screenshots
![image](https://github.com/user-attachments/assets/3582b9d6-44f3-4638-bacc-e6f30d7974c0)


![image](https://github.com/user-attachments/assets/3cb84fe0-9ce2-450a-8820-b5aca0c1dc84)

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
