### PR TITLE
GDB-12361 Fix missing saved repository on startup

### DIFF
--- a/packages/root-config/src/bootstrap/bootstrap.js
+++ b/packages/root-config/src/bootstrap/bootstrap.js
@@ -1,7 +1,6 @@
 import {languageBootstrap} from './language/language-bootstrap';
 import {licenseBootstrap} from './license/license-bootstrap';
 import {productInfoBootstrap} from './product-info/product-info-bootstrap';
-import {repositoryBootstrap} from './repository/repository-bootstrap';
 import {autoCompleteBootstrap} from './autocomplete/autocomplete';
 import {securityBootstrap} from './security/security-bootstrap';
 
@@ -9,7 +8,10 @@ export const bootstrapPromises = [
   ...languageBootstrap,
   ...licenseBootstrap,
   ...productInfoBootstrap,
-  ...repositoryBootstrap,
   ...autoCompleteBootstrap,
   ...securityBootstrap,
 ];
+
+export const settleAllPromises = (bootstrapPromises) => {
+  return Promise.allSettled(bootstrapPromises.map((bootstrapFn) => bootstrapFn()));
+};

--- a/packages/root-config/src/bootstrap/repository/repository-bootstrap.js
+++ b/packages/root-config/src/bootstrap/repository/repository-bootstrap.js
@@ -20,7 +20,7 @@ const loadRepositories = () => {
       repositoryContextService.updateSelectedRepository(repositoryReference);
     })
     .catch((error) => {
-      throw new Error('Could not load repositories', error);
+      console.error('Could not load repositories', error);
     });
 };
 

--- a/packages/root-config/src/ontotext-root-config.js
+++ b/packages/root-config/src/ontotext-root-config.js
@@ -15,13 +15,14 @@ import './styles/onto-stylesheet.scss';
 import './onto-vendor';
 import './styles/main.scss';
 import {defineCustomElements} from '../../shared-components/loader';
-import {bootstrapPromises} from './bootstrap/bootstrap';
+import {bootstrapPromises, settleAllPromises} from './bootstrap/bootstrap';
 import {
   ServiceProvider,
   EventService,
   NavigationEnd,
   NavigationStart
 } from '@ontotext/workbench-api';
+import {repositoryBootstrap} from './bootstrap/repository/repository-bootstrap';
 
 const showSplashScreen = (show) => {
   const splashScreen = document.getElementById('splash-screen');
@@ -90,7 +91,8 @@ const registerSingleSpaRouterListeners = () => {
 };
 
 const bootstrapApplication = () => {
-  Promise.allSettled(bootstrapPromises.map((bootstrapFn) => bootstrapFn()))
+  settleAllPromises(repositoryBootstrap)
+    .then(() => settleAllPromises(bootstrapPromises))
     .then((results) => {
       const rejected = results.filter(r => r.status === 'rejected');
 


### PR DESCRIPTION
## What
Fix missing saved repository on startup

## Why
Upon bootstrap, a request for autocomplete is made, if there is a saved repository in the local store. That repository might have been deleted at the time of startup. The local store shows a saved repository, which prompts the autocomplete-bootstrap to make a request to `/enabled`. Since the repository doesn't exist, the backend throws an error.

## How
Moved the repository bootstrap functions ahead of all other bootstrap functions. Whenever they are resolved, the rest of the bootstrap functions will be triggered. This way we first get the list of existing repositories and then check to see if the last saved repository still exists.

## Testing
n/a

## Screenshots
n/a

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
