### PR TITLE
GDB-12449 fix before unload handler in sparql templates view

### DIFF
--- a/packages/legacy-workbench/src/js/angular/sparql-template/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/sparql-template/controllers.js
@@ -81,7 +81,6 @@ function SparqlTemplatesCtrl($scope, $repositories, SparqlTemplatesRestService, 
     // Subscriptions handlers
     // =========================
     const removeAllListeners = () => {
-        window.removeEventListener('beforeunload', beforeunloadHandler);
         subscriptions.forEach((subscription) => subscription());
     };
 


### PR DESCRIPTION
## What
An error is thrown when user tries to open the create sparql template view.

## Why
There is a redundant call to a beforeUnload function which doesn't exist.

## How
Remove the invocation of the function which doesn't exist in this controller.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
