### PR TITLE
GDB-12484: Clicking on User Guides blocks the entire workbench until refresh

### DIFF
--- a/packages/legacy-workbench/src/js/angular/guides/tour-lib-services/shepherd.service.js
+++ b/packages/legacy-workbench/src/js/angular/guides/tour-lib-services/shepherd.service.js
@@ -921,11 +921,17 @@ function ShepherdService($location, $translate, LocalStorageAdapter, LSKeys, $ro
 
         // We have some Angular bits on the elements and this is needed to make them work
         const scope = angular.element(currentStepElement).scope();
-        if (angular.isFunction(stepDescription.onScope)) {
-            // Step definitions may want to add functions to the scope
-            stepDescription.onScope(scope);
+        // After the migration, the scope here is always undefined.
+        // This broke the "copy query to editor" functionality in the execute-sparql-query plugin.
+        // Note: The scope is used only in the execute-sparql-query plugin.
+        // TODO: To restore this functionality, it needs to be reimplemented in a way that does not depend on AngularJS.
+        if (scope) {
+            if (angular.isFunction(stepDescription.onScope)) {
+                // Step definitions may want to add functions to the scope
+                stepDescription.onScope(scope);
+            }
+            setTimeout(() => scope.$apply(() => $compile(currentStepElement)(scope)));
         }
-        setTimeout(() => scope.$apply(() => $compile(currentStepElement)(scope)));
     };
 
     this._toParagraph = (text, textClass) => {


### PR DESCRIPTION
## What
The Workbench crashes when attempting to start a guide.

## Why
A SPARQL editor step includes functionality that allows a query to be set in the SPARQL editor by clicking a button displayed in the guide dialog. This button is implemented using AngularJS functionality.

In shepherd.service.js, guide steps are compiled as they are AngularJS templates. After compilation, the scope is expected to be bound to the element. However, after the migration, this functionality broke — the scope of the element is now always undefined.

## How
A temporary check was added to prevent the Workbench from crashing when the scope is undefined. This avoids a hard failure, but the affected copy-to-editor functionality no longer works.

To restore this functionality, it needs to be reimplemented in a way that does not depend on AngularJS.

## Testing
N/A

## Screenshots
<div>Before</div>
<img src="https://github.com/user-attachments/assets/b6131bd6-9e98-4675-98cc-81acf5432acf" width="320"/>
<div>After</div>
<img src="https://github.com/user-attachments/assets/dfa966c8-2280-447f-9382-a7cdd277fce8" width="320"/>

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
