### PR TITLE
GDB-12567 Fix restricted page showing on admin user

### DIFF
--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -188,6 +188,7 @@ export class OntoLayout {
       ServiceProvider.get(EventService).subscribe(EventName.LOGOUT, () => {
         this.setNavbarItemVisibility();
         this.updateVisibility();
+        this.securityContextService.updateRestrictedPages(new RestrictedPages());
       })
     );
     this.subscriptions.add(

--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
@@ -3,8 +3,8 @@ import {
   Repository,
   ServiceProvider,
   RepositoryContextService,
-  UriUtil, RepositorySizeInfo,
-} from "@ontotext/workbench-api";
+  UriUtil, RepositorySizeInfo, RestrictedPages, SecurityContextService
+} from '@ontotext/workbench-api';
 import {DropdownItem} from '../../models/dropdown/dropdown-item';
 import {DropdownItemAlignment} from '../../models/dropdown/dropdown-item-alignment';
 import {RepositorySelection} from './repository-selection';
@@ -249,6 +249,11 @@ export class OntoRepositorySelector {
   }
 
   private onRepositoryChanged(selectedRepository: Repository): void {
+    // TODO: Move this in a subscription to updateSelectedRepository, after security is fully migrated.
+    // If we do this now, we get race conditions, between the context services and the components. Both work
+    // in parallel and it causes issues. Migrated components should load their data after updateApplicationDataState
+    // is called, with DATA_LOADED. This will ensure components start loading their data, after the contexts are updated
+    ServiceProvider.get(SecurityContextService).updateRestrictedPages(new RestrictedPages());
     this.repositoryContextService.updateSelectedRepository(selectedRepository);
   }
 


### PR DESCRIPTION
## What
Fix restricted pages showing, when a user has rights to view the page

## Why
Restricted pages were being shown on users, which they shouldn't be

## How
Reset the restricted pages upon user logout. When a user gets a 403 response, the page, which he is in on gets added to a list. That list is not reset for new logins, so every next logged in user would continue with the same restricted pages. If they are visited again, they will not be shown, even though the user may have rights to view them

## Testing
n/a

## Screenshots
n/a

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
