### PR TITLE
GDB-12173 Add initial state tests for the Backup And Restore view

### DIFF
--- a/e2e-tests/e2e-legacy/monitor/backup-and-restore/backup-and-restore-with-repository.spec.js
+++ b/e2e-tests/e2e-legacy/monitor/backup-and-restore/backup-and-restore-with-repository.spec.js
@@ -1,0 +1,36 @@
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {BackupAndRestoreSteps} from "../../../steps/monitoring/backup-and-restore-steps";
+
+describe('Backup And Restore with selected repository', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'backup-and-restore-init-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Backup And Restore page via URL with a repository selected
+        BackupAndRestoreSteps.visit();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation bar', () => {
+        // Given, I visit the Backup And Restore page via the navigation menu with a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnBackupAndRestore();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    const verifyInitialStateWithSelectedRepository = () => {
+        BackupAndRestoreSteps.getInfoMessageElement().contains('No running backup or restore.');
+    };
+})

--- a/e2e-tests/e2e-legacy/monitor/backup-and-restore/backup-and-restore-without-repository.spec.js
+++ b/e2e-tests/e2e-legacy/monitor/backup-and-restore/backup-and-restore-without-repository.spec.js
@@ -1,0 +1,25 @@
+import {ErrorSteps} from "../../../steps/error-steps";
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {BackupAndRestoreSteps} from "../../../steps/monitoring/backup-and-restore-steps";
+
+describe('Backup and Restore without selected repository', () => {
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Backup and Restore page via URL without a repository selected
+        BackupAndRestoreSteps.visit();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the Backup and Restore page via the navigation menu without a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnBackupAndRestore();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    const verifyInitialStateWithSelectedRepository = () => {
+        BackupAndRestoreSteps.getInfoMessageElement().contains('No running backup or restore.');
+    };
+})

--- a/e2e-tests/e2e-legacy/monitor/backup-and-restore/backup-and-restore.spec.js
+++ b/e2e-tests/e2e-legacy/monitor/backup-and-restore/backup-and-restore.spec.js
@@ -1,5 +1,5 @@
-import {BackupAndRestoreSteps} from "../../steps/monitoring/backup-and-restore-steps";
-import {BackupAndRestoreStubs} from "../../stubs/backup-and-restore-stubs";
+import {BackupAndRestoreSteps} from "../../../steps/monitoring/backup-and-restore-steps";
+import {BackupAndRestoreStubs} from "../../../stubs/backup-and-restore-stubs";
 
 describe("Monitoring 'Backup And Restore'", () => {
 

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -127,4 +127,9 @@ export class MainMenuSteps {
         this.clickOnMenuMonitoring();
         this.getSubMenuButton('sub-menu-queries-and-updates').click();
     }
+
+    static clickOnBackupAndRestore() {
+        this.clickOnMenuMonitoring();
+        this.getSubMenuButton('sub-menu-backup-and-restore').click();
+    }
 }

--- a/e2e-tests/steps/monitoring/backup-and-restore-steps.js
+++ b/e2e-tests/steps/monitoring/backup-and-restore-steps.js
@@ -1,14 +1,20 @@
-export class BackupAndRestoreSteps {
+import {BaseSteps} from "../base-steps";
+
+export class BackupAndRestoreSteps extends BaseSteps {
 
     static visit() {
         cy.visit('/monitor/backup-and-restore');
     }
 
+    static getBackupAndRestorePage() {
+        return this.getByTestId('backup-and-restore-page');
+    }
+
     static getInfoMessageElement() {
-        return cy.get('.no-running-backup-and-restore-alert');
+        return this.getBackupAndRestorePage().getByTestId('no-running-backup-and-restore-alert');
     }
 
     static getBackupAndRestoreResults() {
-        return cy.get('.backup-and-restore table tbody tr');
+        return this.getBackupAndRestorePage().find('table tbody tr');
     }
 }

--- a/packages/legacy-workbench/src/js/angular/backup-and-restore/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/backup-and-restore/plugin.js
@@ -19,6 +19,7 @@ PluginRegistry.add('main.menu', {
             order: 2,
             parent: 'Monitor',
             guideSelector: 'sub-menu-backup-and-restore',
+            testSelector: 'sub-menu-backup-and-restore',
             role: 'ROLE_REPO_MANAGER'
         }
     ]

--- a/packages/legacy-workbench/src/pages/monitor/backup-and-restore.html
+++ b/packages/legacy-workbench/src/pages/monitor/backup-and-restore.html
@@ -1,5 +1,5 @@
 <link href="css/backup-and-restore.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
-<div>
+<div data-test="backup-and-restore-page">
     <title>${messages.app.title} : ${messages.jmx.QueryMonitoringPage.title}</title>
 
 
@@ -59,7 +59,7 @@
             </tbody>
         </table>
         </div>
-        <div class="alert alert-info no-icon no-running-backup-and-restore-alert"
+        <div class="alert alert-info no-icon" data-test="no-running-backup-and-restore-alert"
              ng-if="!backupAndRestoreInfos || !backupAndRestoreInfos.length || backupAndRestoreInfos.length === 0">
             {{'view.monitoring.backup_and_restore.no_running_backup_and_restore' | translate}}
         </div>


### PR DESCRIPTION
## What
Added tests to verify the initial state of the Backup And Restore view.

## Why
To ensure that the view loads correctly and prevent navigation issues during the view migration process.

## How
Added a test for the view that verifies:
- Access via the navigation menu;
- Direct access via URL;
- Proper initialization and rendering in the expected initial state.

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
