### PR TITLE
feat(GDB-12347): integrate context updates and AngularJS change detection

### DIFF
--- a/packages/api/src/models/context/test/value-context.spec.ts
+++ b/packages/api/src/models/context/test/value-context.spec.ts
@@ -139,4 +139,23 @@ describe('ValueContext', () => {
     // Verify the value was not updated and callback was not called
     expect(result).toBe(false);
   });
+
+  it('should call afterChangeCallback after the main callback', () => {
+    const value = 123;
+    const callOrder: string[] = [];
+
+    const mainCallback = jest.fn(() => callOrder.push('main'));
+    const afterCallback = jest.fn(() => callOrder.push('after'));
+
+    valueContext.subscribe(mainCallback, undefined, afterCallback);
+
+    jest.spyOn(ObjectUtil, 'deepEqual').mockReturnValue(false);
+
+    valueContext.setValue(value);
+
+    expect(mainCallback).toHaveBeenCalledWith(value);
+    expect(afterCallback).toHaveBeenCalledWith(value);
+    expect(callOrder).toEqual(['main', 'after']);
+  });
+
 });

--- a/packages/api/src/providers/service/lifecycle-hooks.ts
+++ b/packages/api/src/providers/service/lifecycle-hooks.ts
@@ -1,0 +1,30 @@
+/**
+ * Interface for defining lifecycle hooks for {@link Service} instances.
+ *
+ * Classes implementing this interface can hook into specific lifecycle moments,
+ * such as when the instance is created by the {@link ServiceProvider}.
+
+ */
+export interface LifecycleHooks {
+  /**
+   * Hook called immediately after the service instance is created and before it's cached.
+   * Useful for registration or custom setup that requires the fully constructed object.
+   *
+   * Services may use the `onCreated` method to perform additional registrations,
+   * for example registering themselves in context or event registries.
+   *
+   * @example
+   * ```ts
+   * import { ServiceProvider } from '../service.provider';
+   * import { ContextSubscriptionManager } from '../../services/context/context-service-registry';
+   *
+   * class MyService implements Service, LifecycleHooks {
+   *   onCreated(): void {
+   *     // Perform some task when fully created
+   *     foo();
+   *   }
+   * }
+   * ```
+   */
+  onCreated?(): void;
+}

--- a/packages/api/src/providers/service/test/service.provider.spec.ts
+++ b/packages/api/src/providers/service/test/service.provider.spec.ts
@@ -1,7 +1,24 @@
 import {ServiceProvider} from '../service.provider';
 import {RepositoryService} from '../../../services/repository';
