### PR TITLE
WB Migration Improve Cypress test cleanup and artifact handling

### DIFF
--- a/packages/shared-components/cypress.config.js
+++ b/packages/shared-components/cypress.config.js
@@ -46,6 +46,23 @@ module.exports = defineConfig({
           return null;
         }
       });
+
+      on('after:spec', (spec, results) => {
+        if (results && results.video) {
+          const hasFailure = results.tests.some(test =>
+            test.attempts.some(attempt => attempt.state === 'failed')
+          );
+
+          if (!hasFailure) {
+            try {
+              fs.rmSync(results.video, { force: true });
+            } catch (err) {
+              console.error(err)
+            }
+          }
+        }
+      });
+      return config;
     },
   },
 });


### PR DESCRIPTION
## What:
Refine Docker Compose cleanup and save Jenkins artifacts on failed builds only

## Why:
- Relying on currentBuild.result was unreliable, because it remains null for a “green” build and we archived all videos on green builds 

## HOW:
- Added a catchError wrapper around dockerCompose.upCmd(...) in both Cypress stages so that on failure we archive screenshots/videos and stop the job without tearing down containers.
- Introduced a flag (caughtError) to detect test failures and invoke error(...) only after archiving artifacts.
- Ensured dockerCompose.downCmd(...) is called only on success, leaving containers/volumes intact when tests fail.
- In cypress.config.js, added an on('after:spec') hook that deletes any spec’s video file if none of its tests failed.

![image](https://github.com/user-attachments/assets/06a61858-fb85-401d-a6f4-c38c090b02ef)


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
