### PR TITLE
GDB-12553 add repository filtering by rights

### DIFF
--- a/packages/api/src/models/security/index.ts
+++ b/packages/api/src/models/security/index.ts
@@ -5,3 +5,4 @@ export * from './authority';
 export * from './authority-list';
 export * from './restricted-pages';
 export * from './openid-config';
+export * from './rights';

--- a/packages/api/src/models/security/rights.ts
+++ b/packages/api/src/models/security/rights.ts
@@ -1,0 +1,4 @@
+export enum Rights {
+  READ = 'READ',
+  WRITE = 'WRITE'
+}

--- a/packages/api/src/services/repository/repository.service.ts
+++ b/packages/api/src/services/repository/repository.service.ts
@@ -45,4 +45,20 @@ export class RepositoryService implements Service {
     return this.repositoryRestService.getRepositorySizeInfo(repository)
       .then(this.repositorySizeInfoMapper.mapToModel);
   }
+
+  isSystemRepository(repository: Repository): boolean {
+    return repository.id === 'SYSTEM';
+  }
+
+  getLocationSpecificId(repo: Repository): string {
+    return repo.location ? `${repo.id}@${repo.location}` : repo.id;
+  }
+
+  getCurrentRepoAuthority(action: string, repoId: string): string {
+    return `${action}_REPO_${repoId}`;
+  }
+
+  getOverallRepoAuthority(action: string): string {
+    return `${action}_REPO_*`;
+  }
 }

--- a/packages/api/src/services/security/test/authentication.service.spec.ts
+++ b/packages/api/src/services/security/test/authentication.service.spec.ts
@@ -6,14 +6,16 @@ import {AuthenticatedUserMapper} from '../mappers/authenticated-user.mapper';
 import {SecurityContextService} from '../security-context.service';
 import {EventService} from '../../event-service';
 import {Logout} from '../../../models/events';
