### PR TITLE
fix(GDB-12423) Ensure auth check is not cancelled on route change to trigger login redirect

### DIFF
--- a/packages/legacy-workbench/src/js/angular/rest/security.rest.service.js
+++ b/packages/legacy-workbench/src/js/angular/rest/security.rest.service.js
@@ -46,7 +46,9 @@ function SecurityRestService($http) {
     }
 
     function getAuthenticatedUser() {
-        return $http.get(`${SECURITY_AUTHENTICATED_ENDPOINT}`);
+        return $http.get(`${SECURITY_AUTHENTICATED_ENDPOINT}`, {
+            noCancelOnRouteChange: true
+        });
     }
 
     function getAdminUser() {


### PR DESCRIPTION
## WHAT:
Added noCancelOnRouteChange: true to the $http.get() call for the getAuthenticatedUser() request in security.rest.service.js.

## WHY:
When a user is not authenticated, the getAuthenticatedUser() endpoint should return a 401, which is handled by jwt-auth.service.js to trigger a redirect to the login page. However, during route changes, AngularJS may cancel pending $http requests, causing this check to be aborted. As a result, the 401 never reaches the catch, and the user is left on a broken page instead of being redirected.

## HOW:
Set noCancelOnRouteChange: true in the $http.get() options to prevent Angular from cancelling the request when navigating between routes. This ensures the 401 response is properly received and handled.


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
