### PR TITLE
GDB-12536: Fix repository size info on home page

### DIFF
--- a/e2e-tests/e2e-legacy/home/home-page-with-selected-repository.spec.js
+++ b/e2e-tests/e2e-legacy/home/home-page-with-selected-repository.spec.js
@@ -42,6 +42,9 @@ describe('Home page: with selected repository', () => {
     ActiveRepositoryWidgetSteps.getWidget().should('be.visible');
     ActiveRepositoryWidgetSteps.getActiveRepository().should('contain', repositoryId);
     ActiveRepositoryWidgetSteps.getWidgetName().should('contain', 'Active repository');
+    ActiveRepositoryWidgetSteps.getTotalStatements().should('contain', 70);
+    ActiveRepositoryWidgetSteps.getInferredStatements().should('contain', 70);
+    ActiveRepositoryWidgetSteps.getExplicitStatements().should('contain', 0);
   });
 
   it('should not render repository errors widget', () => {

--- a/e2e-tests/steps/widgets/active-repository-widget-steps.js
+++ b/e2e-tests/steps/widgets/active-repository-widget-steps.js
@@ -10,4 +10,16 @@ export class ActiveRepositoryWidgetSteps {
     static getActiveRepository() {
         return this.getWidget().find('.repo-info-home');
     }
+
+    static getTotalStatements() {
+        return this.getWidget().find('.total-statements .data-value');
+    }
+
+    static getExplicitStatements() {
+        return this.getWidget().find('.explicit-statements .data-value');
+    }
+
+    static getInferredStatements() {
+        return this.getWidget().find('.inferred-statements .data-value');
+    }
 }

--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -28,7 +28,7 @@ import 'angularjs-slider/dist/rzslider.min';
 import {debounce} from "lodash";
 import {DocumentationUrlResolver} from "./utils/documentation-url-resolver";
 import {NamespacesListModel} from "./models/namespaces/namespaces-list";
-import {RepositoryContextService, EventService, EventName, ServiceProvider} from "@ontotext/workbench-api";
+import {RepositoryContextService, RepositoryService, EventService, EventName, ServiceProvider} from "@ontotext/workbench-api";
 
 angular
     .module('graphdb.workbench.se.controllers', [
@@ -98,16 +98,23 @@ function homeCtrl($scope,
     // Public functions
     // =========================
     $scope.getActiveRepositorySize = () => {
-        const repo = $repositories.getActiveRepositoryObject();
+        const repo = ServiceProvider.get(RepositoryContextService).getSelectedRepository();
+
         if (!repo) {
             return;
         }
         $scope.activeRepositorySizeError = undefined;
-        RepositoriesRestService.getSize(repo).then(function (res) {
-            $scope.activeRepositorySize = res.data;
-        }).catch(function (e) {
-            $scope.activeRepositorySizeError = e.data.message;
-        });
+
+        ServiceProvider.get(RepositoryService).getRepositorySizeInfo(repo)
+            .then(function (repositorySizeInfo) {
+                $scope.activeRepositorySize = repositorySizeInfo;
+            })
+            .catch(function (e) {
+                $scope.activeRepositorySizeError = e.data.message;
+            })
+            .finally(function () {
+                $scope.$apply();
+            });
     };
 
     $scope.onKeyDown = function (event) {


### PR DESCRIPTION
## What
The repository size info on the home page was not refreshed when refreshing the page. It was only shown when navigating to the home page. Changed logic to use the services from the `ServiceProvider` and the `api` package

## Why
The repository size info fetch method was checking for the repository in repositories map in the legacy `RepositoriesService`. But the list was not initialized when the fetch is executed which returned null for repository.

## How
- replaced `getActiveRepositorySize` function to use the new services from the `api` package

## Testing
Added

## Screenshots
![image](https://github.com/user-attachments/assets/2e86b54e-8493-469b-b9d7-5ac570a9e4b1)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
