### PR TITLE
Gdb 12343 fix rdf tooltip not closing when search is opened

### DIFF
--- a/packages/shared-components/src/components/onto-tooltip/onto-tooltip.tsx
+++ b/packages/shared-components/src/components/onto-tooltip/onto-tooltip.tsx
@@ -67,7 +67,7 @@ export class OntoTooltip {
     }
     }
 
-    componentWillLoad() {
+    connectedCallback() {
         this.handleRemovedNodes();
     }
 


### PR DESCRIPTION
## What
Fix RDF search tooltip not closing

## Why
During the usage of the workbench, single-spa mounts and unmounts microfrontends at various points. The disconnectedCallback then disconnects the observer, listening for DOM changes, which is responsible for removing tooltips of non-existent elements. Upon reconnect `componentWillLoad` is not called and therefore a new observer is not set up

## How
Changed the node removal handling to be done inside `connectedCallback` instead of `componentWillLoad`.

## Testing
n/a

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
