### PR TITLE
GDB-12507: Fix user menu color when opened

### DIFF
--- a/packages/shared-components/src/components/onto-user-menu/onto-user-menu.scss
+++ b/packages/shared-components/src/components/onto-user-menu/onto-user-menu.scss
@@ -20,11 +20,7 @@
     white-space: nowrap;
     place-items: center;
     transition: all 0.15s ease-out;
-
-    & .username {
-      padding: 0 5px;
-      color: var(--secondary-color);
-    }
+    color: var(--secondary-color);
 
     &:hover {
       background-color: #d4d4d4;
@@ -53,6 +49,10 @@
           transform: scale(1.2);
         }
       }
+    }
+
+    .username {
+      padding: 0 5px;
     }
 
     i {


### PR DESCRIPTION
## What
Set user menu color to white when opened

## Why
For consistency

## How
- extracted color from `.username` class so it does not override the white color

## Testing
n/a

## Screenshots
![image](https://github.com/user-attachments/assets/a2fa78f3-45f8-4dcd-8854-d5d0b5812802)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
