### PR TITLE
GDB-12327 - Allow RO user to copy text from Yasqe in different views

### DIFF
--- a/src/js/angular/graphexplore/controllers/graphs-config.controller.js
+++ b/src/js/angular/graphexplore/controllers/graphs-config.controller.js
@@ -517,7 +517,7 @@ function GraphConfigCtrl(
         render: RenderingMode.YASQE,
         maxPersistentResponseSize: 0,
         showYasqeResizer: false,
-        yasqeMode: YasqeMode.PROTECTED,
+        yasqeMode: YasqeMode.READ,
         infer: $scope.newConfig.startQueryIncludeInferred,
         sameAs: $scope.newConfig.startQuerySameAs
     };
@@ -532,7 +532,7 @@ function GraphConfigCtrl(
                 $scope.canEditActiveRepo = $scope.canWriteActiveRepo();
                 const config = angular.extend({}, defaultYasguiConfig, {
                     prefixes: prefixes,
-                    yasqeMode: $scope.canWriteActiveRepo() ? YasqeMode.WRITE : YasqeMode.PROTECTED
+                    yasqeMode: $scope.canWriteActiveRepo() ? YasqeMode.WRITE : YasqeMode.READ
                 });
                 $scope.yasguiConfig = config;
                 repoIsInitialized();

--- a/src/js/angular/jdbc/controllers.js
+++ b/src/js/angular/jdbc/controllers.js
@@ -379,7 +379,7 @@ function JdbcCreateCtrl(
             getCellContent: getCellContent,
             sparqlResponse: $scope.emptySparqlResponse,
             yasqeActionButtons: DISABLE_YASQE_BUTTONS_CONFIGURATION,
-            yasqeMode: $scope.canEditActiveRepo ? YasqeMode.WRITE : YasqeMode.PROTECTED
+            yasqeMode: $scope.canEditActiveRepo ? YasqeMode.WRITE : YasqeMode.READ
         };
     };
 

--- a/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/src/js/angular/similarity/controllers/create-index.controller.js
@@ -552,7 +552,7 @@ function CreateSimilarityIdxCtrl(
             render: $scope.similarityIndexInfo.getSelectedYasguiRenderMode(),
             yasqeActionButtons: $scope.isEditViewMode() || !$scope.similarityIndexInfo.isDataQueryTypeSelected() ? DISABLE_YASQE_BUTTONS_CONFIGURATION : INFERRED_AND_SAME_AS_BUTTONS_CONFIGURATION,
             maxPersistentResponseSize: 0,
-            yasqeMode: $scope.canWriteActiveRepo() ? YasqeMode.WRITE : YasqeMode.PROTECTED,
+            yasqeMode: $scope.canWriteActiveRepo() ? YasqeMode.WRITE : YasqeMode.READ,
         }
 
         const yasguiConfig = {}

--- a/src/js/angular/sparql-template/controllers.js
+++ b/src/js/angular/sparql-template/controllers.js
@@ -187,7 +187,7 @@ function SparqlTemplateCreateCtrl(
             prefixes: prefixes,
             render: RenderingMode.YASQE,
             maxPersistentResponseSize: 0,
-            yasqeMode: $scope.canEditActiveRepo ? YasqeMode.WRITE : YasqeMode.PROTECTED
+            yasqeMode: $scope.canEditActiveRepo ? YasqeMode.WRITE : YasqeMode.READ
         };
     };
 


### PR DESCRIPTION
## What
The RO user will be able to copy the code in `CodeMirror` in the following views:

- SPARQL Template
- Similarity index copy, which leads to Create view
- JDBC SQL table configuration
- Create visual graph config (tabs with editor).

## Why
Copying was not allowed in these views, when the user has RO rights.

## How
I changed the `yasqeMode` in the configuration to allow copying.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
