### PR TITLE
fix(GDB-12496) WBM: Fix cypress config spec pattern path

### DIFF
--- a/e2e-tests/cypress.config.js
+++ b/e2e-tests/cypress.config.js
@@ -21,7 +21,7 @@ module.exports = defineConfig({
             return require('./plugins')(on, config);
         },
         baseUrl: 'http://localhost:9000',
-        specPattern: 'e2e/**/*.{js,jsx,ts,tsx}',
+        specPattern: './**/*.{js,jsx,ts,tsx}',
         supportFile: 'support/e2e.js',
         reporter: "cypress-multi-reporters",
         reporterOptions: {


### PR DESCRIPTION
## WHAT:
Updated the specPattern in e2e-tests/cypress.config.js from 'e2e/**/*.{js,jsx,ts,tsx}' to './**/*.{js,jsx,ts,tsx}'.

## WHY:
The previous pattern only matched files under the e2e/ directory, but our Cypress test files now reside in a different folder structure (e.g. e2e-legacy/, integration/, etc.). As a result, Cypress was not detecting any spec files, causing tests to be skipped and CI builds to fail.

## HOW:
Replaced the hardcoded e2e/**/*.{js,jsx,ts,tsx} glob with ./**/*.{js,jsx,ts,tsx}, allowing Cypress to recursively search from the project root for any matching JavaScript/TypeScript test files.


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
