### PR TITLE
GDB-12484: Fixes "main menu" and "create repository" steps

### DIFF
--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/create-repository/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/create-repository/plugin.js
@@ -21,7 +21,7 @@ PluginRegistry.add('guide.step', [
                         class: 'create-repository-guide-dialog',
                         url: '/repository',
                         elementSelector: GuideUtils.getGuideElementSelector('createRepository'),
-                        onNextClick: (guide) => GuideUtils.clickOnGuideElement('createRepository')().then(() => guide.next())
+                        onNextClick: GuideUtils.clickOnGuideElement('createRepository')
                     }, options)
                 }, {
                     guideBlockName: 'clickable-element',

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/main-menu/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/main-menu/plugin.js
@@ -129,13 +129,7 @@ PluginRegistry.add('guide.step', [
                         }
                         return true;
                     },
-                    onNextClick: (guide) =>
-                        GuideUtils.clickOnGuideElement(menuSelector, mainMenuClickElementPostSelector)()
-                            .then(() => {
-                                if (!submenuSelector) {
-                                    guide.next();
-                                }
-                            }),
+                    onNextClick: GuideUtils.clickOnGuideElement(menuSelector, mainMenuClickElementPostSelector),
                     initPreviousStep: (services, stepId) => {
                         const previousStep = services.ShepherdService.getPreviousStepFromHistory(stepId);
                         if (previousStep) {
@@ -157,14 +151,7 @@ PluginRegistry.add('guide.step', [
                         elementSelector: GuideUtils.getGuideElementSelector(submenuSelector),
                         placement: 'right',
                         canBePaused: false,
-                        showOn: () => {
-                            // If submenu is visible this mean that we have to close menu.
-                            if (!GuideUtils.isGuideElementVisible(submenuSelector)) {
-                                GuideUtils.clickOnGuideElement(menuSelector, ' div')();
-                            }
-                            return true;
-                        },
-                        onNextClick: (guide) => GuideUtils.clickOnGuideElement(submenuSelector, ' a')().then(() => guide.next()),
+                        onNextClick: GuideUtils.clickOnGuideElement(submenuSelector, ' a'),
                         initPreviousStep: (services, stepId) => {
                             const previousStep = services.ShepherdService.getPreviousStepFromHistory(stepId);
                             if (previousStep) {

--- a/packages/shared-components/src/components/onto-navbar/onto-navbar.tsx
+++ b/packages/shared-components/src/components/onto-navbar/onto-navbar.tsx
@@ -270,7 +270,7 @@ export class OntoNavbar {
           </li>
           {this.menuModel.items.map((item) => (
             <li key={item.labelKey} class={{'menu-element': true, 'open': item.open}}
-                data-test-id={item.testSelector}>
+                data-test-id={item.testSelector} guide-selector={item.guideSelector}>
               {item.children.length > 0 &&
                 <Fragment>
                   <div class={{'menu-element-root': true, 'active': item.selected}}
@@ -285,7 +285,7 @@ export class OntoNavbar {
                     {
                       item.children.map((submenu) => (
                         <li key={submenu.labelKey} class={{'sub-menu-item': true, 'active': submenu.selected}}
-                            data-test-id={submenu.testSelector}>
+                            data-test-id={submenu.testSelector}  guide-selector={submenu.guideSelector}>
                           <a class="sub-menu-link" href={submenu.href} onClick={this.handleSelectMenuItem(submenu)}>
                             <translate-label class="menu-item" labelKey={submenu.labelKey}></translate-label>
                             {submenu.icon &&


### PR DESCRIPTION
## What
- The "Main Menu" guide step was not working in the migration branch;
- Removed unnecessary calls to the guide.next() function.

## Why
- The old navigation bar was replaced with a new one from the shared-components package. The new menu items were missing the guide-selector attribute required by the guide service.
- There was a bug causing elements not to respond to clicks in some steps. After fixing that bug, programmatically calling guide.next() led to the second dialog opening unintentionally.

## How
- Each plugin that describes a navigation bar item provides a guideSelector property, which is added as the guide-selector attribute.
- Removed the redundant call to advance to the next guide step.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
