### PR TITLE
(cherry-pick) GDB-12201 - Send missing location param to "/file" endpoint

### DIFF
--- a/src/js/angular/repositories/controllers.js
+++ b/src/js/angular/repositories/controllers.js
@@ -787,13 +787,13 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
     });
 }
 
-EditRepositoryFileCtrl.$inject = ['$scope', '$uibModalInstance', 'RepositoriesRestService', 'file', 'toastr', '$translate', 'dialogTitle'];
+EditRepositoryFileCtrl.$inject = ['$scope', '$uibModalInstance', 'RepositoriesRestService', 'file', 'toastr', '$translate', 'dialogTitle', 'location'];
 
-function EditRepositoryFileCtrl($scope, $uibModalInstance, RepositoriesRestService, file, toastr, $translate, dialogTitle) {
+function EditRepositoryFileCtrl($scope, $uibModalInstance, RepositoriesRestService, file, toastr, $translate, dialogTitle, location) {
 
     $scope.dialogTitle = dialogTitle ? dialogTitle : $translate.instant('update.file.content.header');
     if (file) {
-        RepositoriesRestService.getRepositoryFileContent(file).success(function (data) {
+        RepositoriesRestService.getRepositoryFileContent(file, location).success(function (data) {
             $scope.fileContent = data;
         }).error(function (data) {
             const msg = getError(data);

--- a/src/js/angular/repositories/ontop-repo.directive.js
+++ b/src/js/angular/repositories/ontop-repo.directive.js
@@ -175,6 +175,9 @@ function ontopRepoDirective($uibModal, RepositoriesRestService, toastr, Upload, 
                     },
                     dialogTitle: () => {
                         return title;
+                    },
+                    location: () => {
+                        return $scope.repositoryInfo.location
                     }
                 }
             });

--- a/src/js/angular/rest/repositories.rest.service.js
+++ b/src/js/angular/rest/repositories.rest.service.js
@@ -105,8 +105,8 @@ function RepositoriesRestService($http) {
         return $http.get(`${REPOSITORIES_ENDPOINT}/cluster`);
     }
 
-    function getRepositoryFileContent(file) {
-        return $http.get(`${REPOSITORIES_ENDPOINT}/file`, {params: {fileLocation: file}});
+    function getRepositoryFileContent(file, location) {
+        return $http.get(`${REPOSITORIES_ENDPOINT}/file`, {params: {fileLocation: file, location: location}});
     }
 
     function updateRepositoryFileContent(fileLocation, content, location) {


### PR DESCRIPTION
## What
When creating a repository on a remote location, the parameter for location will be sent, whenever an attached file is edited.
File fields in question:
![image](https://github.com/user-attachments/assets/7e6e37a2-5b13-42e0-8d6a-6b60a9983696)

## Why
The `location` parameter was not sent and the back-end couldn't perform the necessary validations.

## How
I pass in the location to the `Edit controller`, so that it can use it when calling the `Rest service`. When the location is "Local", an empty string is sent, which is handled in the BE.

## Testing
N/A

## Screenshots
Location is remote:
![image](https://github.com/user-attachments/assets/a3a23a31-5509-45cd-bb2d-01563d943f63)

Location is local (empty string):
![image](https://github.com/user-attachments/assets/e6b7b4b7-2297-473e-b4f9-5c05d14b0be0)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
