### PR TITLE
GDB-12173 Add initial state tests for SPARQL view

### DIFF
--- a/e2e-tests/e2e-legacy/sparql-editor/sparql-page-with-selected-repository.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/sparql-page-with-selected-repository.spec.js
@@ -1,0 +1,33 @@
+import SparqlSteps from "../../steps/sparql-steps";
+import HomeSteps from "../../steps/home-steps";
+import {MainMenuSteps} from "../../steps/main-menu-steps";
+
+describe('SPARQL page with selected repository', () => {
+
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'sparql-page-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should render SPARQL page with editor via URL', () => {
+        // Given, I visit the SPARQL page via URL, and I have a selected repository
+        SparqlSteps.visit();
+        // Then, I expect to see the editor
+        SparqlSteps.getQueryArea().should('be.visible');
+    });
+
+    it('Should render SPARQL page with editor via navigation menu', () => {
+        // Given I open the SPARQL page, via navigation through the home page, and I have a selected repository
+        HomeSteps.visit();
+        MainMenuSteps.clickOnSparqlMenu();
+        // Then, I expect to see the editor
+        SparqlSteps.getQueryArea().should('be.visible');
+    });
+})

--- a/e2e-tests/e2e-legacy/sparql-editor/sparql-page-without-selected-repository.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/sparql-page-without-selected-repository.spec.js
@@ -1,0 +1,26 @@
+import SparqlSteps from "../../steps/sparql-steps";
+import HomeSteps from "../../steps/home-steps";
+import {MainMenuSteps} from "../../steps/main-menu-steps";
+import {ErrorSteps} from "../../steps/error-steps";
+
+describe('SPARQL page without selected repository', () => {
+    it('Should render SPARQL page without selected repository via URL', () => {
+        // Given, I visit the SPARQL page via URL and I haven't selected a repository
+        SparqlSteps.visit();
+        // Then
+        validateNoRepositoriesSparqlPage();
+    });
+
+    it('Should render SPARQL page without selected repository via navigation menu', () => {
+        // Given, I visit the SPARQL page via navigation menu and I haven't selected a repository'
+        HomeSteps.visit();
+        MainMenuSteps.clickOnSparqlMenu();
+        // Then
+        validateNoRepositoriesSparqlPage();
+    });
+});
+
+function validateNoRepositoriesSparqlPage() {
+    SparqlSteps.getQueryArea().should('not.exist');
+    ErrorSteps.verifyNoConnectedRepoMessage();
+}

--- a/e2e-tests/steps/error-steps.js
+++ b/e2e-tests/steps/error-steps.js
@@ -6,4 +6,19 @@ export class ErrorSteps {
     static verifyError(errorMessage) {
         ErrorSteps.getErrorElement().contains(errorMessage);
     }
+
+    static getRepositoryErrors() {
+        return cy.get('.card.repository-errors')
+    }
+
+    static getNoConnectedRepoMessage() {
+        return this.getRepositoryErrors().find('.alert.lead.alert-info');
+    }
+
+    static verifyNoConnectedRepoMessage() {
+        this.getRepositoryErrors().should('be.visible');
+        this.getNoConnectedRepoMessage()
+            .should('be.visible')
+            .and('contain', 'Some functionalities are not available because you are not connected to any repository.');
+    }
 }

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -28,6 +28,10 @@ export class MainMenuSteps {
         return MainMenuSteps.getMenuButton('SPARQL');
     }
 
+    static clickOnSparqlMenu() {
+        MainMenuSteps.getMenuSparql().click();
+    }
+
     static getSubmenuAutocomplete() {
         return MainMenuSteps.getSubMenuButton("Autocomplete");
     }


### PR DESCRIPTION
## What
Add initial state tests for SPARQL view

## Why
To ensure the view starts up correctly with and without selected repository

## How
Added spec files with and without selected repository, which assert the initial state in those cases

## Testing
cypress

## Screenshots
n/a

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
