### PR TITLE
GDB-12505 Fix enabled request on repository deletion

### DIFF
--- a/packages/api/src/models/repositories/repository.ts
+++ b/packages/api/src/models/repositories/repository.ts
@@ -19,6 +19,7 @@ export class Repository extends Model<Repository> implements RepositoryReference
   readable: boolean | undefined;
   writable: boolean | undefined;
   unsupported: boolean | undefined;
+  isNew?: boolean;
 
   constructor(data?: Partial<Repository>) {
     super();
@@ -34,8 +35,9 @@ export class Repository extends Model<Repository> implements RepositoryReference
     this.readable = data?.readable;
     this.writable = data?.writable;
     this.unsupported = data?.unsupported;
+    this.isNew = data?.isNew;
   }
-  
+
   toRepositoryReference(): RepositoryReference {
     return {
       id: this.id,


### PR DESCRIPTION
## What
Fix unnecessary autocomplete `/enabled` check, when the selected repository is deleted

## Why
The backend throws an error, since the repository does not exist anymore

## How
Made `updateSelectedRepository` to return the resolved promise of `validatePropertyChange`. Previously, when a repository was deleted, `updateSelectedRepository` was called, but the validations from `validatePropertyChange` happen in a promise, in a separate thread tick. Then `repositoryIsSet` was broadcasted with wrong store data. This caused the application to make a request for autocomplete enabled

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
