### PR TITLE
GDB-12586: Fix WB build running through external context

### DIFF
--- a/packages/api/src/services/autocomplete/autocomplete-rest.service.ts
+++ b/packages/api/src/services/autocomplete/autocomplete-rest.service.ts
@@ -5,7 +5,7 @@ import {HttpService} from '../http/http.service';
  * Service for handling autocomplete REST operations.
  */
 export class AutocompleteRestService extends HttpService {
-  private readonly autocompleteRestPrefix = '/rest/autocomplete';
+  private readonly autocompleteRestPrefix = 'rest/autocomplete';
 
   /**
    * Performs an autocomplete search based on the provided search term.

--- a/packages/api/src/services/autocomplete/test/autocomplete.service.spec.ts
+++ b/packages/api/src/services/autocomplete/test/autocomplete.service.spec.ts
@@ -29,7 +29,7 @@ describe('Autocomplete service', () => {
       ],
     };
     const searchTerm = 'test';
-    TestUtil.mockResponse(new ResponseMock(`/rest/autocomplete/query?q=${searchTerm}`).setResponse(mockSearchResult));
+    TestUtil.mockResponse(new ResponseMock(`rest/autocomplete/query?q=${searchTerm}`).setResponse(mockSearchResult));
 
     // When, I call the search method
     const result = await autocompleteService.search(searchTerm);

--- a/packages/api/src/services/cookie/test/cookie.service.spec.ts
+++ b/packages/api/src/services/cookie/test/cookie.service.spec.ts
@@ -27,7 +27,7 @@ describe('CookiesService', () => {
       }
     });
     ServiceProvider.get(SecurityContextService).updateAuthenticatedUser(mockAuthenticatedUser);
-    TestUtil.mockResponse(new ResponseMock(`/rest/security/users/${mockAuthenticatedUser.username}`).setResponse({}));
+    TestUtil.mockResponse(new ResponseMock(`rest/security/users/${mockAuthenticatedUser.username}`).setResponse({}));
 
     // When I call the acceptCookiePolicy method
     await cookiesService.acceptCookiePolicy();

--- a/packages/api/src/services/language/language-rest.service.ts
+++ b/packages/api/src/services/language/language-rest.service.ts
@@ -5,7 +5,7 @@ import { LanguageConfig, TranslationBundle } from '../../models/language';
  * Service for handling language-related REST operations.
  */
 export class LanguageRestService extends HttpService {
-  private readonly I18N_ENDPOINT = '/assets/i18n';
+  private readonly I18N_ENDPOINT = 'assets/i18n';
 
   /**
    * Retrieves the translation bundle for a specific language.

--- a/packages/api/src/services/language/test/language.service.spec.ts
+++ b/packages/api/src/services/language/test/language.service.spec.ts
@@ -60,7 +60,7 @@ describe('LanguageService', () => {
   test('Should retrieve the language, mapped to a TranslationBundle object', async () => {
     // Given, I have a mocked language
     const mockBundle = { hello: 'World' } as TranslationBundle;
-    TestUtil.mockResponse(new ResponseMock('/assets/i18n/en.json').setResponse(mockBundle));
+    TestUtil.mockResponse(new ResponseMock('assets/i18n/en.json').setResponse(mockBundle));
 
     // When I call the getLanguage method
     const result = await languageService.getLanguage('en');
@@ -84,7 +84,7 @@ describe('LanguageService', () => {
         }
       ]
     } as unknown as LanguageConfig;
-    TestUtil.mockResponse(new ResponseMock('/assets/i18n/language-config.json').setResponse(mockLanguageConfig));
+    TestUtil.mockResponse(new ResponseMock('assets/i18n/language-config.json').setResponse(mockLanguageConfig));
 
     // When I call the getLanguageConfiguration method
     const result = await languageService.getLanguageConfiguration();

--- a/packages/api/src/services/license/license-rest.service.ts
+++ b/packages/api/src/services/license/license-rest.service.ts
@@ -15,6 +15,6 @@ export class LicenseRestService extends HttpService {
    * @returns A Promise that resolves to a License object containing the current license information.
    */
   getLicense(): Promise<License> {
-    return this.get<License>('/rest/graphdb-settings/license');
+    return this.get<License>('rest/graphdb-settings/license');
   }
 }

--- a/packages/api/src/services/license/test/license.service.spec.ts
+++ b/packages/api/src/services/license/test/license.service.spec.ts
@@ -15,7 +15,7 @@ describe('LicenseService', () => {
   test('should retrieve the license, mapped to a License object', async () => {
     // Given, I have a mocked license
     const mockLicense = { licensee: 'Test Company', expiryDate: 1672531200000 } as License;
-    TestUtil.mockResponse(new ResponseMock('/rest/graphdb-settings/license').setResponse(mockLicense));
+    TestUtil.mockResponse(new ResponseMock('rest/graphdb-settings/license').setResponse(mockLicense));
 
     // When I call the getLicense method
     const result = await licenseService.getLicense();

--- a/packages/api/src/services/namespace/namespaces-rest.service.ts
+++ b/packages/api/src/services/namespace/namespaces-rest.service.ts
@@ -5,7 +5,7 @@ import {NamespacesResponse} from '../../models/repositories/namespace/api/namesp
  * Service for interacting with the RDF4J repository REST API.
  */
 export class NamespacesRestService extends HttpService {
-  private readonly REPOSITORIES_ENDPOINT = '/repositories';
+  private readonly REPOSITORIES_ENDPOINT = 'repositories';
 
   /**
    * Retrieves namespace information for a specific repository.

--- a/packages/api/src/services/namespace/test/namespaces.service.spec.ts
+++ b/packages/api/src/services/namespace/test/namespaces.service.spec.ts
@@ -45,7 +45,7 @@ describe('Namespaces Service', () => {
       }
     };
     const repositoryId = 'repository-id';
-    TestUtil.mockResponse(new ResponseMock(`/repositories/${repositoryId}/namespaces`).setResponse(namespaces));
+    TestUtil.mockResponse(new ResponseMock(`repositories/${repositoryId}/namespaces`).setResponse(namespaces));
 
     // When I call the getNamespaces method with the repository ID
     const result = await namespacesService.getNamespaces(repositoryId);

--- a/packages/api/src/services/product-info/product-info-rest.service.ts
+++ b/packages/api/src/services/product-info/product-info-rest.service.ts
@@ -5,7 +5,7 @@ import { HttpService } from '../http/http.service';
  * Service for product information REST calls.
  */
 export class ProductInfoRestService extends HttpService {
-  private readonly VERSION_URL = '/rest/info/version';
+  private readonly VERSION_URL = 'rest/info/version';
 
   /**
    * Retrieves the local version information of the product.

--- a/packages/api/src/services/product-info/test/product-info.service.spec.ts
+++ b/packages/api/src/services/product-info/test/product-info.service.spec.ts
@@ -14,7 +14,7 @@ describe('ProductInfoService', () => {
     // Given, I have a mocked local version information
     // Note: the Workbench property in the response has an uppercase 'W'
     const mockProductInfo = {Workbench: '2.8.0', productVersion: '1.0.0' } as ProductInfo & { Workbench: string };
-    TestUtil.mockResponse(new ResponseMock('/rest/info/version?local=1').setResponse(mockProductInfo));
+    TestUtil.mockResponse(new ResponseMock('rest/info/version?local=1').setResponse(mockProductInfo));
 
     // When I call the getVersionLocal method
     const result = await productInfoService.getProductInfoLocal();

--- a/packages/api/src/services/repository-location/repository-location-rest.service.ts
+++ b/packages/api/src/services/repository-location/repository-location-rest.service.ts
@@ -3,6 +3,6 @@ import {HttpService} from '../http/http.service';
 
 export class RepositoryLocationRestService extends HttpService {
   getActiveRepositoryLocation(): Promise<RepositoryLocation> {
-    return this.get('/rest/locations/active');
+    return this.get('rest/locations/active');
   }
 }

--- a/packages/api/src/services/repository-location/test/repository-location.service.spec.ts
+++ b/packages/api/src/services/repository-location/test/repository-location.service.spec.ts
@@ -13,7 +13,7 @@ describe('RepositoryLocationService', () => {
 
   test('getActiveRepositoryLocation should return the active repository location', async () => {
     const rawRepository = RepositoryLocationMockProvider.provideRawRepositoryLocation('repo-location-uri');
-    TestUtil.mockResponse(new ResponseMock('/rest/locations/active').setResponse(rawRepository));
+    TestUtil.mockResponse(new ResponseMock('rest/locations/active').setResponse(rawRepository));
     const expectedResult = RepositoryLocationMockProvider.provideRepositoryLocation('repo-location-uri');
 
     // When the service is called to fetch the active repository location,

--- a/packages/api/src/services/repository/repository-rest.service.ts
+++ b/packages/api/src/services/repository/repository-rest.service.ts
@@ -3,7 +3,7 @@ import {Repository, RepositorySizeInfo} from '../../models/repositories';
 
 export class RepositoryRestService extends HttpService {
 
-  static readonly REPOSITORIES_ENDPOINT = '/rest/repositories';
+  static readonly REPOSITORIES_ENDPOINT = 'rest/repositories';
 
   getRepositories(): Promise<Record<string, unknown[]>> {
     return this.get(`${RepositoryRestService.REPOSITORIES_ENDPOINT}/all`);

--- a/packages/api/src/services/repository/test/repository.service.spec.ts
+++ b/packages/api/src/services/repository/test/repository.service.spec.ts
@@ -13,7 +13,7 @@ describe('RepositoryService', () => {
 
   test('getRepositories should return repositories', async () => {
     const response = {'': [RepositoryMockProvider.provideRawRepository('repo-id')]};
-    TestUtil.mockResponse(new ResponseMock('/rest/repositories/all').setResponse(response));
+    TestUtil.mockResponse(new ResponseMock('rest/repositories/all').setResponse(response));
     const expectedResult = {items: [RepositoryMockProvider.provideRepository('repo-id')]};
 
     // When the service is called to fetch all repositories,
@@ -33,7 +33,7 @@ describe('RepositoryService', () => {
     };
     const repository: Repository = RepositoryMockProvider.provideRepository('repo-id', 'repo-location');
 
-    TestUtil.mockResponse(new ResponseMock(`/rest/repositories/${repository.id}/size?location=${repository.location}`).setResponse(rawRepositorySizeInfo));
+    TestUtil.mockResponse(new ResponseMock(`rest/repositories/${repository.id}/size?location=${repository.location}`).setResponse(rawRepositorySizeInfo));
     const expectedResult = rawRepositorySizeInfo;
 
     // When the service is called to fetch size info of a repository.

--- a/packages/api/src/services/security/security-rest.service.ts
+++ b/packages/api/src/services/security/security-rest.service.ts
@@ -5,7 +5,7 @@ import {AuthenticatedUser, SecurityConfig} from '../../models/security';
  * Service class for handling security-related REST operations.
  */
 export class SecurityRestService extends HttpService {
-  private readonly SECURITY_ENDPOINT = '/rest/security';
+  private readonly SECURITY_ENDPOINT = 'rest/security';
 
   /**
    * Updates the application settings for a specific user.

--- a/packages/api/src/services/security/test/security.service.spec.ts
+++ b/packages/api/src/services/security/test/security.service.spec.ts
@@ -27,7 +27,7 @@ describe('SecurityService', () => {
       }
     });
 
-    TestUtil.mockResponse(new ResponseMock('/rest/security/users/testuser').setResponse({}));
+    TestUtil.mockResponse(new ResponseMock('rest/security/users/testuser').setResponse({}));
 
     // When the service is called to update the user data
     await securityService.updateUserData(updatedUser);

--- a/packages/legacy-workbench/src/app.js
+++ b/packages/legacy-workbench/src/app.js
@@ -333,7 +333,7 @@ function loadTranslations(language) {
 // Fetch the product version information before bootstrapping the app
 function loadAppInfo() {
     return new Promise((resolve, reject) => {
-        $.get('/rest/info/version?local=1', function (data) {
+        $.get('rest/info/version?local=1', function (data) {
             // Extract major.minor version as short version
             const versionArray = data.productVersion.match(/^(\d+\.\d+)/);
             if (versionArray.length) {

--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -313,7 +313,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
     };
 
     $scope.goToAddRepo = function () {
-        $location.path('/repository/create').search({previous: 'home'});
+        $location.path('repository/create').search({previous: 'home'});
     };
 
     $scope.goToEditRepo = function (repository) {

--- a/packages/root-config/src/index.ejs
+++ b/packages/root-config/src/index.ejs
@@ -13,7 +13,7 @@
       This is needed by babel to share largeish helper code for compiling async/await in older
       browsers. More information at https://github.com/single-spa/create-single-spa/issues/112
     -->
-    <script src="/resources/runtime.js"></script>
+    <script src="resources/runtime.js"></script>
 
     <!--
       This CSP allows any SSL-enabled host and for arbitrary eval(), but you should limit these directives further to increase your app's security.
@@ -51,11 +51,11 @@
         <script type="injector-importmap">
             {
                 "imports": {
-                    "single-spa": "/resources/single-spa.min.js",
-                    "@ontotext/workbench-api": "/<%= apiBundle %>",
-                    "@ontotext/root-config": "/<%= mainBundle %>",
-                    "@ontotext/legacy-workbench": "/<%= legacyWorkbenchBundle %>",
-                    "@ontotext/workbench": "/<%= workbenchAppBundle %>"
+                    "single-spa": "./resources/single-spa.min.js",
+                    "@ontotext/workbench-api": "./<%= apiBundle %>",
+                    "@ontotext/root-config": "./<%= mainBundle %>",
+                    "@ontotext/legacy-workbench": "./<%= legacyWorkbenchBundle %>",
+                    "@ontotext/workbench": "./<%= workbenchAppBundle %>"
                 }
             }
         </script>
@@ -63,7 +63,7 @@
 
     <!-- If you wish to turn off import-map-overrides for specific environments (prod), uncomment the line below -->
     <!-- More info at https://github.com/joeldenning/import-map-overrides/blob/master/docs/configuration.md#domain-list -->
-    <!-- <meta name="import-map-overrides-domains" content="denylist:prod.example.com" /> -->
+    <meta name="import-map-overrides-domains" content="denylist:prod.example.com" />
 
     <!-- Shared dependencies go into this import map. Your shared dependencies must be of one of the following formats:
 
@@ -74,8 +74,8 @@
       More information about shared dependencies can be found at https://single-spa.js.org/docs/recommended-setup#sharing-with-import-maps.
     -->
 
-     <script src="/resources/import-map-overrides.js"></script>
-     <script src="/resources/import-map-injector.js"></script>
+     <script src="resources/import-map-overrides.js"></script>
+     <script src="resources/import-map-injector.js"></script>
 </head>
 <body>
 <noscript>
@@ -89,7 +89,7 @@
 <import-map-overrides-full show-when-local-storage="devtools" dev-libs></import-map-overrides-full>
 <figure id="splash-screen">
   <img decoding="sync"
-       src="/assets/graphdb-splash.svg"
+       src="assets/graphdb-splash.svg"
        alt="GraphDB Workbench is loading...">
 </figure>
 </body>

--- a/packages/shared-components/cypress/e2e/license-alert/license-alert.cy.js
+++ b/packages/shared-components/cypress/e2e/license-alert/license-alert.cy.js
@@ -9,6 +9,6 @@ describe('LicenseAlert', () => {
     LicenseAlertSteps.getLicenseAlert().should('be.visible').click();
 
     // Then, I should be redirected to /license
-    LicenseAlertSteps.getRedirectUrl().should('have.text', 'redirect to /license');
+    LicenseAlertSteps.getRedirectUrl().should('have.text', 'redirect to license');
   });
 });

--- a/packages/shared-components/src/components/onto-license-alert/onto-license-alert.tsx
+++ b/packages/shared-components/src/components/onto-license-alert/onto-license-alert.tsx
@@ -32,6 +32,6 @@ export class OntoLicenseAlert {
     event.preventDefault();
     // Navigate to the license page without reloading.
     // @ts-ignore
-    window.singleSpa.navigateToUrl('/license');
+    window.singleSpa.navigateToUrl('license');
   }
 }

--- a/packages/shared-components/src/components/onto-navbar/onto-navbar.tsx
+++ b/packages/shared-components/src/components/onto-navbar/onto-navbar.tsx
@@ -110,7 +110,7 @@ export class OntoNavbar {
       openInNewTab(externalLink);
       return;
     }
-    
+
     // Skip navigation when the selected item is a parent menu because it has no associated navigation.
     if (!menuItem.hasSubmenus()) {
       navigate(menuItem.href);
@@ -249,8 +249,8 @@ export class OntoNavbar {
     if (!this.menuModel) {
       return;
     }
-    const logoImg1 = '/assets/graphdb-logo.svg#Layer_1';
-    const logoImg2 = '/assets/graphdb-logo-sq.svg#Layer_1';
+    const logoImg1 = 'assets/graphdb-logo.svg#Layer_1';
+    const logoImg2 = 'assets/graphdb-logo-sq.svg#Layer_1';
     return (
       <Host>
         <ul class="navbar-component">

--- a/packages/shared-components/src/pages/fake-server.js
+++ b/packages/shared-components/src/pages/fake-server.js
@@ -1,13 +1,13 @@
 module.exports = function (req, res, next) {
-  if (req.url === '/rest/repositories/all') {
+  if (req.url.includes('/rest/repositories/all')) {
     // custom response overriding the dev server
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(getAllRepositories));
-  } else if (/^\/rest\/repositories\/[^/]+\/size\?location=/.test(req.url)) {
+  } else if (/\/rest\/repositories\/[^/]+\/size\?location=/.test(req.url)) {
     // custom response overriding the dev server
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(repositorySizeInfo));
-  } else if (/^\/rest\/security\/users\/.*/.test(req.url)) {
+  } else if (/\/rest\/security\/users\/.*/.test(req.url)) {
     // custom response overriding the dev server
     // user update does not return a response body
     res.writeHead(200);
@@ -16,7 +16,7 @@ module.exports = function (req, res, next) {
     // custom response overriding the dev server
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(monitoringOperations));
-  } else if (/^\/repositories\/[^/]+\/namespaces/.test(req.url)) {
+  } else if (/\/repositories\/[^/]+\/namespaces/.test(req.url)) {
     res.writeHead(200, {"Content-Type": "application/sparql-results+json"});
     res.end(JSON.stringify(namespaces));
   } else if (req.url.includes('/rest/autocomplete/query?q=')) {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -20,7 +20,8 @@ module.exports = (env, argv) => merge(commonConfig(env, argv), {
         chunkFilename: '[name].[contenthash].bundle.js',
         path: path.resolve(__dirname, 'dist'),
         libraryTarget: "module",
-        publicPath: '/'
+        // Path must be relative for production so that it works behind context
+        publicPath: './'
     },
     plugins: [
         new CopyPlugin({


### PR DESCRIPTION
## What
The workbench now loads and works correct behind a context path

## Why
The GDB and WB can be run in different environments and so they must build correctly

## How
- changed absolute paths to relative for rest calls
- changed absolute paths to relative for scripts and the single spa packages
- changed webpack publicPath to be relative for production build

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
