### PR TITLE
fix(GDB-12503) WBM: Display logout button for external users based on externalAuthUser flag

### DIFF
--- a/packages/api/src/models/security/security-config.ts
+++ b/packages/api/src/models/security/security-config.ts
@@ -15,6 +15,7 @@ export class SecurityConfig extends Model<SecurityConfig> {
   openIdEnabled?: boolean;
   userLoggedIn?: boolean;
   freeAccessActive?: boolean;
+  hasExternalAuthUser?: boolean;
 
   constructor(config: Partial<SecurityConfig>) {
     super();
@@ -26,5 +27,6 @@ export class SecurityConfig extends Model<SecurityConfig> {
     this.openIdEnabled = config.openIdEnabled;
     this.userLoggedIn = config.userLoggedIn;
     this.freeAccessActive = config.freeAccessActive;
+    this.hasExternalAuthUser = config.hasExternalAuthUser;
   }
 }

--- a/packages/api/src/services/security/mappers/test/security-config.mapper.spec.ts
+++ b/packages/api/src/services/security/mappers/test/security-config.mapper.spec.ts
@@ -11,6 +11,7 @@ describe('SecurityConfigMapper', () => {
       methodSettings: {},
       passwordLoginEnabled: true,
       hasExternalAuth: false,
+      hasExternalAuthUser: false,
       authImplementation: 'Local',
       openIdEnabled: false,
     } as unknown as SecurityConfig;

--- a/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
@@ -591,6 +591,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                 let config = {
                     enabled: this.securityEnabled,
                     hasExternalAuth: this.externalAuth,
+                    hasExternalAuthUser: this.hasExternalAuthUser(),
                     openIdEnabled: this.openIDEnabled,
                     passwordLoginEnabled: this.passwordLoginEnabled,
                     overrideAuth: {

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -308,6 +308,10 @@ export namespace Components {
      */
     interface OntoUserMenu {
         /**
+          * Current security config
+         */
+        "securityConfig": SecurityConfig;
+        /**
           * Currently authenticated user
          */
         "user": AuthenticatedUser;
@@ -832,6 +836,10 @@ declare namespace LocalJSX {
      * for navigating to settings and logging out.
      */
     interface OntoUserMenu {
+        /**
+          * Current security config
+         */
+        "securityConfig"?: SecurityConfig;
         /**
           * Currently authenticated user
          */

--- a/packages/shared-components/src/components/onto-header/onto-header.tsx
+++ b/packages/shared-components/src/components/onto-header/onto-header.tsx
@@ -127,7 +127,7 @@ export class OntoHeader {
             totalTripletsFormatter={this.totalTripletsFormatter}
             canWriteRepo={this.canWriteRepo}>
           </onto-repository-selector>
-          {this.securityConfig?.enabled && this.securityConfig?.userLoggedIn ? <onto-user-menu user={this.user}></onto-user-menu> : ''}
+          {this.securityConfig?.enabled && this.securityConfig?.userLoggedIn ? <onto-user-menu user={this.user} securityConfig={this.securityConfig}></onto-user-menu> : ''}
           {this.securityConfig?.enabled && !this.securityConfig?.userLoggedIn && (this.currentRoute !== 'login') ? <onto-user-login></onto-user-login> : ''}
           <onto-language-selector dropdown-alignment="right"></onto-language-selector>
         </div>
@@ -151,7 +151,7 @@ export class OntoHeader {
 
   private subscribeToRepositoryListChanged(): () => void {
     return this.repositoryContextService.onRepositoryListChanged((repositories: RepositoryList) => {
-      if (!repositories || !repositories.getItems().length) {
+      if (!repositories?.getItems().length) {
         this.resetOnMissingRepositories();
       } else {
         this.initOnRepositoryListChanged(repositories);
@@ -239,7 +239,7 @@ export class OntoHeader {
   }
 
   private getRepositoriesDropdownItems(): DropdownItem<Repository>[] {
-    if (!this.repositoryList || !this.repositoryList.getItems().length) {
+    if (!this.repositoryList?.getItems().length) {
       return [];
     }
     this.repositoryList.sortByLocationAndId();
@@ -265,11 +265,11 @@ export class OntoHeader {
     return true;
   }
 
-  private canWriteRepo = (repo: Repository) => {
+  private readonly canWriteRepo = (repo: Repository) => {
     return this.canWriteRepoInLocation(repo);
   };
 
-  private repositorySizeInfoFetcher = (repo: Repository) => {
+  private readonly repositorySizeInfoFetcher = (repo: Repository) => {
     return this.repositoryService.getRepositorySizeInfo(repo);
   };
 
@@ -323,7 +323,7 @@ export class OntoHeader {
       (!this.isActiveLocationLoading || getPathName() === '/repository');
   }
 
-  private showViewResourceMessage= (event:MouseEvent) => {
+  private readonly showViewResourceMessage= (event:MouseEvent) => {
     event.stopPropagation();
     this.toastrService.info(TranslationService.translate('rdf_search.toasts.use_view_resource'));
     this.shouldShowSearch = false;

--- a/packages/shared-components/src/components/onto-user-menu/onto-user-menu.tsx
+++ b/packages/shared-components/src/components/onto-user-menu/onto-user-menu.tsx
@@ -1,5 +1,11 @@
 import {Component, h, Prop, State, Element} from '@stencil/core';
-import {AuthenticatedUser, AuthenticationService, navigateTo, ServiceProvider} from '@ontotext/workbench-api';
+import {
+  AuthenticatedUser,
+  AuthenticationService,
+  navigateTo,
+  SecurityConfig,
+  ServiceProvider
+} from '@ontotext/workbench-api';
 
 /**
  * This component displays the current user's name and provides options
@@ -15,6 +21,8 @@ export class OntoUserMenu {
 
   /** Currently authenticated user */
   @Prop() user: AuthenticatedUser;
+  /** Current security config */
+  @Prop() securityConfig: SecurityConfig;
 
   /** Reference to host element for outside click detection */
   @Element() hostElement: HTMLElement;
@@ -40,7 +48,7 @@ export class OntoUserMenu {
             <section class='onto-user-menu-dropdown'>
               <translate-label onClick={navigateTo('/settings')}
                                labelKey={'user_menu.my_settings'}></translate-label>
-              {!this.user.external ?
+              {!this.securityConfig?.hasExternalAuthUser ?
                 <translate-label onClick={this.logout}
                                  labelKey={'user_menu.logout'}></translate-label> : ''}
             </section> : ''}
@@ -52,7 +60,7 @@ export class OntoUserMenu {
   /**
   * Log out the current user.
   */
-  private logout = (): void => {
+  private readonly logout = (): void => {
     ServiceProvider.get(AuthenticationService).logout();
   }
 
@@ -61,14 +69,14 @@ export class OntoUserMenu {
    *
    * @returns A function that toggles the `isOpen` state between true and false.
    */
-  private toggleDropdown = (): void => {
+  private readonly toggleDropdown = (): void => {
     this.isOpen = !this.isOpen;
   }
 
   /**
    * Closes the dropdown if the user clicks outside the component.
    */
-  private handleOutsideClick = (event: MouseEvent) => {
+  private readonly handleOutsideClick = (event: MouseEvent) => {
     if (this.isOpen && !this.hostElement.contains(event.target as Node)) {
       this.isOpen = false;
     }

--- a/packages/shared-components/src/components/onto-user-menu/readme.md
+++ b/packages/shared-components/src/components/onto-user-menu/readme.md
@@ -12,9 +12,10 @@ for navigating to settings and logging out.
 
 ## Properties
 
-| Property | Attribute | Description                  | Type                | Default     |
-| -------- | --------- | ---------------------------- | ------------------- | ----------- |
-| `user`   | `user`    | Currently authenticated user | `AuthenticatedUser` | `undefined` |
+| Property         | Attribute         | Description                  | Type                | Default     |
+| ---------------- | ----------------- | ---------------------------- | ------------------- | ----------- |
+| `securityConfig` | `security-config` | Current security config      | `SecurityConfig`    | `undefined` |
+| `user`           | `user`            | Currently authenticated user | `AuthenticatedUser` | `undefined` |
 
 
 ## Dependencies

--- a/packages/shared-components/src/pages/user-menu/main.js
+++ b/packages/shared-components/src/pages/user-menu/main.js
@@ -4,10 +4,18 @@ userMenu.user = {
   username: 'john.doe'
 }
 
+userMenu.securityConfig = {
+  hasExternalAuthUser: false
+}
+
 const setExternalUser = () => {
   userMenu.user = {
     ...userMenu.user,
     external: true,
     userLoggedIn: true
+  }
+
+  userMenu.securityConfig = {
+    hasExternalAuthUser: true
   }
 }


### PR DESCRIPTION
## WHAT:
Fixed an issue where the logout button was not shown for users authenticated via OpenLDAP, despite the expectation that it should appear

## WHY:
The existing logic to determine whether to display the logout button was incorrectly based solely on the user.external property. However, for externally authenticated users (e.g., via OpenLDAP), a separate config property in jwt-auth.service.js (hasExternalAuthUser) is the reliable source of truth indicating such authentication. Without this fix, users under OpenLDAP couldn't properly log out from the UI.

## HOW:
- Introduced a new hasExternalAuthUser property to SecurityConfig and populated it in jwt-auth.service.js.
- Updated OntoUserMenu to receive securityConfig as a prop.
- Adjusted the logout button condition to check securityConfig.hasExternalAuthUser instead of user.external.
- Passed securityConfig to OntoUserMenu in OntoHeader
- Several Sonar issues fixed

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
