### PR TITLE
GDB-12338 Fix incorrect legacy autocomplete status on startup

### DIFF
--- a/e2e-tests/e2e-legacy/sparql-editor/actions/inferred-sameas.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/inferred-sameas.spec.js
@@ -1,6 +1,7 @@
 import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
 import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
 import {RepositoriesStub} from "../../../stubs/repositories-stub";
+import {AutocompleteStubs} from "../../../stubs/autocomplete/autocomplete-stubs";
 
 describe('Expand results over owl:sameAs', () => {
 
@@ -11,6 +12,7 @@ describe('Expand results over owl:sameAs', () => {
         cy.setLocalStorage("ontotext.gdb.repository.selectedRepositoryId", repositoryId);
         RepositoriesStub.stubOntopRepository(repositoryId);
         RepositoriesStub.stubNameSpaces(repositoryId);
+        AutocompleteStubs.stubAutocompleteEnabled(false);
     });
 
     it('should not be able to toggle the sameAs button state if repository is virtual', () => {

--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -1081,8 +1081,8 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         const activeRepository = $repositories.getActiveRepository();
         if (activeRepository !== WorkbenchContextService.getSelectedRepositoryId()) {
             WorkbenchContextService.setSelectedRepositoryId(activeRepository);
-            updateAutocompleteStatus();
         }
+        updateAutocompleteStatus();
     };
     $rootScope.$on("repositoryIsSet", onRepositoriesChanged);
 

--- a/packages/root-config/src/bootstrap/autocomplete/autocomplete.js
+++ b/packages/root-config/src/bootstrap/autocomplete/autocomplete.js
@@ -1,4 +1,10 @@
-import {ServiceProvider, AutocompleteService, AutocompleteContextService, RepositoryStorageService} from '@ontotext/workbench-api';
+import {
+  ServiceProvider,
+  AutocompleteService,
+  AutocompleteContextService,
+  RepositoryStorageService,
+  RepositoryContextService
+} from '@ontotext/workbench-api';
 
 /**
  * Check if autocomplete is enabled, when loading(reloading) the application.
@@ -6,7 +12,8 @@ import {ServiceProvider, AutocompleteService, AutocompleteContextService, Reposi
  * If there is no selected repository, the request will not be made.
  */
 const isAutocompleteEnabled = () => {
-  const currentRepository = ServiceProvider.get(RepositoryStorageService).get('selecterRepositoryId').getValue();
+  const repositoryIdSelector = ServiceProvider.get(RepositoryContextService).SELECTED_REPOSITORY_ID;
+  const currentRepository = ServiceProvider.get(RepositoryStorageService).get(repositoryIdSelector).getValue();
   if (!currentRepository) {
     return Promise.resolve();
   }


### PR DESCRIPTION
## What
Fix incorrect value of the autocomplete `enabled` status on application startup

## Why
It wasn't set correctly. It's always false on startup, regardless if the selected repository has autocomplete enabled

## How
Made `updateAutocompleteStatus` to be called regardless, if the newly selected repository is the same as the `WorkbenchContextService` repository. The problem is that now, the `onRepositoriesChanged` method is called within a subscription to repositoryIdChange (the migrated context). The new repository context service emits twice on startup (first with undefined and a second time with the actual value).
 The first problem is that the first call to `onRepositoriesChanged` has different values for new and old repositories, which sets the context to the new value. When new and old value are the same `updateAutocompleteStatus` is not called.
 The second part of the problem is that at the time of the first 2 emits of the context, repositories and license data is not yet loaded, which causes conditions in `updateAutocompleteStatus` to return true and skip loading and updating the autocomplete status.
 Then `onRepositoriesChanged` is called for a third time. This time from the regular legacy workbench flow. At that point the missing data is loaded, but new and old repositories return the same value, which doesn't call `updateAutocompleteStatus`

Now `updateAutocompleteStatus` is called always, regardless if new and old value are the same. During the initial two calls of it, there are no repositories and license, which protects from extra calls to `/enabled`. The third call now works as before and correctly sets the `enabled value in the local store

 ## Testing
 manual

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
