### PR TITLE
GDB-12173 Add initial state specs for users and access

### DIFF
--- a/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
+++ b/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
@@ -1,10 +1,10 @@
-import {UserAndAccessSteps} from "../../steps/setup/user-and-access-steps";
-import {RepositoriesStubs} from "../../stubs/repositories/repositories-stubs";
-import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";
-import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
-import {ToasterSteps} from "../../steps/toaster-steps";
-import HomeSteps from "../../steps/home-steps";
-import {LoginSteps} from "../../steps/login-steps";
+import {UserAndAccessSteps} from "../../../steps/setup/user-and-access-steps";
+import {RepositoriesStubs} from "../../../stubs/repositories/repositories-stubs";
+import {RepositorySelectorSteps} from "../../../steps/repository-selector-steps";
+import {ModalDialogSteps} from "../../../steps/modal-dialog-steps";
+import {ToasterSteps} from "../../../steps/toaster-steps";
+import HomeSteps from "../../../steps/home-steps";
+import {LoginSteps} from "../../../steps/login-steps";
 
 
 /**

--- a/e2e-tests/e2e-legacy/setup/users-and-access/users-and-access-initial-state.spec.js
+++ b/e2e-tests/e2e-legacy/setup/users-and-access/users-and-access-initial-state.spec.js
@@ -1,0 +1,25 @@
+import {UserAndAccessSteps} from "../../../steps/setup/user-and-access-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+
+function validateInitialState() {
+    UserAndAccessSteps.getCreateNewUserButton().should('be.visible');
+    UserAndAccessSteps.getToggleSecuritySwitch().should('be.visible');
+    UserAndAccessSteps.getUsersTable().should('be.visible');
+}
+
+describe('Users and Access initial state', () => {
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Users and Access page via URL
+        UserAndAccessSteps.visit();
+        // Then,
+        validateInitialState();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the Users and Access page via the navigation menu
+        UserAndAccessSteps.visit();
+        MainMenuSteps.clickOnUsersAndAccess();
+        // Then,
+        validateInitialState();
+    });
+})

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -152,4 +152,9 @@ export class MainMenuSteps {
         this.clickOnSetupMenu();
         this.getSubMenuButton('sub-menu-acl-management').click();
     }
+
+    static clickOnUsersAndAccess() {
+        this.clickOnSetupMenu();
+        this.getSubMenuButton('sub-menu-users-and-access').click();
+    }
 }

--- a/packages/legacy-workbench/src/js/angular/security/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/security/plugin.js
@@ -84,7 +84,8 @@ PluginRegistry.add('main.menu', {
                 href: 'user/*',
                 children: []
             }],
-            guideSelector: 'sub-menu-user-and-access'
+            guideSelector: 'sub-menu-user-and-access',
+            testSelector: 'sub-menu-users-and-access'
         },
         {
             label: 'My Settings',


### PR DESCRIPTION
## What
Added tests which assert the initial state of the users and access view.

## Why
To ensure the page loads correctly

## How
Added tests, which verify the state of the view by navigating via URL and by visiting it through the navigation menu. One spec file is added, since the users and access view doesn't change based on presence/absence of repositories

## Testing
cypress

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
