### PR TITLE
GDB-12173 Add initial state tests

### DIFF
--- a/e2e-tests/e2e-legacy/setup/jdbc/jdbc-create.spec.js
+++ b/e2e-tests/e2e-legacy/setup/jdbc/jdbc-create.spec.js
@@ -1,0 +1,329 @@
+import {JdbcSteps} from "../../../steps/setup/jdbc-steps";
+import {JdbcCreateSteps} from "../../../steps/setup/jdbc-create-steps";
+import {ToasterSteps} from "../../../steps/toaster-steps";
+import {YasrSteps} from "../../../steps/yasgui/yasr-steps";
+import {ModalDialogSteps, VerifyConfirmationDialogOptions} from "../../../steps/modal-dialog-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {RepositorySelectorSteps} from "../../../steps/repository-selector-steps";
+import {YasguiLoader} from "../../../steps/yasgui/yasgui-loader";
+
+const FILE_TO_IMPORT = '200-row-allianz.ttl';
+const DEFAULT_QUERY = 'PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n' +
+    '\n' +
+    '# Selects two variables to use as columns\n' +
+    'SELECT ?id ?label {\n' +
+    '    ?id rdfs:label ?label\n' +
+    '    # The following placeholder must be present in the query\n' +
+    '    #!filter\n' +
+    '}';
+// TODO: Fix me. Broken due to migration (Error: unknown)
+describe.skip('JDBC configuration', () => {
+
+    let repositoryId;
+    let secondRepositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'jdbc-repo-' + Date.now();
+        secondRepositoryId = repositoryId + '-second';
+        cy.createRepository({id: repositoryId});
+        cy.createRepository({id: secondRepositoryId});
+        cy.presetRepository(repositoryId);
+        cy.importServerFile(repositoryId, FILE_TO_IMPORT);
+        JdbcCreateSteps.visit();
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+        cy.deleteRepository(secondRepositoryId);
+    });
+
+    it('Should open saved jdbc configs catalog when repository is changed', () => {
+        // Given I have opened the jdbc configurations page
+        // When I change the repository
+        RepositorySelectorSteps.selectRepository(secondRepositoryId);
+        // Then I expect to see the jdbc config catalog page
+        JdbcSteps.verifyUrl();
+        // And the jdbc config catalog should be empty
+        JdbcSteps.getJDBCConfigurations().should('be.visible');
+    });
+
+    it('should not allow preview if query is invalid or column are not selected', () => {
+        // When I open the create JDBC configuration page,
+        // and click on "Preview" button.
+        JdbcCreateSteps.clickOnPreviewButton();
+
+        // Then I expect to see error notification,
+        ToasterSteps.verifyError('Please define at least one column');
+        // and "Column type" tab to be opened,
+        JdbcCreateSteps.getActiveTab().contains('Column types');
+        // and two columns to be suggested.
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 2);
+
+        // When I click "Preview" again.
+        JdbcCreateSteps.clickOnPreviewButton();
+
+        // Then I expect to see loader,
+        YasguiLoader.verifyMessage('Preview of first 100 rows of table', 1);
+        // and see the generated preview.
+        YasrSteps.getResults().should('be.visible');
+    });
+
+    it('should contains exactly columns in preview than selected in Columns type tag', () => {
+        // When I open the create JDBC configuration page,
+        JdbcCreateSteps.openColumnTypesTab();
+        // waite columns to be suggested,
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 2);
+        // and make preview on default query.
+        JdbcCreateSteps.clickOnPreviewButton();
+
+        // Then I expect to see three columns. One for index and others are from the query.
+        YasrSteps.getResultRowCells(1).should('have.length', 3);
+
+        // When I try to remove a column.
+        JdbcCreateSteps.openColumnTypesTab();
+        JdbcCreateSteps.clickOnDeleteColumnButton();
+
+        // Then I expect to be asked to confirm deletion of the column.
+        ModalDialogSteps.verifyDialogBody('Are you sure you want to delete the column \'id\'?');
+
+        // When I click on cancel button.
+        ModalDialogSteps.clickOnCancelButton();
+
+        // Then I expect the column not be deleted.
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 2);
+
+        // When I try to remove a column.
+        JdbcCreateSteps.openColumnTypesTab();
+        JdbcCreateSteps.clickOnDeleteColumnButton();
+
+        // Then I expect to be asked to confirm deletion of the column.
+        ModalDialogSteps.verifyDialogBody('Are you sure you want to delete the column \'id\'?');
+
+        // When I click on close button.
+        ModalDialogSteps.clickOnCloseButton();
+
+        // Then I expect the column not be deleted.
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 2);
+
+        // When I remove a column.
+        JdbcCreateSteps.openColumnTypesTab();
+        JdbcCreateSteps.clickOnDeleteColumnButton();
+
+        // Then I expect to be asked to confirm deletion of the column.
+        ModalDialogSteps.verifyDialogBody('Are you sure you want to delete the column \'id\'?');
+
+        // When I click on confirm button.
+        ModalDialogSteps.clickOnConfirmButton();
+
+        // Then I expect the column be deleted.
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 1);
+
+        // When I click on preview button.
+        JdbcCreateSteps.clickOnPreviewButton();
+
+        // Then I expect to see two columns. One for index and one from the query.
+        YasrSteps.getResultRowCells(1).should('have.length', 2);
+    });
+
+    it('should suggests me all columns when I click on suggest button', () => {
+        // When I open the create JDBC configuration page,
+        JdbcCreateSteps.openColumnTypesTab();
+        // waite columns to be suggested,
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 2);
+        // When I remove all columns.
+        JdbcCreateSteps.clickOnDeleteColumnButton(0);
+        ModalDialogSteps.clickOnConfirmButton();
+        JdbcCreateSteps.clickOnDeleteColumnButton(0);
+        ModalDialogSteps.clickOnConfirmButton();
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 0);
+
+        // When I click on "Suggest" button.
+        JdbcCreateSteps.clickOnSuggestButton();
+        // Then I expect all columns to be suggested without confirmation.
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 2);
+
+        // When I click on "Suggest" button when there are selected columns.
+        JdbcCreateSteps.clickOnDeleteColumnButton(0);
+        ModalDialogSteps.clickOnConfirmButton();
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 1);
+        JdbcCreateSteps.clickOnSuggestButton();
+
+        // Then I expect to be asked to confirm the suggestion.
+        ModalDialogSteps.verifyDialogBody('Are you sure you want to get suggestions for all columns? This action will overwrite all column type mappings!');
+
+        // When I click on close button.
+        ModalDialogSteps.clickOnCloseButton();
+
+        // Then I expect suggestion to not be applied.
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 1);
+
+        // When I click on "Suggestion" button.
+        JdbcCreateSteps.clickOnSuggestButton();
+
+        // Then I expect to be asked to confirm the suggestion.
+        ModalDialogSteps.verifyDialogBody('Are you sure you want to get suggestions for all columns? This action will overwrite all column type mappings!');
+
+        // When I click on cancel button.
+        ModalDialogSteps.clickOnCancelButton();
+
+        // Then I expect suggestion to not be applied.
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 1);
+
+        // When I click on "Suggestion" button.
+        JdbcCreateSteps.clickOnSuggestButton();
+
+        // Then I expect to be asked to confirm the suggestion.
+        ModalDialogSteps.verifyDialogBody('Are you sure you want to get suggestions for all columns? This action will overwrite all column type mappings!');
+
+        // When I click on confirm button.
+        ModalDialogSteps.clickOnConfirmButton();
+
+        // Then I expect suggestion to not be applied.
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 2);
+    });
+
+    it('should not allow configuration to be saved if some of required fields are not filled', () => {
+        // When I open the create JDBC configuration page,
+        // and try to save the configuration.
+        JdbcCreateSteps.clickOnSave();
+
+        // Then I expect to see error message describes that configuration name is required.
+        JdbcCreateSteps.getJdbcConfigurationNameIsRequired().should('be.visible');
+        JdbcCreateSteps.getJdbcConfigurationNameIsRequired().contains('SQL table name is required');
+
+        // When I type the name of the configuration,
+        JdbcCreateSteps.typeTableName('Test table name');
+        // and type wrong query,
+        YasqeSteps.pasteQuery('Wrong query');
+        // and try to save configuration.
+        JdbcCreateSteps.clickOnSave();
+
+        // Then I expect to see error message described that the query must be select query.
+        JdbcCreateSteps.getInvalidQueryMode().should('be.visible');
+        JdbcCreateSteps.getInvalidQueryMode().contains('The data query must be a SELECT query');
+
+        // When I type wrong select query
+        YasqeSteps.pasteQuery('Select * where {?s ?p ?o ?g}');
+        // and try to save the configuration
+        JdbcCreateSteps.clickOnSave();
+
+        // Then I expect to see error message described that the query is not valid.
+        JdbcCreateSteps.getInvalidQuery().should('be.visible');
+        JdbcCreateSteps.getInvalidQuery().contains('Invalid query');
+
+        // When I type correct select query
+        YasqeSteps.pasteQuery(DEFAULT_QUERY);
+        // and try to save the configuration
+        JdbcCreateSteps.clickOnSave();
+
+        // Then I expect to see error message
+        ToasterSteps.verifyError('Please define at least one column');
+    });
+
+    it('should not display confirm message when if the fields of configuration are not changed', () => {
+        // When I open the create JDBC configuration page,
+        // and try to change page
+        JdbcSteps.visit();
+
+        // Then I expect the new page is loaded.
+        JdbcSteps.verifyUrl();
+    });
+
+    it('should display confirm message when configuration name is changed', () => {
+        // When I open the create JDBC configuration page,
+        // type configuration name,
+        JdbcCreateSteps.typeTableName('Configuration name');
+        JdbcCreateSteps.getJDBCConfigNameField().should('have.value', 'Configuration name');
+        ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
+    });
+
+    it('should display confirm message when the configuration query data is changed', () => {
+        // When I open the create JDBC configuration page,
+        // type and change the query,
+        YasqeSteps.writeInEditor("Some changes");
+        ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
+    });
+
+    it('should display confirm message when the selected columns are changed', () => {
+        // When I open the create JDBC configuration page,
+        // and change selected columns.
+        JdbcCreateSteps.openColumnTypesTab();
+        JdbcCreateSteps.clickOnDeleteColumnButton(0);
+        ModalDialogSteps.clickOnConfirmButton();
+        ModalDialogSteps.verifyUrlChangedConfirmation(createVerifyConfirmationDialogOptions());
+    });
+
+    it('should display confirm message when try to change the repository', () => {
+        const secondRepositoryId = 'jdbc-repo-second-repo' + Date.now();
+        cy.createRepository({id: secondRepositoryId});
+
+        // When I open a configuration for edit,
+        createConfigurationAndOpenInEdit('Test table');
+        // Make some changes
+        YasqeSteps.writeInEditor('Make changes');
+
+        // When I try to change the selected repository.
+        RepositorySelectorSteps.selectRepository(secondRepositoryId);
+
+        // Then I expect to be asked to confirm changing of repository.
+        ModalDialogSteps.verifyDialogBody('You have unsaved changes. Are you sure that you want to exit?');
+
+        // When I click on close button.
+        ModalDialogSteps.clickOnCloseButton();
+
+        // Then I expect to stay on same page
+        JdbcCreateSteps.verifyUrl();
+
+        // When I try to change the selected repository.
+        RepositorySelectorSteps.selectRepository(secondRepositoryId);
+
+        // Then I expect to be asked to confirm changing of repository.
+        ModalDialogSteps.verifyDialogBody('You have unsaved changes. Are you sure that you want to exit?');
+
+        // When I click on cancel button.
+        ModalDialogSteps.clickOnCancelButton();
+
+        // Then I expect to stay on same page
+        JdbcCreateSteps.verifyUrl();
+
+        // When I try to change the selected repository.
+        RepositorySelectorSteps.selectRepository(secondRepositoryId);
+
+        // Then I expect to be asked to confirm changing of repository.
+        ModalDialogSteps.verifyDialogBody('You have unsaved changes. Are you sure that you want to exit?');
+
+        // When I click on confirm button.
+        ModalDialogSteps.clickOnConfirmButton();
+
+        // Then I expect to stay on same page
+        JdbcSteps.verifyUrl();
+
+        cy.deleteRepository(secondRepositoryId);
+    });
+});
+
+function createConfigurationAndOpenInEdit(tableName) {
+    JdbcSteps.visit();
+    // Creates a configuration.
+    JdbcSteps.clickOnCreateJdbcConfigurationButton();
+    YasqeSteps.waitUntilQueryIsVisible();
+    JdbcCreateSteps.typeTableName(tableName);
+    JdbcCreateSteps.openColumnTypesTab();
+    // waite selected column to be loaded.
+    JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 2);
+    JdbcCreateSteps.clickOnSave();
+
+    ToasterSteps.verifySuccess('SQL table configuration saved');
+
+    // Opens created configuration for edit.
+    JdbcSteps.clickOnEditButton(0);
+}
+
+function createVerifyConfirmationDialogOptions() {
+    return new VerifyConfirmationDialogOptions()
+        .setChangePageFunction(() => MainMenuSteps.clickOnMenuImport())
+        .setConfirmationMessage('You have unsaved changes. Are you sure that you want to exit?')
+        .setVerifyCurrentUrl(() => cy.url().should('eq', `${Cypress.config('baseUrl')}/jdbc/configuration/create`))
+        .setVerifyRedirectedUrl(() => cy.url().should('eq', `${Cypress.config('baseUrl')}/import#user`));
+}

