### PR TITLE
GDB-12385 - Make navbar menu items same color

### DIFF
--- a/packages/shared-components/src/components/onto-navbar/onto-navbar.scss
+++ b/packages/shared-components/src/components/onto-navbar/onto-navbar.scss
@@ -36,6 +36,12 @@ main menu height*/
   text-decoration: none;
 }
 
+.navbar-component a:not([href]):not([tabindex]),
+.navbar-component a:not([href]):not([tabindex]):focus,
+.navbar-component a:not([href]):not([tabindex]):hover {
+  color: var(--secondary-color);
+}
+
 .navbar-component li .menu-element-root:hover,
 .navbar-component .sub-menu li:hover {
   background-color: rgba(0, 0, 0, .1);


### PR DESCRIPTION
## What
Menu items in the `navbar` will be colored the same.

## Why
Menu items in the `navbar` were inheriting the wrong text color.

## How
Added `scss` rules for the link states to override the inherited `bootstrap` rule.

## Testing
N/A

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/53982470-a711-492d-ac6a-bf51e3b4a4eb)

After:
![Screenshot from 2025-05-29 11-06-37](https://github.com/user-attachments/assets/c19a40f2-72a2-4b12-a906-39074cfa4845)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
