### PR TITLE
GDB-12504: Fix Ontop properties link to open in new tab

### DIFF
--- a/packages/legacy-workbench/src/js/angular/repositories/templates/ontop-repo.html
+++ b/packages/legacy-workbench/src/js/angular/repositories/templates/ontop-repo.html
@@ -165,6 +165,7 @@
         </div>
         <div class="col-xs-12 col-md-4">
             <a class="uri"
+               target="_blank"
                href="{{ontopProperiesLink}}"
                style="text-decoration: underline;">
                 {{'ontop.repo.properties.configuration.link' | translate}}


### PR DESCRIPTION
## What
Fix Ontop properties link to open in new tab

## Why
The legacy would open the link in a new tab even without `target="_blank"`

## How
- added `target="_blank"`

## Testing
n/a

## Screenshots
n/a

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
