### PR TITLE
GDB-12384 - Fix underlines in navbar

### DIFF
--- a/packages/shared-components/src/components/onto-navbar/onto-navbar.scss
+++ b/packages/shared-components/src/components/onto-navbar/onto-navbar.scss
@@ -36,15 +36,28 @@ main menu height*/
   text-decoration: none;
 }
 
+.navbar-component li a.sub-menu-link:not([href=""]):not([tabindex]):hover {
+  // Overriding !important in _anchor.scss
+  text-decoration: none !important;
+}
+
 .navbar-component a:not([href]):not([tabindex]),
 .navbar-component a:not([href]):not([tabindex]):focus,
 .navbar-component a:not([href]):not([tabindex]):hover {
   color: var(--secondary-color);
 }
 
+.navbar-component a.sub-menu-link:not([href]):hover .menu-item,
+.navbar-component a.sub-menu-link[href=""]:hover .menu-item {
+  // Overriding !important in _anchor.scss
+  text-decoration-line: underline !important;
+}
+
 .navbar-component li .menu-element-root:hover,
 .navbar-component .sub-menu li:hover {
   background-color: rgba(0, 0, 0, .1);
+  // Overriding !important in _anchor.scss
+  text-decoration-line: none !important;
 }
 
 .navbar-component li .menu-element-root:hover .menu-item-icon,


### PR DESCRIPTION
## What
Hovering over internal `navbar` links won't underline them. External links will remain underlined.

## Why
All links were underlined before.

## How
I added the necessary styles.

## Testing
N/A

## Screenshots
Hover on external links:
![Screenshot from 2025-05-29 14-59-01](https://github.com/user-attachments/assets/7cc0acc5-ac81-4daf-a337-ad88ad82a837)

Hover on internal links:
![Screenshot from 2025-05-29 14-58-52](https://github.com/user-attachments/assets/47911d7e-8012-4ca7-bfd1-793129d59265)

## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
