### PR TITLE
GDB-12434: Missing license status persisting after license update

### DIFF
--- a/packages/api/src/models/license/license.ts
+++ b/packages/api/src/models/license/license.ts
@@ -23,6 +23,8 @@ export class License extends Model<License> {
   valid?: boolean;
   typeOfUse?: string;
   message?: string;
+  present?: boolean;
+  usageRestriction?: string;
 
   /**
    * Creates a new License instance.
@@ -44,5 +46,7 @@ export class License extends Model<License> {
     this.valid = data.valid;
     this.typeOfUse = data.typeOfUse || '';
     this.message = data.message || '';
+    this.present = data.present || false;
+    this.usageRestriction = data.usageRestriction || '';
   }
 }

--- a/packages/api/src/services/license/test/license.service.spec.ts
+++ b/packages/api/src/services/license/test/license.service.spec.ts
@@ -32,6 +32,8 @@ describe('LicenseService', () => {
       message: '',
       latestPublicationDate: undefined,
       maxCpuCores: undefined,
+      present: false,
+      usageRestriction: '',
       licenseCapabilities: {
         items: []
       },

--- a/packages/legacy-workbench/src/js/angular/core/services/license.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/license.service.js
@@ -1,3 +1,5 @@
+import {License, ServiceProvider, LicenseContextService} from "@ontotext/workbench-api";
+
 const EVALUATION_TYPE_1 = "this is an evaluation license";
 const EVALUATION_TYPE_2 = "evaluation";
 const PRODUCT_FREE = "free";
@@ -45,6 +47,7 @@ function licenseService($window, $document, LicenseRestService, $translate) {
             })
             .then((res) => {
                 _license = res.data;
+                ServiceProvider.get(LicenseContextService).updateGraphdbLicense(new License(_license));
             })
             .catch(() => {
                 _isLicenseHardcoded = true;


### PR DESCRIPTION
## What
The "onto-license-alert" is not shown or hidden when a license is removed or added.

## Why
Setting or removing a license is handled by legacy Workbench functionality, and changes to the license are not reflected in the new UI component because the license in the LicenseContextService is not updated accordingly.

## How
When a license is set or removed, the legacy Workbench functionality retrieves updated license information from the backend. Added license update in LicenseContextService when the legacy Workbench license service is called to fetch license info.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
