### PR TITLE
GDB-12372 - Fix 404 links in agent modal

### DIFF
--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -706,7 +706,7 @@ function TTYGViewCtrl(
      * @param {{repositoryId: string}} payload - The payload containing the repository ID.
      */
     const onGoToCreateSimilarityView = (payload) => {
-        goToView(payload.repositoryId, 'ttyg.agent.create_agent_modal.dialog.confirm_repository_change_before_open_similarity.body', '/similarity/index/create');
+        goToView(payload.repositoryId, 'ttyg.agent.create_agent_modal.dialog.confirm_repository_change_before_open_similarity.body', 'similarity/index/create');
     };
 
     /**
@@ -717,7 +717,7 @@ function TTYGViewCtrl(
      * @param {{repositoryId: string}} payload - The payload containing the repository ID.
      */
     const goToAutocompleteIndexView = (payload) => {
-        goToView(payload.repositoryId, 'ttyg.agent.create_agent_modal.dialog.confirm_repository_change_before_open_autocomplete_index.body', '/autocomplete');
+        goToView(payload.repositoryId, 'ttyg.agent.create_agent_modal.dialog.confirm_repository_change_before_open_autocomplete_index.body', 'autocomplete');
     };
 
     /**
@@ -728,7 +728,7 @@ function TTYGViewCtrl(
      * @param {{repositoryId: string}} payload - The payload containing the repository ID.
      */
     const onGoToConnectorsView = (payload) => {
-        goToView(payload.repositoryId, 'ttyg.agent.create_agent_modal.dialog.confirm_repository_change_before_open_connectors.body', '/connectors');
+        goToView(payload.repositoryId, 'ttyg.agent.create_agent_modal.dialog.confirm_repository_change_before_open_connectors.body', 'connectors');
     };
 
     /**


### PR DESCRIPTION
## What
When opening links in the `Create Agent` modal, the links will resolve correctly behind a context path.
Links in question:
- Similarity index
- Connectors
- Autocomplete index

## Why
Previously, the links would resolve incorrectly and show 404.

## How
I removed the leading `/` in the links.

## Testing
N/A

## Screenshots
![image](https://github.com/user-attachments/assets/43fd61a7-7c81-45f3-aea1-fab9be34b7b5)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
