### PR TITLE
GDB-12477: Fix ACL management view overflow

### DIFF
--- a/packages/root-config/src/microfrontend-layout.html
+++ b/packages/root-config/src/microfrontend-layout.html
@@ -8,7 +8,7 @@
     -->
 
     <onto-layout>
-        <main slot="main">
+        <main slot="main" class="page-content">
             <route path="new-view">
                 <application name="@ontotext/workbench"></application>
             </route>

--- a/packages/shared-components/src/components/onto-footer/onto-footer.scss
+++ b/packages/shared-components/src/components/onto-footer/onto-footer.scss
@@ -3,4 +3,5 @@
 }
 .footer-component {
   padding-left: var(--main-content-rl-padding);
+  height: 1.875rem;
 }


### PR DESCRIPTION
## What
Set `page-content` class on the main slot of the layout

## Why
Something caused an overflow and a scroll bar to be visible. Added a `page-content` class as it is in the legacy workbench.

## How
- added `page-content` class to main slot in the layout
- set footer height to 30px as it is in the legacy

## Testing
n/A

## Screenshots
![image](https://github.com/user-attachments/assets/66157703-6c10-48fa-bec0-8872bb9d9ed2)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
