### PR TITLE
GDB-12173 add initial state tests for cluster view

### DIFF
--- a/e2e-tests/e2e-legacy/setup/cluster/cluster-initial-state-with-cluster.spec.js
+++ b/e2e-tests/e2e-legacy/setup/cluster/cluster-initial-state-with-cluster.spec.js
@@ -1,0 +1,34 @@
+import {ClusterPageSteps} from "../../../steps/cluster/cluster-page-steps";
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {GlobalOperationsStatusesStub} from "../../../stubs/global-operations-statuses-stub";
+import {ClusterStubs} from "../../../stubs/cluster/cluster-stubs";
+
+function verifyInitialStateWithConfiguredCluster() {
+    ClusterPageSteps.getNoClusterImage().should('not.exist');
+    ClusterPageSteps.getUpdateClusterButton().should('be.visible');
+    ClusterPageSteps.getPreviewClusterConfigButton().should('be.visible');
+}
+
+describe('Cluster initial state with configured cluster', () => {
+    beforeEach(() => {
+        ClusterStubs.stubClusterConfig();
+        ClusterStubs.stubClusterGroupStatus();
+        ClusterStubs.stubClusterNodeStatus();
+    });
+
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Cluster page via URL with a configured cluster
+        ClusterPageSteps.visit();
+        // Then,
+        verifyInitialStateWithConfiguredCluster();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the Cluster page via the navigation menu with a configured cluster
+        HomeSteps.visit();
+        MainMenuSteps.clickOnCluster();
+        // Then,
+        verifyInitialStateWithConfiguredCluster();
+    });
+})

--- a/e2e-tests/e2e-legacy/setup/cluster/cluster-initial-state-without-cluster.spec.js
+++ b/e2e-tests/e2e-legacy/setup/cluster/cluster-initial-state-without-cluster.spec.js
@@ -1,0 +1,25 @@
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {ClusterPageSteps} from "../../../steps/cluster/cluster-page-steps";
+
+function verifyInitialStateWithoutConfiguredCluster() {
+    ClusterPageSteps.getNoClusterImage().should('be.visible');
+    ClusterPageSteps.getLegendButton().should('be.visible');
+}
+
+describe('Cluster initial state without configured cluster', () => {
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Cluster page via URL without a configured cluster
+        ClusterPageSteps.visit();
+        // Then,
+        verifyInitialStateWithoutConfiguredCluster();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the Cluster page via the navigation menu without a configured cluster
+        HomeSteps.visit();
+        MainMenuSteps.clickOnCluster();
+        // Then,
+        verifyInitialStateWithoutConfiguredCluster();
+    });
+})

--- a/e2e-tests/steps/cluster/cluster-page-steps.js
+++ b/e2e-tests/steps/cluster/cluster-page-steps.js
@@ -1,10 +1,16 @@
-export class ClusterPageSteps {
+import {BaseSteps} from "../base-steps";
+
+export class ClusterPageSteps extends BaseSteps {
     static visit() {
         cy.visit('/cluster');
     }
 
     static getClusterPage() {
         return cy.get('.cluster-view');
+    }
+
+    static getNoClusterImage() {
+        return this.getClusterPage().find('.no-cluster')
     }
 
     static getCreateClusterButton() {
@@ -47,8 +53,12 @@ export class ClusterPageSteps {
         this.getPreviewClusterConfigButton().click();
     }
 
+    static getLegendButton() {
+        return this.getByTestId('toggle-legend-button');
+    }
+
     static openLegend() {
-        return cy.get('.toggle-legend-btn button').click();
+        return this.getLegendButton().click();
     }
 
     static getLegend() {

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -232,4 +232,9 @@ export class MainMenuSteps {
         this.clickOnMenuHelp();
         this.getSubMenuButton('sub-menu-system-information').click();
     }
+
+    static clickOnCluster() {
+        this.clickOnMenuSetup();
+        this.getSubMenuButton('sub-menu-cluster').click();
+    }
 }

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/plugin.js
@@ -20,7 +20,8 @@ PluginRegistry.add('main.menu', {
         order: 20,
         role: 'ROLE_USER',
         parent: 'Setup',
-        guideSelector: 'sub-menu-cluster'
+        guideSelector: 'sub-menu-cluster',
+        testSelector: 'sub-menu-cluster'
     }]
 });
 

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-legend.html
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-legend.html
@@ -1,5 +1,6 @@
 <div id="toggle-legend-button" class="toggle-legend-btn">
     <button class="btn btn-link"
+            data-test="toggle-legend-button"
             ng-click="toggleLegend()"
             gdb-tooltip="{{'cluster_management.cluster_page.toggle_legend_btn_tooltip' | translate}}"
             tooltip-placement="right">


### PR DESCRIPTION
## What
Added tests which assert the initial state of cluster view.

## Why
To ensure the page loads correctly

## How
Added tests, which verify the state of the view by navigating via URL and by visiting it through the navigation menu. Added tests with and without configured cluster

## Testing
cypress

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
