### PR TITLE
GDB-12535 fix cluster config tabs behavior to prevent redirect to home page on click

### DIFF
--- a/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/cluster-configuration.html
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/cluster-configuration.html
@@ -6,17 +6,17 @@
 
     <ul class="nav nav-tabs configuration-tabs">
         <li class="properties-tab nav-item">
-            <a href="#" class="nav-link"
+            <a href class="nav-link"
                ng-click="switchTab($event, CONFIGURATION_TABS.PROPERTIES)"
                ng-class="{'active': activeTab === CONFIGURATION_TABS.PROPERTIES}"><span>{{'cluster_management.cluster_configuration_properties.label' | translate}}</span><i class="text-primary icon-exclamation" ng-if="dirtyScope.has(ACL_SCOPE.STATEMENT)"></i></a>
         </li>
         <li class="clear-graph-tab nav-item">
-            <a href="#" class="nav-link"
+            <a href class="nav-link"
                ng-click="switchTab($event, CONFIGURATION_TABS.NODES)"
                ng-class="{'active': activeTab === CONFIGURATION_TABS.NODES}"><span>{{'cluster_management.cluster_configuration_nodes.label' | translate}}</span><i class="text-primary icon-exclamation" ng-if="dirtyScope.has(ACL_SCOPE.CLEAR_GRAPH)"></i></a>
         </li>
         <li class="clear-graph-tab nav-item">
-            <a href="#" class="nav-link"
+            <a href class="nav-link"
                ng-click="switchTab($event, CONFIGURATION_TABS.MULTI_REGION)"
                ng-class="{'active': activeTab === CONFIGURATION_TABS.MULTI_REGION}"><span>{{'cluster_management.cluster_configuration_multi_region.label' | translate}}</span><i class="text-primary icon-exclamation" ng-if="dirtyScope.has(ACL_SCOPE.CLEAR_GRAPH)"></i></a>
         </li>


### PR DESCRIPTION
## What
Fix cluster config tabs behavior to prevent redirect to home page on click.

## Why
Clicking on a tab is expected to open the tab content and not to redirect to some other page.

## How
The tabs in cluster config dialog are implemented as anchor tags `a` having `href="#"` attribute and a click handler dealing with the tab switching. The href=# attribute triggers the single-spa router and it performs redirect.

## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