--- a/e2e-tests/e2e-legacy/setup/jdbc/jdbc-with-repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/jdbc/jdbc-with-repository.spec.js
@@ -1,0 +1,39 @@
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {JdbcSteps} from "../../../steps/setup/jdbc-steps";
+
+describe('JDBC with selected repository', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'jdbc-init-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the JDBC page via URL with a repository selected
+        JdbcSteps.visit();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation bar', () => {
+        // Given, I visit the JDBC page via the navigation menu with a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnJDBC();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    const verifyInitialStateWithSelectedRepository = () => {
+        JdbcSteps.getJDBCPage().should('exist');
+        JdbcSteps.getJDBCConfiguration().should('exist');
+        JdbcSteps.getCreateSQLTableConfigurationButton().should('exist');
+        JdbcSteps.getNoSQLConfigurationsMessage().should('exist');
+    };
+})

--- a/e2e-tests/e2e-legacy/setup/jdbc/jdbc-without-repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/jdbc/jdbc-without-repository.spec.js
@@ -1,0 +1,27 @@
+import {ErrorSteps} from "../../../steps/error-steps";
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {JdbcSteps} from "../../../steps/setup/jdbc-steps";
+
+describe('JDBC without selected repository', () => {
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the JDBC page via URL without a repository selected
+        JdbcSteps.visit();
+        // Then,
+        verifyInitialStateWithoutSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the JDBC page via the navigation menu without a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnJDBC();
+        // Then,
+        verifyInitialStateWithoutSelectedRepository();
+    });
+
+    const verifyInitialStateWithoutSelectedRepository = () => {
+        ErrorSteps.verifyNoConnectedRepoMessage();
+        JdbcSteps.getJDBCPage().should('exist');
+        JdbcSteps.getJDBCConfiguration().should('not.exist');
+    };
+})

