### PR TITLE
GDB-12173 Add initial state tests for the License view

### DIFF
--- a/e2e-tests/e2e-legacy/license/license-with-repository.spec.js
+++ b/e2e-tests/e2e-legacy/license/license-with-repository.spec.js
@@ -1,0 +1,113 @@
+import HomeSteps from "../../steps/home-steps";
+import {MainMenuSteps} from "../../steps/main-menu-steps";
+import {LicenseSteps} from "../../steps/license-steps";
+import {LicenseStubs} from "../../stubs/license-stubs";
+
+describe('License with selected repository', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'license-init-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should display the correct initial state when navigating via URL and there is no license', () => {
+        LicenseStubs.stubLicenseHardcoded(false)
+        LicenseStubs.stubLicenseNotSet();
+        // Given, I visit the License page via URL with a repository selected and there is no license
+        LicenseSteps.visit();
+        // Then,
+        LicenseSteps.verifyLicenseNotSet();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation bar and there is no license', () => {
+        LicenseStubs.stubLicenseHardcoded(false)
+        LicenseStubs.stubLicenseNotSet();
+        // Given, I visit the License page via the navigation menu with a repository selected and there is no license
+        HomeSteps.visit();
+        MainMenuSteps.clickOnLicense();
+        // Then,
+        LicenseSteps.verifyLicenseNotSet();
+    });
+
+    it('Should display the correct initial state when navigating via URL and there is no valid license', () => {
+        LicenseStubs.stubLicenseHardcoded(false);
+        LicenseStubs.stubNoValidLicense();
+        // Given, I visit the License page via URL with a repository selected and there is no valid license
+        LicenseSteps.visit();
+        // Then,
+        LicenseSteps.verifyNoValidLicense();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation bar and there is no valid license', () => {
+        LicenseStubs.stubLicenseHardcoded(false);
+        LicenseStubs.stubNoValidLicense();
+        // Given, I visit the License page via the navigation menu with a repository selected and there is no valid license
+        HomeSteps.visit();
+        MainMenuSteps.clickOnLicense();
+        // Then,
+        LicenseSteps.verifyNoValidLicense();
+    });
+
+    it('Should display the correct initial state when navigating via URL and there is no valid hardcoded license', () => {
+        LicenseStubs.stubLicenseHardcoded(true);
+        LicenseStubs.stubNoValidLicense();
+        // Given, I visit the License page via URL with a repository selected and there is no valid hardcoded license
+        LicenseSteps.visit();
+        // Then,
+        LicenseSteps.verifyNoValidLicenseHardcoded();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation bar and there is no valid hardcoded license', () => {
+        LicenseStubs.stubLicenseHardcoded(true);
+        LicenseStubs.stubNoValidLicense();
+        // Given, I visit the License page via the navigation menu with a repository selected and there is no valid license
+        HomeSteps.visit();
+        MainMenuSteps.clickOnLicense();
+        // Then,
+        LicenseSteps.verifyNoValidLicenseHardcoded();
+    });
+
+    it('Should display the correct initial state when navigating via URL and there is valid license', () => {
+        LicenseStubs.stubLicenseHardcoded(false);
+        LicenseStubs.stubEnterpriseLicense();
+        // Given, I visit the License page via URL with a repository selected and there is valid license
+        LicenseSteps.visit();
+        // Then,
+        LicenseSteps.verifyValidLicense();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation bar and there is valid license', () => {
+        LicenseStubs.stubLicenseHardcoded(false);
+        LicenseStubs.stubEnterpriseLicense();
+        // Given, I visit the License page via the navigation menu with a repository selected and there is valid license
+        HomeSteps.visit();
+        MainMenuSteps.clickOnLicense();
+        // Then,
+        LicenseSteps.verifyValidLicense();
+    });
+
+    it('Should display the correct initial state when navigating via URL and there is valid hardcoded license', () => {
+        LicenseStubs.stubLicenseHardcoded(true);
+        LicenseStubs.stubEnterpriseLicense();
+        // Given, I visit the License page via URL with a repository selected and there is valid hardcoded license
+        LicenseSteps.visit();
+        // Then,
+        LicenseSteps.verifyValidLicenseHardcoded();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation bar and there is valid hardcoded license', () => {
+        LicenseStubs.stubLicenseHardcoded(true);
+        LicenseStubs.stubEnterpriseLicense();
+        // Given, I visit the License page via the navigation menu with a repository selected and there is valid hardcoded license
+        HomeSteps.visit();
+        MainMenuSteps.clickOnLicense();
+        // Then,
+        LicenseSteps.verifyValidLicenseHardcoded();
+    });
+})

