### PR TITLE
GDB-12573: AngularJS digest cycle is not triggered when the selected repository is changed

### DIFF
--- a/packages/api/src/models/common/subscription-list.ts
+++ b/packages/api/src/models/common/subscription-list.ts
@@ -23,6 +23,14 @@ export class SubscriptionList extends ModelList<Subscription> {
   }
   
   /**
+   * Adds multiple subscriptions to the list.
+   * @param subscriptions - An array of Subscription functions to be added.
+   */
+  addAll(subscriptions: Subscription[]): void {
+    this.items.push(...subscriptions);
+  }
+  
+  /**
    * Calls all subscription functions in the list and then clears the list. Calling a subscription
    * function unsubscribes the subscription. This effectively unsubscribes all subscriptions
    * and removes them from the list.

--- a/packages/api/src/services/context/context.service.ts
+++ b/packages/api/src/services/context/context.service.ts
@@ -112,7 +112,7 @@ export abstract class ContextService<TFields extends Record<string, unknown>> im
   ): Subscription {
     const unsubscribeFns: SubscriptionList = new SubscriptionList();
     // iterate through service-defined fields
-    for (const key of this.context.keys()) {
+    for (const key of this.getContextFields()) {
       unsubscribeFns.add(
         this.subscribe<T>(
           key,
@@ -124,7 +124,39 @@ export abstract class ContextService<TFields extends Record<string, unknown>> im
     }
     return (): void => unsubscribeFns.unsubscribeAll();
   }
-
+  
+  /**
+   * Retrieves the names of all context fields defined in the service,
+   * which will be used to register change subscriptions.
+   *
+   * This method is part of the abstract base class for context services.
+   * Each subclass defines a specific set of properties that are managed
+   * through methods such as `updateProperty` and `onPropertyChanged`.
+   *
+   * This method generically collects all string-typed values defined in the subclass,
+   * under the assumption that all such values represent valid context property names.
+   * It assumes that:
+   * - Subclasses will only define properties related to the context (i.e., no extra fields).
+   * - These properties are managed entirely by the base service logic.
+   *
+   * While this design simplifies property management and change detection,
+   * it is a known limitation that it does not strictly enforce property scoping.
+   * It may inadvertently include properties that are not intended for context management
+   * if subclasses define unrelated string values.
+   *
+   * **Note**: This approach is a temporary solution and will be deprecated once
+   * all pages are migrated away from AngularJS. At that point, this generic behavior
+   * will be replaced with more explicit and type-safe mechanisms.
+   *
+   * Subclasses may override this method if they wish to manually control
+   * which context fields are exposed for subscription.
+   *
+   * @returns An array of property names (strings) to which change subscriptions should be applied.
+   */
+  protected getContextFields(): string[] {
+    return Object.values(this).filter((value): value is string => typeof value === 'string');
+  }
+  
   /**
    * Retrieves the value context for a specific property or creates a new context if it doesn't exist.
    *


### PR DESCRIPTION
## What
The AngularJS digest cycle is not triggered when the selected repository is changed.

## Why
We use a ContextSubscriptionManager that is responsible for triggering the AngularJS digest cycle. It registers subscriptions for all context fields in the supported contexts, and when a context value changes, the digest cycle is triggered. The registration occurs in two steps:
When the legacy Workbench is mounted: the manager registers all available context services at that time. Later during lazy loading: when a new (singleton) context service is created, its fields are also registered. The subscription registration is implemented generically—it attempts to register subscribers for all properties in each context. However, a key issue arises: not all properties may have values yet when registration occurs. Properties are only added to the context when they are updated for the first time. In this specific issue, when the subscribers for the RepositoryContextService fields are registered, the service's context is still empty (repositories have not been loaded, and no repository is selected). As a result, no subscribers are registered, and changes to the selected repository do not trigger a digest.

## How
The generic subscription registration has been updated to register all properties of a context, regardless of whether they currently have values. This ensures that all properties are monitored, and any future changes will correctly trigger an AngularJS digest cycle.

## Additional work
There was also a problem with unsubscribing from all subscriptions.

When the legacy Workbench is mounted, the subscription registration function returns an unsubscribe function. However, this function only unsubscribes the currently available context properties. Subscriptions added later through lazy-loaded context services were not being tracked and thus were never unsubscribed, leading to a memory leak.

This has been fixed by changing the manager to maintain an internal list of all subscriptions. The initial unsubscribe function now returns this complete list, and additional subscriptions from lazy-loaded services are added to it. As a result, when the legacy Workbench is unmounted, all subscriptions are properly cleaned up.

## Screenshots
N/A

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
