### PR TITLE
GDB-12159 - Fix cookie banner flicker on refresh

### DIFF
--- a/src/js/angular/core/services/tracking/tracking.service.js
+++ b/src/js/angular/core/services/tracking/tracking.service.js
@@ -97,7 +97,9 @@ function TrackingService($window, $jwtAuth, $licenseService, InstallationCookieS
                     return new CookieConsent(undefined, true, true);
                 }
 
-                return CookieConsent.fromJSON(principal.appSettings.COOKIE_CONSENT);
+                return CookieConsent.fromJSON({
+                    policyAccepted: principal.appSettings.COOKIE_CONSENT
+                });
             });
     };
 


### PR DESCRIPTION
## What
When the page loads, if the user has accepted cookies, the banner will not show on the screen at all.

## Why
The cookie consent directive would initialize and call `getCookieConsent()`, which always returned `undefined` in this test scenario. The reason for `undefined` was that `CookieConsent.fromJSON()` inside `getCookieConsent()` received a boolean, when it expected properties like `policyAccepted` to build a `CookieConsent` object. Instead the `CookieConsent` object the directive received would have all `undefined` properties.

## How
I pass in the cookie consent boolean under the correct property name `policyAccepted`

## Testing
N/A

## Screenshots
N/A

## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
