### PR TITLE
GDB-12472 Update components subscriptions

### DIFF
--- a/packages/shared-components/src/components/onto-footer/onto-footer.tsx
+++ b/packages/shared-components/src/components/onto-footer/onto-footer.tsx
@@ -42,14 +42,6 @@ export class OntoFooter {
       .then(() => this.shouldShowCookieConsent = false);
   }
 
-  /**
-   * Sets up a subscription to product info changes.
-   */
-  componentWillLoad(): void {
-    this.subscribeToProductInfoChange();
-    this.subscribeToUserChange();
-  }
-
   render() {
     return (
       <Host>
@@ -66,10 +58,14 @@ export class OntoFooter {
     );
   }
 
-  /**
-   * Lifecycle method called when the component is about to be removed from the DOM.
-   * Unsubscribes from all subscriptions to prevent memory leaks.
-   */
+  // ========================
+  // Lifecycle methods
+  // ========================
+  connectedCallback(): void {
+    this.subscribeToProductInfoChange();
+    this.subscribeToUserChange();
+  }
+
   disconnectedCallback(): void {
     this.subscriptions.unsubscribeAll();
   }

--- a/packages/shared-components/src/components/onto-search-icon/onto-search-icon.tsx
+++ b/packages/shared-components/src/components/onto-search-icon/onto-search-icon.tsx
@@ -14,7 +14,11 @@ export class OntoSearchIcon {
   private tooltipKey: string = 'rdf_search.labels.search';
   private readonly subscriptions = new SubscriptionList();
 
-  componentWillLoad() {
+
+  // ========================
+  // Lifecycle methods
+  // ========================
+  connectedCallback() {
     this.onTooltipChange();
   }
 

--- a/packages/shared-components/src/components/onto-toggle-switch/onto-toggle-switch.tsx
+++ b/packages/shared-components/src/components/onto-toggle-switch/onto-toggle-switch.tsx
@@ -64,7 +64,7 @@ export class OntoToggleSwitch {
     this.subscriptions.unsubscribeAll();
   }
 
-  componentWillLoad() {
+  connectedCallback() {
     this.subscribeToLanguageChange();
   }
 


### PR DESCRIPTION
## What
Moved component subscriptions from `componentWillLoad` to `connectedCallback`

## Why
Because during runtime, single-spa unmounts and mounts microfrontends, which triggers disconnectedCallback. This is where all subscriptions are unsubscribed, to avoid memory leaks. When the microfrontend is mounted again, `componentWillLoad` is not called, so subscriptions don't work anymore

## How
Moved subscriptions from `componentWillLoad` to `connectedCallback`, because it is called, when a microfrontend is mounted

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