--- a/e2e-tests/e2e-legacy/license/license-without-repository.spec.js
+++ b/e2e-tests/e2e-legacy/license/license-without-repository.spec.js
@@ -1,0 +1,103 @@
+import HomeSteps from "../../steps/home-steps";
+import {MainMenuSteps} from "../../steps/main-menu-steps";
+import {LicenseSteps} from "../../steps/license-steps";
+import {LicenseStubs} from "../../stubs/license-stubs";
+
+describe('License without selected repository', () => {
+
+    it('Should display the correct initial state when navigating via URL and there is no license', () => {
+        LicenseStubs.stubLicenseHardcoded(false)
+        LicenseStubs.stubLicenseNotSet();
+        // Given, I visit the License page via URL without a repository selected and there is no license
+        LicenseSteps.visit();
+        // Then,
+        LicenseSteps.verifyLicenseNotSet();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu and there is no license', () => {
+        LicenseStubs.stubLicenseHardcoded(false)
+        LicenseStubs.stubLicenseNotSet();
+        // Given, I visit the License page via the navigation menu without a repository selected and there is no license
+        HomeSteps.visit();
+        MainMenuSteps.clickOnLicense();
+        // Then,
+        LicenseSteps.verifyLicenseNotSet();
+    });
+
+    it('Should display the correct initial state when navigating via URL and there is no valid license', () => {
+        LicenseStubs.stubLicenseHardcoded(false);
+        LicenseStubs.stubNoValidLicense();
+        // Given, I visit the License page via URL without a repository selected and there is no valid license
+        LicenseSteps.visit();
+        // Then,
+        LicenseSteps.verifyNoValidLicense();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu and there is no valid license', () => {
+        LicenseStubs.stubLicenseHardcoded(false);
+        LicenseStubs.stubNoValidLicense();
+        // Given, I visit the License page via the navigation menu without a repository selected and there is no valid license
+        HomeSteps.visit();
+        MainMenuSteps.clickOnLicense();
+        // Then,
+        LicenseSteps.verifyNoValidLicense();
+    });
+
+    it('Should display the correct initial state when navigating via URL and there is no valid hardcoded license', () => {
+        LicenseStubs.stubLicenseHardcoded(true);
+        LicenseStubs.stubNoValidLicense();
+        // Given, I visit the License page via URL without a repository selected and there is no valid hardcoded license
+        LicenseSteps.visit();
+        // Then,
+        LicenseSteps.verifyNoValidLicenseHardcoded();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu and there is no valid hardcoded license', () => {
+        LicenseStubs.stubLicenseHardcoded(true);
+        LicenseStubs.stubNoValidLicense();
+        // Given, I visit the License page via the navigation menu without a repository selected and there is no valid hardcoded license
+        HomeSteps.visit();
+        MainMenuSteps.clickOnLicense();
+        // Then,
+        LicenseSteps.verifyNoValidLicenseHardcoded();
+    });
+
+    it('Should display the correct initial state when navigating via URL and there is valid license', () => {
+        LicenseStubs.stubLicenseHardcoded(false);
+        LicenseStubs.stubEnterpriseLicense();
+        // Given, I visit the License page via URL without a repository selected and there is valid license
+        LicenseSteps.visit();
+        // Then,
+        LicenseSteps.verifyValidLicense();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu and there is valid license', () => {
+        LicenseStubs.stubLicenseHardcoded(false);
+        LicenseStubs.stubEnterpriseLicense();
+        // Given, I visit the License page via the navigation menu without a repository selected and there is valid license
+        HomeSteps.visit();
+        MainMenuSteps.clickOnLicense();
+        // Then,
+        LicenseSteps.verifyValidLicense();
+    });
+
+
+    it('Should display the correct initial state when navigating via URL and there is valid hardcoded license', () => {
+        LicenseStubs.stubLicenseHardcoded(true);
+        LicenseStubs.stubEnterpriseLicense();
+        // Given, I visit the License page via URL without a repository selected and there is valid hardcoded license
+        LicenseSteps.visit();
+        // Then,
+        LicenseSteps.verifyValidLicenseHardcoded();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu and there is valid harcoded license', () => {
+        LicenseStubs.stubLicenseHardcoded(true);
+        LicenseStubs.stubEnterpriseLicense();
+        // Given, I visit the License page via the navigation menu without a repository selected and there is valid hardcoded license
+        HomeSteps.visit();
+        MainMenuSteps.clickOnLicense();
+        // Then,
+        LicenseSteps.verifyValidLicenseHardcoded();
+    });
+})