--- a/e2e-tests/e2e-legacy/setup/jdbc/jdbc.spec.js
+++ b/e2e-tests/e2e-legacy/setup/jdbc/jdbc.spec.js
@@ -1,0 +1,161 @@
+import {JdbcSteps} from "../../../steps/setup/jdbc-steps";
+import {JdbcCreateSteps} from "../../../steps/setup/jdbc-create-steps";
+import {ModalDialogSteps} from "../../../steps/modal-dialog-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {JdbcStubs} from "../../../stubs/jdbc/jdbc-stubs";
+import {ApplicationSteps} from "../../../steps/application-steps";
+
+const FILE_TO_IMPORT = '200-row-allianz.ttl';
+
+// The closing brace is intentionally omitted because when cypress types in the query, the editor will automatically add it.
+const EDIT_QUERY = `
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    SELECT ?id ?label {
+        ?id rdfs:label ?label
+    #!filter
+}
+`;
+
+describe('JDBC configuration', () => {
+
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'jdbc-repo-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        cy.importServerFile(repositoryId, FILE_TO_IMPORT);
+        JdbcSteps.visit();
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should be able to cancel JDBC configuration creation', () => {
+        // When I am on JDBC configurations page and click on create a new table configuration button.
+        JdbcSteps.clickOnCreateJdbcConfigurationButton();
+
+        // Then I expect to  be redirected to create JDBC configuration page.
+        JdbcCreateSteps.verifyUrl();
+
+        // When I fill correct data,
+        JdbcCreateSteps.typeTableName('JdbcTest');
+        JdbcCreateSteps.openColumnTypesTab();
+
+        // And click on cancel button.
+        JdbcCreateSteps.clickOnCancel();
+
+        // Then, I expect to be asked to confirm the cancellation.
+        // When I confirm
+        ModalDialogSteps.clickOnConfirmButton();
+
+        // Then I expect to be redirected to Jdbc configurations page,
+        JdbcSteps.verifyUrl();
+        // and the configuration to not be created.
+        JdbcSteps.getJDBCConfigurations().should('contain', 'No tables are defined');
+    });
+
+    it('Should create a new JDBC configuration, edit, preview, then delete', () => {
+        // When I am on JDBC configurations page and click on create a new table configuration button.
+        JdbcSteps.clickOnCreateJdbcConfigurationButton();
+
+        // Then I expect to  be redirected to create JDBC configuration page.
+        JdbcCreateSteps.verifyUrl();
+
+        // When I fill correct data,
+        JdbcCreateSteps.typeTableName('JdbcTest');
+        // and columns are selected.
+        JdbcCreateSteps.openColumnTypesTab();
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 2);
+
+        // And click on save button.
+        JdbcCreateSteps.clickOnSave();
+
+        // Then I expect to be redirected to Jdbc configurations page,
+        JdbcSteps.verifyUrl();
+        // and the configuration not be created.
+        JdbcSteps.getJDBCConfigurationResults().should('have.length', 1);
+
+        // When I click on edit button,
+        JdbcSteps.clickOnEditButton();
+        // change the query,
+        YasqeSteps.clearEditor();
+        YasqeSteps.pasteQuery(EDIT_QUERY);
+        // and click on save button.
+        JdbcCreateSteps.clickOnSave();
+
+        // Then I expect to be redirected to JDBC configurations page.
+        JdbcSteps.verifyUrl();
+
+        // When I click on delete button.
+        JdbcSteps.clickOnDeleteButton();
+
+        // Then I expect to be asked to confirm the deletion,
+        // and click on close dialog button.
+        ModalDialogSteps.clickOnCloseButton();
+
+        // Then I expect configuration to not be deleted.
+        JdbcSteps.getJDBCConfigurationResults().should('have.length', 1);
+
+        // When I click on delete button.
+        JdbcSteps.clickOnDeleteButton();
+
+        // Then I expect to be asked to confirm the deletion,
+        // and click on cancel dialog button.
+        ModalDialogSteps.clickOnCancelButton();
+
+        // Then I expect configuration to not be deleted.
+        JdbcSteps.getJDBCConfigurationResults().should('have.length', 1);
+
+        // When I click on delete button.
+        JdbcSteps.clickOnDeleteButton();
+
+        // Then I expect to be asked to confirm the deletion,
+        // and when click on confirm dialog button.
+        ModalDialogSteps.clickOnConfirmButton();
+
+        // Then I expect the configuration to be deleted.
+        JdbcSteps.getJDBCConfigurations().should('contain', 'No tables are defined');
+    });
+
+    it('Should show error notification on server error during jdbc configuration creation', () => {
+        // Given that the server will return an error on saving the JDBC configuration
+        JdbcStubs.stubJdbcCreateError();
+        // And I have configured a new JDBC configuration
+        JdbcSteps.clickOnCreateJdbcConfigurationButton();
+        JdbcCreateSteps.verifyUrl();
+        JdbcCreateSteps.typeTableName('JdbcTest');
+        JdbcCreateSteps.openColumnTypesTab();
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 2);
+        // When I click on save button.
+        JdbcCreateSteps.clickOnSave();
+        // Then I expect to see a notification with the error message.
+        ApplicationSteps.getErrorNotifications().should('contain', 'Could not save SQL table configuration');
+        // And the configuration to not be created.
+        cy.url().should('include', '/jdbc/configuration/create');
+        JdbcCreateSteps.getSaveButton().should('be.visible').and('be.enabled');
+    });
+
+    it('Should show error notification on server error during jdbc configuration creation', () => {
+        // Given that the server will return an error on saving the JDBC configuration
+        JdbcStubs.stubJdbcUpdateError();
+        // And I have configured and saved a new JDBC configuration
+        JdbcSteps.clickOnCreateJdbcConfigurationButton();
+        JdbcCreateSteps.verifyUrl();
+        JdbcCreateSteps.typeTableName('JdbcTest2');
+        JdbcCreateSteps.openColumnTypesTab();
+        JdbcCreateSteps.getColumnSuggestionRows().should('have.length', 2);
+        JdbcCreateSteps.clickOnSave();
+        JdbcSteps.verifyUrl();
+        JdbcSteps.getJDBCConfigurationResults().should('have.length', 1);
+        // When I edit the configuration
+        JdbcSteps.clickOnEditButton();
+        YasqeSteps.clearEditor();
+        YasqeSteps.pasteQuery(EDIT_QUERY);
+        // And click on save button.
+        JdbcCreateSteps.clickOnSave();
+        // Then I expect to see a notification with the error message.
+        ApplicationSteps.getErrorNotifications().should('contain', 'Could not save SQL table configuration');
+    });
+});