+import {Repository} from '../../../models/repositories';
 
 describe('AuthenticationService', () => {
   let authService: AuthenticationService;
+  const securityContextService = ServiceProvider.get(SecurityContextService);
 
   beforeEach(() => {
     authService = new AuthenticationService();
     ServiceProvider.get(AuthenticationStorageService).remove('jwt');
-    ServiceProvider.get(SecurityContextService).updateSecurityConfig({} as unknown as SecurityConfig);
+    securityContextService.updateSecurityConfig({} as unknown as SecurityConfig);
   });
 
   test('login should return the correct login message', () => {
@@ -92,33 +94,40 @@ describe('AuthenticationService', () => {
     const userWithRole = MapperProvider.get(AuthenticatedUserMapper).mapToModel(
         {external: false, authorities: [userRole]} as unknown as AuthenticatedUser
     );
-      // And, I have a security config with enabled free access
+    securityContextService.updateAuthenticatedUser(userWithRole);
+
+    // And, I have a security config with enabled free access
     const securityConfigWithFreeAccess = {enabled: true, freeAccess: {enabled: true}} as unknown as SecurityConfig;
+    securityContextService.updateSecurityConfig(securityConfigWithFreeAccess);
 
     // When, I check, if the user has the role
     // Then, I expect, to have the role
-    expect(authService.hasRole(userRole, securityConfigWithFreeAccess, userWithRole)).toEqual(true);
+    expect(authService.hasRole(userRole)).toEqual(true);
 
     // When, I have a disabled security
     const securityConfigWithoutSecurity = {enabled: false} as unknown as SecurityConfig;
+    securityContextService.updateSecurityConfig(securityConfigWithoutSecurity);
 
     // When, I check, if the user has the role
     // Then, I expect to have the role
-    expect(authService.hasRole(userRole, securityConfigWithoutSecurity, userWithRole)).toEqual(true);
+    expect(authService.hasRole(userRole)).toEqual(true);
 
     // When, I have a user without the role
     const userWithoutRole = {external: false, authorities: []} as unknown as AuthenticatedUser;
+    securityContextService.updateAuthenticatedUser(userWithoutRole);
 
     // When, I check, if the user has a role, without supplying one
     // Then, I expect, to have the role
-    expect(authService.hasRole(undefined, securityConfigWithFreeAccess, userWithoutRole)).toEqual(true);
+    expect(authService.hasRole(undefined)).toEqual(true);
 
     // When, I have 'IS_AUTHENTICATED_FULLY' authority
     // Then, I expect, to have the role
     const userWithIsAuthenticatedFullyAuthority = MapperProvider.get(AuthenticatedUserMapper).mapToModel(
         {external: false, authorities: []} as unknown as AuthenticatedUser
     );
-    expect(authService.hasRole(Authority.IS_AUTHENTICATED_FULLY, securityConfigWithFreeAccess, userWithIsAuthenticatedFullyAuthority)).toEqual(true);
+    securityContextService.updateAuthenticatedUser(userWithIsAuthenticatedFullyAuthority);
+
+    expect(authService.hasRole(Authority.IS_AUTHENTICATED_FULLY)).toEqual(true);
   });
 
   test('hasRole should return false if the user does not have the specified role/free access', () => {
@@ -127,16 +136,19 @@ describe('AuthenticationService', () => {
     const userWithRole = MapperProvider.get(AuthenticatedUserMapper).mapToModel(
         {external: false, authorities: [userRole]} as unknown as AuthenticatedUser
     );
-      // And, I have a security config with disabled free access
+    securityContextService.updateAuthenticatedUser(userWithRole);
+
+    // And, I have a security config with disabled free access
     const securityConfigWithFreeAccess = {enabled: true, freeAccess: {enabled: false}} as unknown as SecurityConfig;
+    securityContextService.updateSecurityConfig(securityConfigWithFreeAccess);
 
     // When, I check, if the user has a higher role
     // Then, I expect, not to have the role
-    expect(authService.hasRole(Authority.ROLE_MONITORING, securityConfigWithFreeAccess, userWithRole)).toEqual(false);
+    expect(authService.hasRole(Authority.ROLE_MONITORING)).toEqual(false);
 
     // When, don't have a user and check, if the user has a role
     // Then, I expect, not to have the role
-    expect(authService.hasRole(Authority.ROLE_MONITORING, securityConfigWithFreeAccess, undefined)).toEqual(false);
+    expect(authService.hasRole(Authority.ROLE_MONITORING)).toEqual(false);
   });
 
   test('logout should emit a Logout event', () => {
@@ -146,4 +158,182 @@ describe('AuthenticationService', () => {
     expect(emitSpy).toHaveBeenCalledWith(expect.any(Logout));
   });
 
+  test('canReadRepo should return false when the repository is undefined', () => {
+    expect(authService.canReadRepo(undefined)).toBe(false);
+  });
+
+  test('canReadRepo should return false when the repository ID is empty', () => {
+    expect(authService.canReadRepo({ id: '' } as Repository)).toBe(false);
+  });
+
+  test('canReadRepo should return false when security is enabled but user is not authenticated', () => {
+    // Given, I have enabled security
+    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    securityContextService.updateSecurityConfig(securityConfig);
+
+    // When, I check if I can read a repository
+    const repository = {id: 'testRepo'} as Repository;
+
+    // Then, I expect not to have read access
+    expect(authService.canReadRepo(repository)).toBe(false);
+  });
+
+  test('canReadRepo should return true when user has ROLE_ADMIN', () => {
+    // Given, I have enabled security
+    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityContextService = ServiceProvider.get(SecurityContextService);
+    securityContextService.updateSecurityConfig(securityConfig);
+
+    // And, I have a user with ROLE_ADMIN authority
+    const adminUser = MapperProvider.get(AuthenticatedUserMapper).mapToModel(
+      {external: false, authorities: [Authority.ROLE_ADMIN]} as unknown as AuthenticatedUser
+    );
+    securityContextService.updateAuthenticatedUser(adminUser);
+
+    // When, I check if I can read a repository
+    const repository = {id: 'testRepo'} as Repository;
+
+    // Then, I expect to have read access
+    expect(authService.canReadRepo(repository)).toBe(true);
+
+    // And I should have read access even to the SYSTEM repository
+    const systemRepo = {id: 'SYSTEM'} as Repository;
+    expect(authService.canReadRepo(systemRepo)).toBe(true);
+  });
+
+  test('canReadRepo should return true when user has ROLE_REPO_MANAGER', () => {
+    // Given, I have enabled security
+    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityContextService = ServiceProvider.get(SecurityContextService);
+    securityContextService.updateSecurityConfig(securityConfig);
+
+    // And, I have a user with ROLE_REPO_MANAGER authority
+    const repoManagerUser = MapperProvider.get(AuthenticatedUserMapper).mapToModel(
+      {external: false, authorities: [Authority.ROLE_REPO_MANAGER]} as unknown as AuthenticatedUser
+    );
+    securityContextService.updateAuthenticatedUser(repoManagerUser);
+
+    // When, I check if I can read a repository
+    const repository = {id: 'testRepo'} as Repository;
+
+    // Then, I expect to have read access
+    expect(authService.canReadRepo(repository)).toBe(true);
+
+    // And I should have read access even to the SYSTEM repository
+    const systemRepo = {id: 'SYSTEM'} as Repository;
+    expect(authService.canReadRepo(systemRepo)).toBe(true);
+  });
+
+  test('canReadRepo should return false when user tries to access SYSTEM repository', () => {
+    // Given, I have enabled security
+    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityContextService = ServiceProvider.get(SecurityContextService);
+    securityContextService.updateSecurityConfig(securityConfig);
+
+    // And, I have a user with ROLE_USER authority
+    const user = MapperProvider.get(AuthenticatedUserMapper).mapToModel(
+      {external: false, authorities: [Authority.ROLE_USER]} as unknown as AuthenticatedUser
+    );
+    securityContextService.updateAuthenticatedUser(user);
+
+    // When, I check if I can read a repository
+    const systemRepo = {id: 'SYSTEM'} as Repository;
+
+    // Then, I expect not to have read access
+    expect(authService.canReadRepo(systemRepo)).toBe(false);
+  });
+
+  test('canReadRepo should return true when security is not enabled regardless of user authentication status', () => {
+    // Given, I have disabled security
+    const securityConfig = {enabled: false} as unknown as SecurityConfig;
+    const securityContextService = ServiceProvider.get(SecurityContextService);
+    securityContextService.updateSecurityConfig(securityConfig);
+
+    // When, I check if I can read a repository
+    const repository = {id: 'testRepo'} as Repository;
+
+    // Then, I expect to have read access because security is disabled
+    expect(authService.canReadRepo(repository)).toBe(true);
+
+    // And the result should be the same for SYSTEM repository
+    const systemRepo = {id: 'SYSTEM'} as Repository;
+    expect(authService.canReadRepo(systemRepo)).toBe(true);
+  });
+
+  test('canReadRepo should return true when user has READ rights on a non-SYSTEM repository', () => {
+    // Given, I have enabled security
+    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityContextService = ServiceProvider.get(SecurityContextService);
+    securityContextService.updateSecurityConfig(securityConfig);
+
+    // And, I have a regular user with specific READ rights for a repository
+    const repositoryId = 'testRepo';
+    const readRepoAuthority = `READ_REPO_${repositoryId}` as Authority;
+    const regularUser = MapperProvider.get(AuthenticatedUserMapper).mapToModel(
+      {external: false, authorities: [Authority.ROLE_USER, readRepoAuthority]} as unknown as AuthenticatedUser
+    );
+    securityContextService.updateAuthenticatedUser(regularUser);
+
+    // When, I check if I can read a repository
+    const repository = {id: repositoryId} as Repository;
+
+    // Then, I expect to have read access
+    expect(authService.canReadRepo(repository)).toBe(true);
+
+    // But I should still not have access to SYSTEM repository
+    const systemRepo = {id: 'SYSTEM'} as Repository;
+    expect(authService.canReadRepo(systemRepo)).toBe(false);
+  });
+
+  test('canReadRepo should return false when user does not have READ rights on repository', () => {
+    // Given, I have enabled security
+    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityContextService = ServiceProvider.get(SecurityContextService);
+    securityContextService.updateSecurityConfig(securityConfig);
+
+    // And, I have a regular user without specific READ rights for the repository
+    const repositoryId = 'testRepo';
+    const regularUser = MapperProvider.get(AuthenticatedUserMapper).mapToModel(
+      {external: false, authorities: [Authority.ROLE_USER]} as unknown as AuthenticatedUser
+    );
+    securityContextService.updateAuthenticatedUser(regularUser);
+
+    // When, I check if I can read a repository
+    const repository = {id: repositoryId} as Repository;
+
+    // Then, I expect not to have read access
+    expect(authService.canReadRepo(repository)).toBe(false);
+  });
+
+  test('canReadRepo should return true for authenticated users with base READ rights for a specific repository location', () => {
+    // Given, I have enabled security
+    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityContextService = ServiceProvider.get(SecurityContextService);
+    securityContextService.updateSecurityConfig(securityConfig);
+
+    // And, I have a repository with a location
+    const repositoryId = 'testRepo';
+    const location = 'testLocation';
+    const repository = {id: repositoryId, location: location} as Repository;
+
+    // And, I have a regular user with specific READ rights for the repository with location
+    const readRepoWithLocationAuthority = `READ_REPO_${repositoryId}@${location}` as Authority;
+    const userWithSpecificLocationRights = MapperProvider.get(AuthenticatedUserMapper).mapToModel(
+      {external: false, authorities: [Authority.ROLE_USER, readRepoWithLocationAuthority]} as unknown as AuthenticatedUser
+    );
+    securityContextService.updateAuthenticatedUser(userWithSpecificLocationRights);
+
+    // When, I check if I can read a repository
+    // Then, I expect to have read access
+    expect(authService.canReadRepo(repository)).toBe(true);
+
+    // And when I have a user with wildcard read rights
+    const userWithWildcardRights = MapperProvider.get(AuthenticatedUserMapper).mapToModel(
+      {external: false, authorities: [Authority.ROLE_USER, 'READ_REPO_*' as Authority]} as unknown as AuthenticatedUser
+    );
+    securityContextService.updateAuthenticatedUser(userWithWildcardRights);
+
+    // Then, I expect to have read access to any repository
+    expect(authService.canReadRepo(repository)).toBe(true);
+  });
 });

--- a/packages/shared-components/src/components/onto-header/onto-header.tsx
+++ b/packages/shared-components/src/components/onto-header/onto-header.tsx
@@ -25,7 +25,7 @@ import {
   LanguageService,
   LanguageContextService,
   ObjectUtil,
-  getCurrentRoute,
+  getCurrentRoute, AuthenticationService
 } from '@ontotext/workbench-api';
 import {TranslationService} from '../../services/translation.service';
 import {HtmlUtil} from '../../utils/html-util';
@@ -56,6 +56,7 @@ export class OntoHeader {
   private readonly languageService: LanguageService = ServiceProvider.get(LanguageService);
   private readonly UPDATE_ACTIVE_OPERATION_TIME_INTERVAL = 2000;
   private readonly fibonacciGenerator = new FibonacciGenerator();
+  private readonly authService = ServiceProvider.get(AuthenticationService);
 
   // ========================
   // State
@@ -252,8 +253,8 @@ export class OntoHeader {
       repositories = this.repositoryList.getItems();
     }
 
-    // TODO: GDB-10442 filter if not rights to read repo see jwt-auth.service.js canReadRepo function
     return repositories
+      .filter((repository) => this.authService.canReadRepo(repository))
       .map((repository) => {
         return new DropdownItem<Repository>()
           .setName(<SelectorItemButton repository={repository}/>)

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -233,7 +233,7 @@ export class OntoLayout {
 
   private shouldShowMenu(role: Authority): boolean {
     return this.isAuthenticatedFully()
-      && ServiceProvider.get(AuthenticationService).hasRole(role, this.securityConfig, this.authenticatedUser);
+      && ServiceProvider.get(AuthenticationService).hasRole(role);
   }
 
   // ========================


### PR DESCRIPTION
## What
Add filtering to the repository dropdown, based on user rights

## Why
It currently shows repositories, to which the user has no access to

## How
Implemented a `canReadRepo` method in `authentication.service`, which contains the existing logic from `jwt-auth.service`. Added a filter by that function in `onto-header`

## Testing
jest

## Screenshots
What repositories, the user sees
![image](https://github.com/user-attachments/assets/28510742-38e3-40d8-900e-b32d27cb2cc7)
What repositories does the user have access to
![image](https://github.com/user-attachments/assets/ae4cbd8c-80d6-451d-a779-9f9436447788)
Available repositories at the moment
![image](https://github.com/user-attachments/assets/6c895e2b-d639-4782-930c-539eb6a0c2b9)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