--- a/e2e-tests/e2e-legacy/license/license.spec.js
+++ b/e2e-tests/e2e-legacy/license/license.spec.js
@@ -9,8 +9,8 @@ describe('License', () => {
       LicenseSteps.getLicenseHeader().should('have.text', "GraphDB Enterprise Edition");
 
       LicenseSteps.getHardcodedAlertMessage().should('exist');
-      LicenseSteps.getRemoveLicenseLicenseButton().should('not.exist');
-      LicenseSteps.getSetNewLicenseElement().should('not.exist');
+      LicenseSteps.getRemoveLicenseButton().should('not.exist');
+      LicenseSteps.getSetNewLicenseButton().should('not.exist');
    });
 
    it('Should not displays an informational message if the license is not provided through a file (not hardcoded)', () => {
@@ -20,7 +20,7 @@ describe('License', () => {
       LicenseSteps.getLicenseHeader().should('have.text', "GraphDB Enterprise Edition");
 
       LicenseSteps.getHardcodedAlertMessage().should('not.exist');
-      LicenseSteps.getRemoveLicenseLicenseButton().should('exist');
-      LicenseSteps.getSetNewLicenseElement().should('exist');
+      LicenseSteps.getRemoveLicenseButton().should('exist');
+      LicenseSteps.getSetNewLicenseButton().should('exist');
    });
 });

