### PR TITLE
GDB-12543: Sidebar dropdowns briefly not responding after clicking import

### DIFF
--- a/packages/shared-components/src/components/onto-navbar/navbar-model.ts
+++ b/packages/shared-components/src/components/onto-navbar/navbar-model.ts
@@ -395,7 +395,19 @@ export class NavbarItemModel {
       this.addChild(child);
     });
   }
-
+  
+  /**
+   * Determines whether the current menu item has submenus.
+   * In this context, items with a href value of '#' are treated as parent items
+   * and are expected to have submenus. This behavior is due to the fact that
+   * all top-level items are registered with href set to '#' when added to the PluginRegistry.
+   *
+   * @returns {boolean} True if the item is a parent (has submenus), otherwise false.
+   */
+  hasSubmenus(): boolean {
+    return this._href === '#';
+  }
+  
   get parent(): string {
     return this._parent;
   }

--- a/packages/shared-components/src/components/onto-navbar/onto-navbar.tsx
+++ b/packages/shared-components/src/components/onto-navbar/onto-navbar.tsx
@@ -19,6 +19,7 @@ import {
   EventName,
   EventService, getCurrentRoute, isHomePage,
   navigateTo, openInNewTab, ProductInfo, ProductInfoContextService,
+  navigate,
   ServiceProvider,
   SubscriptionList, UriUtil
 } from '@ontotext/workbench-api';
@@ -109,12 +110,11 @@ export class OntoNavbar {
       openInNewTab(externalLink);
       return;
     }
-    // Navigate to respective url without reloading if possible.
-    // #navigateToUrl function is exposed by the root-config and comes from the single-spa.
-    // It's currently provided this way in order to prevent components to depend
-    // from single-spa. Although this is not the best approach, it'd work for now.
-    // @ts-ignore
-    window.singleSpa.navigateToUrl(menuItem.href);
+    
+    // Skip navigation when the selected item is a parent menu because it has no associated navigation.
+    if (!menuItem.hasSubmenus()) {
+      navigate(menuItem.href);
+    }
 
     if (menuItem.children.length) {
       if (!menuItem.open) {


### PR DESCRIPTION
## What
The menu items with submenus do not respond the first time after opening the Import view.

Steps to reproduce:
1. Open the Import view
2. Click on a menu item with submenus

## Why
When clicking on a menu item that has submenus, we expect the submenu to be displayed instead of navigating to another page. However, in the onto-navbar component, we always navigate to the href of the selected item, regardless of whether it's a parent or not. All parent menu items have "#" as their href, and this somehow (possibly due to single-spa) breaks the expected functionality.

## How
Updated the logic to skip navigation if the clicked item is a menu with submenus.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
