### PR TITLE
fix(GDB-12403) WB migration: Fix repository status tooltip issues

### DIFF
--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.scss
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.scss
@@ -64,7 +64,7 @@
     box-shadow: 1px 3px 6px rgba(0, 0, 0, 0.2);
 
     .repository-tooltip-title {
-      font-size: 0.875rem;
+      font-size: 1rem;
       font-weight: 400;
       padding: 8px 14px;
       background-color: #f7f7f7;
@@ -91,6 +91,10 @@
 
       &.total {
         margin-top: 1.2em;
+      }
+
+      .value {
+        margin-left: .6em;
       }
     }
   }

--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
@@ -81,7 +81,7 @@ export class OntoRepositorySelector {
    */
   @Watch('items')
   onItemsChanged(newItems: DropdownItem<Repository>[]) {
-    if (!newItems || !newItems.length) {
+    if (!(newItems?.length)) {
       this.dropdownItems = [];
       return;
     }
@@ -93,7 +93,7 @@ export class OntoRepositorySelector {
     this.subscriptions.push(...this.subscribeToTranslationChanged());
 
     // Manually apply tooltip functions to each item on first mount.
-    if (this.items && this.items.length) {
+    if (this.items?.length) {
       this.dropdownItems = this.attachTooltipsToItems(this.items);
     } else {
       this.dropdownItems = [];
@@ -128,7 +128,10 @@ export class OntoRepositorySelector {
   }
 
   private attachTooltipsToItems(items: DropdownItem<Repository>[]): DropdownItem<Repository>[] {
-    return items && items.map((item) => item.setTooltip(this.createTooltipFunctionForRepository(item.value)));
+    if (!items) {
+      return [];
+    }
+    return items.map((item) => item.setTooltip(this.createTooltipFunctionForRepository(item.value)));
   }
 
   private tooltipAlignment(isOpen: boolean): OntoTooltipPlacement {
@@ -167,15 +170,15 @@ export class OntoRepositorySelector {
     </div>
     <div class="repository-tooltip-content">
       <div class="repository-tooltip-row">
-        <div class="label">${TranslationService.translate('repository-selector.tooltip.location')} :</div>
+        <div class="label">${TranslationService.translate('repository-selector.tooltip.location')}:</div>
         <div class="value">${repository.location ? repository.location : TranslationService.translate('repository-selector.tooltip.local')}</div>
       </div>
       <div class="repository-tooltip-row">
-        <div class="label">${TranslationService.translate('repository-selector.tooltip.type')} :</div>
+        <div class="label">${TranslationService.translate('repository-selector.tooltip.type')}:</div>
         <div class="value">${TranslationService.translate('repository-selector.tooltip.types.' + (repository.type || 'unknown'))}</div>
       </div>
       <div class="repository-tooltip-row">
-        <div class="label">${TranslationService.translate('repository-selector.tooltip.access')} :</div>
+        <div class="label">${TranslationService.translate('repository-selector.tooltip.access')}:</div>
         <div class="value">${TranslationService.translate(this.canWriteRepo(repository) ? 'repository-selector.tooltip.accesses.read_write' : 'repository-selector.tooltip.accesses.read')}</div>
       </div>`;
 
@@ -194,14 +197,14 @@ export class OntoRepositorySelector {
 
     let html = `
     <div class="repository-tooltip-row total">
-      <div class="label">${TranslationService.translate('repository-selector.tooltip.repository-size.total')} :</div>
+      <div class="label">${TranslationService.translate('repository-selector.tooltip.repository-size.total')}:</div>
       <div class="value">${this.totalTripletsFormatter.format(repositorySizeInfo.total)}</div>
     </div>`;
 
     if (repositorySizeInfo.explicit >= 0) {
       html += `
       <div class="repository-tooltip-row">
-        <div class="label">${TranslationService.translate('repository-selector.tooltip.repository-size.explicit')} :</div>
+        <div class="label">${TranslationService.translate('repository-selector.tooltip.repository-size.explicit')}:</div>
         <div class="value">${this.totalTripletsFormatter.format(repositorySizeInfo.explicit)}</div>
       </div>`;
     }
@@ -209,16 +212,20 @@ export class OntoRepositorySelector {
     if (repositorySizeInfo.inferred >= 0) {
       html += `
       <div class="repository-tooltip-row">
-        <div class="label">${TranslationService.translate('repository-selector.tooltip.repository-size.inferred')} :</div>
+        <div class="label">${TranslationService.translate('repository-selector.tooltip.repository-size.inferred')}:</div>
         <div class="value">${this.totalTripletsFormatter.format(repositorySizeInfo.inferred)}</div>
       </div>`;
     }
 
-    if (repositorySizeInfo.total >= 0 && repositorySizeInfo.explicit > 0) {
+    if (repositorySizeInfo.total >= 0) {
       html += `
       <div class="repository-tooltip-row">
-        <div class="label">${TranslationService.translate('repository-selector.tooltip.repository-size.expansion_ratio')} :</div>
-        <div class="value">${this.totalTripletsFormatter.format(repositorySizeInfo.total / repositorySizeInfo.explicit)}</div>
+        <div class="label">${TranslationService.translate('repository-selector.tooltip.repository-size.expansion_ratio')}:</div>
+        <div class="value">${
+          repositorySizeInfo.explicit > 0
+            ? this.totalTripletsFormatter.format(repositorySizeInfo.total / repositorySizeInfo.explicit)
+            : '-'
+        }</div>
       </div>`;
     }
 
@@ -241,10 +248,10 @@ export class OntoRepositorySelector {
   }
 
   private getLocation() {
-    if (this.currentRepository && this.currentRepository.location) {
-      return `@${UriUtil.shortenIri(this.currentRepository.location)}`;
+    if (!this.currentRepository?.location) {
+      return ``;
     }
-    return ``;
+    return `@${UriUtil.shortenIri(this.currentRepository.location)}`;
   }
 
   private getButtonLabel() {


### PR DESCRIPTION
## WHAT:
Fixes layout and logic issues in the repository status tooltip for the repository selector component.

## WHY:
During the migration, visual and logical inconsistencies were introduced in the tooltip showing repository size details. Specifically:

- The tooltip layout lacked spacing between labels and values.
- The logic for showing the expansion ratio was duplicated and could result in confusing output when the explicit value was 0.

## HOW:
- Updated the SCSS to add left margin between the label and value fields within the tooltip rows.
- Refactored the conditional logic that renders the expansion ratio
- Fixed 4 sonarqube issues

## Screenshots
![image](https://github.com/user-attachments/assets/b608c252-a004-433e-abd0-e4197ebfac4d)


## Checklist
- [X] Branch name
- [X] Commit messages
- [X] Target branch
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
