### PR TITLE
GDB-12546: fixing anchor selector

### DIFF
--- a/packages/root-config/src/styles/partials/anchor/_anchor.scss
+++ b/packages/root-config/src/styles/partials/anchor/_anchor.scss
@@ -1,6 +1,6 @@
 a {
   &:hover:not(.btn, .nav-link, .menu-element-root, .nodes-list .data-value),
-  &:active:not(.btn, .nav-link, .menu-element-root .nodes-list .data-value),
+  &:active:not(.btn, .nav-link, .menu-element-root, .nodes-list .data-value),
   &[href^="http"]:not(.nodes-list .data-value),
   &[href^="http"]:hover,
   &[href^="http"]:active {


### PR DESCRIPTION
## What
Fixes an incorrect anchor selector.

## Why
The [MR](https://github.com/Ontotext-AD/graphdb-workbench/pull/2106) that addresses GDB-12546 introduced an incorrect CSS selector.

## How
Corrects the CSS rule.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
