### PR TITLE
GDB-11243 - fix context when using this keyword

### DIFF
--- a/src/js/angular/core/services/jwt-auth.service.js
+++ b/src/js/angular/core/services/jwt-auth.service.js
@@ -261,7 +261,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                         enabled: enabled ? 'true' : 'false',
                         authorities: authorities,
                         appSettings: appSettings
-                    }).then(function () {
+                    }).then(() => {
                         this.freeAccess = enabled;
                         if (updateFreeAccess) {
                             toastr.success($translate.instant('jwt.auth.free.access.updated.msg'));

--- a/test-cypress/integration-flaky/setup/users-and-access/security-and-free-access.spec.js
+++ b/test-cypress/integration-flaky/setup/users-and-access/security-and-free-access.spec.js
@@ -1,0 +1,53 @@
+import {UserAndAccessSteps} from "../../../steps/setup/user-and-access-steps";
+import {RepositoriesStubs} from "../../../stubs/repositories/repositories-stubs";
+import {ModalDialogSteps} from "../../../steps/modal-dialog-steps";
+import {ToasterSteps} from "../../../steps/toaster-steps";
+
+const DEFAULT_ADMIN_PASSWORD = "root";
+// Moved out of the standard test suite, because Cypress can't verify Free Access is ON in CI
+describe('Security and Free Access', () => {
+    beforeEach(() => {
+        UserAndAccessSteps.visit();
+        cy.window();
+        // Users table should be visible
+        UserAndAccessSteps.getUsersTable().should('be.visible');
+    });
+
+    afterEach(() => {
+        UserAndAccessSteps.visit();
+        UserAndAccessSteps.getToggleSecurityCheckbox()
+            .then(($toggle) => {
+                if ($toggle.prop('checked')) {
+                    // Uncheck the security toggle button at the end of each test, if it is checked
+                    UserAndAccessSteps.toggleSecurity();
+                }
+            });
+    });
+
+    it('should toggle free access after Admin has logged in', () => {
+        // Given I have available repositories to allow Free Access for
+        RepositoriesStubs.stubRepositories();
+        // When I enable security
+        UserAndAccessSteps.toggleSecurity();
+        // When I log in as an Admin
+        UserAndAccessSteps.loginWithUser("admin", DEFAULT_ADMIN_PASSWORD);
+        // Then the page should load
+        UserAndAccessSteps.getSplashLoader().should('not.be.visible');
+        UserAndAccessSteps.getUsersTable().should('be.visible');
+        // The Free Access toggle should be OFF
+        UserAndAccessSteps.getFreeAccessSwitchInput().should('not.be.checked');
+        // When I toggle Free Access ON
+        UserAndAccessSteps.toggleFreeAccess();
+        // Then I click OK in the modal
+        ModalDialogSteps.clickOKButton();
+        // Then the toggle button should be ON
+        UserAndAccessSteps.getFreeAccessSwitchInput().should('be.checked');
+        // And I should see a success message
+        ToasterSteps.verifySuccess('Free access has been enabled.');
+        UserAndAccessSteps.getUsersTable().should('be.visible');
+        // When I toggle Free Access OFF
+        UserAndAccessSteps.toggleFreeAccess();
+        // Then I should see a success message
+        ToasterSteps.verifySuccess('Free access has been disabled.');
+    });
+});

--- a/test-cypress/steps/modal-dialog-steps.js
+++ b/test-cypress/steps/modal-dialog-steps.js
@@ -39,6 +39,10 @@ export class ModalDialogSteps {
         ModalDialogSteps.getConfirmButton().click();
     }
 
+    static clickOKButton() {
+        ModalDialogSteps.getDialogFooter().find('.btn-primary').click();
+    }
+
     static confirm() {
         ModalDialogSteps.getConfirmButton().click();
     }

--- a/test-cypress/steps/setup/user-and-access-steps.js
+++ b/test-cypress/steps/setup/user-and-access-steps.js
@@ -23,8 +23,23 @@ export class UserAndAccessSteps {
         return cy.get('#toggle-security span.switch');
     }
 
+    static getToggleSecurityCheckbox() {
+        return cy.get('#toggle-security input[type="checkbox"]');
+    }
     static toggleSecurity() {
         this.getToggleSecuritySwitch().click();
+    }
+
+    static getFreeAccessSwitchInput() {
+        return cy.get('#toggle-freeaccess .switch input');
+    }
+
+    static getFreeAccessSwitch() {
+        return cy.get('#toggle-freeaccess span.switch');
+    }
+
+    static toggleFreeAccess() {
+        this.getFreeAccessSwitch().click();
     }
 
     static getSecuritySwitchLabel() {


### PR DESCRIPTION
## What
When toggling `Free Access` ON, while `Security` is ON, the user will not get an error.

## Why
The error, which appeared was due to the context being undefined when trying to set `freeAccess`.

## How
I used an arrow function syntax, in order to preserve the context.

## Testing
I added a test.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
