### PR TITLE
GDB-12203 - Extend error util

### DIFF
--- a/src/js/angular/utils/error-utils.js
+++ b/src/js/angular/utils/error-utils.js
@@ -32,6 +32,9 @@
                 if ('responseText' in data) {
                     msg = data.responseText;
                 }
+                if ('errorMessage' in data) {
+                    msg = data.errorMessage;
+                }
             }
 
             if (limit > 0 && msg.length > limit) {


### PR DESCRIPTION
## What
When an invalid `.pie` file is uploaded, the response will be 422 and the error message will be correctly displayed.

## Why
After the BE change, the invalid file would trigger a toastr with a "Generic error". The actual error message in the response would be lost.

## How
I extended the `error util` to check for `errorMessage` in the received data object.

## Testing
N/A

## Screenshots
Before: 
![Screenshot from 2025-05-22 16-04-29](https://github.com/user-attachments/assets/dd03ab38-b5c1-4df2-b95c-73079ee4b0c9)

After:
![Screenshot from 2025-05-22 16-03-03](https://github.com/user-attachments/assets/bdfc87da-4cd5-430e-9c6c-106b84cdcccb)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
