### PR TITLE
(cherry-pick) GDB-12203 - Extend error util

### DIFF
--- a/src/js/angular/utils/error-utils.js
+++ b/src/js/angular/utils/error-utils.js
@@ -32,6 +32,9 @@
                 if ('responseText' in data) {
                     msg = data.responseText;
                 }
+                if ('errorMessage' in data) {
+                    msg = data.errorMessage;
+                }
             }
 
             if (limit > 0 && msg.length > limit) {


### PR DESCRIPTION
## What
When an invalid `.pie` file is uploaded, the response will be 422 and the error message will be correctly displayed.

## Why
After the BE change, the invalid file would trigger a `toastr` with a "Generic error". The actual error message in the response would be lost.

## How
I extended the `error util` to check for `errorMessage` in the received data object.

## Testing
N/A

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/f04bfa6c-6912-4117-9dfb-b634083bde80)

After:
![image](https://github.com/user-attachments/assets/f52ea6d2-97bc-4fae-9202-8ad632421171)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
