### PR TITLE
GDB-12533: Fix repository selector popover blocking UI

### DIFF
--- a/packages/shared-components/src/components/onto-dropdown/onto-dropdown.tsx
+++ b/packages/shared-components/src/components/onto-dropdown/onto-dropdown.tsx
@@ -218,10 +218,11 @@ export class OntoDropdown {
   private toggleButtonClickHandler() {
     return (event: MouseEvent) => {
       const target = event.currentTarget as HTMLElementWithTooltip;
-      if (target?.hideTooltip) {
-        target.hideTooltip();
-      }
       this.toggleComponent();
+      if (target?.hideTooltip) {
+        // in a timeout so that the state is updated before the tooltip is hidden
+        setTimeout(() => target.hideTooltip(), 50)
+      }
     }
   }
 


### PR DESCRIPTION
## What
Fix repository selector popover blocking repository selection

## Why
The repo info popover is closed when the dropdown is clicked, so that it does not block the repository selection. There are some cases where this does not happen because of retriggering the tooltip.

## How
- added a timeout with a minimal delay of 50ms so that the state of the repository selector is updated correctly before retriggering the popover

## Testing
n/a

## Screenshots
![image](https://github.com/user-attachments/assets/43b472bb-0699-4913-a58a-3fbbcab42ba9)
![image](https://github.com/user-attachments/assets/da2faada-756d-488d-821a-62de92b2f7b0)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
