### PR TITLE
GDB-12417: Fix navigation menu to highlight item

### DIFF
--- a/packages/legacy-workbench/src/js/angular/graphexplore/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/plugin.js
@@ -84,7 +84,11 @@ PluginRegistry.add('main.menu', {
             parent: 'Explore',
             children: [{
                 href: 'graphs-visualizations/config/save',
-                children: []
+                children: [
+                    {
+                        href: 'graphs-visualizations/config/save/*',
+                    }
+                ]
             }],
             guideSelector: 'sub-menu-visual-graph',
             testSelector: 'sub-menu-visual-graph'

--- a/packages/legacy-workbench/src/js/angular/jdbc/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/jdbc/plugin.js
@@ -26,6 +26,19 @@ PluginRegistry.add('route', [
 
 PluginRegistry.add('main.menu', {
     'items': [
-        {label: 'JDBC', labelKey: 'menu.jdbc.label', href: 'jdbc', order: 50, parent: 'Setup', role: "IS_AUTHENTICATED_FULLY", guideSelector: 'sub-menu-jdbs'}
+        {
+            label: 'JDBC',
+            labelKey: 'menu.jdbc.label',
+            href: 'jdbc',
+            order: 50,
+            parent: 'Setup',
+            role: "IS_AUTHENTICATED_FULLY",
+            guideSelector: 'sub-menu-jdbs',
+            children: [
+                {
+                    href: 'jdbc/configuration/create'
+                }
+            ]
+        }
     ]
 });

--- a/packages/legacy-workbench/src/js/angular/repositories/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/plugin.js
@@ -49,11 +49,19 @@ PluginRegistry.add('main.menu', {
             order: 1,
             role: 'ROLE_REPO_MANAGER',
             parent: 'Setup',
-            children: [{
-                href: 'repository/create',
-                children: []
-            }],
-            guideSelector: 'sub-menu-repositories'
-        }
-    ]
+            children: [
+                {
+                    href: 'repository/create',
+                    children: [
+                        {
+                            href: 'repository/create/*',
+                        }
+                    ]
+                },
+                {
+                    href: 'repository/edit/*'
+                }
+            ]
+            , guideSelector: 'sub-menu-repositories'
+        }]
 });

