### PR TITLE
GDB-12452 - Remove underline on Import tabs

### DIFF
--- a/packages/legacy-workbench/src/pages/import.html
+++ b/packages/legacy-workbench/src/pages/import.html
@@ -13,11 +13,11 @@
 
         <ul class="nav nav-tabs mb-2">
             <li class="nav-item" id="wb-import-tabUpload">
-                <a class="nav-link" ng-class="activeTabId == 'user' ? 'active' : ''" href ng-click="openTab('user')"
+                <a id="userTab" class="nav-link" ng-class="activeTabId == 'user' ? 'active' : ''" href ng-click="openTab('user')"
                    data-toggle="tab">{{'user.data' | translate}}</a>
             </li>
             <li class="nav-item" id="wb-import-tabServer" ng-hide="isS4()">
-                <a class="nav-link" ng-class="activeTabId == 'server' ? 'active' : ''" href
+                <a id="serverTab" class="nav-link" ng-class="activeTabId == 'server' ? 'active' : ''" href
                    ng-click="openTab('server')" data-toggle="tab">{{'server.files' | translate}}</a>
             </li>
             <li class="nav-item">

--- a/packages/root-config/src/styles/partials/anchor/_anchor.scss
+++ b/packages/root-config/src/styles/partials/anchor/_anchor.scss
@@ -1,6 +1,6 @@
 a {
-  &:hover:not(.btn),
-  &:active:not(.btn),
+  &:hover:not(.btn, .nav-link, .menu-element-root),
+  &:active:not(.btn, .nav-link, .menu-element-root),
   &[href^="http"],
   &[href^="http"]:hover,
   &[href^="http"]:active {


### PR DESCRIPTION
## What
The Import page "Server files" and "User data" tabs will be styled like in the legacy WB. All `.nav-link` and `.menu-element-root` will not be styled from the `_anchor.scss`. This includes `.nav-link` tabs in:
- ACL management
- Cluster configuration
- Create similarity index
- Graph explore
- Graph config
- Graph visualizations
- Import
- System info
- JDBC create
- Resources
- RDF rank

The `.menu-element-root`  exception will not underline navbar root items (Import and SPARQL).

## Why
The tabs picked up the wrong styling (they were underlined on hover and click).

## How
Added rule exceptions.

## Testing
N/A

## Screenshots
![image](https://github.com/user-attachments/assets/5827ced8-dc1b-42be-857f-1db41080fb23)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