--- a/e2e-tests/e2e-legacy/setup/rdf-rank/rdf-rank-with-repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/rdf-rank/rdf-rank-with-repository.spec.js
@@ -1,0 +1,40 @@
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {RdfRankSteps} from "../../../steps/setup/rdf-rank-steps";
+
+describe('RDF Rank with selected repository', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'rdf-rank-init-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the RDF Rank page via URL with a repository selected
+        RdfRankSteps.visit();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation bar', () => {
+        // Given, I visit the RDF Rank page via the navigation menu with a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnRDFRank();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    const verifyInitialStateWithSelectedRepository = () => {
+        RdfRankSteps.getRDFRankPage().should('be.visible');
+        RdfRankSteps.getRDFRankContent().should('be.visible');
+        RdfRankSteps.getRDFRankLabel().should('be.visible');
+        RdfRankSteps.getRDFRandComputeButton().should('be.visible');
+        RdfRankSteps.getFilter().should('be.visible');
+    };
+})

--- a/e2e-tests/e2e-legacy/setup/rdf-rank/rdf-rank-without-repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/rdf-rank/rdf-rank-without-repository.spec.js
@@ -1,0 +1,30 @@
+import {ErrorSteps} from "../../../steps/error-steps";
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {RdfRankSteps} from "../../../steps/setup/rdf-rank-steps";
+
+describe('Rdf Rank without selected repository', () => {
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Rdf Rank page via URL without a repository selected
+        RdfRankSteps.visit();
+        // Then,
+        verifyInitialStateWithoutSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the Rdf Rank page via the navigation menu without a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnRDFRank();
+        // Then,
+        verifyInitialStateWithoutSelectedRepository();
+    });
+
+    const verifyInitialStateWithoutSelectedRepository = () => {
+        ErrorSteps.verifyNoConnectedRepoMessage();
+        RdfRankSteps.getRDFRankPage().should('exist');
+        RdfRankSteps.getRDFRankContent().should('not.be.visible');
+        RdfRankSteps.getRDFRankLabel().should('not.be.visible');
+        RdfRankSteps.getRDFRandComputeButton().should('not.be.visible');
+        RdfRankSteps.getFilter().should('not.be.visible');
+    };
+})

