### PR TITLE
GDB-12588 fix workbench initial load, when there is no backend

### DIFF
--- a/packages/root-config/src/bootstrap/security/security-bootstrap.js
+++ b/packages/root-config/src/bootstrap/security/security-bootstrap.js
@@ -7,6 +7,7 @@ export const loadSecurityConfig = () => {
     })
     .catch((error) => {
       console.error('Could not load security config', error);
+      throw error;
     });
 };
 

--- a/packages/root-config/src/ontotext-root-config.js
+++ b/packages/root-config/src/ontotext-root-config.js
@@ -88,7 +88,11 @@ const registerSingleSpaRouterListeners = () => {
 };
 
 registerSingleSpaRouterListeners();
-bootstrapWorkbench().then(() => showSplashScreen(false));
+bootstrapWorkbench()
+  .then(() => showSplashScreen(false))
+  .catch((error) => {
+    console.error('Error during bootstrap of workbench', error);
+  });
 
 // window.addEventListener("single-spa:routing-event", (evt) => {
 //     console.log("single-spa finished mounting/unmounting applications!");


### PR DESCRIPTION
## What
Fix the initial load of the workbench, when there is no running GraphDb instance

## Why
Because it partially loads the workbench and looks broken. It should display a splash screen

## How
Added `resolve` and `reject` to `getSecurityConfig`, since the `catch` clause was resolving the promise, when it needed to reject. Removed the `catch` clause from the `bootstrapWorkbench` definition to the call for the same reason. Now when there is an error with the security config, the workbench does not load, but rather shows the splash screen

## Testing
n/a

## Screenshots
![Screenshot from 2025-06-24 11-13-47](https://github.com/user-attachments/assets/2c4515df-4f46-44e7-a31c-5d4afa9b82ee)
![Screenshot from 2025-06-24 11-14-34](https://github.com/user-attachments/assets/e85fa269-0109-498d-bc35-bb8cab8df333)


## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
