### PR TITLE
GDB-12369: Change the tokens usage icon in TTYG conversation

### DIFF
--- a/src/css/ttyg/chat-item-details.css
+++ b/src/css/ttyg/chat-item-details.css
@@ -17,6 +17,12 @@
     width: calc(100% - var(--assistan-icon-weight) - var(--assistant-container-gap));
 }
 
+.chat-panel .user-message .question-text .markdown-content * {
+    /* Render newline characters (\n) as line breaks */
+    white-space: pre-line;
+    overflow-wrap: anywhere;
+}
+
 .chat-detail .assistant-message .answer {
     line-height: var(--line-height);
 }

--- a/src/css/ttyg/chat-panel.css
+++ b/src/css/ttyg/chat-panel.css
@@ -59,14 +59,10 @@
 
 .chat-panel .user-message .question {
     max-width: 70%;
-    padding: 0.5rem 1rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 1rem;
     color: var(--text-color);
-    line-height: var(--line-height);
-}
-
-.chat-panel .user-message .question .question-text {
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
 }
 
 .chat-panel .messages-hint {

--- a/src/js/angular/ttyg/templates/chat-item-detail.html
+++ b/src/js/angular/ttyg/templates/chat-item-detail.html
@@ -4,7 +4,8 @@
     <div class="user-message" ng-if="chatItemDetail.question">
         <div class="question alert-help"
              gdb-tooltip="{{ 'ttyg.chat_panel.labels.question_asked' | translate : { date: getHumanReadableQuestionTimestamp(chatItemDetail.question.timestamp), time: (chatItemDetail.question.timestamp | date:'HH:mm') } }}">
-            <div class="question-text">{{chatItemDetail.question.message}}</div>
+            <markdown-content class="question-text"
+                              content="{{chatItemDetail.question.message}}"></markdown-content>
         </div>
     </div>
     <div class="answers" ng-repeat="answer in chatItemDetail.answers">
@@ -31,7 +32,7 @@
                          popover-class="token-usage-info"
                          popover-placement="bottom-right"
                          popover-trigger="mouseenter">
-                        <i class="fa fa-message-question"></i>
+                        <i class="fa fa-coin-blank"></i>
                     </button>
                     <button class="btn btn-link btn-link-only-icons btn-sm explain-response-btn" guide-selector="explain-response-btn"
                             ng-click="explainResponse(answer.id)"


### PR DESCRIPTION
## What
Updated the tokens usage icon in the TTYG conversation UI.

## Why
During the sprint demo, feedback was given that the existing icon looked more like a help icon. Based on this feedback, we decided to change it for better clarity.

## How
Replaced the previous icon with the "fa-coin-blank" icon.

### Additional work
Changed the user question to be displayed using the markdown component.

## Testing
N/A

## Screenshots
<img src="https://github.com/user-attachments/assets/737a9128-210d-479a-88aa-e8b22b134a92" width="320">
<img src="https://github.com/user-attachments/assets/f036ddf2-25d0-4ad4-9328-927695b79512" width="320">


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
