### PR TITLE
GDB-12421 fix infinite loading in create graphql endpoint view

### DIFF
--- a/packages/legacy-workbench/src/js/angular/graphql/directives/configure-endpoint.directive.js
+++ b/packages/legacy-workbench/src/js/angular/graphql/directives/configure-endpoint.directive.js
@@ -2,9 +2,9 @@ angular
     .module('graphdb.framework.graphql.directives.configure-endpoint', [])
     .directive('configureEndpoint', ConfigureEndpointComponent);
 
-ConfigureEndpointComponent.$inject = ['ModalService', '$translate', 'GraphqlService', 'GraphqlContextService'];
+ConfigureEndpointComponent.$inject = ['$q', 'ModalService', '$translate', 'GraphqlService', 'GraphqlContextService'];
 
-function ConfigureEndpointComponent(ModalService, $translate, GraphqlService, GraphqlContextService) {
+function ConfigureEndpointComponent($q, ModalService, $translate, GraphqlService, GraphqlContextService) {
     return {
         restrict: 'E',
         templateUrl: 'js/angular/graphql/templates/step-configure-endpoint.html',
@@ -100,7 +100,7 @@ function ConfigureEndpointComponent(ModalService, $translate, GraphqlService, Gr
 
             const loadData = () => {
                 $scope.loadingData = true;
-                Promise.all([loadGenerationSettings()])
+                $q.all([loadGenerationSettings()])
                     .then(([generationSettings]) => {
                         $scope.endpointConfiguration.settings = generationSettings;
                     })

--- a/packages/legacy-workbench/src/js/angular/graphql/directives/select-schema-sources.directive.js
+++ b/packages/legacy-workbench/src/js/angular/graphql/directives/select-schema-sources.directive.js
@@ -11,9 +11,9 @@ angular
     .module('graphdb.framework.graphql.directives.select-schema-sources', modules)
     .directive('selectSchemaSources', SelectSchemaSourcesComponent);
 
-SelectSchemaSourcesComponent.$inject = ['ModalService', '$translate', 'toastr', '$repositories', 'GraphqlContextService', 'GraphqlService', 'RDF4JRepositoriesService'];
+SelectSchemaSourcesComponent.$inject = ['$q', 'ModalService', '$translate', 'toastr', '$repositories', 'GraphqlContextService', 'GraphqlService', 'RDF4JRepositoriesService'];
 
-function SelectSchemaSourcesComponent(ModalService, $translate, toastr, $repositories, GraphqlContextService, GraphqlService, RDF4JRepositoriesService) {
+function SelectSchemaSourcesComponent($q, ModalService, $translate, toastr, $repositories, GraphqlContextService, GraphqlService, RDF4JRepositoriesService) {
     return {
         restrict: 'E',
         templateUrl: 'js/angular/graphql/templates/step-select-schema-sources.html',
@@ -267,7 +267,7 @@ function SelectSchemaSourcesComponent(ModalService, $translate, toastr, $reposit
              */
             const loadData = (endpointConfiguration) => {
                 $scope.loadingData = true;
-                Promise.all([loadPrefixes(), loadAllGraphs(), loadGraphqlSchemaShapes(), loadShaclShapeGraphs()])
+                $q.all([loadPrefixes(), loadAllGraphs(), loadGraphqlSchemaShapes(), loadShaclShapeGraphs()])
                     .then(([prefixes, graphs, graphqlShapes, shaclShapeGraphs]) => {
                         $scope.graphqlSchemaShapes = graphqlShapes;
                         $scope.graphs = graphs;


### PR DESCRIPTION
## What
Fix infinite loading in create graphql endpoint view.

## Why
Usage of Promise.all should be avoided in angularjs because the framework knows and uses the $q library to handle promises and although it has similar API as the Promises, it doesn't react properly to this particular expression.

## How
Replaced the `Promise.all` with `$q.all` which is properly handled by angularjs.


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
