### PR TITLE
GDB-12173 Add initial state tests for the System monitoring view

### DIFF
--- a/e2e-tests/e2e-legacy/monitor/system/monitor.resources.spec.js
+++ b/e2e-tests/e2e-legacy/monitor/system/monitor.resources.spec.js
@@ -1,3 +1,5 @@
+import {SystemMonitoringSteps} from "../../../steps/monitoring/system-monitoring-steps";
+
 describe('Monitor Resources', () => {
 
     let repositoryId;
@@ -10,8 +12,7 @@ describe('Monitor Resources', () => {
     beforeEach(() => {
         cy.presetRepository(repositoryId);
 
-        cy.visit('/monitor/system');
-        cy.window();
+        SystemMonitoringSteps.visit();
 
         // Wait for loaders to disappear
         getTabsPanel().should('be.visible');
@@ -105,8 +106,7 @@ describe('Monitor Resources', () => {
         verifyCharts(charts);
     });
 
-    // TODO: Fix me. Broken due to migration (Error: unknown)
-    it.skip('Performance monitoring tab should show charts', () => {
+    it('Performance monitoring tab should show charts', () => {
         getTabButtons().eq(1).click();
         const charts = [{
             id: 'activeQueries',

--- a/e2e-tests/e2e-legacy/monitor/system/system-monitoring-with-repository.spec.js
+++ b/e2e-tests/e2e-legacy/monitor/system/system-monitoring-with-repository.spec.js
@@ -1,0 +1,32 @@
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {SystemMonitoringSteps} from "../../../steps/monitoring/system-monitoring-steps";
+
+describe('System monitoring with selected repository', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'system-monitoring-init-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the System monitoring page via URL with a repository selected
+        SystemMonitoringSteps.visit();
+        // Then,
+        SystemMonitoringSteps.verifyInitialStateWithSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation bar', () => {
+        // Given, I visit the System monitoring page via the navigation menu with a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnSystemMonitoring();
+        // Then,
+        SystemMonitoringSteps.verifyInitialStateWithSelectedRepository();
+    });
+})

--- a/e2e-tests/e2e-legacy/monitor/system/system-monitoring-without-repository.spec.js
+++ b/e2e-tests/e2e-legacy/monitor/system/system-monitoring-without-repository.spec.js
@@ -1,0 +1,20 @@
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {SystemMonitoringSteps} from "../../../steps/monitoring/system-monitoring-steps";
+
+describe('System monitoring without selected repository', () => {
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the System monitoring page via URL without a repository selected
+        SystemMonitoringSteps.visit();
+        // Then,
+        SystemMonitoringSteps.verifyInitialStateWithSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the System monitoring page via the navigation menu without a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnSystemMonitoring();
+        // Then,
+        SystemMonitoringSteps.verifyInitialStateWithSelectedRepository();
+    });
+})

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -132,4 +132,10 @@ export class MainMenuSteps {
         this.clickOnMenuMonitoring();
         this.getSubMenuButton('sub-menu-backup-and-restore').click();
     }
+
+
+    static clickOnSystemMonitoring() {
+        this.clickOnMenuMonitoring();
+        this.getSubMenuButton('sub-menu-system-monitoring').click();
+    }
 }

--- a/e2e-tests/steps/monitoring/system-monitoring-steps.js
+++ b/e2e-tests/steps/monitoring/system-monitoring-steps.js
@@ -1,0 +1,40 @@
+import {BaseSteps} from "../base-steps";
+
+export class SystemMonitoringSteps extends BaseSteps {
+    static visit() {
+        cy.visit('/monitor/system');
+    }
+
+    static getSystemMonitoringPage() {
+        return this.getByTestId('system-monitoring-page');
+    }
+
+    static getCPUUsageChart() {
+        return this.getSystemMonitoringPage().getByTestId('cpu-usage-chart');
+    }
+
+    static getFileDescriptorChart() {
+        return this.getSystemMonitoringPage().getByTestId('file-descriptor-chart');
+    }
+
+    static getHeapMemoryChart() {
+        return this.getSystemMonitoringPage().getByTestId('heap-memory-chart');
+    }
+
+    static getOffHeapMemoryChart() {
+        return this.getSystemMonitoringPage().getByTestId('off-heap-memory-chart');
+    }
+
+    static getDiskStorageChart() {
+        return this.getSystemMonitoringPage().getByTestId('disk-storage-chart');
+    }
+
+    static verifyInitialStateWithSelectedRepository() {
+        this.getSystemMonitoringPage().should('be.visible');
+        this.getCPUUsageChart().should('be.visible');
+        this.getFileDescriptorChart().should('be.visible');
+        this.getHeapMemoryChart().should('be.visible');
+        this.getOffHeapMemoryChart().should('be.visible');
+        this.getDiskStorageChart().should('be.visible');
+    }
+}

--- a/packages/legacy-workbench/src/js/angular/resources/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/resources/plugin.js
@@ -22,7 +22,8 @@ PluginRegistry.add('main.menu', {
             role: 'ROLE_MONITORING',
             order: 3,
             parent: 'Monitor',
-            guideSelector: 'sub-menu-resources'
+            guideSelector: 'sub-menu-system-monitoring',
+            testSelector: 'sub-menu-system-monitoring'
         }
     ]
 });

--- a/packages/legacy-workbench/src/pages/monitor/resources.html
+++ b/packages/legacy-workbench/src/pages/monitor/resources.html
@@ -11,7 +11,7 @@
     <page-info-tooltip></page-info-tooltip>
 </h1>
 
-<div id="wb-monitoringResources" class="ot-owlim-resources">
+<div id="wb-monitoringResources" data-test="system-monitoring-page" class="ot-owlim-resources">
     <div class="ot-loader ot-main-loader" onto-loader size="50" ng-if="loader"></div>
 
     <div ng-if="!loader" class="graphics row">
@@ -30,7 +30,7 @@
                     <div class="tabs ml-2 mr-2">
                         <div class="tab-pane fade in" ng-if="activeTab === AVAILABLE_TABS.RESOURCE_MONITOR" id="resourceTab">
                             <div class="row mt-2">
-                                <div id="CPUUsageGraphic" class="col-lg-12 col-xl-6">
+                                <div id="CPUUsageGraphic" data-test="cpu-usage-chart" class="col-lg-12 col-xl-6">
                                     <div class="title h4" style="text-align: center;">
                                         {{'resource.system.cpu_load.label' | translate}}
                                         <span class="btn btn-link" uib-popover="{{'resource.system.cpu_load.tooltip' | translate}}" popover-trigger="mouseenter"
@@ -45,7 +45,7 @@
                                          chart="resourceMonitorData.charts.cpuLoad"
                                          style="width: 100%; height: 500px"></div>
                                 </div>
-                                <div id="openFileDescriptors" class="col-lg-12 col-xl-6">
+                                <div id="openFileDescriptors" data-test="file-descriptor-chart" class="col-lg-12 col-xl-6">
                                     <div class="title h4" style="text-align: center;">
                                         {{'resource.system.file_descriptors.label' | translate}}
                                         <span class="btn btn-link" uib-popover="{{'resource.system.file_descriptors.tooltip' | translate}}" popover-trigger="mouseenter"
@@ -62,7 +62,7 @@
                                 </div>
                             </div>
                             <div class="row mt-2">
-                                <div id="heapMemoryGraphic" class="col-lg-12 col-xl-6">
+                                <div id="heapMemoryGraphic" data-test="heap-memory-chart" class="col-lg-12 col-xl-6">
                                     <div class="title h4" style="text-align: center;">
                                         {{'resource.memory.heap.label' | translate}}
                                         <span class="btn btn-link" uib-popover="{{'resource.memory.heap.tooltip' | translate}}" popover-trigger="mouseenter"
@@ -77,7 +77,7 @@
                                          chart="resourceMonitorData.charts.heapMemory"
                                          style="width: 100%; height: 500px"></div>
                                 </div>
-                                <div id="offHeapMemoryGraphic" class="col-lg-12 col-xl-6">
+                                <div id="offHeapMemoryGraphic" data-test="off-heap-memory-chart" class="col-lg-12 col-xl-6">
                                     <div class="title h4" style="text-align: center;">
                                         {{'resource.memory.non_heap.label' | translate}}
                                         <span class="btn btn-link" uib-popover="{{'resource.memory.non_heap.tooltip' | translate}}" popover-trigger="mouseenter"
@@ -94,7 +94,7 @@
                                 </div>
                             </div>
                             <div class="row mt-2">
-                                <div id="diskStorage" class="col-lg-12 col-xl-6">
+                                <div id="diskStorage" data-test="disk-storage-chart" class="col-lg-12 col-xl-6">
                                     <div class="title h4" style="text-align: center;">
                                         {{'resource.storage.label' | translate}}
                                         <span class="btn btn-link" uib-popover="{{'resource.storage.tooltip' | translate}}" popover-trigger="mouseenter"


### PR DESCRIPTION
## What
Added tests to verify the initial state of the System monitoring view.

## Why
To ensure that the view loads correctly and prevent navigation issues during the view migration process.

## How
Added a test for the view that verifies:
- Access via the navigation menu;
- Direct access via URL;
- Proper initialization and rendering in the expected initial state.

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
