### PR TITLE
GDB-12173 Add initial state tests for the Autocomplete view

### DIFF
--- a/e2e-tests/e2e-legacy/setup/autocomplete/autocomplete-with-repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/autocomplete/autocomplete-with-repository.spec.js
@@ -1,0 +1,40 @@
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {AutocompleteSteps} from "../../../steps/setup/autocomplete-steps";
+
+describe('Autocomplete with selected repository', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'autocomplete-init-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Autocomplete page via URL with a repository selected
+        AutocompleteSteps.visit();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation bar', () => {
+        // Given, I visit the Autocomplete page via the navigation menu with a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnAutocomplete();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    const verifyInitialStateWithSelectedRepository = () => {
+        AutocompleteSteps.getAutocompletePage().should('exist');
+        AutocompleteSteps.getAutocompletePageContent().should('exist');
+        AutocompleteSteps.getAutocompletePage().should('exist');
+        AutocompleteSteps.getAutocompleteHeader().contains('Autocomplete for repository');
+        AutocompleteSteps.getAutocompleteLabelsContainer().should('exist');
+    };
+})

--- a/e2e-tests/e2e-legacy/setup/autocomplete/autocomplete-without-repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/autocomplete/autocomplete-without-repository.spec.js
@@ -1,0 +1,27 @@
+import {ErrorSteps} from "../../../steps/error-steps";
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {AutocompleteSteps} from "../../../steps/setup/autocomplete-steps";
+
+describe('Autocomplete without selected repository', () => {
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Autocomplete page via URL without a repository selected
+        AutocompleteSteps.visit();
+        // Then,
+        verifyInitialStateWithoutSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the Autocomplete page via the navigation menu without a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnAutocomplete();
+        // Then,
+        verifyInitialStateWithoutSelectedRepository()
+    });
+
+    const verifyInitialStateWithoutSelectedRepository = () => {
+        ErrorSteps.verifyNoConnectedRepoMessage();
+        AutocompleteSteps.getAutocompletePage().should('exist');
+        AutocompleteSteps.getAutocompletePageContent().should('not.exist');
+    };
+})

--- a/e2e-tests/e2e-legacy/setup/autocomplete/autocomplete.spec.js
+++ b/e2e-tests/e2e-legacy/setup/autocomplete/autocomplete.spec.js
@@ -1,5 +1,5 @@
-import {AutocompleteSteps} from "../../steps/setup/autocomplete-steps";
-import {LicenseStubs} from "../../stubs/license-stubs";
+import {AutocompleteSteps} from "../../../steps/setup/autocomplete-steps";
+import {LicenseStubs} from "../../../stubs/license-stubs";
 
 describe('Autocomplete ', () => {
 

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -190,4 +190,9 @@ export class MainMenuSteps {
         this.clickOnMenuSetup();
         this.getSubMenuButton('sub-menu-my-settings').click();
     }
+
+    static clickOnAutocomplete() {
+        this.clickOnMenuSetup();
+        this.getSubmenuAutocomplete().click();
+    }
 }

--- a/e2e-tests/steps/setup/autocomplete-steps.js
+++ b/e2e-tests/steps/setup/autocomplete-steps.js
@@ -1,4 +1,6 @@
-export class AutocompleteSteps {
+import {BaseSteps} from "../base-steps";
+
+export class AutocompleteSteps extends BaseSteps {
 
     static visit() {
         cy.visit('/autocomplete');
@@ -23,7 +25,11 @@ export class AutocompleteSteps {
     }
 
     static getAutocompletePage() {
-        return cy.get('#autocomplete');
+        return this.getByTestId('autocomplete-page');
+    }
+
+    static getAutocompletePageContent() {
+        return this.getAutocompletePage().getByTestId('autocomplete-content');
     }
 
     static getAutocompleteIndex() {
@@ -31,7 +37,11 @@ export class AutocompleteSteps {
     }
 
     static getAutocompleteHeader() {
-        return this.getAutocompleteIndex().find('.autocomplete-header');
+        return this.getAutocompletePageContent().getByTestId('autocomplete-header');
+    }
+
+    static getAutocompleteLabelsContainer() {
+        return this.getAutocompletePage().getByTestId('autocomplete-labels-container');
     }
 
     static getAutocompleteSwitch() {

--- a/packages/legacy-workbench/src/pages/autocomplete.html
+++ b/packages/legacy-workbench/src/pages/autocomplete.html
@@ -1,5 +1,5 @@
 <link href="css/autocomplete.css?v=[AIV]{version}[/AIV]" rel="stylesheet">
-<div id="autocomplete" class="page">
+<div id="autocomplete" class="page" data-test="autocomplete-page">
 	<h1>
 		{{title}}
         <page-info-tooltip></page-info-tooltip>
@@ -22,14 +22,15 @@
         ng-if="isLicenseValid()">
     </inactive-plugin-directive>
 
-    <div ng-if="isLicenseValid() && canWriteActiveRepo() && !loading && !isRestricted && pluginIsActive">
+    <div ng-if="isLicenseValid() && canWriteActiveRepo() && !loading && !isRestricted && pluginIsActive"
+		 data-test="autocomplete-content">
 		<div class="alert alert-info autocomplete-configuring-not-supported-alert" ng-if="!loader && pluginFound && getDegradedReason()">
 			<h4>{{'autocomplete.not.supported' | translate}}</h4>
 			<p>{{'autocomplete.config.not.supported' | translate}} {{getDegradedReason()}}</p>
 		</div>
 		<div ng-if="pluginFound && !getDegradedReason()">
             <div class="lead mb-1" id="toggleIndex">
-				<span class="autocomplete-header">{{'autocomplete.for.repo' | translate}} <strong>{{getActiveRepository()}}</strong> {{'is.label' | translate}} <span class="tag {{autocompleteEnabled ? 'tag-primary' : 'tag-default'}}">{{autocompleteEnabled ? 'common.on.btn' : 'common.off.btn' | translate}}</span></span>
+				<span class="autocomplete-header" data-test="autocomplete-header">{{'autocomplete.for.repo' | translate}} <strong>{{getActiveRepository()}}</strong> {{'is.label' | translate}} <span class="tag {{autocompleteEnabled ? 'tag-primary' : 'tag-default'}}">{{autocompleteEnabled ? 'common.on.btn' : 'common.off.btn' | translate}}</span></span>
 				<span gdb-tooltip="{{'click.to' | translate}} {{autocompleteEnabled ? 'disable.label' : 'enable.label' | translate}} {{'autocomplete.sentence.end' | translate}}"
                       tooltip-placement="top"
                       ng-click="toggleAutocomplete()"
@@ -83,7 +84,10 @@
                 </span>
 			</div>
 
-			<table id="wb-autocomplete-labels" class="table table-striped table-hover" aria-describedby="Autocomplete labels table">
+			<table id="wb-autocomplete-labels"
+				   data-test="autocomplete-labels-container"
+				   class="table table-striped table-hover"
+				   aria-describedby="Autocomplete labels table">
 				<thead>
 				<tr>
 					<th id="labelIRIColumn">{{'label.iri' | translate}}</th>


### PR DESCRIPTION
## What
Added tests to verify the initial state of the Autocomplete view.

## Why
To ensure that the view loads correctly and prevent navigation issues during the view migration process.

## How
Added a test for the view that verifies:
- Access via the navigation menu;
- Direct access via URL;
- Proper initialization and rendering in the expected initial state.

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