--- a/e2e-tests/e2e-legacy/setup/rdf-rank/rdf-rank.spec.js
+++ b/e2e-tests/e2e-legacy/setup/rdf-rank/rdf-rank.spec.js
@@ -1,4 +1,4 @@
-import {RdfRankSteps} from "../../steps/setup/rdf-rank-steps";
+import {RdfRankSteps} from "../../../steps/setup/rdf-rank-steps";
 
 describe('RDF Rank view', () => {
 

--- a/e2e-tests/e2e-legacy/setup/sparql-template/sparql-template-create.js
+++ b/e2e-tests/e2e-legacy/setup/sparql-template/sparql-template-create.js
@@ -1,14 +1,12 @@
-import {SparqlCreateUpdateSteps} from "../../steps/setup/sparql-create-update-steps";
-import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
-import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
-import {MainMenuSteps} from "../../steps/main-menu-steps";
-import {RepositorySelectorSteps} from "../../steps/repository-selector-steps";
-import {SparqlTemplatesSteps} from "../../steps/setup/sparql-templates-steps";
-import {ImportUserDataSteps} from "../../steps/import/import-user-data-steps";
+import {SparqlCreateUpdateSteps} from "../../../steps/setup/sparql-create-update-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {ModalDialogSteps} from "../../../steps/modal-dialog-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {RepositorySelectorSteps} from "../../../steps/repository-selector-steps";
+import {SparqlTemplatesSteps} from "../../../steps/setup/sparql-templates-steps";
+import {ImportUserDataSteps} from "../../../steps/import/import-user-data-steps";
 
-/**
-* TODO: Fix me. Broken due to migration (unknown - locally passes)
-*/
+// TODO: Fix me. Broken due to migration (Error: unknown)
 describe.skip('SPARQL create template', () => {
 
     let repositoryId;

--- a/e2e-tests/e2e-legacy/setup/sparql-template/sparql-template-with-repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/sparql-template/sparql-template-with-repository.spec.js
@@ -1,0 +1,39 @@
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {SparqlTemplatesSteps} from "../../../steps/setup/sparql-templates-steps";
+
+describe('Sparql templates with selected repository', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'sparql-template-init-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Sparql templates page via URL with a repository selected
+        SparqlTemplatesSteps.visit();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation bar', () => {
+        // Given, I visit the Sparql templates page via the navigation menu with a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnSparqlTemplates();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    const verifyInitialStateWithSelectedRepository = () => {
+        SparqlTemplatesSteps.getSparqlTemplatesPage().should('exist');
+        SparqlTemplatesSteps.getSparqlTemplatesContent().should('be.visible');
+        SparqlTemplatesSteps.getSparqlTemplatesCreateLink().should('be.visible');
+        SparqlTemplatesSteps.getNoSparqlTemplatesMessage().should('be.visible');
+    };
+})

--- a/e2e-tests/e2e-legacy/setup/sparql-template/sparql-template-without-repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/sparql-template/sparql-template-without-repository.spec.js
@@ -1,0 +1,29 @@
+import {ErrorSteps} from "../../../steps/error-steps";
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {SparqlTemplatesSteps} from "../../../steps/setup/sparql-templates-steps";
+
+describe('Sparql templates without selected repository', () => {
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Sparql templates page via URL without a repository selected
+        SparqlTemplatesSteps.visit();
+        // Then,
+        verifyInitialStateWithoutSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the Sparql templates page via the navigation menu without a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnSparqlTemplates();
+        // Then,
+        verifyInitialStateWithoutSelectedRepository()
+    });
+
+    const verifyInitialStateWithoutSelectedRepository = () => {
+        ErrorSteps.verifyNoConnectedRepoMessage();
+        SparqlTemplatesSteps.getSparqlTemplatesPage().should('exist');
+        SparqlTemplatesSteps.getSparqlTemplatesContent().should('not.exist');
+        SparqlTemplatesSteps.getSparqlTemplatesCreateLink().should('not.exist');
+        SparqlTemplatesSteps.getNoSparqlTemplatesMessage().should('not.exist');
+    };
+})

