### PR TITLE
GDB-12399 translate french language option in language selector

### DIFF
--- a/packages/root-config/package.json
+++ b/packages/root-config/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "validate": "node ./src/scripts/validate-translations.js",
+    "validate": "node ./scripts/validate-translations.js",
     "test": "jest",
     "test:watch": "jest --watch"
   },

--- a/packages/root-config/scripts/validate-translations.js
+++ b/packages/root-config/scripts/validate-translations.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
 // Either use SCRIPT_ROOT env param, or go up 4 levels to project root where packages/ lives
-const baseDir = process.env.SCRIPT_ROOT || path.resolve(__dirname, '..', '..', '..', '..');
+const baseDir = process.env.SCRIPT_ROOT || path.resolve(__dirname, '..', '..', '..');
 const packagesDir = path.join(baseDir, 'packages');
 
 // Verified identical translations - no warnings or errors about them
@@ -47,6 +47,8 @@ const identicalTranslations = [
   "Google Analytics (GA4)",
   "Index",
   "<div><span class=\"graph\">GRAPH</span><span class=\"wise\">WISE</span></div><div class=\"thrives\">AI THRIVES ON WHOLE DATA</div>",
+  "fr &middot; Français",
+  "Changer la langue en Français",
 
   // File formats:
   "JSON",

--- a/packages/root-config/test/validate-translations.test.js
+++ b/packages/root-config/test/validate-translations.test.js
@@ -5,7 +5,7 @@ const os = require('os');
 const { spawnSync } = require('child_process');
 
 describe('translation-report script', () => {
-  const scriptPath = path.resolve(__dirname, '../src/scripts/validate-translations.js');
+  const scriptPath = path.resolve(__dirname, '../scripts/validate-translations.js');
   const fixturesDir = path.resolve(__dirname, 'fixtures', 'packages');
   let tmpDir = null;
 

--- a/packages/root-config/test/validate-utils.test.js
+++ b/packages/root-config/test/validate-utils.test.js
@@ -5,7 +5,7 @@ const {
   hasPlaceholderDifference,
   isUntranslated,
   validate
-} = require('../src/scripts/validate-translations');
+} = require('../scripts/validate-translations');
 
 describe('Utility functions', () => {
   describe('getAllKeys()', () => {

--- a/packages/shared-components/src/assets/i18n/en.json
+++ b/packages/shared-components/src/assets/i18n/en.json
@@ -66,10 +66,10 @@
         }
       },
       "fr": {
-        "label": "fr &middot; French",
+        "label": "fr &middot; Français",
         "tooltip": {
           "selected": "Current language",
-          "not_selected":"Change language to French"
+          "not_selected":"Changer la langue en Français"
         }
       }
     }


### PR DESCRIPTION
## What
Translate french language option in language selector..

## Why
For consistency with the legacy workbench.

## How
Updated French language labels in i18n file. Changed the French language label and tooltip text to use French terms ("Français").

## Screenshots
![image](https://github.com/user-attachments/assets/5615ed2e-1e9d-4e6e-84f7-bc41f7bd82bd)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
