### PR TITLE
fix(GDB-11410): WBM Fix import-user-data-file-upload tests

### DIFF
--- a/e2e-tests/e2e-legacy/import/import-user-data-file-upload.spec.js
+++ b/e2e-tests/e2e-legacy/import/import-user-data-file-upload.spec.js
@@ -14,9 +14,7 @@ const jsonld = JSON.stringify({
     "ab:email": "richard491@hotmail.com"
 });
 
-// TODO: Fix me. Broken due to migration (Error: beforeEach)
-describe.skip('Import user data: File upload', () => {
-
+describe('Import user data: File upload', () => {
     let repositoryId;
     const testFiles = [
         'bnodes.ttl',
@@ -40,7 +38,8 @@ describe.skip('Import user data: File upload', () => {
         // Given there are no files uploaded yet
         ImportUserDataSteps.getResourcesTable().should('be.hidden');
         // When I start to upload a file
-        ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[0], bnodes));
+        const file1 = ImportUserDataSteps.createFile(testFiles[0], bnodes);
+        ImportUserDataSteps.selectFile(file1);
         // Then the import settings dialog should open automatically
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         ImportSettingsDialogSteps.import();
@@ -64,7 +63,8 @@ describe.skip('Import user data: File upload', () => {
         // Given there are no files uploaded yet
         ImportUserDataSteps.getResourcesTable().should('be.hidden');
         // And I have selected to upload a file
-        ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[0], bnodes));
+        const file = ImportUserDataSteps.createFile(testFiles[0], bnodes);
+        ImportUserDataSteps.selectFile(file);
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         // When I cancel the file upload via the cancel button
         ImportSettingsDialogSteps.cancelUpload();
@@ -73,7 +73,7 @@ describe.skip('Import user data: File upload', () => {
         // And there should be no files uploaded
         ImportUserDataSteps.getResourcesTable().should('be.hidden');
         // When I select to upload a file again
-        ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[0], bnodes));
+        ImportUserDataSteps.selectFile(file);
         // Then the import settings dialog should open
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         // And I close the file upload dialog via the close button
@@ -88,7 +88,8 @@ describe.skip('Import user data: File upload', () => {
         // Given there are no files uploaded yet
         ImportUserDataSteps.getResourcesTable().should('be.hidden');
         // When I start to upload a file
-        ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[0], bnodes));
+        const file = ImportUserDataSteps.createFile(testFiles[0], bnodes);
+        ImportUserDataSteps.selectFile(file);
         // Then the import settings dialog should open automatically
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         // And the option for replace graph should be active
@@ -99,21 +100,24 @@ describe.skip('Import user data: File upload', () => {
         // Given there are no files uploaded yet
         ImportUserDataSteps.getResourcesTable().should('be.hidden');
         // When I upload a file
-        ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[0], bnodes));
+        const file = ImportUserDataSteps.createFile(testFiles[0], bnodes);
+        ImportUserDataSteps.selectFile(file);
         // Then the import settings dialog should open automatically
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         ImportSettingsDialogSteps.import();
         // Then I should see the uploaded file
         ImportUserDataSteps.checkImportedResource(0, 'bnodes.ttl');
         // When I upload another file
-        ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[1], jsonld));
+        const file2 = ImportUserDataSteps.createFile(testFiles[1], jsonld);
+        ImportUserDataSteps.selectFile(file2);
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         ImportSettingsDialogSteps.import();
         // Then I should see the uploaded file - it becomes first in the list
         ImportUserDataSteps.checkImportedResource(0, 'jsonld.jsonld');
         ImportUserDataSteps.checkImportedResource(1, 'bnodes.ttl');
         // When I override the first file
-        ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[0], bnodes));
+        const file3 = ImportUserDataSteps.createFile(testFiles[0], bnodes);
+        ImportUserDataSteps.selectFile(file3);
         FileOverwriteDialogSteps.overwrite();
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         ImportSettingsDialogSteps.import();
@@ -122,7 +126,7 @@ describe.skip('Import user data: File upload', () => {
         ImportUserDataSteps.checkImportedResource(0, 'jsonld.jsonld');
         ImportUserDataSteps.checkImportedResource(1, 'bnodes.ttl');
         // When I override the second file
-        ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[1], jsonld));
+        ImportUserDataSteps.selectFile(file2);
         FileOverwriteDialogSteps.overwrite();
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         ImportSettingsDialogSteps.import();
@@ -131,14 +135,12 @@ describe.skip('Import user data: File upload', () => {
         ImportUserDataSteps.checkImportedResource(1, 'bnodes.ttl');
     });
 
-    /**
-     * TODO: Fix me. Broken due to migration (Changes in main menu)
-     */
-    it.skip('should be able to only upload a single file without importing it', () => {
+    it('should be able to only upload a single file without importing it', () => {
         // Given there are no files uploaded yet
         ImportUserDataSteps.getResourcesTable().should('be.hidden');
         // When I start to upload a file
-        ImportUserDataSteps.selectFile(ImportUserDataSteps.createFile(testFiles[0], bnodes));
+        const file = ImportUserDataSteps.createFile(testFiles[0], bnodes);
+        ImportUserDataSteps.selectFile(file);
         // Then the import settings dialog should open automatically
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         ImportSettingsDialogSteps.uploadOnly();
@@ -151,10 +153,7 @@ describe.skip('Import user data: File upload', () => {
         ImportUserDataSteps.getResources().should('have.length', 1);
     });
 
-    /**
-     * TODO: Fix me. Broken due to migration (Changes in main menu)
-     */
-    it.skip('Should be able to upload multiple unique files', () => {
+    it('Should be able to upload multiple unique files', () => {
         // Given there are no files uploaded yet
         ImportUserDataSteps.getResourcesTable().should('be.hidden');
         // When I upload a file

--- a/e2e-tests/steps/import/import-steps.js
+++ b/e2e-tests/steps/import/import-steps.js
@@ -67,13 +67,7 @@ class ImportSteps {
         }
 
         cy.visit('/import#' + type);
-
-        // cy.get('.ot-splash').should('not.be.visible');
-
         cy.get('#import-' + type).should('be.visible');
-
-        // cy.get('.ot-loader').should('not.be.visible');
-
         return this;
     }
 
@@ -98,7 +92,6 @@ class ImportSteps {
     }
 
     static openUserDataTab() {
-        // cy.get('.ot-loader').should('not.be.visible');
         return this.getTabs().eq(0).click();
     }
 
@@ -111,7 +104,6 @@ class ImportSteps {
     }
 
     static openServerFilesTab() {
-        // cy.get('.ot-loader').should('not.be.visible');
         return this.getTabs().eq(1).click();
     }
 
@@ -198,7 +190,6 @@ class ImportSteps {
     }
 
     static checkImportedResource(index, resourceName, expectedStatus) {
-        if (expectedStatus === undefined) {}
         const status = expectedStatus || 'Imported successfully';
         this.getResourceByName(resourceName).should('contain', resourceName);
         this.getResourceStatus(resourceName).should('contain', status);
@@ -209,7 +200,6 @@ class ImportSteps {
     }
 
     static checkUserDataUploadedResource(index, resourceName) {
-        // this.getResource(index).should('contain', resourceName);
         this.getResourceByName(resourceName).should('contain', resourceName);
         this.getResourceStatus(resourceName).should('be.hidden');
     }
@@ -272,7 +262,7 @@ class ImportSteps {
     }
 
     static importFile(index) {
-        this.getResource(index).find('.import-resource-action-import-btn').click();
+        this.getResource(index).find('.import-resource-action-import-btn').invoke('show').trigger('click');
     }
 
     static importResourceByName(name) {
@@ -296,7 +286,8 @@ class ImportSteps {
     }
 
     static selectFile(files) {
-        cy.get('#wb-import-uploadFile label').selectFile(files);
+        cy.wait(1000)
+        cy.get('#wb-import-uploadFile label').selectFile(files, { force: true });
     }
 
     static uploadFile(filePath) {


### PR DESCRIPTION
## WHAT:
Fixed and re-enabled the flaky `import-user-data-file-upload.spec.js` end-to-end test suite.

## WHY:
The test suite was disabled due to migration caused issues

## HOW:
- in `import-user-data-file-upload.spec.js`, the `createFile()` call was decoupled from the `selectFile()` call. The file object is now created once and stored in a `const` variable. This constant is then passed to the `selectFile` step.
- re-enabled all tests
- removed commented and obsolete code

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [X] Tests
