### PR TITLE
(cherry-pick) GDB-12159 - Fix cookie banner flicker on refresh

### DIFF
--- a/src/js/angular/controllers.js
+++ b/src/js/angular/controllers.js
@@ -186,6 +186,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
     $scope.productInfo = productInfo;
     $scope.guidePaused = 'true' === LocalStorageAdapter.get(GUIDE_PAUSE);
     $scope.startGuideAfterSecurityInit = true;
+    let licenseIsSet = false;
 
     $scope.hideRdfResourceSearch = false;
     $scope.showRdfResourceSearch = () => {
@@ -975,8 +976,12 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
                     setTimeout(() => $scope.getSavedQueries(), 500);
                 });
             $licenseService.checkLicenseStatus()
-                .then(() => TrackingService.applyTrackingConsent())
+                .then(() => {
+                    licenseIsSet = true;
+                    TrackingService.applyTrackingConsent()
+                })
                 .catch((error) => {
+                    licenseIsSet = false;
                     const msg = getError(error.data, error.status);
                     toastr.error(msg, $translate.instant('common.error'));
                 });
@@ -990,6 +995,9 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
     });
 
     $scope.isTrackingAllowed = function () {
+        if (licenseIsSet) {
+            return;
+        }
         return TrackingService.isTrackingAllowed();
     };
 


### PR DESCRIPTION
## What
When the page loads, if the user has accepted cookies, the banner will not show on the screen at all.

## Why
The check for allowed tracking would return before the license was set, causing the cookie banner would appear. Then after the tracking consent returned the correct state based on the license, the banner would disappear.

## How
I delay the tracking consent, if no license is set.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
