### PR TITLE
refactor(GDB-12332) WBM: centralize tooltip logic and remove redundant trigger attributes

### DIFF
--- a/packages/shared-components/src/components/onto-dropdown/onto-dropdown.tsx
+++ b/packages/shared-components/src/components/onto-dropdown/onto-dropdown.tsx
@@ -140,10 +140,10 @@ export class OntoDropdown {
           </span>
           <i class={`fa-regular fa-angle-down ${this.open ? 'fa-rotate-180' : ''}`}></i>
         </button>
-        
+
         <div
           class={'onto-dropdown-menu ' + dropdownAlignmentClass}>
-          {this.items && this.items.map(item =>
+          {this.items?.map((item) =>
             <button class={'onto-dropdown-menu-item ' + item.cssClass}
                     tooltip-placement={OntoTooltipPlacement.LEFT}
                     tooltip-trigger={item.dropdownTooltipTrigger}
@@ -177,7 +177,7 @@ export class OntoDropdown {
       }
       this.buttonTooltipContent = tooltipContent;
 
-      // FIXME: Tooltip update is not reactive – this logic should be decoupled from DOM traversal
+      // FIXME: Tooltip update is not reactive – this logic should be decoupled from DOM traversal see GDB-12506
       if (tooltipContent !== '') {
         TooltipUtil.updateTooltipContent(target, tooltipContent);
       } else {

--- a/packages/shared-components/src/components/onto-license-alert/onto-license-alert.tsx
+++ b/packages/shared-components/src/components/onto-license-alert/onto-license-alert.tsx
@@ -19,11 +19,11 @@ export class OntoLicenseAlert {
 
   render() {
     return (
-      <Host tooltip-content={this.license?.message} tooltip-placement={OntoTooltipPlacement.BOTTOM} tooltip-trigger="mouseover">
-        <a class="onto-license-alert onto-btn" onClick={this.onLicenseAlertClick}>
+      <Host tooltip-content={this.license?.message} tooltip-placement={OntoTooltipPlacement.BOTTOM}>
+        <button class="onto-license-alert onto-btn" onClick={this.onLicenseAlertClick}>
           <span class="icon-warning"></span>
           <translate-label labelKey={'license_alert.label'}></translate-label>
-        </a>
+        </button>
       </Host>
     );
   }

--- a/packages/shared-components/src/components/onto-rdf-search/onto-rdf-search.tsx
+++ b/packages/shared-components/src/components/onto-rdf-search/onto-rdf-search.tsx
@@ -70,7 +70,6 @@ export class OntoRdfSearch {
         <section class={`search-area ${this.isOpen ? 'visible' : 'invisible'}`}>
           <i onClick={this.setIsOpen(false)}
              tooltip-content={TranslationService.translate('rdf_search.tooltips.close_search_area')}
-             tooltip-trigger={'mouseover'}
              tooltip-placement={OntoTooltipPlacement.BOTTOM}
              class="fa-light fa-xmark-large close-btn"></i>
           <onto-search-resource-input buttonConfig={this.buttonConfig}

--- a/packages/shared-components/src/components/onto-search-icon/onto-search-icon.tsx
+++ b/packages/shared-components/src/components/onto-search-icon/onto-search-icon.tsx
@@ -11,7 +11,7 @@ import {OntoTooltipPlacement} from "../onto-tooltip/models/onto-tooltip-placemen
 export class OntoSearchIcon {
   @State() private tooltipLabel: string;
 
-  private tooltipKey: string = 'rdf_search.labels.search';
+  private readonly tooltipKey: string = 'rdf_search.labels.search';
   private readonly subscriptions = new SubscriptionList();
 
 
@@ -30,7 +30,6 @@ export class OntoSearchIcon {
     return (
       <i tooltip-content={this.tooltipLabel}
          tooltip-placement={OntoTooltipPlacement.BOTTOM}
-         tooltip-trigger={'mouseover'}
          class="fa-light fa-magnifying-glass"></i>
     );
   }

--- a/packages/shared-components/src/components/onto-search-resource-input/onto-search-resource-input.tsx
+++ b/packages/shared-components/src/components/onto-search-resource-input/onto-search-resource-input.tsx
@@ -122,7 +122,6 @@ export class OntoSearchResourceInput {
             {this.inputValue?.length ?
               <i onClick={this.clearInput}
                  tooltip-content={TranslationService.translate('rdf_search.tooltips.clear')}
-                 tooltip-trigger={'mouseover'}
                  tooltip-placement={OntoTooltipPlacement.BOTTOM}
                  class="fa-light fa-xmark clear-input"></i> : ''
             }
@@ -160,7 +159,7 @@ export class OntoSearchResourceInput {
   /**
    * Updates the local inputValue with the html input element's value.'
    */
-  private handleInput = (event: Event) => {
+  private readonly handleInput = (event: Event) => {
     const target = event.target as HTMLInputElement;
     if (!target.value) {
       this.clearInput();
@@ -182,7 +181,7 @@ export class OntoSearchResourceInput {
   /**
    * Clears the search input field.
    */
-  private clearInput = () => {
+  private readonly clearInput = () => {
     this.setInputValue('');
     if(this.preserveSearch) {
       this.resourceSearchStorageService.clearStoredSearch();
@@ -266,7 +265,7 @@ export class OntoSearchResourceInput {
     );
   }
 
-  private onKeyDown = (event: KeyboardEvent) => {
+  private readonly onKeyDown = (event: KeyboardEvent) => {
     switch (event.key) {
       case 'Enter':
         this.onEnter(event);

--- a/packages/shared-components/src/components/onto-toggle-switch/onto-toggle-switch.scss
+++ b/packages/shared-components/src/components/onto-toggle-switch/onto-toggle-switch.scss
@@ -3,9 +3,20 @@ $default-checked-color-hsl: 210, 3%, 22%;
 $default-checked-color: #373a3c;
 
 .toggle-switch {
+  all: unset;
   clear: both;
   margin: 0 5px;
   width: 36px;
+
+  &:focus {
+    outline: none;
+    box-shadow: none;
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: none;
+  }
 
   input {
     &:empty {

--- a/packages/shared-components/src/components/onto-toggle-switch/onto-toggle-switch.tsx
+++ b/packages/shared-components/src/components/onto-toggle-switch/onto-toggle-switch.tsx
@@ -46,7 +46,7 @@ export class OntoToggleSwitch {
    */
   @Event() toggleChanged: EventEmitter<ToggleEventPayload>;
 
-  private toggle = () => {
+  private readonly toggle = () => {
     this.checked = !this.checked;
     this.toggleChanged.emit({checked: this.checked, context: this.context});
   };
@@ -79,15 +79,14 @@ export class OntoToggleSwitch {
             </strong>
           </label>
         }
-        <span class="toggle-switch"
+        <button class="toggle-switch"
               onClick={this.toggle}
               tooltip-append-to="parent"
               tooltip-content={this.tooltipLabel}
-              tooltip-trigger={'mouseover'}
               tooltip-placement={OntoTooltipPlacement.TOP}>
           <input type="checkbox" checked={this.checked}/>
           <label></label>
-        </span>
+        </button>
       </section>
     );
   }

--- a/packages/shared-components/src/components/onto-tooltip/onto-tooltip.tsx
+++ b/packages/shared-components/src/components/onto-tooltip/onto-tooltip.tsx
@@ -1,109 +1,85 @@
 import {Component, h, Host, Listen} from '@stencil/core';
-import tippy, {Instance} from 'tippy.js';
-import {OntoTooltipConfiguration} from './models/onto-tooltip-configuration';
-import {HTMLElementWithTooltip} from "./models/html-element-with-tooltip";
-import {OntoTooltipPlacement} from "./models/onto-tooltip-placement";
+import {TooltipUtil} from "../../utils/tooltip-util";
 
 @Component({
-    tag: 'onto-tooltip',
-    styleUrl: 'onto-tooltip.scss',
-    shadow: false,
+  tag: 'onto-tooltip',
+  styleUrl: 'onto-tooltip.scss',
+  shadow: false,
 })
 export class OntoTooltip {
+  private observer: MutationObserver;
 
-    private static readonly ATTR_CONTENT = 'tooltip-content';
-    private static readonly ATTR_THEME = 'tooltip-theme';
-    private static readonly ATTR_PLACEMENT = 'tooltip-placement';
-    private static readonly ATTR_TRIGGER = 'tooltip-trigger';
-    private static readonly ATTR_APPEND_TO = 'tooltip-append-to';
-
-    private observer: MutationObserver;
-
-    /**
-     * Checks if the target of the 'mouseover' event has tooltip configuration.
-     * If it does, creates a tooltip instance and displays it.
-     *
-     * @param event - The 'mouseover' event triggered on a document element.
-     */
-    @Listen('mouseover', {target: 'document'})
-    onMouseover(event: MouseEvent): void {
-        const target = this.getTooltipTarget(event.target as HTMLElement);
-        if (!target) {
-            return;
-        }
-
-        let tooltipInstance = this.getTooltipInstance(target);
-        // Avoid recreating an instance if it already exists
-        if (!tooltipInstance) {
-            tooltipInstance = tippy(target, this.getConfig(target));
-        }
-        tooltipInstance.show();
-        target.hideTooltip = () => {
-            tooltipInstance.hide()
-        };
+  /**
+   * Checks if the target of the 'mouseover' event has tooltip configuration.
+   * If it does, creates a tooltip instance and displays it.
+   *
+   * @param event - The 'mouseover' event triggered on a document element.
+   */
+  @Listen('mouseover', {target: 'document'})
+  onMouseover(event: MouseEvent): void {
+    const target = TooltipUtil.getTooltipTarget(event.target as HTMLElement);
+    if (!target) {
+      return;
     }
 
-    /**
-     * Destroys the tooltip if it is present.
-     *
-     * @param event - The 'mouseout' event triggered on a document element.
-     */
-    @Listen('mouseout', { target: 'document' })
-    onMouseout(event: MouseEvent): void {
-        const target = this.getTooltipTarget(event.target as HTMLElement);
-        if (!target) {
-            return;
-        }
-        const relatedTarget = event.relatedTarget as HTMLElement;
-
-        // Ensure the mouse is completely outside the target and its children
-        if (!relatedTarget || !target.contains(relatedTarget)) {
-            const tooltipInstance = this.getTooltipInstance(target);
-            if (tooltipInstance) {
-                if (tooltipInstance.props.trigger !== 'manual') {
-                tooltipInstance.destroy();
-            }
-        }
-    }
-    }
-
-    connectedCallback() {
-        this.handleRemovedNodes();
-    }
-
-    disconnectedCallback() {
-        this.observer?.disconnect();
-    }
-
-    render() {
-        return <Host></Host>;
-    }
-
-    /**
-     * Get the tippy instance associated with an element.
-     */
-    private getTooltipInstance(element: HTMLElement): Instance | undefined {
-        // @ts-ignore
-        return element._tippy;
-    }
-
-    /**
-     * Clears tooltips associated with elements that have been removed from the DOM.
-     *
-     * @param records - An array of MutationRecord objects, each representing a change to the DOM tree.
-     *                  The function iterates over these records to find and clear tooltips for removed nodes.
-     */
-    private clearTooltipsForRemovedElements = (records: MutationRecord[]): void => {
-        for (const record of records) {
-            for (const node of Array.from(record.removedNodes)) {
-                if (this.removeTooltipFromNode(node)) {
-                  // stop iterating if a tooltip is found and destroyed,
-                  // since we can't have more than one tooltip
-                  return;
-                }
-            }
-        }
+    const tooltipInstance = TooltipUtil.getOrCreateTooltipInstance(target);
+    tooltipInstance.show();
+    target.hideTooltip = () => {
+      tooltipInstance.hide()
     };
+  }
+
+  /**
+   * Destroys the tooltip if it is present.
+   *
+   * @param event - The 'mouseout' event triggered on a document element.
+   */
+  @Listen('mouseout', { target: 'document' })
+  onMouseout(event: MouseEvent): void {
+    const target = TooltipUtil.getTooltipTarget(event.target as HTMLElement);
+    if (!target) {
+      return;
+    }
+    const relatedTarget = event.relatedTarget as HTMLElement;
+
+    // Ensure the mouse is completely outside the target and its children
+    if (!relatedTarget || !target.contains(relatedTarget)) {
+      const tooltipInstance = TooltipUtil.getTooltipInstance(target);
+      if (tooltipInstance && tooltipInstance.props.trigger === 'manual') {
+        TooltipUtil.destroyTooltip(target);
+      }
+    }
+  }
+
+  connectedCallback() {
+    this.handleRemovedNodes();
+  }
+
+  disconnectedCallback() {
+    this.observer?.disconnect();
+  }
+
+  render() {
+    return <Host></Host>;
+  }
+
+  /**
+   * Clears tooltips associated with elements that have been removed from the DOM.
+   *
+   * @param records - An array of MutationRecord objects, each representing a change to the DOM tree.
+   *                  The function iterates over these records to find and clear tooltips for removed nodes.
+   */
+  private readonly clearTooltipsForRemovedElements = (records: MutationRecord[]): void => {
+    for (const record of records) {
+      for (const node of Array.from(record.removedNodes)) {
+        if (this.removeTooltipFromNode(node)) {
+          // stop iterating if a tooltip is found and destroyed,
+          // since we can't have more than one tooltip
+          return;
+        }
+      }
+    }
+  };
 
   /**
    * Recursively removes tooltips from a given node and its children.
@@ -114,52 +90,24 @@ export class OntoTooltip {
    * @param node - The DOM node to check for tooltips.
    * @returns A boolean indicating whether a tooltip was found and destroyed (true) or not (false).
    */
-  private removeTooltipFromNode = (node: Node): boolean => {
-      if (node instanceof HTMLElement) {
-          const tooltipInstance = this.getTooltipInstance(node);
-          if (tooltipInstance) {
-              tooltipInstance.destroy();
-              return true;
-          }
-          node.childNodes.forEach(this.removeTooltipFromNode);
+  private readonly removeTooltipFromNode = (node: Node): boolean => {
+    if (node instanceof HTMLElement) {
+      const tooltipInstance = TooltipUtil.getTooltipInstance(node);
+      if (tooltipInstance) {
+        TooltipUtil.destroyTooltip(node);
+        return true;
       }
-      return false;
+      node.childNodes.forEach(this.removeTooltipFromNode);
+    }
+    return false;
   };
 
-    /**
-     * Initializes a MutationObserver to monitor the document body for removed nodes.
-     * When nodes are removed, it triggers the clearing of tooltips associated with those nodes.
-     */
-    private handleRemovedNodes(): void {
-        this.observer = new MutationObserver(this.clearTooltipsForRemovedElements);
-        this.observer.observe(document.body, {childList: true, subtree: true});
-    }
-
-    /**
-     * Creates a tooltip configuration for the provided element.
-     *
-     * @param element - an element with tooltip configuration.
-     */
-    private getConfig(element: HTMLElement): OntoTooltipConfiguration {
-        return new OntoTooltipConfiguration()
-            .setContent(element.getAttribute(OntoTooltip.ATTR_CONTENT))
-            .setTheme(element.getAttribute(OntoTooltip.ATTR_THEME))
-            .setPlacement(element.getAttribute(OntoTooltip.ATTR_PLACEMENT) as OntoTooltipPlacement)
-            .setTrigger(element.getAttribute(OntoTooltip.ATTR_TRIGGER))
-            .setAppendTo(element.getAttribute(OntoTooltip.ATTR_APPEND_TO));
-    }
-
-    /**
-     * Recursively finds the closest ancestor (including the given element itself) that has a `tooltip-content` attribute.
-     * This is used to identify the element associated with a tooltip when an event occurs on a child element.
-     *
-     * @param element - The starting HTML element where the search begins.
-     * @returns The closest HTML element with the `tooltip-content` attribute, or `null` if no such element is found.
-     */
-    private getTooltipTarget(element: HTMLElement): HTMLElementWithTooltip | null {
-        while (element && !element.getAttribute(OntoTooltip.ATTR_CONTENT)) {
-            element = element.parentElement;
-        }
-        return element;
-    }
+  /**
+   * Initializes a MutationObserver to monitor the document body for removed nodes.
+   * When nodes are removed, it triggers the clearing of tooltips associated with those nodes.
+   */
+  private handleRemovedNodes(): void {
+    this.observer = new MutationObserver(this.clearTooltipsForRemovedElements);
+    this.observer.observe(document.body, {childList: true, subtree: true});
+  }
 }

--- a/packages/shared-components/src/pages/tooltip/index.html
+++ b/packages/shared-components/src/pages/tooltip/index.html
@@ -40,7 +40,6 @@
 <div class="elements-container">
   <div class="plane-text-tooltip">
     <button tooltip-content="Test plain text tooltip"
-            tooltip-trigger="mouseover"
             tooltip-placement="right">
       <span class="button-icon">&#x1F50D;</span>
       <span class="button-label">Button</span>
@@ -49,7 +48,6 @@
 
   <div class="html-tooltip">
     <button tooltip-content="<div><div class='header'>Header</div><div class='body'>Body</div></div>"
-            tooltip-trigger="mouseover"
             tooltip-placement="right">
       <span class="button-icon">&#x1F50D;</span>
       <span class="button-label">Button</span>
@@ -58,7 +56,6 @@
 
   <div class="tooltip-bottom">
     <button tooltip-content="<div><div class='header'>Header</div><div class='body'>Body</div></div>"
-            tooltip-trigger="mouseover"
             tooltip-placement="bottom">
       <span class="button-icon">&#x1F50D;</span>
       <span class="button-label">Button</span>
@@ -67,7 +64,6 @@
 
   <div class="tooltip-right">
     <button tooltip-content="<div><div class='header'>Header</div><div class='body'>Body</div></div>"
-            tooltip-trigger="mouseover"
             tooltip-placement="right">
       <span class="button-icon">&#x1F50D;</span>
       <span class="button-label">Button</span>
@@ -76,7 +72,6 @@
 
   <div class="tooltip-custom-theme">
     <button tooltip-content="<div><div class='header'>Header</div><div class='body'>Body</div></div>"
-            tooltip-trigger="mouseover"
             tooltip-placement="bottom"
             tooltip-theme="custom-theme">
       <span class="button-icon">&#x1F50D;</span>
@@ -86,7 +81,6 @@
 
   <div class="tooltip-default-theme">
     <button tooltip-content="<div><div class='header'>Header</div><div class='body'>Body</div></div>"
-            tooltip-trigger="mouseover"
             tooltip-placement="bottom">
       <span class="button-icon">&#x1F50D;</span>
       <span class="button-label">Button</span>
@@ -95,7 +89,6 @@
 
   <button onclick="removeElement()"
           id="remove-me"
-          tooltip-trigger="mouseover"
           tooltip-content="Remove me"
           tooltip-placement="bottom">
     Click to remove me

--- a/packages/shared-components/src/utils/tooltip-util.spec.ts
+++ b/packages/shared-components/src/utils/tooltip-util.spec.ts
@@ -1,0 +1,129 @@
+import { TooltipUtil } from './tooltip-util';
+import tippy, { Instance } from 'tippy.js';
+
+jest.mock('tippy.js');
+
+describe('TooltipUtil', () => {
+  let element: HTMLElement;
+
+  beforeEach(() => {
+    element = document.createElement('button');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.resetAllMocks();
+  });
+
+  describe('getTooltipInstance', () => {
+    it('should return undefined when no tooltip is attached', () => {
+      expect(TooltipUtil.getTooltipInstance(element)).toBeUndefined();
+    });
+
+    it('should return the existing tooltip instance', () => {
+      const instance = {} as Instance;
+      // @ts-ignore
+      element._tippy = instance;
+      expect(TooltipUtil.getTooltipInstance(element)).toBe(instance);
+    });
+  });
+
+  describe('createTooltip', () => {
+    it('should call tippy.js with config from element attributes', () => {
+      element.setAttribute('tooltip-content', 'test');
+      element.setAttribute('tooltip-theme', 'dark');
+      element.setAttribute('tooltip-placement', 'top');
+      element.setAttribute('tooltip-trigger', 'click');
+      element.setAttribute('tooltip-append-to', 'body');
+
+      TooltipUtil.createTooltip(element);
+
+      expect(tippy).toHaveBeenCalledWith(element, expect.objectContaining({
+        content: 'test',
+        theme: 'dark',
+        placement: 'top',
+        trigger: 'click',
+        appendTo: expect.anything(),
+      }));
+    });
+  });
+
+  describe('getOrCreateTooltipInstance', () => {
+    it('should return existing tooltip instance if present', () => {
+      const instance = {} as Instance;
+      // @ts-ignore
+      element._tippy = instance;
+      const result = TooltipUtil.getOrCreateTooltipInstance(element);
+      expect(result).toBe(instance);
+    });
+
+    it('should create new instance if none exists', () => {
+      element.setAttribute('tooltip-content', 'new');
+      TooltipUtil.getOrCreateTooltipInstance(element);
+      expect(tippy).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateTooltipContent', () => {
+    it('should update content if tooltip exists and content is not empty', () => {
+      const setContent = jest.fn();
+      const instance = { setContent } as unknown as Instance;
+      // @ts-ignore
+      element._tippy = instance;
+
+      TooltipUtil.updateTooltipContent(element, 'Updated');
+      expect(setContent).toHaveBeenCalledWith('Updated');
+    });
+
+    it('should do nothing if no tooltip is present', () => {
+      expect(() => TooltipUtil.updateTooltipContent(element, 'Noop')).not.toThrow();
+    });
+
+    it('should do nothing if content is empty', () => {
+      const setContent = jest.fn();
+      const instance = { setContent } as unknown as Instance;
+      // @ts-ignore
+      element._tippy = instance;
+
+      TooltipUtil.updateTooltipContent(element, '');
+      expect(setContent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('destroyTooltip', () => {
+    it('should destroy tooltip if instance exists', () => {
+      const destroy = jest.fn();
+      const instance = { destroy } as unknown as Instance;
+      // @ts-ignore
+      element._tippy = instance;
+
+      TooltipUtil.destroyTooltip(element);
+      expect(destroy).toHaveBeenCalled();
+    });
+
+    it('should not throw if no instance exists', () => {
+      expect(() => TooltipUtil.destroyTooltip(element)).not.toThrow();
+    });
+  });
+
+  describe('getTooltipTarget', () => {
+    it('should return self if element has tooltip-content', () => {
+      element.setAttribute('tooltip-content', 'yes');
+      expect(TooltipUtil.getTooltipTarget(element)).toBe(element);
+    });
+
+    it('should return parent with tooltip-content', () => {
+      const parent = document.createElement('div');
+      parent.setAttribute('tooltip-content', 'yes');
+      parent.appendChild(element);
+      document.body.appendChild(parent);
+
+      expect(TooltipUtil.getTooltipTarget(element)).toBe(parent);
+    });
+
+    it('should return null if no matching element found', () => {
+      expect(TooltipUtil.getTooltipTarget(element)).toBeNull();
+    });
+  });
+});

--- a/packages/shared-components/src/utils/tooltip-util.ts
+++ b/packages/shared-components/src/utils/tooltip-util.ts
@@ -1,11 +1,63 @@
+import {OntoTooltipConfiguration} from "../components/onto-tooltip/models/onto-tooltip-configuration";
+import tippy, {Instance} from "tippy.js";
+import {OntoTooltipPlacement} from "../components/onto-tooltip/models/onto-tooltip-placement";
+import {HTMLElementWithTooltip} from "../components/onto-tooltip/models/html-element-with-tooltip";
+
 export class TooltipUtil {
+  private static readonly ATTR_CONTENT = 'tooltip-content';
+  private static readonly ATTR_THEME = 'tooltip-theme';
+  private static readonly ATTR_PLACEMENT = 'tooltip-placement';
+  private static readonly ATTR_TRIGGER = 'tooltip-trigger';
+  private static readonly ATTR_APPEND_TO = 'tooltip-append-to';
+
+  /**
+   * Returns the Tippy instance associated with an element, if it exists.
+   */
+  static getTooltipInstance(element: HTMLElement): import('tippy.js').Instance | undefined {
+    // @ts-ignore
+    return element._tippy;
+  }
+
+  /**
+   * Creates a new Tippy tooltip instance on the given element using
+   * the OntoTooltipConfiguration.
+   *
+   * @param target - The HTMLElement to attach the tooltip to.
+   * @returns The newly created Tippy Instance.
+   */
+  static createTooltip(target: HTMLElement): Instance {
+    return tippy(target, TooltipUtil.getConfig(target));
+  }
+
+  /**
+   * Returns an existing Tippy instance or creates a new one if not present.
+   *
+   * @param target - The HTMLElement to find or attach the tooltip to.
+   * @returns The existing or newly created Tippy Instance.
+   */
+  static getOrCreateTooltipInstance(target: HTMLElement): Instance {
+    const existing = TooltipUtil.getTooltipInstance(target);
+    if (existing) {
+      return existing;
+    }
+    return TooltipUtil.createTooltip(target);
+  }
+
+  private static getConfig(element: HTMLElement): OntoTooltipConfiguration {
+    return new OntoTooltipConfiguration()
+      .setContent(element.getAttribute(TooltipUtil.ATTR_CONTENT))
+      .setTheme(element.getAttribute(TooltipUtil.ATTR_THEME))
+      .setPlacement(element.getAttribute(TooltipUtil.ATTR_PLACEMENT) as OntoTooltipPlacement)
+      .setTrigger(element.getAttribute(TooltipUtil.ATTR_TRIGGER))
+      .setAppendTo(element.getAttribute(TooltipUtil.ATTR_APPEND_TO));
+  }
+
   /**
    * Updates the content of an existing Tippy tooltip, if present.
-   * Does nothing if tooltip does not exist.
+   * Does nothing if tooltip does not exist or content is empty.
    */
   static updateTooltipContent(target: HTMLElement, content: string): void {
-    // @ts-ignore
-    const tip = target?._tippy;
+    const tip = TooltipUtil.getTooltipInstance(target);
     if (tip && content !== '') {
       tip.setContent(content);
     }
@@ -15,11 +67,23 @@ export class TooltipUtil {
    * Destroys the Tippy tooltip on the given element, if present.
    */
   static destroyTooltip(target: HTMLElement): void {
-    // @ts-ignore
-    const tip = target?._tippy;
+    const tip = TooltipUtil.getTooltipInstance(target);
     if (tip) {
       tip.destroy();
     }
   }
-}
 
+  /**
+   * Recursively finds the closest ancestor (including the given element itself) that has a `tooltip-content` attribute.
+   * This is used to identify the element associated with a tooltip when an event occurs on a child element.
+   *
+   * @param element - The starting HTML element where the search begins.
+   * @returns The closest HTML element with the `tooltip-content` attribute, or `null` if no such element is found.
+   */
+  static getTooltipTarget(element: HTMLElement): HTMLElementWithTooltip | null {
+    while (element && !element.getAttribute(TooltipUtil.ATTR_CONTENT)) {
+      element = element.parentElement;
+    }
+    return element;
+  }
+}


### PR DESCRIPTION
## WHAT:
- Removed explicit `tooltip-trigger="mouseover"` attributes from multiple components.
- Introduced `TooltipUtil.getOrCreateTooltipInstance` to abstract instance management.
- Refactored `onto-tooltip` to fully delegate creation, retrieval, and destruction of Tippy instances to `TooltipUtil`.

## WHY:
- Default behavior for Tippy is `manual`
- Consolidating tooltip logic in `TooltipUtil` improves maintainability, ensures consistency across components, and reduces code duplication.

## HOW:
- Created a utility method `getOrCreateTooltipInstance()` in `TooltipUtil`.
- Moved tooltip configuration parsing into `TooltipUtil.getConfig(...)`.
- Updated `onto-tooltip` component to use the new utility methods instead of directly managing Tippy instances.
- Removed all `tooltip-trigger="mouseover"` attributes from components and test HTML files.
- Several Sonar issues fixed

## Testing
- Added unit tests.


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [X] Tests
