### PR TITLE
GDB-12546: Nodes in Cluster Configuration are underlined without mouse hover

### DIFF
--- a/packages/root-config/src/styles/partials/anchor/_anchor.scss
+++ b/packages/root-config/src/styles/partials/anchor/_anchor.scss
@@ -1,7 +1,7 @@
 a {
-  &:hover:not(.btn, .nav-link, .menu-element-root),
-  &:active:not(.btn, .nav-link, .menu-element-root),
-  &[href^="http"],
+  &:hover:not(.btn, .nav-link, .menu-element-root, .nodes-list .data-value),
+  &:active:not(.btn, .nav-link, .menu-element-root .nodes-list .data-value),
+  &[href^="http"]:not(.nodes-list .data-value),
   &[href^="http"]:hover,
   &[href^="http"]:active {
     text-decoration-line: underline !important;


### PR DESCRIPTION
## What
Links in the Nodes tab of the Cluster Management view are underlined even when not hovered.

## Why
A CSS declaration sets text-decoration, which overrides the styles defined in the legacy Workbench.

## How
The CSS rule was updated to exclude links in the Nodes tab, preserving the expected appearance.

## Testing
N/A

## Screenshots

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/7f846645-5a3b-4fcf-98fb-3eb08bb61d55) | ![After](https://github.com/user-attachments/assets/ebf514bc-a40a-42ad-829b-29fb287c9716) |





## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
