### PR TITLE
fix(GDB-12496) WBM: Fix test:core paths to use e2e-legacy directories

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -13,7 +13,7 @@
     "cy:run-legacy": "cypress run --config-file cypress-legacy.config.js --browser chrome",
     "cy:run-flaky": "cypress run --config-file cypress-flaky.config.js --browser chrome",
     "test": "npm run cy:run-legacy",
-    "test:core": "cypress run --spec e2e-broken/repository/**,integration/import/**,integration/sparql-editor/**,integration/monitor/**,integration/cluster/**,integration/ttyg/**"
+    "test:core": "cypress run --spec e2e-legacy/repository/**,e2e-legacy/import/**,e2e-legacy/sparql-editor/**,e2e-legacy/monitor/**,e2e-legacy/cluster/**,e2e-legacy/ttyg/**"
   },
   "author": {
     "name": "Ontotext AD",


### PR DESCRIPTION
## WHAT:
Updated the test:core npm script in e2e-tests/package.json to point at the correct e2e-legacy folder structure

## WHY:
The previous glob patterns referenced non-existent or deprecated directories, causing Cypress to find zero spec files and failing the build

## HOW:
Replaced the existing command


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
