### PR TITLE
GDB-12408 Fix sidebar glitching from My Settings

### DIFF
--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -36,6 +36,7 @@ export * from './services/toastr';
 export * from './services/autocomplete';
 export * from './services/namespace';
 export * from './services/rdf-search';
+export * from './services/navigation';
 
 // Export utils for external usages.
 export * from './services/utils';

--- a/packages/api/src/services/navigation/index.ts
+++ b/packages/api/src/services/navigation/index.ts
@@ -1,0 +1,1 @@
+export {NavigationContextService} from './navigation-context.service';

--- a/packages/api/src/services/navigation/navigation-context.service.ts
+++ b/packages/api/src/services/navigation/navigation-context.service.ts
@@ -1,0 +1,44 @@
+import {DeriveContextServiceContract} from '../../models/context/update-context-method';
+import {ContextService} from '../context';
+
+type NavigationContextFields = {
+  readonly PREVIOUS_ROUTE: string;
+}
+
+type NavigationContextFieldParams = {
+  readonly PREVIOUS_ROUTE: string;
+}
+
+/**
+ * Service for managing navigation context within the application.
+ */
+export class NavigationContextService extends ContextService<NavigationContextFields> implements DeriveContextServiceContract<NavigationContextFields, NavigationContextFieldParams> {
+  /** Key used to store the previous route in the context */
+  readonly PREVIOUS_ROUTE = 'previousRoute';
+
+  /**
+   * Updates the previous route in the navigation context.
+   *
+   * @param value - The route path to store as the previous route
+   */
+  updatePreviousRoute(value: string): void {
+    this.updateContextProperty(this.PREVIOUS_ROUTE, value);
+  }
+
+  /**
+   * Retrieves the previous route from the navigation context.
+   * If the route ends with a '#' character, it will be removed as single-spa
+   * doesn't handle trailing hash characters correctly.
+   *
+   * @returns The previous route path or undefined if not set
+   */
+  getPreviousRoute(): string | undefined {
+    let previousRoute = this.getContextPropertyValue<string>(this.PREVIOUS_ROUTE);
+    if (previousRoute?.endsWith('#')) {
+      // Remove trailing '#' if present, because single-spa doesn't handle it correctly
+      // e.g. /import# doesn't trigger navigation
+      previousRoute = previousRoute.slice(0, -1);
+    }
+    return previousRoute;
+  }
+}

--- a/packages/api/src/services/utils/routing-utils.ts
+++ b/packages/api/src/services/utils/routing-utils.ts
@@ -1,5 +1,6 @@
 /**
  * Redirects the current page to a specified URL using the single-spa framework.
+ * Made to be used from views. If you are not navigating from a view, use <code>navigate</code> instead
  *
  * @param url - The target URL to which the page should be redirected.
  */
@@ -8,8 +9,17 @@ export function navigateTo(url: string): (event: Event) => void {
     if (event) {
       event.preventDefault();
     }
-    window.singleSpa.navigateToUrl(url);
+    navigate(url);
   };
+}
+
+/**
+ * Navigates to the specified URL using the single-spa framework.
+ * Suitable for in-code navigation. If you need to navigate from a view, use <code>navigateTo</code> instead.
+ * @param url - The target URL to which the page should be redirected.
+ */
+export function navigate(url: string) {
+  window.singleSpa.navigateToUrl(url);
 }
 
 /**

--- a/packages/legacy-workbench/src/js/angular/security/controllers/user-settings.controller.js
+++ b/packages/legacy-workbench/src/js/angular/security/controllers/user-settings.controller.js
@@ -3,6 +3,7 @@ import {GRAPHQL, READ_REPO, WRITE_REPO} from "../services/constants";
 import {UserType} from 'angular/utils/user-utils';
 import {parseAuthorities} from "../services/authorities-util";
 import {UpdateUserPayload} from "../../models/security/security";
+import {navigate, ServiceProvider, NavigationContextService} from "@ontotext/workbench-api";
 import {CookiePolicyModalController} from "../../core/directives/cookie-policy/cookie-policy-modal-controller";
 
 angular
@@ -92,12 +93,8 @@ function UserSettingsController($scope, toastr, $window, $timeout, $jwtAuth, $ro
     };
 
     $scope.goBack = function () {
-        const timer = $timeout(function () {
-            $window.history.back();
-        }, 100);
-        $scope.$on('$destroy', function () {
-            $timeout.cancel(timer);
-        });
+        const previousRoute = ServiceProvider.get(NavigationContextService).getPreviousRoute();
+        navigate(previousRoute || '/');
     };
 
     $scope.getPrincipal = function () {

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -129,10 +129,6 @@ export namespace Components {
           * Configuration whether the navbar should be collapsed.
          */
         "navbarCollapsed": boolean;
-        /**
-          * The selected menu item. If provided, the menu item will be highlighted.
-         */
-        "selectedMenu": string;
     }
     interface OntoOperationsNotification {
         /**
@@ -728,10 +724,6 @@ declare namespace LocalJSX {
           * Event fired when the navbar is toggled.
          */
         "onNavbarToggled"?: (event: OntoNavbarCustomEvent<NavbarToggledEvent>) => void;
-        /**
-          * The selected menu item. If provided, the menu item will be highlighted.
-         */
-        "selectedMenu"?: string;
     }
     interface OntoOperationsNotification {
         /**

--- a/packages/shared-components/src/components/onto-navbar/readme.md
+++ b/packages/shared-components/src/components/onto-navbar/readme.md
@@ -11,7 +11,6 @@
 | ----------------- | ------------------ | ------------------------------------------------------------------------------------------------------------ | -------------------------- | ----------- |
 | `menuItems`       | `menu-items`       | Configuration for the menu items model. This is the external model that is used to build the internal model. | `ExternalMenuItemsModel[]` | `undefined` |
 | `navbarCollapsed` | `navbar-collapsed` | Configuration whether the navbar should be collapsed.                                                        | `boolean`                  | `undefined` |
-| `selectedMenu`    | `selected-menu`    | The selected menu item. If provided, the menu item will be highlighted.                                      | `string`                   | `undefined` |
 
 
 ## Events


### PR DESCRIPTION
## What
Fix sidebar glitching from My Settings menu

## Why
It has random glitches, when you select a menu, redirects you to a different menu and page. Also when you visit the My settings mage from the Imports menu and press `Cancel`, it does not redirect you back to `Import`

## How
- Replaced `window.history.back()` with the single-spa native `navigateTo` in `user-settings.controller.js`. Removed the timeout, in which the navigation happened.
- Added `navigation-context.service`, which holds the last url in the application. It is used to navigate to the previously visited page, when `cancel` is pressed. It strips ending `#` symbols from the URL, because single-spa doesn't redirect, when they are present for some reason

- Removed `currentRoute` from `onto-layout`. Whenever single-spa unmounts/mounts microfrontends, it was not being recalculated, as it is in `componentWillLoad`. The mount triggers a change in the menuModel, which causes it to be reinitialized with an old value of the route. That causes a selection of a wrong menu item. Now the navbar gets the route by itself, instead of getting it as an input.

- Added translation subscriptions to the subscription list, since they weren't being unsubscribed from. That caused extra re-renders

- Moved the `init` function from `connectedCallback` to `componentWillLoad` since it doesn't need to be run on every component mount. 

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
