### PR TITLE
GDB-12401 - Remove underline on hover for the "Create new repository" button

### DIFF
--- a/packages/legacy-workbench/src/css/repositories.css
+++ b/packages/legacy-workbench/src/css/repositories.css
@@ -413,6 +413,11 @@ span.label {
     padding: 0 13px;
 }
 
+.btns-all .btn-group #wb-repositories-addRepositoryLink:hover {
+    /* Override _anchor.scss style */
+    text-decoration-line: none !important;
+}
+
 .remote-location-type-title {
     padding: 0;
 }


### PR DESCRIPTION
## What
The `Create new repository` button will not be underlined on hover.

## Why
The button text was underlined on hover, which did not match the legacy WB behavior.

## How
Edit style in legacy WB.

## Testing
N/A

## Screenshots
On hover:
![Screenshot from 2025-05-29 16-42-50](https://github.com/user-attachments/assets/7f51a58a-aba2-4924-93c9-55a58e7229ce)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
