### PR TITLE
fix(GDB-11410): WBM Enable tests broken due to migration part 4

### DIFF
--- a/e2e-tests/e2e-legacy/cluster/cluster-configuration/cluster-configuration-multi-region.spec.js
+++ b/e2e-tests/e2e-legacy/cluster/cluster-configuration/cluster-configuration-multi-region.spec.js
@@ -6,10 +6,7 @@ import {ClusterConfigurationSteps} from "../../../steps/cluster/cluster-configur
 import {ModalDialogSteps} from "../../../steps/modal-dialog-steps";
 import {ApplicationSteps} from "../../../steps/application-steps";
 
-/**
- * TODO: Fix me. Broken due to migration (Error: unknown)
- */
-describe.skip('Cluster configuration', () => {
+describe('Cluster configuration', () => {
     let repositoryId;
 
     beforeEach(() => {

--- a/e2e-tests/e2e-legacy/cluster/cluster-configuration/cluster-configuration-nodes.spec.js
+++ b/e2e-tests/e2e-legacy/cluster/cluster-configuration/cluster-configuration-nodes.spec.js
@@ -18,10 +18,7 @@ describe('Cluster configuration', () => {
         RemoteLocationStubs.stubRemoteLocationStatusInCluster();
     });
 
-    /**
-     * TODO: Fix me. Broken due to migration (Error: unknown)
-     */
-    it.skip('should display the nodes list with correct node information in the modal', () => {
+    it('should display the nodes list with correct node information in the modal', () => {
         // Given I have opened the cluster management page
         ClusterPageSteps.visit();
         // When I click on edit properties and open Nodes tab

--- a/e2e-tests/e2e-legacy/cluster/cluster-configuration/cluster-configuration.spec.js
+++ b/e2e-tests/e2e-legacy/cluster/cluster-configuration/cluster-configuration.spec.js
@@ -12,10 +12,7 @@ describe('Cluster configuration', () => {
         GlobalOperationsStatusesStub.stubNoOperationsResponse(repositoryId);
     });
 
-    /**
-     * TODO: Broken due to migration  (Error: unknown)
-     */
-    it.skip('Should display cluster configuration', () => {
+    it('Should display cluster configuration', () => {
         // Given there is an existing cluster created
         ClusterStubs.stubClusterConfig();
         ClusterStubs.stubClusterGroupStatus();

--- a/e2e-tests/e2e-legacy/resource/resource.spec.js
+++ b/e2e-tests/e2e-legacy/resource/resource.spec.js
@@ -17,8 +17,7 @@ const OBJECT_RESOURCE = 'http:%2F%2Fexample.com%2Fontology%23Metric';
 const IMPLICIT_EXPLICIT_RESOURCE = 'http:%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23type';
 const TRIPLE_RESOURCE = '%3C%3C%3Chttp:%2F%2Fexample.com%2Fresource%2Fperson%2FW6J1827%3E%20%3Chttp:%2F%2Fexample.com%2Fontology%23hasAddress%3E%20%3Chttp:%2F%2Fexample.com%2Fresource%2Fperson%2FW6J1827%2Faddress%3E%3E%3E';
 
-// TODO: Fix me. Broken due to migration (Error: unknown)
-describe.skip('Resource view', () => {
+describe('Resource view', () => {
     let repositoryId;
     beforeEach(() => {
         repositoryId = 'repository-' + Date.now();
@@ -63,10 +62,7 @@ describe.skip('Resource view', () => {
         YasrSteps.getResults().should('have.length', 5);
     });
 
-    /**
-     * TODO: Fix me. Broken due to migration (problem with '/graphs-visualizations' view)
-     */
-    it.skip('should navigate to visual graph view', () => {
+    it('should navigate to visual graph view', () => {
         // When I am on resource view and page loaded a resource.
         ResourceSteps.visit(`uri=${SUBJECT_RESOURCE}&role=subject`);
 
@@ -326,11 +322,7 @@ describe.skip('Resource view', () => {
         });
     });
 
-    /**
-     * TODO: Fix me. Broken due to migration (problem with yasgui in resource view)
-     */
-    context.skip('Triple resource', () => {
-
+    context('Triple resource', () => {
         it('should show triple resource', {
             retries: {
                 runMode: 1,
@@ -343,6 +335,8 @@ describe.skip('Resource view', () => {
             // Then I expect resource link to exist.
             ResourceSteps.getTripleResourceLink().should('contain.text', '<<<W6J1827> <hasAddress> <address>>>');
 
+            // And I expect to see data table
+            ResourceSteps.getDataTable().should('exist').and('be.visible');
             // When I click on the link.
             ResourceSteps.clickOnTripleResourceLink();
 
@@ -358,6 +352,8 @@ describe.skip('Resource view', () => {
             // Then I expect target link to exist.
             ResourceSteps.getTargetLink().should('contain.text', '<<<http://example.com/resource/person/W6J1827> <http://example.com/ontology#hasAddress> <http://example.com/resource/person/W6J1827/address>>>');
 
+            // And I expect to see data table
+            ResourceSteps.getDataTable().should('exist').and('be.visible');
             // When I click on the link.
             ResourceSteps.clickOnTripleResourceLink();
 
@@ -374,6 +370,18 @@ describe.skip('Resource view', () => {
         it('should download as JSON-LD and then restore defaults', () => {
             // Given I am in the Resource view
             ResourceSteps.visit(`uri=${SUBJECT_RESOURCE}&role=subject`);
+            cy.window().then((win) => {
+                expect(win.jsonld).to.exist;
+                cy.stub(win.jsonld, 'compact').resolves({
+                    "@context": {
+                        "dc11": "http://purl.org/dc/elements/1.1/",
+                        "ex": "http://example.org/vocab#",
+                        "ex:authored": {"@type": "@id"},
+                        "ex:contains": {"@type": "@id"},
+                        "foaf": "http://xmlns.com/foaf/0.1/"
+                    }
+                });
+            });
             ResourceSteps.verifyActiveRoleTab('subject');
 
             // When I download as JSON-LD

--- a/e2e-tests/steps/resource/resource-steps.js
+++ b/e2e-tests/steps/resource/resource-steps.js
@@ -151,4 +151,8 @@ export class ResourceSteps {
     static clickOnTripleResourceLink() {
         ResourceSteps.getTripleResourceLink().click();
     }
+
+    static getDataTable() {
+        return cy.get('.dataTable');
+    }
 }

--- a/packages/legacy-workbench/src/js/angular/explore/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/explore/controllers.js
@@ -271,6 +271,28 @@ function ExploreCtrl(
         ModalService.openCopyToClipboardModal(uri);
     };
 
+    /**
+     * ================================================
+     * Cypress test support — global exposure hack ️
+     * ================================================
+     * `jsonld` id imported as local ES modules
+     * and is not available in the global `window` scope at runtime.
+     *
+     * However, Cypress tests often rely on mocking/stubbing or spying on
+     * functions like `jsonld.compact()` to isolate behavior.
+     *
+     * Cypress’ `cy.stub(win, 'someFunction')` only works for **own properties**
+     * of the `window` object. That means: unless `jsonld` is explicitly attached
+     * to `window`, Cypress cannot replace or observe it.
+     *
+     * This block ensures that in cypress mode (`window.Cypress`),
+     * we attach `jsonld` to `window`, making it accessible
+     * to Cypress tests that need to stub or assert usage.
+     */
+    if (window.Cypress) {
+        window.jsonld = jsonld;
+    }
+
     // =========================
     // Private functions
     // =========================


### PR DESCRIPTION
## WHAT:
Fixed when needed and re-enabled skipped test suites due changes in the main menu.

## WHY:
The test suites were disabled due to migration caused issues

## HOW:
- re-enabled tests

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [X] Tests
