### PR TITLE
GDB-12468: Fix guide autostart with security and slow connection

### DIFF
--- a/src/js/angular/rest/guides.rest.service.js
+++ b/src/js/angular/rest/guides.rest.service.js
@@ -11,7 +11,10 @@ function GuidesRestService($http) {
     const GUIDES_DOWNLOAD_URL = `${GUIDES_LIST_URL}/download`;
 
     const getGuides = () => {
-        return $http.get(GUIDES_LIST_URL);
+        return $http.get(GUIDES_LIST_URL, {
+            // Added so that location changes would not cancel the request
+            noCancelOnRouteChange: true
+        });
     };
 
     const downloadGuideResource = (guideResourceName) => {


### PR DESCRIPTION
## What
Fix autostart of guides when security is on and the connection is slow

## Why
The slow connection causes a racing conditions with the login redirect in the workbench, which cancels the guides request.

## How
- added `noCancelOnRouteChange: true` for the guide fetch request so it is not canceled on navigation

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
