### PR TITLE
GDB-12348: Remove test navigation link to the new Angular page from the navigation bar

### DIFF
--- a/packages/legacy-workbench/src/js/angular/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/plugin.js
@@ -39,15 +39,6 @@ PluginRegistry.add('main.menu', {
                 icon: "fa fa-flask",
                 guideSelector: 'menu-lab',
                 children: []
-            },
-            {
-                label: 'NewView',
-                labelKey: 'menu.newview',
-                href: 'new-view',
-                order: 1001,
-                role: 'IS_AUTHENTICATED_FULLY',
-                icon: "fa fa-sparkles",
-                children: []
             }
         ]
     }


### PR DESCRIPTION
## What
A temporary navigation link to a test page implemented in the new Angular module is currently present in the navigation bar.

## Why
This test link was added for development purposes and is no longer needed in production. It should be removed to clean up the UI and prevent user confusion.

## How
Remove the menu item from the navigation model.

## Testing
N/A

## Screenshots
<img src="https://github.com/user-attachments/assets/a7252814-2a11-4c6a-a8c9-ad157a00357f" width="320">
<img src="https://github.com/user-attachments/assets/ae177ee5-0776-4144-8b1e-c6ce382ae387" width="320">

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
