### PR TITLE
fix(GDB-12483)WBM: add missing test script to prevent GraphDB build failure

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -12,6 +12,7 @@
     "cy:run:partial": "cypress run --config-file cypress-legacy.config.js --spec \"e2e-legacy/graphql/graphql-endpoint-management-view.spec.js\" --browser chrome",
     "cy:run-legacy": "cypress run --config-file cypress-legacy.config.js --browser chrome",
     "cy:run-flaky": "cypress run --config-file cypress-flaky.config.js --browser chrome",
+    "test": "npm run cy:run-legacy",
     "test:core": "cypress run --spec e2e-broken/repository/**,integration/import/**,integration/sparql-editor/**,integration/monitor/**,integration/cluster/**,integration/ttyg/**"
   },
   "author": {


### PR DESCRIPTION
## What:
- Added "test": "npm run cy:run-legacy" in e2e-tests/package.json.

## Why:
- The graphdb-test-functional-cypress module invokes npm test to run the Cypress suite during the GraphDB build process. Without a "test" script defined, the build fails because npm test has no target in e2e-tests.

## How:
- Inserted "test": "npm run cy:run-legacy"


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
