### PR TITLE
GDB-12173 Add initial state specs for connectors

### DIFF
--- a/e2e-tests/e2e-legacy/setup/connectors/connectors-initial-state-with-selected-repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/connectors/connectors-initial-state-with-selected-repository.spec.js
@@ -1,0 +1,41 @@
+import {ConnectorsSteps} from "../../../steps/setup/connectors-steps";
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+
+const expectedButtons = ['elasticsearch', 'opensearch', 'solr', 'lucene', 'kafka', 'chatgpt-retrieval'];
+
+function verifyConnectorsPage() {
+    expectedButtons.forEach(buttonId => {
+        ConnectorsSteps.getConnectorButton(buttonId).should('be.visible');
+    });
+    ConnectorsSteps.getReloadAllButton().should('be.visible');
+}
+
+describe('Connectors initial state with repositories', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'connectors-init-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Connectors page via URL without a repository selected
+        ConnectorsSteps.visit();
+        // Then,
+        verifyConnectorsPage();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the Connectors page via the navigation menu without a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnConnectors();
+        // Then,
+        verifyConnectorsPage();
+    });
+});

--- a/e2e-tests/e2e-legacy/setup/connectors/connectors-initial-state-without-repositories.spec.js
+++ b/e2e-tests/e2e-legacy/setup/connectors/connectors-initial-state-without-repositories.spec.js
@@ -1,0 +1,21 @@
+import {ErrorSteps} from "../../../steps/error-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import HomeSteps from "../../../steps/home-steps";
+import {ConnectorsSteps} from "../../../steps/setup/connectors-steps";
+
+describe('Connectors initial state without repositories', () => {
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Connectors page via URL without a repository selected
+        ConnectorsSteps.visit();
+        // Then,
+        ErrorSteps.verifyNoConnectedRepoMessage();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the Connectors page via the navigation menu without a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnConnectors();
+        // Then,
+        ErrorSteps.verifyNoConnectedRepoMessage();
+    });
+})

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -180,4 +180,9 @@ export class MainMenuSteps {
         this.clickOnMenuSetup();
         this.getSubMenuButton('sub-menu-rdf-rank').click();
     }
+
+    static clickOnConnectors() {
+        this.clickOnMenuSetup();
+        this.getSubMenuButton('sub-menu-connectors').click();
+    }
 }

--- a/e2e-tests/steps/setup/connectors-steps.js
+++ b/e2e-tests/steps/setup/connectors-steps.js
@@ -1,0 +1,19 @@
+import {BaseSteps} from "../base-steps";
+
+export class ConnectorsSteps extends BaseSteps {
+    static visit() {
+        super.visit('/connectors');
+    }
+
+    static getConnectorsPage() {
+        return this.getByTestId('connectors-page');
+    }
+
+    static getConnectorButton(buttonId) {
+        return this.getConnectorsPage().getByTestId(`connector-${buttonId}`);
+    }
+
+    static getReloadAllButton() {
+        return this.getConnectorsPage().getByTestId('reload-all-connectors');
+    }
+}

--- a/packages/legacy-workbench/src/js/angular/externalsync/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/externalsync/plugin.js
@@ -20,7 +20,8 @@ PluginRegistry.add('main.menu', {
             order: 10,
             parent: 'Setup',
             role: 'IS_AUTHENTICATED_FULLY',
-            guideSelector: 'sub-menu-connectors'
+            guideSelector: 'sub-menu-connectors',
+            testSelector: 'sub-menu-connectors'
         }
     ]
 });

--- a/packages/legacy-workbench/src/pages/connectorsInfo.html
+++ b/packages/legacy-workbench/src/pages/connectorsInfo.html
@@ -1,4 +1,4 @@
-<div class="connectorsPage">
+<div class="connectorsPage" data-test="connectors-page">
     <h1>
         {{title}}
         <page-info-tooltip></page-info-tooltip>
@@ -14,6 +14,7 @@
         <div class="pull-right">
             <button class="btn btn-lg btn-link p-0" type="button"
                     ng-click="getConnectors()"
+                    data-test="reload-all-connectors"
                     gdb-tooltip="{{'reload.all.connector.info' | translate}}" tooltip-placement="left">
                 <em class="icon-reload"></em>
             </button>
@@ -165,7 +166,9 @@
                     <div ng-hide="existing[connector.key].length">{{'no.connector.instances' | translate}}</div>
                 </section>
                 <section>
-                    <button class="btn btn-primary new-connector-btn" ng-click="newConnector(connector)"><em class="icon-plus"></em>
+                    <button class="btn btn-primary new-connector-btn"
+                            ng-click="newConnector(connector)"
+                            data-test="connector-{{connector.key.replace(' ', '-') | lowercase}}"><em class="icon-plus"></em>
                         {{'new.sentence.start' | translate}} {{connector.key}} {{'connector.label' | translate}}
                     </button>
                 </section>


### PR DESCRIPTION
## What
Added tests which assert the initial state of connectors view.

## Why
To ensure the page loads correctly

## How
Added tests, which verify the state of the view by navigating via URL and by visiting it through the navigation menu. Added tests with a selected repo and without any repositories

## Testing
cypress

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
