### PR TITLE
GDB-12389 - Add space between nav text and icon for external link

### DIFF
--- a/packages/shared-components/src/components/onto-navbar/onto-navbar.scss
+++ b/packages/shared-components/src/components/onto-navbar/onto-navbar.scss
@@ -41,6 +41,10 @@ main menu height*/
   text-decoration: none !important;
 }
 
+.navbar-component .sub-menu-item a.sub-menu-link:not([href]) translate-label.menu-item {
+  padding-right: 3.5px;
+}
+
 .navbar-component a:not([href]):not([tabindex]),
 .navbar-component a:not([href]):not([tabindex]):focus,
 .navbar-component a:not([href]):not([tabindex]):hover {


### PR DESCRIPTION
## What
The Documentation, Tutorials and Support links will have space between the text and the external link icon.

## Why
The space is present in the legacy WB.

## How
The reason for the space in the legacy WB is an empty space character, which is underlined on hover. In order to avoid underlining an empty character, I added padding to match a space width for font size 16px.

## Testing
N/A

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/ecf3ddb1-871f-416e-8245-a376ab0604dc)

After:
![Screenshot from 2025-05-29 20-10-53](https://github.com/user-attachments/assets/816530ca-4acd-4a95-b627-2bc397507112)

## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
