### PR TITLE
GDB-12173 Add initial state specs for repositories

### DIFF
--- a/e2e-tests/e2e-legacy/setup/repositories/repositories-view-with-repositories.spec.js
+++ b/e2e-tests/e2e-legacy/setup/repositories/repositories-view-with-repositories.spec.js
@@ -1,0 +1,40 @@
+import {RepositorySteps} from "../../../steps/repository-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import HomeSteps from "../../../steps/home-steps";
+
+function verifyInitialRepositoriesState() {
+    RepositorySteps.getRepositoriesList().should('be.visible');
+    RepositorySteps.getLocalGraphDBTable()
+        .should('be.visible')
+        .and('have.length', 1)
+        .and('contain', 'repository-');
+}
+
+describe('Repositories view initial state', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'repository-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Repositories page via URL
+        RepositorySteps.visit();
+        // Then,
+        verifyInitialRepositoriesState();
+    });
+
+    it('should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the Repositories page via the navigation menu
+        HomeSteps.visit();
+        MainMenuSteps.clickOnRepositories();
+        // Then,
+        verifyInitialRepositoriesState();
+    })
+})

--- a/e2e-tests/e2e-legacy/setup/repositories/repositories-view-without-repositories.spec.js
+++ b/e2e-tests/e2e-legacy/setup/repositories/repositories-view-without-repositories.spec.js
@@ -1,0 +1,28 @@
+import {RepositorySteps} from "../../../steps/repository-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import HomeSteps from "../../../steps/home-steps";
+
+function verifyInitialRepositoriesState() {
+    RepositorySteps.getRepositoriesList().should('not.exist');
+    RepositorySteps.getLocalGraphDBTable()
+        .should('be.visible')
+        .and('have.length', 1)
+        .and('contain', 'There are no repositories in the current location');
+}
+
+describe('Repositories view initial state', () => {
+    it('should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Repositories page via URL
+        RepositorySteps.visit();
+        // Then,
+        verifyInitialRepositoriesState();
+    });
+
+    it('should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the Repositories page via the navigation menu
+        HomeSteps.visit();
+        MainMenuSteps.clickOnRepositories();
+        // Then,
+        verifyInitialRepositoriesState();
+    })
+})

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -21,7 +21,7 @@ export class MainMenuSteps {
     }
 
     static getMenuSetup() {
-        return MainMenuSteps.getMenuButton('Setup');
+        return this.getMainMenu().getByTestId('menu-setup');
     }
 
     static getMenuSparql() {
@@ -137,5 +137,14 @@ export class MainMenuSteps {
     static clickOnSystemMonitoring() {
         this.clickOnMenuMonitoring();
         this.getSubMenuButton('sub-menu-system-monitoring').click();
+    }
+
+    static clickOnSetupMenu() {
+        this.getMenuSetup().click()
+    }
+
+    static clickOnRepositories() {
+        this.clickOnSetupMenu();
+        this.getSubMenuButton('sub-menu-repositories').click();
     }
 }

--- a/e2e-tests/steps/repository-steps.js
+++ b/e2e-tests/steps/repository-steps.js
@@ -35,7 +35,7 @@ export class RepositorySteps {
     }
 
     static getRepositoriesDropdown() {
-        return cy.get('#repositorySelectDropdown')
+        return cy.getByTestId('onto-repository-selector')
             .scrollIntoView()
             .should('be.visible');
     }

--- a/packages/legacy-workbench/src/js/angular/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/plugin.js
@@ -17,6 +17,7 @@ PluginRegistry.add('main.menu', {
                 role: 'IS_AUTHENTICATED_FULLY',
                 icon: "icon-settings",
                 guideSelector: 'menu-setup',
+                testSelector: 'menu-setup',
                 children: []
             },
             {

--- a/packages/legacy-workbench/src/js/angular/repositories/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/plugin.js
@@ -61,7 +61,8 @@ PluginRegistry.add('main.menu', {
                 {
                     href: 'repository/edit/*'
                 }
-            ]
-            , guideSelector: 'sub-menu-repositories'
+            ],
+            guideSelector: 'sub-menu-repositories',
+            testSelector: 'sub-menu-repositories'
         }]
 });

--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
@@ -116,6 +116,7 @@ export class OntoRepositorySelector {
       <Host>
         <onto-dropdown
           class='onto-repository-selector'
+          data-test={'onto-repository-selector'}
           onValueChanged={this.onValueChanged()}
           dropdownButtonName={repositorySelection}
           dropdownButtonTooltip={this.createTooltipFunctionForRepository(this.currentRepository)}


### PR DESCRIPTION
## What
Added tests which assert the initial state of the repository view with and without available repositories

## Why
To ensure the page loads correctly

## How
Added tests, which verify the state of the view by navigating via URL and by visiting it through the navigation menu

## Testing
cypress

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
