### PR TITLE
(cherry-pick) GDB-12372 - Fix 404 links in agent modal

### DIFF
--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -726,7 +726,7 @@ function TTYGViewCtrl(
     };
 
     const openCreateSimilarityView = () => {
-        $window.open('/similarity/index/create', '_blank');
+        $window.open('similarity/index/create', '_blank');
     };
 
     /**
@@ -750,14 +750,13 @@ function TTYGViewCtrl(
                         openConnectorsView();
                     });
             }
-
         } else {
             openConnectorsView();
-        }
+    }
     };
 
     const openConnectorsView = () => {
-        $window.open('/connectors', '_blank');
+        $window.open('connectors', '_blank');
     };
 
     /**


### PR DESCRIPTION
## What
When opening links in the `Create Agent` modal, the links will resolve correctly behind a context path.
Links in question:
- Similarity index
- Connectors

## Why
Previously, the links would resolve incorrectly and show 404.

## How
I removed the leading `/` in the links.

## Testing
N/A

## Screenshots
![image](https://github.com/user-attachments/assets/c9e3289b-46b9-4991-900e-970a01311115)

## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
