### PR TITLE
GDB-12395 Remove underline from button links

### DIFF
--- a/packages/legacy-workbench/src/css/repositories.css
+++ b/packages/legacy-workbench/src/css/repositories.css
@@ -413,11 +413,6 @@ span.label {
     padding: 0 13px;
 }
 
-.btns-all .btn-group #wb-repositories-addRepositoryLink:hover {
-    /* Override _anchor.scss style */
-    text-decoration-line: none !important;
-}
-
 .remote-location-type-title {
     padding: 0;
 }

--- a/packages/root-config/src/styles/partials/anchor/_anchor.scss
+++ b/packages/root-config/src/styles/partials/anchor/_anchor.scss
@@ -1,5 +1,5 @@
 a {
-  &:hover,
+  &:hover:not(.btn),
   &:active,
   &[href^="http"],
   &[href^="http"]:hover,


### PR DESCRIPTION
## What
Remove underline from button links

## Why
To be consistent with the legacy workbench

## How
Added a CSS psudo class to not apply anchor styling on `.btn` anchor elements

## Testing
n/a

## Screenshots
![Screenshot from 2025-05-30 14-01-44](https://github.com/user-attachments/assets/4eb92b17-bd67-4fed-afc9-3efa8b49d83c)
![Screenshot from 2025-05-30 14-01-56](https://github.com/user-attachments/assets/9f490356-80a0-46fa-b87b-e2ec711b0772)
![Screenshot from 2025-05-30 14-02-02](https://github.com/user-attachments/assets/bcbd5606-75f8-4222-92c7-e48648e59e6d)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