--- a/packages/legacy-workbench/src/js/angular/security/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/security/plugin.js
@@ -74,9 +74,14 @@ PluginRegistry.add('route', [
 PluginRegistry.add('main.menu', {
     'items': [
         {
-            label: 'Users and Access', labelKey: 'menu.users.and.access.label', href: 'users', order: 2, parent: 'Setup', role: 'ROLE_ADMIN',
+            label: 'Users and Access',
+            labelKey: 'menu.users.and.access.label',
+            href: 'users',
+            order: 2,
+            parent: 'Setup',
+            role: 'ROLE_ADMIN',
             children: [{
-                href: 'user/create',
+                href: 'user/*',
                 children: []
             }],
             guideSelector: 'sub-menu-user-and-access'

--- a/packages/legacy-workbench/src/js/angular/sparql-template/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/sparql-template/plugin.js
@@ -26,6 +26,19 @@ PluginRegistry.add('route', [
 
 PluginRegistry.add('main.menu', {
     'items': [
-        {label: 'SPARQL Templates', labelKey: 'menu.sparql.template.label', href: 'sparql-templates', order: 51, parent: 'Setup', role: "IS_AUTHENTICATED_FULLY", guideSelector: 'sub-menu-sparql-templates'}
+        {
+            label: 'SPARQL Templates',
+            labelKey: 'menu.sparql.template.label',
+            href: 'sparql-templates',
+            order: 51,
+            parent: 'Setup',
+            role: "IS_AUTHENTICATED_FULLY",
+            guideSelector: 'sub-menu-sparql-templates',
+            children: [
+                {
+                    href: 'sparql-template/create'
+                }
+            ]
+        }
     ]
 });

--- a/packages/shared-components/src/components/onto-navbar/navbar-service.ts
+++ b/packages/shared-components/src/components/onto-navbar/navbar-service.ts
@@ -18,7 +18,7 @@ export class NavbarService {
           if (navbarModel.hasParent(item.label)) {
             console.warn("Doubled parent definition: ", item);
           } else {
-            navbarModel.addItem(this.toMenuItemModel(item, item.children, undefined));
+            navbarModel.addItem(this.toMenuItemModel(item, undefined, item.children));
           }
         });
     });
@@ -32,12 +32,12 @@ export class NavbarService {
           const topLevelItem = navbarModel.getTopLevelItem(item.parent)
           // Some submenu items in the external menu model have children which is unusual.
           // I'm not sure if and where these children are used. For now, I'm ignoring them.
-          topLevelItem?.addChildren(this.toMenuItemModel(item, [], topLevelItem));
+          topLevelItem?.addChildren(this.toMenuItemModel(item, topLevelItem, item.children));
         });
     });
   }
 
-  private static toMenuItemModel(item: ExternalMenuItemModel, children: ExternalMenuItemModel[] = [], parent: NavbarItemModel): NavbarItemModel {
+  private static toMenuItemModel(item: ExternalMenuItemModel, parent: NavbarItemModel, children: ExternalMenuItemModel[] = []): NavbarItemModel {
     const itemModel = new NavbarItemModel({
       label: item.label,
       labelKey: item.labelKey,
@@ -50,11 +50,13 @@ export class NavbarService {
       icon: item.icon,
       guideSelector: item.guideSelector,
       hasParent: !!parent,
+      parentModel: parent,
       parent: item.parent,
       selected: false,
       testSelector: item.testSelector,
     });
-    itemModel.children = children.map((childrenItem) => this.toMenuItemModel(childrenItem, childrenItem.children, itemModel));
+    const childrenModels = children.map((childrenItem) => this.toMenuItemModel(childrenItem, itemModel, childrenItem.children));
+    itemModel.addChildren(...childrenModels);
     return itemModel;
   };
 }

--- a/packages/shared-components/src/components/onto-navbar/test/navbar-model.spec.tsx
+++ b/packages/shared-components/src/components/onto-navbar/test/navbar-model.spec.tsx
@@ -104,7 +104,7 @@ describe('NavbarModel', () => {
       itemWithChildren.open = true;
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([new NavbarItemModel(item1), itemWithChildren]);
 
       expect(model.isParentOpened(child2)).toBeTruthy();
@@ -115,7 +115,7 @@ describe('NavbarModel', () => {
       itemWithChildren.open = false;
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([new NavbarItemModel(item1), itemWithChildren]);
 
       expect(model.isParentOpened(child2)).toBeFalsy();
@@ -127,7 +127,7 @@ describe('NavbarModel', () => {
       const itemWithChildren = new NavbarItemModel(item2);
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([new NavbarItemModel(item1), itemWithChildren]);
 
       expect(model.getTopLevelItem('Explore')).toEqual(itemWithChildren);
@@ -137,7 +137,7 @@ describe('NavbarModel', () => {
       const itemWithChildren = new NavbarItemModel(item2);
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([new NavbarItemModel(item1), itemWithChildren]);
 
       expect(model.getTopLevelItem('Settings')).toBeUndefined();
@@ -150,7 +150,7 @@ describe('NavbarModel', () => {
       const itemWithChildren = new NavbarItemModel(item2);
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([topItem1, itemWithChildren]);
 
       expect(model.getParentItem(child2)).toEqual(itemWithChildren);
@@ -160,7 +160,7 @@ describe('NavbarModel', () => {
       const itemWithChildren = new NavbarItemModel(item2);
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([new NavbarItemModel(item1), itemWithChildren]);
 
       expect(model.getParentItem(new NavbarItemModel(item6))).toBeUndefined();
@@ -173,7 +173,7 @@ describe('NavbarModel', () => {
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
       child2.selected = true;
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([new NavbarItemModel(item1), itemWithChildren]);
 
       model.deselectAll();
@@ -187,7 +187,7 @@ describe('NavbarModel', () => {
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
       child2.open = true;
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([new NavbarItemModel(item1), itemWithChildren]);
 
       model.closeAll();
@@ -224,7 +224,7 @@ describe('NavbarModel', () => {
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
       child2.selected = true;
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([new NavbarItemModel(item1), itemWithChildren]);
 
       expect(model.hasSelectedSubmenu(itemWithChildren)).toBeTruthy();
@@ -234,9 +234,8 @@ describe('NavbarModel', () => {
       const itemWithChildren = new NavbarItemModel(item2);
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([new NavbarItemModel(item1), itemWithChildren]);
-
       expect(model.hasSelectedSubmenu(itemWithChildren)).toBeFalsy();
     });
 
@@ -245,7 +244,7 @@ describe('NavbarModel', () => {
       const itemWithChildren = new NavbarItemModel(item2);
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren]);
 
       expect(model.hasSelectedSubmenu(itemWithoutChildren)).toBeFalsy();
@@ -260,7 +259,7 @@ describe('NavbarModel', () => {
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
       child2.selected = true;
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren]);
 
       model.closeOpened();
@@ -274,7 +273,7 @@ describe('NavbarModel', () => {
       itemWithChildren.open = true;
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren]);
 
       model.closeOpened();
@@ -287,7 +286,7 @@ describe('NavbarModel', () => {
       const itemWithChildren = new NavbarItemModel(item2);
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren]);
 
       model.closeOpened();
@@ -303,9 +302,9 @@ describe('NavbarModel', () => {
       itemWithChildren1.open = true;
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren1.children = [child1, child2];
+      itemWithChildren1.addChildren(child1, child2);
       const itemWithChildren2 = new NavbarItemModel(item6);
-      itemWithChildren2.children = [new NavbarItemModel(item5), new NavbarItemModel(item6)];
+      itemWithChildren2.addChildren(new NavbarItemModel(item5),new NavbarItemModel(item6));
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren1, itemWithChildren2]);
 
       model.open(itemWithChildren2);
@@ -321,10 +320,10 @@ describe('NavbarModel', () => {
       itemWithChildren1.open = true;
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren1.children = [child1, child2];
+      itemWithChildren1.addChildren(child1, child2);
       const itemWithChildren2 = new NavbarItemModel(item6);
       itemWithChildren2.open = true;
-      itemWithChildren2.children = [new NavbarItemModel(item5), new NavbarItemModel(item6)];
+      itemWithChildren2.addChildren(new NavbarItemModel(item5), new NavbarItemModel(item6));
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren1, itemWithChildren2]);
 
       model.closeOtherParents(child1);
@@ -340,7 +339,7 @@ describe('NavbarModel', () => {
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
       child2.selected = true;
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren]);
 
       model.highlightSelected();
@@ -352,7 +351,7 @@ describe('NavbarModel', () => {
       const itemWithChildren = new NavbarItemModel(item2);
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren]);
 
       model.highlightSelected();
@@ -368,7 +367,7 @@ describe('NavbarModel', () => {
       itemWithChildren.open = true;
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren]);
 
       model.unhighlightSelected();
@@ -381,7 +380,7 @@ describe('NavbarModel', () => {
       itemWithChildren.selected = true;
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren]);
 
       model.unhighlightSelected();
@@ -407,7 +406,7 @@ describe('NavbarModel', () => {
       itemWithChildren.selected = true;
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren]);
 
       expect(model.getSelectedItem()).toEqual(itemWithChildren);
@@ -419,7 +418,7 @@ describe('NavbarModel', () => {
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
       child2.selected = true;
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren]);
 
       expect(model.getSelectedItem()).toEqual(child2);
@@ -432,7 +431,7 @@ describe('NavbarModel', () => {
       const itemWithChildren = new NavbarItemModel(item2);
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren]);
 
       model.initSelected('import');
@@ -444,7 +443,7 @@ describe('NavbarModel', () => {
       const itemWithChildren = new NavbarItemModel(item2);
       const child1 = new NavbarItemModel(item3);
       const child2 = new NavbarItemModel(item4);
-      itemWithChildren.children = [child1, child2];
+      itemWithChildren.addChildren(child1, child2);
       const model = buildModelFromInstances([itemWithoutChildren, itemWithChildren]);
 
       model.initSelected('relationships');

--- a/packages/shared-components/src/components/onto-navbar/test/navbar-service.spec.tsx
+++ b/packages/shared-components/src/components/onto-navbar/test/navbar-service.spec.tsx
@@ -77,7 +77,7 @@ describe('NavbarService', () => {
       const navbarModel = NavbarService.map(mockExternalMenuModel);
       expect(navbarModel).toBeInstanceOf(NavbarModel);
       const actual = new NavbarModel();
-      actual.addItem(new NavbarItemModel({
+      const importItem = new NavbarItemModel({
         label: 'Import',
         labelKey: 'common.import',
         href: 'import',
@@ -89,8 +89,8 @@ describe('NavbarService', () => {
         hasParent: false,
         selected: false,
         shouldShow: true
-      }));
-      actual.addItem(new NavbarItemModel({
+      });
+      const exploreItem = new NavbarItemModel({
         label: 'Explore',
         labelKey: 'menu.explore.label',
         href: '#',
@@ -101,45 +101,48 @@ describe('NavbarService', () => {
         hasParent: false,
         selected: false,
         shouldShow: true,
-        children: [
-          new NavbarItemModel({
-            label: 'Class hierarchy',
-            labelKey: 'menu.class.hierarchy.label',
-            href: 'hierarchy',
-            order: 1,
-            parent: 'Explore',
-            guideSelector: 'menu-class-hierarchy',
-            children: [],
-            hasParent: true,
-            selected: false,
-            shouldShow: true
-          }),
-          new NavbarItemModel({
-            label: 'Class relationships',
-            labelKey: 'menu.class.relationships.label',
-            href: 'relationships',
-            order: 2,
-            parent: 'Explore',
-            guideSelector: 'sub-menu-class-relationships',
-            children: [],
-            hasParent: true,
-            selected: false,
-            shouldShow: true
-          }),
-          new NavbarItemModel({
-            label: 'Visual graph',
-            labelKey: 'visual.graph.label',
-            href: 'graphs-visualizations',
-            order: 5,
-            parent: 'Explore',
-            children: [],
-            guideSelector: 'sub-menu-visual-graph',
-            hasParent: true,
-            selected: false,
-            shouldShow: true
-          })
-        ]
-      }));
+        children: []
+      });
+      exploreItem.addChildren(
+        new NavbarItemModel({
+          label: 'Class hierarchy',
+          labelKey: 'menu.class.hierarchy.label',
+          href: 'hierarchy',
+          order: 1,
+          parent: 'Explore',
+          guideSelector: 'menu-class-hierarchy',
+          children: [],
+          hasParent: true,
+          selected: false,
+          shouldShow: true
+        }),
+        new NavbarItemModel({
+          label: 'Class relationships',
+          labelKey: 'menu.class.relationships.label',
+          href: 'relationships',
+          order: 2,
+          parent: 'Explore',
+          guideSelector: 'sub-menu-class-relationships',
+          children: [],
+          hasParent: true,
+          selected: false,
+          shouldShow: true
+        }),
+        new NavbarItemModel({
+          label: 'Visual graph',
+          labelKey: 'visual.graph.label',
+          href: 'graphs-visualizations',
+          order: 5,
+          parent: 'Explore',
+          children: [],
+          guideSelector: 'sub-menu-visual-graph',
+          hasParent: true,
+          selected: false,
+          shouldShow: true
+        })
+      )
+      actual.addItem(importItem);
+      actual.addItem(exploreItem);
       expect(navbarModel).toEqual(actual)
     });
   });


### PR DESCRIPTION
## What
Fixed menu to highlight items when their children are selected. Also added logic to match against wildcard hrefs with changing parameters

## Why
Menu was left unselected when navigating to any child route

## How
- added parent model to the `NavbarItemModel`
- added methods for adding children and removed the setter to properly add them
- added/changed methods in `NavbarModel` to do stuff recursively
- added logic to match against a wildcard href containing `*`
- changed method in the `NavbarService` to include `ExternalMenuItemModel` children and to set the parent model
- changed some plugin definitions to include correct children
- amended tests to use new methods -

## Testing
fixed

## Screenshots
![image](https://github.com/user-attachments/assets/5a4cb00d-aea6-4b82-bedf-b8d4ef4733a4)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
