### PR TITLE
GDB-12432 Fix missing cookie banner modal

### DIFF
--- a/packages/api/src/models/license/license.ts
+++ b/packages/api/src/models/license/license.ts
@@ -9,22 +9,20 @@ import { MapperProvider } from '../../providers';
  * Inherits copy functionality from {@link Model} and contains various properties of a GraphDB license.
  */
 export class License extends Model<License> {
-  // Epoch
-  expiryDate?: number;
-  // Epoch
-  latestPublicationDate?: number;
-  licensee?: string;
-  maxCpuCores?: number;
-  product?: string;
-  productType?: string;
-  licenseCapabilities?: CapabilityList;
-  version?: string;
-  installationId?: string;
-  valid?: boolean;
-  typeOfUse?: string;
-  message?: string;
-  present?: boolean;
-  usageRestriction?: string;
+  private _expiryDate?: number;
+  private _latestPublicationDate?: number;
+  private _licensee?: string;
+  private _maxCpuCores?: number;
+  private _product?: string;
+  private _productType?: string;
+  private _licenseCapabilities?: CapabilityList;
+  private _version?: string;
+  private _installationId?: string;
+  private _valid?: boolean;
+  private _typeOfUse?: string;
+  private _message?: string;
+  private _present?: boolean;
+  private _usageRestriction?: string;
 
   /**
    * Creates a new License instance.
@@ -48,5 +46,117 @@ export class License extends Model<License> {
     this.message = data.message || '';
     this.present = data.present || false;
     this.usageRestriction = data.usageRestriction || '';
+  }
+
+  get expiryDate(): number | undefined {
+    return this._expiryDate;
+  }
+
+  set expiryDate(value: number | undefined) {
+    this._expiryDate = value;
+  }
+
+  get latestPublicationDate(): number | undefined {
+    return this._latestPublicationDate;
+  }
+
+  set latestPublicationDate(value: number | undefined) {
+    this._latestPublicationDate = value;
+  }
+
+  get licensee(): string | undefined {
+    return this._licensee;
+  }
+
+  set licensee(value: string | undefined) {
+    this._licensee = value;
+  }
+
+  get maxCpuCores(): number | undefined {
+    return this._maxCpuCores;
+  }
+
+  set maxCpuCores(value: number | undefined) {
+    this._maxCpuCores = value;
+  }
+
+  get product(): string | undefined {
+    return this._product;
+  }
+
+  set product(value: string | undefined) {
+    this._product = value;
+  }
+
+  get productType(): string | undefined {
+    return this._productType;
+  }
+
+  set productType(value: string | undefined) {
+    this._productType = value;
+  }
+
+  get licenseCapabilities(): CapabilityList | undefined {
+    return this._licenseCapabilities;
+  }
+
+  set licenseCapabilities(value: CapabilityList | undefined) {
+    this._licenseCapabilities = value;
+  }
+
+  get version(): string | undefined {
+    return this._version;
+  }
+
+  set version(value: string | undefined) {
+    this._version = value;
+  }
+
+  get installationId(): string | undefined {
+    return this._installationId;
+  }
+
+  set installationId(value: string | undefined) {
+    this._installationId = value;
+  }
+
+  get valid(): boolean | undefined {
+    return this._valid;
+  }
+
+  set valid(value: boolean | undefined) {
+    this._valid = value;
+  }
+
+  get typeOfUse(): string | undefined {
+    return this._typeOfUse;
+  }
+
+  set typeOfUse(value: string | undefined) {
+    this._typeOfUse = value;
+  }
+
+  get message(): string | undefined {
+    return this._message;
+  }
+
+  set message(value: string | undefined) {
+    this._message = value;
+  }
+
+  get present(): boolean | undefined {
+    return this._present;
+  }
+
+  set present(value: boolean | undefined) {
+    this._present = value;
+  }
+
+  get usageRestriction(): string | undefined {
+    return this._usageRestriction;
+  }
+
+  set usageRestriction(value: string | undefined) {
+    this._usageRestriction = value;
   }
 }

--- a/packages/api/src/services/license/license.service.ts
+++ b/packages/api/src/services/license/license.service.ts
@@ -11,6 +11,8 @@ import {LicenseContextService} from './license-context.service';
 export class LicenseService implements Service {
   private readonly licenseRestService: LicenseRestService = ServiceProvider.get(LicenseRestService);
   private readonly licenseMapper: LicenseMapper = ServiceProvider.get(LicenseMapper);
+  private readonly trackableProductTypes = ['free', 'sandbox'];
+  private readonly trackableTypesOfUse = ['evaluation', 'this is an evaluation license'];
 
   /**
    * Retrieves the current license information.
@@ -26,21 +28,24 @@ export class LicenseService implements Service {
   }
 
   /**
-   * Determines if the current license is a free license.
+   * Determines if the current license can be tracked.
    *
    * This function checks the product type and type of use of the current license
-   * to determine if it's a free license. A license is considered free if:
+   * to determine if it's a trackable license. A license is considered trackable if:
+   * - A license is not present, or
    * - The product type is 'free', or
+   * - The product type is `sandbox`, or
    * - The type of use is `evaluation` (case-insensitive), or
    * - The type of use is `this is an evaluation license` (case-insensitive)
    *
    * @returns {boolean} True if the license is a free license, false otherwise.
    */
-  isFreeLicense(): boolean {
+  isTrackableLicense(): boolean {
     const license = ServiceProvider.get(LicenseContextService).getLicense();
     const licenseTypeOfUse = license?.typeOfUse?.toLowerCase() || '';
-    return license?.productType === 'free'
-      || licenseTypeOfUse === 'evaluation'
-      || licenseTypeOfUse === 'this is an evaluation license';
+    const productType = license?.productType?.toLowerCase() || '';
+    return !license?.present
+      || this.trackableProductTypes.includes(productType)
+      || this.trackableTypesOfUse.includes(licenseTypeOfUse);
   }
 }

--- a/packages/api/src/services/license/test/license.service.spec.ts
+++ b/packages/api/src/services/license/test/license.service.spec.ts
@@ -1,5 +1,5 @@
 import { LicenseService } from '../license.service';
-import { License } from '../../../models/license';
+import {CapabilityList, License} from '../../../models/license';
 import { TestUtil } from '../../utils/test/test-util';
 import { ResponseMock } from '../../http/test/response-mock';
 import {ServiceProvider} from '../../../providers';
@@ -20,8 +20,25 @@ describe('LicenseService', () => {
     // When I call the getLicense method
     const result = await licenseService.getLicense();
 
+    const expectedLicense = {
+      licensee: 'Test Company',
+      expiryDate: 1672531200000,
+      product: '',
+      productType: '',
+      version: '',
+      installationId: '',
+      valid: undefined,
+      typeOfUse: '',
+      message: '',
+      latestPublicationDate: undefined,
+      maxCpuCores: undefined,
+      present: false,
+      usageRestriction: '',
+      licenseCapabilities: [] as unknown as CapabilityList,
+    };
+
     // Then, I should get a License object, with default property values
-    expect(result).toEqual(new License(mockLicense));
+    expect(result).toEqual(new License(expectedLicense));
   });
 
   test('should return a true for a trackable license', () => {

--- a/packages/legacy-workbench/src/js/angular/core/services/license.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/license.service.js
@@ -47,7 +47,6 @@ function licenseService($window, $document, LicenseRestService, $translate) {
             })
             .then((res) => {
                 _license = res.data;
-                ServiceProvider.get(LicenseContextService).updateGraphdbLicense(new License(_license));
             })
             .catch(() => {
                 _isLicenseHardcoded = true;
@@ -60,6 +59,7 @@ function licenseService($window, $document, LicenseRestService, $translate) {
             .finally(() => {
                 _showLicense = true;
                 _loadingLicense = false;
+                ServiceProvider.get(LicenseContextService).updateGraphdbLicense(new License(_license));
             });
     };
 

--- a/packages/shared-components/src/pages/footer/main.js
+++ b/packages/shared-components/src/pages/footer/main.js
@@ -12,6 +12,7 @@ function getLicense(productType) {
   return {
     productType,
     valid: true,
+    present: true
   };
 }
 

--- a/packages/shared-components/src/pages/layout/main.js
+++ b/packages/shared-components/src/pages/layout/main.js
@@ -1,5 +1,5 @@
 const layoutElement = document.querySelector("onto-layout");
-
+window.wbDevMode = true;
 const setUserRole = (role) => {
   setAuthUser({
     ...user,


### PR DESCRIPTION
## What
Fix missing cookie banner modal

## Why
It wasn't showing up, when a license is deleted

## How
- Synchronized the logic, which shows/hides the banner with master. Recent changes, were not propagated to the migration branch and the logic differed.
- Added a subscription to license change in `onto-footer` to recalculate visibility, whenever a license has changed
- Moved `updateGraphdbLicense` from `then` into `finally`, because the license object will be different if the request to the backend returns an error

## Testing
cypress

## Screenshots
![Screenshot from 2025-06-05 15-08-47](https://github.com/user-attachments/assets/c6c651b9-9962-4a7e-a364-219a79858f10)
![Screenshot from 2025-06-05 15-09-07](https://github.com/user-attachments/assets/9cb9acf6-599a-46c0-bfe5-22441f75e61d)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
