### PR TITLE
GDB-12518: Fix class hierarchy view styles leak

### DIFF
--- a/packages/legacy-workbench/src/css/rdf-class-hierarchy-labels.css
+++ b/packages/legacy-workbench/src/css/rdf-class-hierarchy-labels.css
@@ -1,4 +1,4 @@
-.label {
+.rdf-class-hierarchy .label {
   	font: 20px var(--main-font);
   	text-anchor: middle;
   	alignment-baseline: middle;
@@ -7,7 +7,7 @@
   	fill: white;
 }
 
-.child-label {
+.rdf-class-hierarchy .child-label {
     text-shadow: 0 0 0.5em white;
     fill: #606060;
 }


### PR DESCRIPTION
## What
Fixed class hierarchy view styles leak to other components, by making them more specific

## Why
Since there is no encapsulation adn classnames where very common, they leaked into other components (repository info popover)

## How
- made classes more specific

## Testing
n/a

## Screenshots
![image](https://github.com/user-attachments/assets/ecb69518-dffa-43a9-9b42-725a81046724)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
