### PR TITLE
GDB-12484: Interactive guides don't work on the migration branch

### DIFF
--- a/e2e-tests/e2e-legacy/guides/movies-interactive-guide.spec.js
+++ b/e2e-tests/e2e-legacy/guides/movies-interactive-guide.spec.js
@@ -3,10 +3,7 @@ import {MoviesGuideSteps} from "../../steps/guides/movies-guide-steps";
 
 const MOVIES_FILE_FOR_IMPORT = 'movies.ttl';
 
-/**
- * TODO: Fix me. Broken due to migration (Error: Changes in main menu)
- */
-describe.skip('Interactive guides', () => {
+describe('Interactive guides', () => {
 
     let repositoryId;
 
@@ -25,7 +22,6 @@ describe.skip('Interactive guides', () => {
 
     context('Describes "Movies" interactive guide', () => {
         it('Tests movies interactive guide using "Next" button to the end', () => {
-
             const stepAssertions = [
                 {assert: MoviesGuideSteps.assertExploreClassHierarchyStep1},
                 {assert: MoviesGuideSteps.assertExploreClassHierarchyStep2},

--- a/e2e-tests/e2e-legacy/guides/star-wars-interactive-guide.js
+++ b/e2e-tests/e2e-legacy/guides/star-wars-interactive-guide.js
@@ -3,11 +3,7 @@ import {StarWarsGuideSteps} from "../../steps/guides/star-wars-guide-steps";
 
 const STAR_WARS_FILE_FOR_IMPORT = 'starwars.ttl';
 
-
-/**
- * TODO: Fix me. Broken due to migration (Changes in main menu)
- */
-describe.skip('Describes "Starwars" interactive guide', () => {
+describe('Describes "Starwars" interactive guide', () => {
 
     let repositoryId;
 

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -47,15 +47,15 @@ export class MainMenuSteps {
     }
 
     static getSubmenuAutocomplete() {
-        return MainMenuSteps.getSubMenuButton("Autocomplete");
+        return MainMenuSteps.getSubMenuButton("sub-menu-autocomplete");
     }
 
     static getSubmenuClassHierarchy() {
-        return MainMenuSteps.getSubMenuButton("Class hierarchy");
+        return MainMenuSteps.getSubMenuButton("menu-class-hierarchy");
     }
 
     static getSubmenuVisualGraph() {
-        return MainMenuSteps.getSubMenuButton("Visual graph");
+        return MainMenuSteps.getSubMenuButton("sub-menu-visual-graph");
     }
 
     static clickOnMenu(menuName) {

--- a/packages/legacy-workbench/src/js/angular/autocomplete/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/autocomplete/plugin.js
@@ -13,6 +13,15 @@ PluginRegistry.add('route', {
 
 PluginRegistry.add('main.menu', {
     'items': [
-        {label: 'Autocomplete', labelKey: 'menu.autocomplete.label', href: 'autocomplete', order: 40, parent: 'Setup', role: "IS_AUTHENTICATED_FULLY", guideSelector: 'sub-menu-autocomplete'}
+        {
+            label: 'Autocomplete',
+            labelKey: 'menu.autocomplete.label',
+            href: 'autocomplete',
+            order: 40,
+            parent: 'Setup',
+            role: "IS_AUTHENTICATED_FULLY",
+            guideSelector: 'sub-menu-autocomplete',
+            testSelector: 'sub-menu-autocomplete'
+        }
     ]
 });

--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/rdf-class-hierarchy.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/rdf-class-hierarchy.controller.js
@@ -173,6 +173,10 @@ function RdfClassHierarchyCtlr($scope, $rootScope, $location, $repositories, $li
         }
     });
 
+    $scope.goToResourceView = () => {
+        $location.path("sparql").search($scope.resourceViewInstancesUriParameters);
+    }
+
     function instancesFilterFunc(inst) {
         return inst.resolvedUri
             .toLowerCase()
@@ -332,10 +336,14 @@ function RdfClassHierarchyCtlr($scope, $rootScope, $location, $repositories, $li
 
         const query = "prefix onto:<http://www.ontotext.com/>\nselect ?s {\n    ?s a <" + uri + "> .\n}";
 
-        const encodedQuery = encodeURIComponent(query);
-
-        // generate url for redirecting to sparql view, opening a new tab, writing the generated query and executing it
-        $scope.viewInstancesUri = 'sparql?name=' + name + '&infer=true&sameAs=false&query=' + encodedQuery + '&execute=true';
+        // Prepare parameters for redirecting to sparql view, opening a new tab, writing the generated query and executing it
+        $scope.resourceViewInstancesUriParameters = {
+            name,
+            infer: true,
+            sameAs: false,
+            query,
+            execute: true
+        }
 
         GraphDataRestService.getRdfsLabelAndComment(uri)
             .success(function (response) {

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/class-hierarchy/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/class-hierarchy/plugin.js
@@ -166,11 +166,7 @@ PluginRegistry.add('guide.step', [
                         canBePaused: false,
                         elementSelector: instanceCountSelector,
                         class: 'class-hierarchy-side-panel-instances-count-guide-dialog',
-                        onNextClick: (guide, step) => {
-                            GuideUtils.waitFor(step.elementSelector, 3)
-                                .then(() => $(step.elementSelector).trigger('click'));
-                            guide.next();
-                        }
+                        onNextClick: GuideUtils.clickOnGuideElement('instances-count')
                     }, options)
                 });
 

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/import-rdf-file/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/import-rdf-file/plugin.js
@@ -70,7 +70,7 @@ PluginRegistry.add('guide.step', [
                             }
                         },
                         onNextValidate: () => {
-                            return Promise.allSettled([GuideUtils.getOrWaitFor('.confirm-duplicate-files-dialog'), GuideUtils.getOrWaiteFor(GuideUtils.getGuideElementSelector('import-file-' + options.resourceFile))])
+                            return Promise.allSettled([GuideUtils.getOrWaitFor('.confirm-duplicate-files-dialog'), GuideUtils.getOrWaitFor(GuideUtils.getGuideElementSelector('import-file-' + options.resourceFile))])
                                 .then(([confirmDialogPromise, importButtonPromise]) => {
                                     // There are two ways to exit this step: if the duplication dialog is opened or if the import button for the guide file is displayed.
                                     // The first scenario indicates that the user is trying to upload the same file,

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/select-repository/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/select-repository/plugin.js
@@ -3,8 +3,17 @@ const getRepositoryName = (services, options) => {
 };
 
 const getRepositoryElementSelector = (services, options) => {
-    return services.GuideUtils.getGuideElementSelector(`repository-${getRepositoryName(services, options)}-button`);
+    return services.GuideUtils.getGuideElementSelector(`repository-id-${getRepositoryName(services, options)}`);
 };
+
+const setRepositorySelectorAutoClose = (autoClose) => {
+    const component = document.querySelector('.onto-repository-selector');
+    if (component) {
+        // Enable auto-close when the guide step is closed.
+        component.autoClose = autoClose;
+    }
+}
+
 
 PluginRegistry.add('guide.step', [
     {
@@ -19,9 +28,9 @@ PluginRegistry.add('guide.step', [
                 options: angular.extend({}, {
                     skipPoint: true,
                     content: 'guide.step_plugin.choose-repository.content',
-                    elementSelector: GuideUtils.getGuideElementSelector('repositoriesGroupButton'),
+                    elementSelector: '.onto-repository-selector',
                     class: 'repositories-group-button-guide-dialog',
-                    onNextClick: (guide) => GuideUtils.clickOnGuideElement('repositoriesGroupButton')().then(() => guide.next())
+                    onNextClick: GuideUtils.clickOnElement('.onto-repository-selector .onto-dropdown-button')
                 }, options)
             }, {
                 guideBlockName: 'clickable-element',
@@ -38,7 +47,7 @@ PluginRegistry.add('guide.step', [
                             throw (error);
                         }),
                     show: (guide) => () => {
-                        $('#repositorySelectDropdown').addClass('autoCloseOff');
+                        setRepositorySelectorAutoClose(false);
                         // Added listener to the element.
                         $(getRepositoryElementSelector(services, options))
                             .on('mouseup.selectRepositoryButtonClick', function () {
@@ -47,11 +56,10 @@ PluginRegistry.add('guide.step', [
                     },
                     onNextClick: (guide) => {
                         $(getRepositoryElementSelector(services, options)).off('mouseup.selectRepositoryButtonClick');
-                        $('#repositorySelectDropdown').removeClass('autoCloseOff');
                         GuideUtils.clickOnElement(getRepositoryElementSelector(services, options))().then(() => guide.next());
                     },
                     hide: () => () => {
-                        $('#repositorySelectDropdown').removeClass('autoCloseOff');
+                        setRepositorySelectorAutoClose(true);
                         // Remove ths listener from element. It is important when step is hided.
                         $(getRepositoryElementSelector(services, options)).off('mouseup.selectRepositoryButtonClick');
                     },

--- a/packages/legacy-workbench/src/pages/rdfClassHierarchyInfo.html
+++ b/packages/legacy-workbench/src/pages/rdfClassHierarchyInfo.html
@@ -173,8 +173,20 @@
                     <p class="alert alert-warning" ng-switch-when="0">
                     	{{'no.instances.for.selected.class.type' | translate}}
                     </p>
-					<p ng-switch-when="1"><a class="btn btn-link px-0" href={{viewInstancesUri}} guide-selector="instances-count">{{'view.instance.in.sparql.label' | translate}}</a></p>
-                    <p ng-switch-default><a class="btn btn-link px-0" href={{viewInstancesUri}} guide-selector="instances-count">{{'view.all.label' | translate}} {{selectedClass.data.instancesCount | number}} {{'instances.in.sparql' | translate}}</a></p>
+					<p ng-switch-when="1">
+						<a class="btn btn-link px-0"
+						   href=''
+						   ng-click="goToResourceView()"
+						   guide-selector="instances-count">{{'view.instance.in.sparql.label' | translate}}
+						</a>
+					</p>
+                    <p ng-switch-default>
+						<a class="btn btn-link px-0"
+						   href=''
+						   ng-click="goToResourceView()"
+						   guide-selector="instances-count">{{'view.all.label' | translate}} {{selectedClass.data.instancesCount | number}} {{'instances.in.sparql' | translate}}
+						</a>
+					</p>
                 </div>
 
                 <div class="ot-loader ot-main-loader" onto-loader size="100" ng-show="instancesLoader"></div>


### PR DESCRIPTION
## What
- Extended the dropdown component with the ability to configure whether it should automatically close when the user clicks outside of it.
- Fixed the "View all <count> instances in SPARQL" link in the right-hand Class Hierarchy info sidebar, which wasn't working.
- Updated all guide steps to function correctly in the migration branch.

## Why
- When the guide is on a step that requires selecting a repository, the dropdown must remain open even when the user clicks elsewhere. Otherwise, the dropdown closes and breaks the guide flow.
- The link used a href attribute for navigation, which did not work correctly with the Single-SPA setup.

## How
- When the "Select repository" guide step is active, the dropdown auto-close behavior is disabled. Once the step is completed, auto-close is re-enabled.
- Refactored the link to use ng-click. When the user clicks the link, the bound function uses $location to navigate to the resource view.

## Testing
Fixed and re-enabled all previously skipped tests.

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
