### PR TITLE
GDB-12406: Fix search resource input hint font-size

### DIFF
--- a/packages/legacy-workbench/src/css/search-resource-input.css
+++ b/packages/legacy-workbench/src/css/search-resource-input.css
@@ -1,0 +1,3 @@
+.autocomplete-hint {
+    font-size: 12px;
+}

--- a/packages/legacy-workbench/src/js/angular/core/templates/search-resource-input.html
+++ b/packages/legacy-workbench/src/js/angular/core/templates/search-resource-input.html
@@ -1,3 +1,5 @@
+<link href="css/search-resource-input.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+
 <div id="search-resource-box" class="input-group btn-group" ng-class="{'input-group-lg': !radioButtons}" style="white-space: nowrap">
     <input type="text" class="form-control view-res-input" placeholder="{{placeholder}}" ng-model="searchInput"
            ng-change="onChange()"


### PR DESCRIPTION
## What
Set correct styling for the search resource input hint font-size

## Why
The search resource input used a css which was loaded by another directive which wrapped the SRI. Since this other directive is replaced by an Onto component, it no longer loads the styles.

## How
- extracted the SRI style into its own file and loaded it

## Testing
n/a

## Screenshots
![image](https://github.com/user-attachments/assets/0f2c3f41-ecc5-4706-8b33-cff0a29f41e6)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
