### PR TITLE
GDB-12574: Trigger digest cycle after API service rest calls

### DIFF
--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -42,3 +42,6 @@ export * from './services/app-lifecycle';
 
 // Export utils for external usages.
 export * from './services/utils';
+
+// Export constants for external usages.
+export {HTTP_REQUEST_DONE_EVENT} from './services/http/http.service';

--- a/packages/api/src/services/http/http.service.ts
+++ b/packages/api/src/services/http/http.service.ts
@@ -2,14 +2,18 @@ import {HttpOptions} from '../../models/http/http-options';
 import {InterceptorService} from '../interceptor/interceptor.service';
 import {HttpRequest} from '../../models/http/http-request';
 import {ServiceProvider} from '../../providers';
+import {EventEmitter} from '../../emitters/event.emitter';
 
 const JSON_CONTENT_TYPES = ['application/json', 'application/sparql-results+json'];
+
+export const HTTP_REQUEST_DONE_EVENT = 'http-request-done-event';
 
 /**
  * A service class for performing HTTP requests.
  */
 export class HttpService {
   private readonly interceptorService = ServiceProvider.get(InterceptorService);
+  private readonly eventEmitter = new EventEmitter<undefined>();
 
   /**
    * Performs an HTTP GET request.
@@ -122,7 +126,8 @@ export class HttpService {
         }
         const isJson = this.hasValidJson(response);
         return (isJson ? response.json() : Promise.resolve()) as Promise<T>;
-      });
+      })
+      .finally(() => this.eventEmitter.emit({NAME: HTTP_REQUEST_DONE_EVENT, payload: undefined}));
   }
 
   private hasValidJson(response: Response) {

--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -111,9 +111,6 @@ function homeCtrl($scope,
             })
             .catch(function (e) {
                 $scope.activeRepositorySizeError = e.data.message;
-            })
-            .finally(function () {
-                $scope.$apply();
             });
     };
 


### PR DESCRIPTION
## What
Trigger digest cycle in legacy workbench after each request done by the rest services in the API package

## Why
This will ensure that the legacy workbench is updated

## How
- added an event emitter in the `HttpService` in the `API` package, which will emit a new event after each request completed,
- added a listener for this event in the `mount` function for the legacy workbench

## Testing
N/A

## Screenshots
n/a

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