--- a/e2e-tests/e2e-legacy/setup/sparql-template/sparql-templates.spec.js
+++ b/e2e-tests/e2e-legacy/setup/sparql-template/sparql-templates.spec.js
@@ -1,7 +1,7 @@
-import {SparqlTemplatesSteps} from "../../steps/setup/sparql-templates-steps";
-import {SparqlCreateUpdateSteps} from "../../steps/setup/sparql-create-update-steps";
-import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
-import {ToasterSteps} from "../../steps/toaster-steps";
+import {SparqlTemplatesSteps} from "../../../steps/setup/sparql-templates-steps";
+import {SparqlCreateUpdateSteps} from "../../../steps/setup/sparql-create-update-steps";
+import {ModalDialogSteps} from "../../../steps/modal-dialog-steps";
+import {ToasterSteps} from "../../../steps/toaster-steps";
 
 describe('SPARQL Templates', () => {
 
@@ -36,8 +36,7 @@ describe('SPARQL Templates', () => {
         SparqlTemplatesSteps.getNoTemplateDefinedElement().should('contain.text', 'No templates are defined');
     });
 
-    // TODO: Fix me. Broken due to migration (Error: unknown)
-    it.skip('should create a query and delete it', () => {
+    it('should create a query and delete it', () => {
         // When I visit 'Sparql templates' view,
         // and click on create template button.
         SparqlTemplatesSteps.clickOnCreateSparqlTemplateButton();

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -157,4 +157,19 @@ export class MainMenuSteps {
         this.clickOnSetupMenu();
         this.getSubMenuButton('sub-menu-users-and-access').click();
     }
+
+    static clickOnSparqlTemplates() {
+        this.clickOnSetupMenu();
+        this.getSubMenuButton('sub-menu-sparql-templates').click();
+    }
+
+    static clickOnJDBC() {
+        this.clickOnSetupMenu();
+        this.getSubMenuButton('sub-menu-jdbc').click();
+    }
+
+    static clickOnRDFRank() {
+        this.clickOnSetupMenu();
+        this.getSubMenuButton('sub-menu-rdf-rank').click();
+    }
 }

--- a/e2e-tests/steps/setup/jdbc-steps.js
+++ b/e2e-tests/steps/setup/jdbc-steps.js
@@ -1,4 +1,6 @@
-export class JdbcSteps {
+import {BaseSteps} from "../base-steps";
+
+export class JdbcSteps extends BaseSteps {
 
     static visit() {
         cy.visit('/jdbc');
@@ -8,12 +10,24 @@ export class JdbcSteps {
         cy.url().should('include', '/jdbc');
     }
 
-    static getCreateNewJDBCConfigurationButton() {
-        return cy.get('.create-sql-table-configuration');
+    static getJDBCPage() {
+        return this.getByTestId('jdbc-page');
+    }
+
+    static getJDBCConfiguration() {
+        return this.getJDBCPage().getByTestId('jdbc-configurations');
+    }
+
+    static getCreateSQLTableConfigurationButton() {
+        return this.getJDBCConfiguration().getByTestId('create-sql-table-configuration');
+    }
+
+    static getNoSQLConfigurationsMessage() {
+        return this.getJDBCConfiguration().getByTestId('no-sql-configurations-message');
     }
 
     static clickOnCreateJdbcConfigurationButton() {
-        JdbcSteps.getCreateNewJDBCConfigurationButton().click();
+        JdbcSteps.getCreateSQLTableConfigurationButton().click();
     }
 
     static getJDBCConfigurations() {

--- a/e2e-tests/steps/setup/rdf-rank-steps.js
+++ b/e2e-tests/steps/setup/rdf-rank-steps.js
@@ -1,5 +1,6 @@
+import {BaseSteps} from "../base-steps";
 
-export class RdfRankSteps {
+export class RdfRankSteps extends BaseSteps {
     static visit() {
         cy.visit('/rdfrank');
     }
@@ -22,6 +23,26 @@ export class RdfRankSteps {
 
     static getRdfRankPage() {
         return cy.get('#rdfRank');
+    }
+
+    static getRDFRankPage() {
+        return this.getByTestId('rdf-rank-page');
+    }
+
+    static getRDFRankContent() {
+        return this.getRDFRankPage().getByTestId('rdf-rank-content');
+    }
+
+    static getRDFRankLabel() {
+        return this.getRDFRankPage().getByTestId('rdf-rank-status-label');
+    }
+
+    static getRDFRandComputeButton() {
+        return this.getRDFRankPage().getByTestId('compute-rdf-rank-btn');
+    }
+
+    static getFilter() {
+        return this.getRdfRankPage().getByTestId('filter-content');
     }
 
     static getRdfStatusHeader() {

--- a/e2e-tests/steps/setup/sparql-templates-steps.js
+++ b/e2e-tests/steps/setup/sparql-templates-steps.js
@@ -1,4 +1,6 @@
-export class SparqlTemplatesSteps {
+import {BaseSteps} from "../base-steps";
+
+export class SparqlTemplatesSteps extends BaseSteps {
 
     static visit() {
         cy.visit('/sparql-templates');
@@ -6,6 +8,22 @@ export class SparqlTemplatesSteps {
 
     static verifyUrl() {
         cy.url().should('include', '/sparql-templates');
+    }
+
+    static getSparqlTemplatesPage() {
+        return this.getByTestId('sparql-templates-page');
+    }
+
+    static getSparqlTemplatesContent() {
+        return this.getSparqlTemplatesPage().getByTestId('sparql-templates-content');
+    }
+
+    static getSparqlTemplatesCreateLink() {
+        return this.getSparqlTemplatesPage().getByTestId('create-sparql-template-link');
+    }
+
+    static getNoSparqlTemplatesMessage() {
+        return this.getSparqlTemplatesPage().getByTestId('no-sparql-templates-message');
     }
 
     static getSparqlTemplatesListContainer() {

--- a/packages/legacy-workbench/src/js/angular/jdbc/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/jdbc/plugin.js
@@ -33,7 +33,8 @@ PluginRegistry.add('main.menu', {
             order: 50,
             parent: 'Setup',
             role: "IS_AUTHENTICATED_FULLY",
-            guideSelector: 'sub-menu-jdbs',
+            guideSelector: 'sub-menu-jdbc',
+            testSelector: 'sub-menu-jdbc',
             children: [
                 {
                     href: 'jdbc/configuration/create'

--- a/packages/legacy-workbench/src/js/angular/rdfrank/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/rdfrank/plugin.js
@@ -20,7 +20,8 @@ PluginRegistry.add('main.menu', {
             order: 45,
             parent: 'Setup',
             role: 'IS_AUTHENTICATED_FULLY',
-            guideSelector: 'sub-menu-rdf-rank'
+            guideSelector: 'sub-menu-rdf-rank',
+            testSelector: 'sub-menu-rdf-rank'
         }
     ]
 });

--- a/packages/legacy-workbench/src/js/angular/sparql-template/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/sparql-template/plugin.js
@@ -34,6 +34,7 @@ PluginRegistry.add('main.menu', {
             parent: 'Setup',
             role: "IS_AUTHENTICATED_FULLY",
             guideSelector: 'sub-menu-sparql-templates',
+            testSelector: 'sub-menu-sparql-templates',
             children: [
                 {
                     href: 'sparql-template/create'

--- a/packages/legacy-workbench/src/pages/jdbc.html
+++ b/packages/legacy-workbench/src/pages/jdbc.html
@@ -1,13 +1,17 @@
-<div class="container-fluid">
+<div class="container-fluid" data-test="jdbc-page">
     <h1>
         {{title}}
         <page-info-tooltip></page-info-tooltip>
     </h1>
     <div core-errors ontop fedx></div>
-    <div class="jdbc-list-configurations card mb-2" ng-if="getActiveRepository() && !isActiveRepoOntopType() && !isActiveRepoFedXType()">
-        <div class="card-block" ng-init="getSqlConfigurations();">
+    <div class="jdbc-list-configurations card mb-2"
+         ng-if="getActiveRepository() && !isActiveRepoOntopType() && !isActiveRepoFedXType()">
+        <div class="card-block" ng-init="getSqlConfigurations();" data-test="jdbc-configurations">
             <div class="clearfix">
-                <a ng-href="jdbc/configuration/create" ng-if="canWriteActiveRepo()" class="btn btn-link pull-right">
+                <a ng-href="jdbc/configuration/create"
+                   ng-if="canWriteActiveRepo()"
+                   data-test="create-sql-table-configuration"
+                   class="btn btn-link pull-right">
                     <span class="icon-plus create-sql-table-configuration"></span> {{'jdbc.create.new.configuration' | translate}}
                 </a>
                 <h3 class="mb-0"><span class="collapsible-heading" data-toggle="collapse"
@@ -16,7 +20,9 @@
             </div>
 
             <div class="collapse in mt-1" id="configurations-table">
-                <div class="no-indexes" ng-if="jdbcConfigurations.length == 0"><em>{{'jdbc.no.tables.defined' | translate}}</em></div>
+                <div class="no-indexes"
+                     data-test="no-sql-configurations-message"
+                     ng-if="jdbcConfigurations.length == 0"><em>{{'jdbc.no.tables.defined' | translate}}</em></div>
                 <table class="table table-hover mb-0" aria-describedby="JDBC configurations table">
                     <tbody>
                     <tr ng-repeat="index in jdbcConfigurations track by $index"

--- a/packages/legacy-workbench/src/pages/rdfrank.html
+++ b/packages/legacy-workbench/src/pages/rdfrank.html
@@ -1,7 +1,7 @@
 <link href="css/rdfrank.css?v=[AIV]{version}[/AIV]" rel="stylesheet">
 <link href="css/lib/ng-tags-input/ng-tags-input.min.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 
-<div id="rdfRank" class="page">
+<div id="rdfRank" class="page" data-test="rdf-rank-page">
 	<h1>
 		{{title}}
         <page-info-tooltip></page-info-tooltip>
@@ -24,14 +24,16 @@
         ng-if="isLicenseValid()">
     </inactive-plugin-directive>
 
-    <div ng-show="isLicenseValid() && canWriteActiveRepo() && !loading && pluginIsActive">
+    <div ng-show="isLicenseValid() && canWriteActiveRepo() && !loading && pluginIsActive"
+		 data-test="rdf-rank-content">
 		<div class="alert alert-info" ng-if="!loader && pluginFound && getDegradedReason()">
 			<h4>{{'not.fully.supported.rdfrank.warning' | translate}}</h4>
 			<p>{{'configuring.rdfrank.not.supported.warning' | translate}} {{getDegradedReason()}}</p>
 		</div>
 		<div ng-show="!isRestricted && pluginFound && !getDegradedReason()">
             <div class="lead mb-1" id="toggleIndex">
-				<span class="rdf-rank-status">{{'rdfrank.for.repo.label' | translate}} <strong>{{getActiveRepository()}}</strong> {{'is.with.status.label' | translate}}</span>
+				<span class="rdf-rank-status"
+					  data-test="rdf-rank-status-label">{{'rdfrank.for.repo.label' | translate}} <strong>{{getActiveRepository()}}</strong> {{'is.with.status.label' | translate}}</span>
                 <span class="tag tag-success" ng-show="currentRankStatus.indexOf('COMPUTED') == 0"><em class="icon-check icon-lg"></em> {{'computed.status' | translate}}</span>
 
                 <span ng-show="currentRankStatus == 'COMPUTING'">
@@ -50,7 +52,10 @@
                 <span class="tag tag-warning" ng-show="currentRankStatus == rdfStatus.EMPTY"><em class="icon-info icon-lg"></em> {{'rdfrank.not.build.yet.warning' | translate}}</span>
 
 				<p class="pull-right">
-					<button ng-disabled="currentRankStatus == rdfStatus.COMPUTING" ng-click="computeRank()" class="btn btn-primary compute-rdf-rank-btn">{{'compute.full.btn' | translate}}</button>
+					<button ng-disabled="currentRankStatus == rdfStatus.COMPUTING"
+							ng-click="computeRank()"
+							data-test="compute-rdf-rank-btn"
+							class="btn btn-primary compute-rdf-rank-btn">{{'compute.full.btn' | translate}}</button>
                     <button ng-hide="currentRankStatus != rdfStatus.OUTDATED"
 							ng-click="computeIncrementalRank()" class="btn btn-primary">{{'compute.incremental.btn' | translate}}</button>
 				</p>
@@ -58,7 +63,7 @@
 
 			<br>
 
-			<div id="toggleFilterMode">
+			<div id="toggleFilterMode" data-test="filter-content">
 				<h3 class="d-inline-block mr-1">{{'filtering.header' | translate}}</h3>
 				<span class="tag {{filteringEnabled ? 'tag-primary' : 'tag-default'}}">{{filteringEnabled ? 'common.on.btn' : 'common.off.btn' | translate}}</span>
                 <span gdb-tooltip="{{'click.to' | translate}} {{filteringEnabled ? 'disable' : 'enable' | translate}} {{'filtering' | translate}}" tooltip-placement="top" ng-click="toggleFiltering()" class="switch rdf-rank-filter-switch">

--- a/packages/legacy-workbench/src/pages/sparql-templates.html
+++ b/packages/legacy-workbench/src/pages/sparql-templates.html
@@ -1,4 +1,4 @@
-<div class="container-fluid">
+<div class="container-fluid" data-test="sparql-templates-page">
     <h1>
         {{title}}
         <page-info-tooltip></page-info-tooltip>
@@ -11,10 +11,15 @@
         set-plugin-active="setPluginIsActive(isPluginActive)"
         ng-if="isLicenseValid()">
     </inactive-plugin-directive>
-    <div class="sparql-templates-list card mb-2" ng-if="isLicenseValid() && pluginIsActive && getActiveRepository() && !isActiveRepoOntopType() && !isActiveRepoFedXType()">
+    <div class="sparql-templates-list card mb-2"
+         ng-if="isLicenseValid() && pluginIsActive && getActiveRepository() && !isActiveRepoOntopType() && !isActiveRepoFedXType()"
+         data-test="sparql-templates-content">
         <div class="card-block" ng-init="getSparqlTemplates();">
             <div class="clearfix">
-                <a ng-href="sparql-template/create" ng-if="canWriteActiveRepo()" class="btn btn-link pull-right create-sparql-template">
+                <a ng-href="sparql-template/create"
+                   ng-if="canWriteActiveRepo()"
+                   data-test="create-sparql-template-link"
+                   class="btn btn-link pull-right create-sparql-template">
                     <span class="icon-plus create-sql-table-configuration"></span> {{'create.new.sparql.template' | translate}}
                 </a>
                 <h3 class="mb-0"><span class="collapsible-heading" data-toggle="collapse"
@@ -23,7 +28,9 @@
             </div>
 
             <div class="collapse in mt-1" id="configurations-table">
-                <div class="no-indexes" ng-if="sparqlTemplateIds.length == 0"><em>{{'no.sparql.templates.defined' | translate}}</em></div>
+                <div class="no-indexes"
+                     data-test="no-sparql-templates-message"
+                     ng-if="sparqlTemplateIds.length == 0"><em>{{'no.sparql.templates.defined' | translate}}</em></div>
                 <table class="table table-hover mb-0" aria-describedby="SPARQL templates">
                     <tbody>
                     <tr ng-repeat="templateID in sparqlTemplateIds track by $index"

--- a/packages/shared-components/src/pages/js/main.js
+++ b/packages/shared-components/src/pages/js/main.js
@@ -320,7 +320,7 @@ menuItems = [
         "order": 50,
         "parent": "Setup",
         "role": "IS_AUTHENTICATED_FULLY",
-        "guideSelector": "sub-menu-jdbs",
+        "guideSelector": "sub-menu-jdbc",
         "shouldShow": true
       }
     ]


### PR DESCRIPTION
## What
- Added tests to verify the initial state of the Sparql templates view;
- Added tests to verify the initial state of the JDBC view;
- Added tests to verify the initial state of the RDF Rank view.

## Why
To ensure that the view loads correctly and prevent navigation issues during the view migration process.

## How
Added a test for the view that verifies:
- Access via the navigation menu;
- Direct access via URL;
- Proper initialization and rendering in the expected initial state.

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
