### PR TITLE
GDB-12431 Fix workbench layout height

### DIFF
--- a/packages/shared-components/src/components/onto-layout/onto-layout.scss
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.scss
@@ -1,5 +1,6 @@
 :host {
   display: block;
+  height: 100%;
 }
 .wb-layout {
   display: grid;
@@ -9,7 +10,6 @@
         "nav header"
         "nav main"
         "nav footer";
-  height: 100vh;
   margin: 0;
 
   &.expanded {


### PR DESCRIPTION
## What
Fix the height of the workbench layout.

## Why
Prevent hiding static/sticky elements on vertical scroll because the html and body tags hosting the layout weren't properly sized.

## How
Set layout height to 100% and remove 100vh usage
Updated the `:host` to use 100% height for better adaptability within parent containers. Removed the 100vh height from `.wb-layout` to prevent potential layout issues on resizing.


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
