### PR TITLE
feat(GDB-12506): Refactor tooltip update to use component lifecycle

### DIFF
--- a/packages/shared-components/src/utils/tooltip-util.ts
+++ b/packages/shared-components/src/utils/tooltip-util.ts
@@ -68,7 +68,7 @@ export class TooltipUtil {
    */
   static destroyTooltip(target: HTMLElement): void {
     const tip = TooltipUtil.getTooltipInstance(target);
-    if (tip) {
+    if (tip && !tip.state?.isDestroyed) {
       tip.destroy();
     }
   }


### PR DESCRIPTION
## WHAT:
Refactored the `onto-dropdown` component to handle tooltip content updates for the dropdown button in a reactive way

## WHY:
The previous implementation directly manipulated the DOM from within an event handler (`onMouseEnter`) to update the tooltip content

## HOW:
The logic for updating the tooltip has been moved from the event handler to the `componentDidUpdate` lifecycle hook.
1.  A reference to the dropdown button element is now captured using `ref` and stored in a class property.
2.  The `onMouseEnter` handler's sole responsibility is now to calculate the new tooltip content and update the component's state via `@State() buttonTooltipContent`.
3.  When the state changes, Stencil re-renders the component. Immediately after the render, `componentDidUpdate` is called.
4.  Inside `componentDidUpdate`, the imperative `TooltipUtil` functions are called to update or destroy the tooltip instance on the referenced button element, ensuring the tooltip is always in sync with the component's state.

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
