### PR TITLE
GDB-12173 Add initial state specs for ACL management

### DIFF
--- a/e2e-tests/e2e-legacy/setup/aclmanagement/acl-management-with-selected repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/aclmanagement/acl-management-with-selected repository.spec.js
@@ -1,0 +1,40 @@
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {AclManagementSteps} from "../../../steps/setup/acl-management-steps";
+
+function verifyStateWithSelectedRepository() {
+    AclManagementSteps.getPageHeading().should('be.visible');
+    AclManagementSteps.getAclTable().should('be.visible');
+    AclManagementSteps.getNoDataMessage().should('be.visible');
+    AclManagementSteps.getAddFirstRuleButton().should('be.visible');
+    AclManagementSteps.getAclTabs().should('be.visible').and('have.length', 4);
+}
+
+describe('ACL Management initial state with repositories', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'acl-management-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the ACL Management page via URL with a repository selected
+        AclManagementSteps.visit();
+        // Then,
+        verifyStateWithSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the ACL Management page via the navigation menu with a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnACLManagement();
+        // Then,
+        verifyStateWithSelectedRepository();
+    });
+})

--- a/e2e-tests/e2e-legacy/setup/aclmanagement/acl-management-without-repositories.spec.js
+++ b/e2e-tests/e2e-legacy/setup/aclmanagement/acl-management-without-repositories.spec.js
@@ -1,0 +1,21 @@
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import HomeSteps from "../../../steps/home-steps";
+import {ErrorSteps} from "../../../steps/error-steps";
+import {AclManagementSteps} from "../../../steps/setup/acl-management-steps";
+
+describe('ACL Management initial state without repositories', () => {
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the ACL Management page via URL without repositories selected
+        AclManagementSteps.visit();
+        // Then,
+        ErrorSteps.verifyNoConnectedRepoMessage();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the ACL Management page via the navigation menu without repositories selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnACLManagement();
+        // Then,
+        ErrorSteps.verifyNoConnectedRepoMessage();
+    });
+});

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -147,4 +147,9 @@ export class MainMenuSteps {
         this.clickOnSetupMenu();
         this.getSubMenuButton('sub-menu-repositories').click();
     }
+
+    static clickOnACLManagement() {
+        this.clickOnSetupMenu();
+        this.getSubMenuButton('sub-menu-acl-management').click();
+    }
 }

--- a/packages/legacy-workbench/src/js/angular/aclmanagement/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/aclmanagement/plugin.js
@@ -20,7 +20,8 @@ PluginRegistry.add('main.menu', {
             order: 6,
             parent: 'Setup',
             role: "ROLE_ADMIN",
-            guideSelector: 'sub-menu-aclmanagement'
+            guideSelector: 'sub-menu-aclmanagement',
+            testSelector: 'sub-menu-acl-management'
         }
     ]
 });


### PR DESCRIPTION
## What
Added tests which assert the initial state of the acl management view.

## Why
To ensure the page loads correctly

## How
Added tests, which verify the state of the view by navigating via URL and by visiting it through the navigation menu. Added tests with a selected repo and without any repositories

## Testing
cypress

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
