### PR TITLE
GDB-12388 Fix repository dropdown text not changing

### DIFF
--- a/e2e-tests/e2e-legacy/home/home-page-without-repositories.spec.js
+++ b/e2e-tests/e2e-legacy/home/home-page-without-repositories.spec.js
@@ -23,7 +23,7 @@ describe('Home page: without repositories', () => {
     HomeSteps.getRDFSearchButton().should('not.be.visible');
     // Repository selector menu should be visible and empty
     HomeSteps.getRepositorySelector().should('be.visible');
-    HomeSteps.getSelectedRepository().should('contain', 'Choose repository');
+    HomeSteps.getSelectedRepository().should('contain', 'No accessible repositories');
     // Language selector menu should be visible and default to English
     HomeSteps.getLanguageSelector().should('be.visible');
     HomeSteps.getSelectedLanguage().should('contain', 'en');

--- a/packages/shared-components/src/assets/i18n/en.json
+++ b/packages/shared-components/src/assets/i18n/en.json
@@ -76,7 +76,8 @@
   },
   "repository-selector": {
     "btn": {
-      "toggle": "Choose repository"
+      "toggle": "Choose repository",
+      "no_repositories": "No accessible repositories"
     },
     "tooltip": {
       "repository": "Repository",

--- a/packages/shared-components/src/assets/i18n/fr.json
+++ b/packages/shared-components/src/assets/i18n/fr.json
@@ -76,7 +76,8 @@
   },
   "repository-selector": {
     "btn": {
-      "toggle": "Choisissez le dépôt"
+      "toggle": "Choisissez le dépôt",
+      "no_repositories": "Aucun dépôt accessible"
     },
     "tooltip": {
       "repository": "Dépôt",

--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
@@ -65,6 +65,11 @@ export class OntoRepositorySelector {
   @State() defaultToggleButtonName: string;
 
   /**
+   * The message to display when there are no repositories available.
+   */
+  @State() noRepositoriesButtonMessage: string;
+
+  /**
    * A list derived from the `items` input prop, with tooltip functions attached.
    *
    * Tooltip generation is centralized here to ensure consistency and avoid redundant operations.
@@ -85,7 +90,7 @@ export class OntoRepositorySelector {
   }
 
   connectedCallback() {
-    this.subscriptions.push(this.subscribeToTranslationChanged());
+    this.subscriptions.push(...this.subscribeToTranslationChanged());
 
     // Manually apply tooltip functions to each item on first mount.
     if (this.items && this.items.length) {
@@ -104,12 +109,13 @@ export class OntoRepositorySelector {
   }
 
   render() {
+    const buttonLabel = this.getButtonLabel();
     return (
       <Host>
         <onto-dropdown
           class='onto-repository-selector'
           onValueChanged={this.onValueChanged()}
-          dropdownButtonName={<SelectorButton repository={this.currentRepository} defaultToggleButtonName={this.defaultToggleButtonName}  location={this.getLocation()}/>}
+          dropdownButtonName={<SelectorButton repository={this.currentRepository} defaultToggleButtonName={buttonLabel}  location={this.getLocation()}/>}
           dropdownButtonTooltip={this.createTooltipFunctionForRepository(this.currentRepository)}
           dropdownTooltipTrigger='mouseenter focus'
           dropdownAlignment={DropdownItemAlignment.RIGHT}
@@ -219,10 +225,15 @@ export class OntoRepositorySelector {
     return html;
   }
 
-  private subscribeToTranslationChanged(): () => void {
-    return TranslationService.onTranslate('repository-selector.btn.toggle', [], (toggleButtonName) => {
-      this.defaultToggleButtonName = toggleButtonName;
-    })
+  private subscribeToTranslationChanged(): Array<() => void> {
+    return [
+      TranslationService.onTranslate('repository-selector.btn.toggle', [], (toggleButtonName) => {
+        this.defaultToggleButtonName = toggleButtonName;
+      }),
+      TranslationService.onTranslate('repository-selector.btn.no_repositories', [], (noRepositoriesButtonMessage) => {
+        this.noRepositoriesButtonMessage = noRepositoriesButtonMessage;
+      })
+    ];
   }
 
   private onRepositoryChanged(selectedRepository: Repository): void {
@@ -234,5 +245,11 @@ export class OntoRepositorySelector {
       return `@${UriUtil.shortenIri(this.currentRepository.location)}`;
     }
     return ``;
+  }
+
+  private getButtonLabel() {
+    return this.items?.length
+      ? this.defaultToggleButtonName
+      : this.noRepositoriesButtonMessage;
   }
 }


### PR DESCRIPTION
## What
Fixed the repository dropdown text, which didn't change, depending on the availability/absence of repositories

## Why
The text should be different, depending on whether there are available repositories or not

## How
Added another `@State` label for `No accessible repositories` and added a condition to switch labels based on the presence/absence of repositories

## Testing
cypress

## Screenshots
![Screenshot from 2025-05-30 10-44-41](https://github.com/user-attachments/assets/69e2c674-e0e7-49f1-ab8c-1200f2942317)
![Screenshot from 2025-05-30 10-45-04](https://github.com/user-attachments/assets/53675c1f-0b33-4db7-9c92-fe73edbdeeb8)

## Checklist

- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