--- a/e2e-tests/steps/license-steps.js
+++ b/e2e-tests/steps/license-steps.js
@@ -1,25 +1,107 @@
-export class LicenseSteps {
+import {BaseSteps} from "./base-steps";
+
+export class LicenseSteps extends BaseSteps {
     static visit() {
         cy.visit('/license');
     }
 
-    static getLicense() {
-        return cy.get('.license-container');
+    static getLicensePage() {
+        return this.getByTestId('license-info-page');
+    }
+
+    static getLicenseAlertButton() {
+        return this.getByTestId('onto-license-alert');
     }
 
     static getLicenseHeader() {
-        return LicenseSteps.getLicense().find('.card-header');
+        return LicenseSteps.getLicensePage().find('.card-header');
+    }
+
+    static getRemoveLicenseButton() {
+        return LicenseSteps.getLicensePage().getByTestId('remove-license-button');
+    }
+
+    static getSetNewLicenseButton() {
+        return LicenseSteps.getLicensePage().getByTestId('set-new-license-link');
+    }
+
+    static getNoValidLicenseAlert() {
+        return LicenseSteps.getLicensePage().getByTestId('no-valid-license-alert');
+    }
+
+    static getNoLicenseAlertTitle() {
+        return LicenseSteps.getLicensePage().getByTestId('no-license-title');
+    }
+
+    static getValidLicenseAlertTitle() {
+        return LicenseSteps.getLicensePage().getByTestId('valid-license-title');
+    }
+
+    static getLicenseContent() {
+        return LicenseSteps.getLicensePage().getByTestId('license-content');
     }
 
     static getHardcodedAlertMessage() {
-        return cy.get('.license-hardcoded-alert-message');
+        return cy.getByTestId('license-hardcoded-alert-message');
     }
 
-    static getRemoveLicenseLicenseButton() {
-        return LicenseSteps.getLicense().find('.revert-to-free-license-btn');
+    static verifyLicenseNotSet() {
+        LicenseSteps.getLicensePage().should('be.visible');
+        LicenseSteps.getLicenseAlertButton().should('exist');
+        LicenseSteps.getRemoveLicenseButton().should('be.visible').should('be.disabled');
+        LicenseSteps.getSetNewLicenseButton().should('be.visible');
+        LicenseSteps.getNoValidLicenseAlert().should('exist');
+        LicenseSteps.getNoLicenseAlertTitle().should('exist');
+        LicenseSteps.getValidLicenseAlertTitle().should('not.exist');
+        LicenseSteps.getLicenseContent().should('not.exist');
+        LicenseSteps.getHardcodedAlertMessage().should('not.exist');
     }
 
-    static getSetNewLicenseElement() {
-        return LicenseSteps.getLicense().find('.set-new-license-link');
+    static verifyNoValidLicense() {
+       LicenseSteps.getLicensePage().should('be.visible');
+       LicenseSteps.getLicenseAlertButton().should('be.visible');
+       LicenseSteps.getRemoveLicenseButton().should('exist');
+       LicenseSteps.getSetNewLicenseButton().should('be.visible');
+       LicenseSteps.getNoValidLicenseAlert().should('be.visible');
+       LicenseSteps.getNoLicenseAlertTitle().should('not.exist');
+       LicenseSteps.getValidLicenseAlertTitle().should('exist');
+       LicenseSteps.getLicenseContent().should('exist');
+       LicenseSteps.getHardcodedAlertMessage().should('not.exist');
+    }
+
+    static verifyValidLicense() {
+        LicenseSteps.getLicensePage().should('be.visible');
+        LicenseSteps.getLicenseAlertButton().should('not.exist');
+        LicenseSteps.getRemoveLicenseButton().should('be.visible').should('be.enabled');
+        LicenseSteps.getSetNewLicenseButton().should('be.visible');
+        LicenseSteps.getNoValidLicenseAlert().should('not.exist');
+        LicenseSteps.getNoLicenseAlertTitle().should('not.exist');
+        LicenseSteps.getValidLicenseAlertTitle().should('exist');
+        LicenseSteps.getLicenseContent().should('exist');
+        LicenseSteps.getHardcodedAlertMessage().should('not.exist');
+    }
+
+    static verifyNoValidLicenseHardcoded() {
+        LicenseSteps.getLicensePage().should('be.visible');
+        LicenseSteps.getLicenseAlertButton().should('be.visible');
+        LicenseSteps.getRemoveLicenseButton().should('not.exist');
+        LicenseSteps.getSetNewLicenseButton().should('not.exist');
+        LicenseSteps.getNoValidLicenseAlert().should('exist');
+        LicenseSteps.getNoLicenseAlertTitle().should('not.exist');
+        LicenseSteps.getValidLicenseAlertTitle().should('exist');
+        LicenseSteps.getLicenseContent().should('exist');
+        LicenseSteps.getHardcodedAlertMessage().should('exist');
+    }
+
+    static verifyValidLicenseHardcoded() {
+        LicenseSteps.getLicensePage().should('be.visible');
+        LicenseSteps.getLicenseAlertButton().should('not.exist');
+        LicenseSteps.getRemoveLicenseButton().should('not.exist');
+        LicenseSteps.getSetNewLicenseButton().should('not.exist');
+        LicenseSteps.getNoValidLicenseAlert().should('not.exist');
+        LicenseSteps.getNoLicenseAlertTitle().should('not.exist');
+        LicenseSteps.getValidLicenseAlertTitle().should('exist');
+        LicenseSteps.getLicenseContent().should('exist');
+        LicenseSteps.getHardcodedAlertMessage().should('exist');
     }
 }

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -20,10 +20,6 @@ export class MainMenuSteps {
         return MainMenuSteps.getMenuButton('Explore');
     }
 
-    static getMenuSetup() {
-        return this.getMainMenu().getByTestId('menu-setup');
-    }
-
     static getMenuSparql() {
         return MainMenuSteps.getMenuButton('SPARQL');
     }
@@ -139,37 +135,49 @@ export class MainMenuSteps {
         this.getSubMenuButton('sub-menu-system-monitoring').click();
     }
 
-    static clickOnSetupMenu() {
-        this.getMenuSetup().click()
+    // --------------------------
+    // --     Setup menu  --
+    // --------------------------
+    static getMenuSetup() {
+        return MainMenuSteps.getMainMenu().getByTestId('menu-setup');
+    }
+
+    static clickOnMenuSetup() {
+        this.getMenuSetup().click();
     }
 
     static clickOnRepositories() {
-        this.clickOnSetupMenu();
+        this.clickOnMenuSetup();
         this.getSubMenuButton('sub-menu-repositories').click();
     }
 
     static clickOnACLManagement() {
-        this.clickOnSetupMenu();
+        this.clickOnMenuSetup();
         this.getSubMenuButton('sub-menu-acl-management').click();
     }
 
     static clickOnUsersAndAccess() {
-        this.clickOnSetupMenu();
+        this.clickOnMenuSetup();
         this.getSubMenuButton('sub-menu-users-and-access').click();
     }
 
+    static clickOnLicense() {
+        this.clickOnMenuSetup();
+        this.getSubMenuButton('sub-menu-license').click();
+    }
+
     static clickOnSparqlTemplates() {
-        this.clickOnSetupMenu();
+        this.clickOnMenuSetup();
         this.getSubMenuButton('sub-menu-sparql-templates').click();
     }
 
     static clickOnJDBC() {
-        this.clickOnSetupMenu();
+        this.clickOnMenuSetup();
         this.getSubMenuButton('sub-menu-jdbc').click();
     }
 
     static clickOnRDFRank() {
-        this.clickOnSetupMenu();
+        this.clickOnMenuSetup();
         this.getSubMenuButton('sub-menu-rdf-rank').click();
     }
 }

--- a/e2e-tests/stubs/license-stubs.js
+++ b/e2e-tests/stubs/license-stubs.js
@@ -18,6 +18,57 @@ export class LicenseStubs {
         }).as('enterpriseLicense');
     }
 
+    static stubLicenseNotSet() {
+        cy.intercept('GET', '/rest/graphdb-settings/license', {
+            statusCode: 200,
+            body:{
+                "installationId": null,
+                "message": "No license was set",
+                "productType": "unknown",
+                "licenseCapabilities": [],
+                "present": false,
+                "valid": false,
+                "version": "Invalid",
+                "product": "Invalid",
+                "licensee": "Invalid",
+                "typeOfUse": "Invalid",
+                "maxCpuCores": 0,
+                "usageRestriction": "Invalid",
+                "expiryDate": 0,
+                "latestPublicationDate": 0
+            }
+        }).as('licenseNotSet');
+    }
+
+    static stubNoValidLicense() {
+        cy.intercept('GET', '/rest/graphdb-settings/license', {
+            statusCode: 200,
+            body:{
+                "installationId": null,
+                "message": "The license key expired on 2025-01-31",
+                "valid": false,
+                "productType": "enterprise",
+                "licenseCapabilities": [
+                    "Lucene connector",
+                    "Solr connector",
+                    "Elasticsearch connector",
+                    "OpenSearch connector",
+                    "Kafka connector",
+                    "Cluster"
+                ],
+                "version": null,
+                "product": "GRAPHDB_ENTERPRISE",
+                "licensee": "ONTOTEXT_INTERNAL",
+                "typeOfUse": "Non-commercial research only",
+                "usageRestriction": null,
+                "expiryDate": 1738274400000,
+                "latestPublicationDate": null,
+                "maxCpuCores": null,
+                "present": true
+            }
+        }).as('noValidLicense');
+    }
+
     static stubEvaluationLicense() {
         cy.intercept('GET', '/rest/graphdb-settings/license', {
             statusCode: 200,

--- a/packages/legacy-workbench/src/js/angular/settings/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/settings/plugin.js
@@ -31,6 +31,7 @@ PluginRegistry.add('main.menu', {
         order: 100,
         role: 'ROLE_ADMIN',
         parent: 'Setup',
-        guideSelector: 'sub-menu-license'
+        guideSelector: 'sub-menu-license',
+        testSelector: 'sub-menu-license',
     }]
 });

--- a/packages/legacy-workbench/src/pages/licenseInfo.html
+++ b/packages/legacy-workbench/src/pages/licenseInfo.html
@@ -7,17 +7,17 @@
 
 <div class="ot-loader ot-main-loader" onto-loader size="100" ng-show="loadingLicense()"></div>
 
-<div class="license-container" ng-show="!loadingLicense()">
+<div class="license-container" data-test="license-info-page" ng-show="!loadingLicense()">
     <div class="card">
-        <h4 ng-if="isLicensePresent()" class="card-header">GraphDB {{getProductType() | titlecase}} {{'edition' | translate}}</h4>
-        <h4 ng-if="!isLicensePresent()" class="card-header">{{'no.license' | translate}}</h4>
-        <div class="alert alert-danger" ng-if="!isLicenseValid()">
+        <h4 ng-if="isLicensePresent()" class="card-header" data-test="valid-license-title">GraphDB {{getProductType() | titlecase}} {{'edition' | translate}}</h4>
+        <h4 ng-if="!isLicensePresent()" class="card-header" data-test="no-license-title">{{'no.license' | translate}}</h4>
+        <div class="alert alert-danger" ng-if="!isLicenseValid()" data-test="no-valid-license-alert">
             <strong>{{getLicenseErrorMsg()}}</strong>
             <div ng-bind-html="'supply.license.or.contact.us.warning' | translate | trustAsHtml"></div>
             <div class="mt-1">{{'no.license.restrictions' | translate}}</div>
         </div>
         <div class="card-block">
-            <div ng-if="isLicensePresent()">
+            <div ng-if="isLicensePresent()" data-test="license-content">
                 <div class="float-xs-left d-inline-block mr-2 mb-1">
                     {{'licensed.to' | translate}}
                     <span class="data-value d-block">{{getLicense().licensee}}</span>
@@ -55,10 +55,13 @@
             <div class="text-right">
                 <button ng-click="removeLicense()" ng-if="!isLicenseHardcoded() && isAdmin()"
                         ng-disabled="!isLicensePresent()"
-                        class="btn btn-secondary revert-to-free-license-btn">
+                        class="btn btn-secondary revert-to-free-license-btn"
+                        data-test="remove-license-button">
                     {{'remove.license' | translate}}
                 </button>
-                <a href="license/register" ng-if="!isLicenseHardcoded() && isAdmin()" class="btn btn-primary set-new-license-link">
+                <a href="license/register" ng-if="!isLicenseHardcoded() && isAdmin()"
+                   class="btn btn-primary set-new-license-link"
+                   data-test="set-new-license-link">
                     {{'core.errors.set.new.license.warning.msg' | translate}}
                 </a>
             </div>
@@ -66,7 +69,9 @@
     </div>
 </div>
 
-<div class="alert alert-warning license-hardcoded-alert-message" ng-if="isLicenseHardcoded() && isAdmin()">
+<div class="alert alert-warning license-hardcoded-alert-message"
+     data-test="license-hardcoded-alert-message"
+     ng-if="isLicenseHardcoded() && isAdmin()">
     {{'license.cannot.be.changed.from.wb.warning' | translate}}
 </div>
 

--- a/packages/shared-components/src/components/onto-license-alert/onto-license-alert.tsx
+++ b/packages/shared-components/src/components/onto-license-alert/onto-license-alert.tsx
@@ -19,7 +19,7 @@ export class OntoLicenseAlert {
 
   render() {
     return (
-      <Host tooltip-content={this.license?.message} tooltip-placement={OntoTooltipPlacement.BOTTOM}>
+      <Host tooltip-content={this.license?.message} tooltip-placement={OntoTooltipPlacement.BOTTOM} data-test='onto-license-alert'>
         <button class="onto-license-alert onto-btn" onClick={this.onLicenseAlertClick}>
           <span class="icon-warning"></span>
           <translate-label labelKey={'license_alert.label'}></translate-label>


### PR DESCRIPTION
## What
Added tests to verify the initial state of the License view.

## Why
To ensure that the view loads correctly and prevent navigation issues during the view migration process.

## How
Added a test for the view that verifies:
- Access via the navigation menu;
- Direct access via URL;
- Proper initialization and rendering in the expected initial state.

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
