### PR TITLE
GDB-12450 Remove text underline on active link buttons

### DIFF
--- a/packages/legacy-workbench/src/css/import.css
+++ b/packages/legacy-workbench/src/css/import.css
@@ -23,7 +23,7 @@
     padding: 0;
 }
 
-.upload-buttons .upload-rdf-files-btn > a {
+.upload-buttons .upload-rdf-files-btn > div {
     width: 100%;
     padding: 0.75em 1.2em;
 }

--- a/packages/legacy-workbench/src/pages/import.html
+++ b/packages/legacy-workbench/src/pages/import.html
@@ -46,7 +46,7 @@
                              popover-trigger="mouseenter"
                              popover-placement="bottom"
                              guide-selector="uploadRdfFileButton">
-                            <a id="wb-import-uploadFile" class="pointer clearfix"
+                            <div id="wb-import-uploadFile" class="pointer clearfix"
                                accept="{{fileFormatsExtended}}"
                                ngf-multiple="true"
                                ngf-select
@@ -65,7 +65,7 @@
                                         </small>
                                     </label>
                                 </div>
-                            </a>
+                            </div>
                         </div>
                     </div>
 

--- a/packages/root-config/src/styles/partials/anchor/_anchor.scss
+++ b/packages/root-config/src/styles/partials/anchor/_anchor.scss
@@ -1,6 +1,6 @@
 a {
   &:hover:not(.btn),
-  &:active,
+  &:active:not(.btn),
   &[href^="http"],
   &[href^="http"]:hover,
   &[href^="http"]:active {


### PR DESCRIPTION
## What
Remove the anchor styling from active buttons, which contain anchors in them.

## Why
Because they were incorrectly styled as links with underline

## How
Added a condition to `_anchor.scss` not to style active links with `.btn` class. Also changed the import RDF button to be `div` instead of `<a>`, since it was styled incorrectly

## Testing
n/a

## Screenshots
![image](https://github.com/user-attachments/assets/4509f00c-c539-4616-aa89-cf03eb65c021)
![Screenshot from 2025-06-02 13-54-06](https://github.com/user-attachments/assets/dbe43617-9765-4bd5-8f7d-3ec83780e796)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