+import {Service} from '../service';
+import {LifecycleHooks} from '../lifecycle-hooks';
+
+class DummyService implements Service {}
+class BaseService implements Service {}
+class DerivedService extends BaseService {}
+class AnotherService implements Service, LifecycleHooks {
+  public static wasCreated  = false;
+  onCreated(): void {
+    AnotherService.wasCreated = true;
+  }
+}
 
 describe('ServiceProvider', () => {
+  beforeEach(() => {
+    // Clear internal map before each test to avoid leaks
+    ServiceProvider['SERVICE_INSTANCES'].clear();
+    AnotherService.wasCreated = false;
+  });
 
   test('get should return singleton instance of service', () => {
     // Given:
@@ -11,5 +28,31 @@ describe('ServiceProvider', () => {
     const secondRepositoryServiceInstance = ServiceProvider.get(RepositoryService);
     // Then I expect the second instance to be the same reference as the first one.
     expect(firstRepositoryServiceInstance).toBe(secondRepositoryServiceInstance);
+  });
+
+  test('get should return singleton instance of a service', () => {
+    const instance1 = ServiceProvider.get(DummyService);
+    const instance2 = ServiceProvider.get(DummyService);
+    expect(instance1).toBe(instance2);
+  });
+
+  test('get should call onCreated() on LifecycleHooks service', () => {
+    const instance = ServiceProvider.get(AnotherService);
+    expect(instance).toBeInstanceOf(AnotherService);
+    expect(AnotherService.wasCreated).toBe(true);
+  });
+
+  test('getAllBySuperType should return all services that inherit from a given base class', () => {
+    ServiceProvider.get(DummyService);
+    ServiceProvider.get(DerivedService);
+    const services = ServiceProvider.getAllBySuperType(BaseService);
+    expect(services.length).toBe(1);
+    expect(services[0]).toBeInstanceOf(DerivedService);
+  });
+
+  test('getAllBySuperType should return empty array if no matches found', () => {
+    ServiceProvider.get(DummyService);
+    const services = ServiceProvider.getAllBySuperType(BaseService);
+    expect(services).toEqual([]);
   });
 });

--- a/packages/api/src/services/autocomplete/autocomplete-context.service.ts
+++ b/packages/api/src/services/autocomplete/autocomplete-context.service.ts
@@ -3,6 +3,7 @@ import {DeriveContextServiceContract} from '../../models/context/update-context-
 import {ValueChangeCallback} from '../../models/context/value-change-callback';
 import {ServiceProvider} from '../../providers';
 import {AutocompleteStorageService} from './autocomplete-storage.service';
+import {LifecycleHooks} from '../../providers/service/lifecycle-hooks';
 
 type AutocompleteContextFields = {
   readonly AUTOCOMPLETE_ENABLED: string;
@@ -15,7 +16,7 @@ type AutocompleteContextFieldParams = {
 /**
  * Service for managing autocomplete context state across the application.
  */
-export class AutocompleteContextService extends ContextService<AutocompleteContextFields> implements DeriveContextServiceContract<AutocompleteContextFields, AutocompleteContextFieldParams> {
+export class AutocompleteContextService extends ContextService<AutocompleteContextFields> implements DeriveContextServiceContract<AutocompleteContextFields, AutocompleteContextFieldParams>, LifecycleHooks {
   /**
    * Context property key for the autocomplete enabled state.
    */

--- a/packages/api/src/services/context/context-subscription-manager.ts
+++ b/packages/api/src/services/context/context-subscription-manager.ts
@@ -1,0 +1,96 @@
+import {ContextService} from './context.service';
+import {Service} from '../../providers/service/service';
+import {ValueChangeCallback} from '../../models/context/value-change-callback';
+import {BeforeChangeValidationPromise} from '../../models/context/before-change-validation-promise';
+import {ServiceProvider} from '../../providers';
+import {SubscriptionList} from '../../models/common';
+
+/**
+ * Describes a global subscription to value changes in any registered ContextService.
+ * This is used to apply the same callback logic to all context-managed properties across services.
+ */
+type GlobalSubscription = {
+  callback: ValueChangeCallback<unknown>;
+  beforeChangeValidationPromise?: BeforeChangeValidationPromise<unknown>;
+  afterChangeCallback?: ValueChangeCallback<unknown>;
+};
+
+/**
+ * Manages subscriptions to value changes across all registered ContextService instances.
+ *
+ * This class enables centralized handling of property change events, allowing consumers to subscribe
+ * to all context-managed values at once, including those from context registered later.
+ */
+export class ContextSubscriptionManager implements Service {
+  private readonly subscribers: GlobalSubscription[] = [];
+
+  /**
+   * Subscribes a ContextService instance to all currently registered global subscriptions.
+   *
+   * This ensures that the provided service receives all value change notifications
+   * configured through {@link subscribeToAllRegisteredContexts}.
+   *
+   * @param service - The ContextService instance whose properties should be globally observed.
+   * @returns A function that, when called, unsubscribes this service from all global subscriptions.
+   */
+  subscribeToService(service: ContextService<Record<string, unknown>>): () => void {
+    const unsubFns: (() => void)[] = this.subscribers.map(sub =>
+      service.subscribeAll(
+        sub.callback,
+        sub.beforeChangeValidationPromise,
+        sub.afterChangeCallback
+      )
+    );
+    return () => unsubFns.forEach(unsub => unsub());
+  }
+
+  /**
+   * Subscribes globally to all currently registered context services and ensures that future ones
+   * receive the same callbacks as well.
+   *
+   * @param callback - Function that will be called for every value change.
+   * @param beforeChangeValidationPromise - Optional validation function called before value is applied.
+   * @param afterChangeCallback - Optional function called after value is updated.
+   * @returns A function that unsubscribes from all context changes.
+   */
+  subscribeToAllRegisteredContexts(
+    callback: ValueChangeCallback<unknown>,
+    beforeChangeValidationPromise?: BeforeChangeValidationPromise<unknown>,
+    afterChangeCallback?: ValueChangeCallback<unknown>
+  ): () => void {
+    const unsubFns: SubscriptionList = new SubscriptionList();
+
+    const services = ServiceProvider.getAllBySuperType(ContextService)
+      .filter(service => service.canSubscribeAll);
+    // Subscribe to already registered context services
+    for (const service of services) {
+      unsubFns.add(service.subscribeAll(callback, beforeChangeValidationPromise, afterChangeCallback));
+    }
+
+    const subscriber: GlobalSubscription = {
+      callback,
+      beforeChangeValidationPromise,
+      afterChangeCallback
+    };
+
+    this.subscribers.push(subscriber);
+
+    // Return idempotent unsubscribe function
+    let unsubscribed = false;
+    return () => {
+      if (unsubscribed) {
+        return;
+      }
+      unsubscribed = true;
+
+      // Unsubscribe from all previously registered services
+      unsubFns.unsubscribeAll();
+
+      // Remove global subscriber
+      const index = this.subscribers.indexOf(subscriber);
+      if (index >= 0) {
+        this.subscribers.splice(index, 1);
+      }
+    };
+  }
+}

--- a/packages/api/src/services/context/index.ts
+++ b/packages/api/src/services/context/index.ts
@@ -1,1 +1,2 @@
 export * from './context.service';
+export * from './context-subscription-manager';

--- a/packages/api/src/services/context/test/context-subscription-manager.spec.ts
+++ b/packages/api/src/services/context/test/context-subscription-manager.spec.ts
@@ -1,0 +1,234 @@
+import {ServiceProvider} from '../../../providers';
+import {ContextSubscriptionManager} from '../context-subscription-manager';
+import {ValueChangeCallback} from '../../../models/context/value-change-callback';
+import {BeforeChangeValidationPromise} from '../../../models/context/before-change-validation-promise';
+import {ContextService} from '../context.service';
+
+interface MockContextService {
+  canSubscribeAll: boolean;
+  subscribeAll: jest.Mock<() => void>;
+}
+
+describe('ContextSubscriptionManager test cases', () => {
+  let originalGetAllBySuperType: typeof ServiceProvider.getAllBySuperType;
+
+  beforeAll(() => {
+    originalGetAllBySuperType = ServiceProvider.getAllBySuperType;
+  });
+
+  afterAll(() => {
+    ServiceProvider.getAllBySuperType = originalGetAllBySuperType;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createMockService(): MockContextService {
+    const subscribeAllMock = jest.fn(() => {
+      return jest.fn();
+    });
+    return {
+      canSubscribeAll: true,
+      subscribeAll: subscribeAllMock,
+    };
+  }
+
+  test('registerContextService should store the service instance', () => {
+    ServiceProvider.getAllBySuperType = jest.fn().mockReturnValue([]);
+    const globalSub = new ContextSubscriptionManager();
+
+    const serviceA = createMockService();
+    const typedServiceA = (serviceA as unknown) as ContextService<Record<string, unknown>>;
+
+    const unsubA = globalSub.subscribeToService(typedServiceA);
+    expect(serviceA.subscribeAll).not.toHaveBeenCalled();
+
+    const cbGlobal: ValueChangeCallback<unknown> = jest.fn();
+    const beforeGlobal: BeforeChangeValidationPromise<unknown> = jest.fn();
+    const afterGlobal: ValueChangeCallback<unknown> = jest.fn();
+
+    const unsubGlobal = globalSub.subscribeToAllRegisteredContexts(
+      cbGlobal,
+      beforeGlobal,
+      afterGlobal
+    );
+
+    globalSub.subscribeToService(typedServiceA);
+
+    expect(serviceA.subscribeAll).toHaveBeenCalledTimes(1);
+    expect(serviceA.subscribeAll).toHaveBeenCalledWith(
+      cbGlobal,
+      beforeGlobal,
+      afterGlobal
+    );
+
+    // Cleanup
+    unsubA();
+    unsubGlobal();
+  });
+
+  test('subscribeToAllRegisteredContexts should call subscribeAll on newly registered service', () => {
+    ServiceProvider.getAllBySuperType = jest.fn().mockReturnValue([]);
+
+    const globalSub = new ContextSubscriptionManager();
+    const cbGlobal: ValueChangeCallback<unknown> = jest.fn();
+    const beforeGlobal: BeforeChangeValidationPromise<unknown> = jest.fn();
+    const afterGlobal: ValueChangeCallback<unknown> = jest.fn();
+
+    const unsubGlobal = globalSub.subscribeToAllRegisteredContexts(
+      cbGlobal,
+      beforeGlobal,
+      afterGlobal
+    );
+
+    const serviceB = createMockService();
+    const typedServiceB = (serviceB as unknown) as ContextService<Record<string, unknown>>;
+
+    const unsubB = globalSub.subscribeToService(typedServiceB);
+
+    expect(serviceB.subscribeAll).toHaveBeenCalledTimes(1);
+    expect(serviceB.subscribeAll).toHaveBeenCalledWith(
+      cbGlobal,
+      beforeGlobal,
+      afterGlobal
+    );
+
+    // Cleanup
+    unsubB();
+    unsubGlobal();
+  });
+
+  test('unsubscribe function should remove subscriber and call unsub functions', () => {
+    const service1 = createMockService();
+    const service2 = createMockService();
+    ServiceProvider.getAllBySuperType = jest
+      .fn()
+      .mockReturnValue([service1, service2]);
+
+    const globalSub = new ContextSubscriptionManager();
+    const cbGlobal: ValueChangeCallback<unknown> = jest.fn();
+    const beforeGlobal: BeforeChangeValidationPromise<unknown> = jest.fn();
+    const afterGlobal: ValueChangeCallback<unknown> = jest.fn();
+
+    const unsubGlobal = globalSub.subscribeToAllRegisteredContexts(
+      cbGlobal,
+      beforeGlobal,
+      afterGlobal
+    );
+
+    expect(service1.subscribeAll).toHaveBeenCalledTimes(1);
+    expect(service2.subscribeAll).toHaveBeenCalledTimes(1);
+
+    const unsubFn1 = service1.subscribeAll.mock.results[0]
+      .value as jest.Mock;
+    const unsubFn2 = service2.subscribeAll.mock.results[0]
+      .value as jest.Mock;
+
+    unsubGlobal();
+
+    expect(unsubFn1).toHaveBeenCalledTimes(1);
+    expect(unsubFn2).toHaveBeenCalledTimes(1);
+
+    unsubGlobal();
+    expect(unsubFn1).toHaveBeenCalledTimes(1);
+    expect(unsubFn2).toHaveBeenCalledTimes(1);
+
+    const service3 = createMockService();
+    const typedService3 = (service3 as unknown) as ContextService<Record<string, unknown>>;
+    const unsub3 = globalSub.subscribeToService(typedService3);
+
+    expect(service3.subscribeAll).not.toHaveBeenCalled();
+
+    // Cleanup
+    unsub3();
+  });
+
+  test('subscribeToAllRegisteredContexts passes afterChangeCallback to services', () => {
+    const serviceX = createMockService();
+    ServiceProvider.getAllBySuperType = jest.fn().mockReturnValue([serviceX]);
+
+    const globalSub = new ContextSubscriptionManager();
+    const cbGlobal: ValueChangeCallback<unknown> = jest.fn();
+    const beforeGlobal: BeforeChangeValidationPromise<unknown> = jest.fn();
+    const afterGlobal: ValueChangeCallback<unknown> = jest.fn();
+
+    const unsubGlobal = globalSub.subscribeToAllRegisteredContexts(
+      cbGlobal,
+      beforeGlobal,
+      afterGlobal
+    );
+
+    expect(serviceX.subscribeAll).toHaveBeenCalledTimes(1);
+    expect(serviceX.subscribeAll).toHaveBeenCalledWith(
+      cbGlobal,
+      beforeGlobal,
+      afterGlobal
+    );
+
+    const serviceY = createMockService();
+    ServiceProvider.getAllBySuperType = jest.fn().mockReturnValue([serviceY]);
+    const globalSub2 = new ContextSubscriptionManager();
+    const cb2: ValueChangeCallback<unknown> = jest.fn();
+    const before2: BeforeChangeValidationPromise<unknown> = jest.fn();
+
+    const unsubGlobal2 = globalSub2.subscribeToAllRegisteredContexts(
+      cb2,
+      before2
+    );
+
+    expect(serviceY.subscribeAll).toHaveBeenCalledTimes(1);
+    expect(serviceY.subscribeAll.mock.calls[0]).toEqual([cb2, before2, undefined]);
+
+    // Cleanup
+    unsubGlobal();
+    unsubGlobal2();
+  });
+
+  test('unsubscribing from global subscription does not affect individual property subscriptions', () => {
+    const serviceZ = createMockService();
+    ServiceProvider.getAllBySuperType = jest.fn().mockReturnValue([serviceZ]);
+
+    const globalSub = new ContextSubscriptionManager();
+
+    const cbIndividual: ValueChangeCallback<unknown> = jest.fn();
+    const unsubIndividual = serviceZ.subscribeAll(cbIndividual); // returns its own jest.fn()
+
+    expect(serviceZ.subscribeAll).toHaveBeenCalledTimes(1);
+
+    const cbGlobal: ValueChangeCallback<unknown> = jest.fn();
+    const beforeGlobal: BeforeChangeValidationPromise<unknown> = jest.fn();
+    const afterGlobal: ValueChangeCallback<unknown> = jest.fn();
+
+    const unsubGlobal = globalSub.subscribeToAllRegisteredContexts(
+      cbGlobal,
+      beforeGlobal,
+      afterGlobal
+    );
+    expect(serviceZ.subscribeAll).toHaveBeenCalledTimes(2);
+
+    const unsubFromGlobal = serviceZ.subscribeAll.mock.results[1]
+      .value as jest.Mock;
+
+    unsubGlobal();
+    expect(unsubFromGlobal).toHaveBeenCalledTimes(1);
+    expect(unsubIndividual).not.toHaveBeenCalled();
+
+    // Cleanup: manually unsubscribe the individual subscription
+    unsubIndividual();
+  });
+
+  test('subscribeToService after global unsub does nothing', () => {
+    const globalSub = new ContextSubscriptionManager();
+    const cb = jest.fn();
+    const unsub = globalSub.subscribeToAllRegisteredContexts(cb);
+
+    unsub();
+
+    const service = createMockService();
+    globalSub.subscribeToService(service as unknown as ContextService<Record<string, unknown>>);
+
+    expect(service.subscribeAll).not.toHaveBeenCalled();
+  });
+});
+

--- a/packages/api/src/services/context/test/context.service.spec.ts
+++ b/packages/api/src/services/context/test/context.service.spec.ts
@@ -151,6 +151,26 @@ describe('ContextService', () => {
     // And callback should have been called once on initial subscription
     expect(callBackFunction).toHaveBeenCalledTimes(1);
   });
+
+  test('ContextService should call afterChangeCallback after the main callback with the same value', () => {
+    const valueOfTestProperty = {a: 1, b: [1, 2]};
+    const propertyName = 'testProperty';
+
+    const callSequence: string[] = [];
+
+    const mainCallback = jest.fn(() => callSequence.push('main'));
+    const afterCallback = jest.fn(() => callSequence.push('after'));
+
+    contextService.subscribeToProperty(propertyName, mainCallback, undefined, afterCallback);
+
+    callSequence.length = 0;
+    contextService.updateProperty(propertyName, valueOfTestProperty);
+
+    expect(mainCallback).toHaveBeenLastCalledWith(valueOfTestProperty);
+    expect(afterCallback).toHaveBeenLastCalledWith(valueOfTestProperty);
+    expect(callSequence).toEqual(['main', 'after']);
+  });
+
 });
 
 type TestContextFields = {
@@ -177,7 +197,12 @@ class TestContextService extends ContextService<TestContextFields> implements De
     return this.getContextPropertyValue(propertyName);
   }
 
-  public subscribeToProperty<T>(propertyName: string, callback: (value?: T) => void, beforeChangeValidationPromise?: BeforeChangeValidationPromise<T>): () => void {
-    return this.subscribe(propertyName, callback, beforeChangeValidationPromise);
+  public subscribeToProperty<T>(
+    propertyName: string,
+    callback: (value?: T) => void,
+    beforeChangeValidationPromise?: BeforeChangeValidationPromise<T>,
+    afterChangeCallback?: (value?: T) => void
+  ): () => void {
+    return this.subscribe(propertyName, callback, beforeChangeValidationPromise, afterChangeCallback);
   }
 }

--- a/packages/api/src/services/language/language-context.service.ts
+++ b/packages/api/src/services/language/language-context.service.ts
@@ -6,6 +6,7 @@ import {LanguageService} from './language.service';
 import {DeriveContextServiceContract} from '../../models/context/update-context-method';
 import {LanguageConfig, TranslationBundle} from '../../models/language';
 import {BeforeChangeValidationPromise} from '../../models/context/before-change-validation-promise';
+import {LifecycleHooks} from '../../providers/service/lifecycle-hooks';
 
 type LanguageContextFields = {
   readonly SELECTED_LANGUAGE: string;
@@ -14,7 +15,7 @@ type LanguageContextFields = {
 /**
  * The LanguageService class manages the application's language context.
  */
-export class LanguageContextService extends ContextService<LanguageContextFields> implements DeriveContextServiceContract<LanguageContextFields> {
+export class LanguageContextService extends ContextService<LanguageContextFields> implements DeriveContextServiceContract<LanguageContextFields>, LifecycleHooks {
   private readonly LANGUAGE_CONFIG = 'languageConfig';
   readonly SELECTED_LANGUAGE = 'selectedLanguage';
   readonly LANGUAGE_BUNDLE = 'languageBundle';

--- a/packages/api/src/services/license/license-context.service.ts
+++ b/packages/api/src/services/license/license-context.service.ts
@@ -2,6 +2,7 @@ import {License} from '../../models/license';
 import {ValueChangeCallback} from '../../models/context/value-change-callback';
 import {ContextService} from '../context';
 import {DeriveContextServiceContract} from '../../models/context/update-context-method';
+import {LifecycleHooks} from '../../providers/service/lifecycle-hooks';
 
 type LicenseContextFields = {
   readonly GRAPHDB_LICENSE: string;
@@ -15,7 +16,7 @@ type LicenseContextFieldParams = {
  * Service for managing license context in the application.
  * Extends the base ContextService to provide license-specific functionality.
  */
-export class LicenseContextService extends ContextService<LicenseContextFields> implements DeriveContextServiceContract<LicenseContextFields, LicenseContextFieldParams> {
+export class LicenseContextService extends ContextService<LicenseContextFields> implements DeriveContextServiceContract<LicenseContextFields, LicenseContextFieldParams>, LifecycleHooks {
   readonly GRAPHDB_LICENSE = 'graphDbLicense';
 
   /**

--- a/packages/api/src/services/namespace/namespaces-context.service.ts
+++ b/packages/api/src/services/namespace/namespaces-context.service.ts
@@ -2,6 +2,7 @@ import {ContextService} from '../context';
 import {NamespaceMap} from '../../models/repositories';
 import {DeriveContextServiceContract} from '../../models/context/update-context-method';
 import {ValueChangeCallback} from '../../models/context/value-change-callback';
+import {LifecycleHooks} from '../../providers/service/lifecycle-hooks';
 
 type NamespacesContextFields = {
   readonly NAMESPACES: string;
@@ -14,7 +15,7 @@ type NamespacesContextFieldParams = {
 /**
  * Service for managing namespaces context in the application.
  */
-export class NamespacesContextService extends ContextService<NamespacesContextFields> implements DeriveContextServiceContract<NamespacesContextFields, NamespacesContextFieldParams> {
+export class NamespacesContextService extends ContextService<NamespacesContextFields> implements DeriveContextServiceContract<NamespacesContextFields, NamespacesContextFieldParams>, LifecycleHooks {
   readonly NAMESPACES = 'namespaces';
 
   /**

--- a/packages/api/src/services/product-info/product-info-context.service.ts
+++ b/packages/api/src/services/product-info/product-info-context.service.ts
@@ -2,6 +2,7 @@ import { ContextService } from '../context';
 import { ProductInfo } from '../../models/product-info';
 import { ValueChangeCallback } from '../../models/context/value-change-callback';
 import {DeriveContextServiceContract} from '../../models/context/update-context-method';
+import {LifecycleHooks} from '../../providers/service/lifecycle-hooks';
 
 type ProductInfoContextFields = {
   readonly PRODUCT_INFO: string;
@@ -14,7 +15,7 @@ type ProductInfoContextFieldParams = {
 /**
  * Service for managing product information context.
  */
-export class ProductInfoContextService extends ContextService<ProductInfoContextFields> implements DeriveContextServiceContract<ProductInfoContextFields, ProductInfoContextFieldParams> {
+export class ProductInfoContextService extends ContextService<ProductInfoContextFields> implements DeriveContextServiceContract<ProductInfoContextFields, ProductInfoContextFieldParams>, LifecycleHooks {
   readonly PRODUCT_INFO = 'productInfo';
 
   /**

--- a/packages/api/src/services/repository-location/repository-location-context.service.ts
+++ b/packages/api/src/services/repository-location/repository-location-context.service.ts
@@ -2,6 +2,7 @@ import {ContextService} from '../context';
 import {ValueChangeCallback} from '../../models/context/value-change-callback';
 import {RepositoryLocation} from '../../models/repository-location';
 import {DeriveContextServiceContract} from '../../models/context/update-context-method';
+import {LifecycleHooks} from '../../providers/service/lifecycle-hooks';
 
 type RepositoryLocationContextFields = {
   readonly ACTIVE_REPOSITORY_LOCATION: string;
@@ -16,7 +17,7 @@ type RepositoryLocationContextFieldParams = {
 /**
  * The RepositoryLocationContextService class manages the application's repository location context.
  */
-export class RepositoryLocationContextService extends ContextService<RepositoryLocationContextFields> implements DeriveContextServiceContract<RepositoryLocationContextFields, RepositoryLocationContextFieldParams> {
+export class RepositoryLocationContextService extends ContextService<RepositoryLocationContextFields> implements DeriveContextServiceContract<RepositoryLocationContextFields, RepositoryLocationContextFieldParams>, LifecycleHooks {
 
   readonly ACTIVE_REPOSITORY_LOCATION = 'activeRepositoryLocation';
   readonly IS_LOADING = 'isLoading';

--- a/packages/api/src/services/repository/repository-context.service.ts
+++ b/packages/api/src/services/repository/repository-context.service.ts
@@ -5,6 +5,7 @@ import {DeriveContextServiceContract} from '../../models/context/update-context-
 import {ServiceProvider} from '../../providers';
 import {RepositoryStorageService} from './repository-storage.service';
 import {BeforeChangeValidationPromise} from '../../models/context/before-change-validation-promise';
+import {LifecycleHooks} from '../../providers/service/lifecycle-hooks';
 
 type RepositoryContextFields = {
   readonly REPOSITORY_LIST: string;
@@ -19,7 +20,7 @@ type RepositoryContextFieldParams = {
 /**
  * The RepositoryContextService class manages the application's repository context.
  */
-export class RepositoryContextService extends ContextService<RepositoryContextFields> implements DeriveContextServiceContract<RepositoryContextFields, RepositoryContextFieldParams> {
+export class RepositoryContextService extends ContextService<RepositoryContextFields> implements DeriveContextServiceContract<RepositoryContextFields, RepositoryContextFieldParams>, LifecycleHooks {
   readonly SELECTED_REPOSITORY = 'selectedRepository';
   readonly REPOSITORY_LIST = 'repositoryList';
 

--- a/packages/api/src/services/security/security-context.service.ts
+++ b/packages/api/src/services/security/security-context.service.ts
@@ -2,6 +2,7 @@ import {ContextService} from '../context';
 import {ValueChangeCallback} from '../../models/context/value-change-callback';
 import {DeriveContextServiceContract} from '../../models/context/update-context-method';
 import {AuthenticatedUser, RestrictedPages, SecurityConfig, OpenIdConfig} from '../../models/security';
+import {LifecycleHooks} from '../../providers/service/lifecycle-hooks';
 
 type SecurityContextFields = {
   readonly RESTRICTED_PAGES: string
@@ -22,7 +23,7 @@ type SecurityContextFieldParams = {
 /**
  * The SecurityContextService class manages the various fields in the security context.
  */
-export class SecurityContextService extends ContextService<SecurityContextFields> implements DeriveContextServiceContract<SecurityContextFields, SecurityContextFieldParams> {
+export class SecurityContextService extends ContextService<SecurityContextFields> implements DeriveContextServiceContract<SecurityContextFields, SecurityContextFieldParams>, LifecycleHooks {
   readonly RESTRICTED_PAGES = 'restrictedPages';
   readonly SECURITY_CONFIG = 'securityConfig';
   readonly AUTHENTICATED_USER = 'authenticatedUser';

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -269,6 +269,12 @@ export namespace Components {
           * @param restrictedPages - the map with restricted pages to be set in context service as new value.
          */
         "updateRestrictedPage": (restrictedPages: Record<string, boolean>) => Promise<void>;
+        /**
+          * Updates the selected repository in the application context.
+          * @method updateSelectedRepository
+          * @param repositoryReference - The RepositoryReference object representing the repository to select.
+          * @returns A Promise that resolves when the selected repository has been updated.
+         */
         "updateSelectedRepository": (repositoryReference: RepositoryReference) => Promise<void>;
     }
     /**

--- a/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
+++ b/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
@@ -157,6 +157,13 @@ export class OntoTestContext {
     return Promise.resolve();
   }
 
+  /**
+   * Updates the selected repository in the application context.
+   *
+   * @method updateSelectedRepository
+   * @param repositoryReference - The RepositoryReference object representing the repository to select.
+   * @returns A Promise that resolves when the selected repository has been updated.
+   */
   @Method()
   updateSelectedRepository(repositoryReference: RepositoryReference): Promise<void> {
     ServiceProvider.get(RepositoryContextService).updateSelectedRepository(repositoryReference);

--- a/packages/shared-components/src/components/onto-test-context/readme.md
+++ b/packages/shared-components/src/components/onto-test-context/readme.md
@@ -210,19 +210,19 @@ Type: `Promise<void>`
 
 ### `updateSelectedRepository(repositoryReference: RepositoryReference) => Promise<void>`
 
-
+Updates the selected repository in the application context.
 
 #### Parameters
 
-| Name                  | Type                  | Description |
-| --------------------- | --------------------- | ----------- |
-| `repositoryReference` | `RepositoryReference` |             |
+| Name                  | Type                  | Description                                                             |
+| --------------------- | --------------------- | ----------------------------------------------------------------------- |
+| `repositoryReference` | `RepositoryReference` | - The RepositoryReference object representing the repository to select. |
 
 #### Returns
 
 Type: `Promise<void>`
 
-
+A Promise that resolves when the selected repository has been updated.
 
 
 ----------------------------------------------


### PR DESCRIPTION
## WHAT
- Introduced LifecycleHooks interface with onCreated() method.
- Centralized context service registration via ContextServiceRegistry.
- Enabled global context subscriptions using subscribeToAllRegisteredContexts.
- Ensured afterChangeCallback is invoked after main callback.
- Hooked AngularJS $rootScope.$apply() to context changes during mount.
- Unsubscribed automatically on unmount to prevent memory leaks.

## WHY
- Eliminate tight coupling and manual registration of context services.
- Support reactive cross-cutting logic through lifecycle hooks.
- Trigger AngularJS digest cycles on external context changes.

## HOW
- Added LifecycleHooks and integrated into ServiceProvider.get.
- Context services self-register via onCreated() into the registry.
- Replaced legacy static subscription utility with registry-based logic.
- Mounted subscribeToAllRegisteredContexts inside single-spa-angularjs and stored unsub fn.
- Updated and extended tests


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [X] Tests
