### PR TITLE
GDB-12173 Add initial state tests for the Namespaces view

### DIFF
--- a/e2e-tests/e2e-legacy/setup/namespaces/namespaces-with-repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/namespaces/namespaces-with-repository.spec.js
@@ -1,0 +1,44 @@
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {NamespaceSteps} from "../../../steps/setup/namespace-steps";
+
+describe('Namespaces with selected repository', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'namespaces-init-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Namespaces page via URL with a repository selected
+        NamespaceSteps.visit();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation bar', () => {
+        // Given, I visit the Namespaces page via the navigation menu with a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnNamespaces();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    const verifyInitialStateWithSelectedRepository = () => {
+        NamespaceSteps.getNamespacesView().should('exist');
+        NamespaceSteps.getNamespacesContent().should('exist');
+        NamespaceSteps.getAddNamespaceForm().should('be.visible');
+        NamespaceSteps.getNamespacePrefixField().should('be.visible');
+        NamespaceSteps.getNamespaceValueField().should('be.visible');
+        NamespaceSteps.getAddNamespaceButton().should('be.visible');
+        NamespaceSteps.getNamespacesPerPageMenu().should('be.visible');
+        NamespaceSteps.getNamespacesFilterField().should('be.visible');
+        NamespaceSteps.getNamespacesTable().should('be.visible');
+    };
+})

--- a/e2e-tests/e2e-legacy/setup/namespaces/namespaces-without-repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/namespaces/namespaces-without-repository.spec.js
@@ -1,0 +1,27 @@
+import {ErrorSteps} from "../../../steps/error-steps";
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {NamespaceSteps} from "../../../steps/setup/namespace-steps";
+
+describe('Namespaces without selected repository', () => {
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Namespaces page via URL without a repository selected
+        NamespaceSteps.visit();
+        // Then,
+        verifyInitialStateWithoutSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the Namespaces page via the navigation menu without a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnNamespaces();
+        // Then,
+        verifyInitialStateWithoutSelectedRepository()
+    });
+
+    const verifyInitialStateWithoutSelectedRepository = () => {
+        ErrorSteps.verifyNoConnectedRepoMessage();
+        NamespaceSteps.getNamespacesView().should('exist');
+        NamespaceSteps.getNamespacesContent().should('not.be.visible');
+    };
+})

--- a/e2e-tests/e2e-legacy/setup/namespaces/namespaces.spec.js
+++ b/e2e-tests/e2e-legacy/setup/namespaces/namespaces.spec.js
@@ -1,7 +1,7 @@
-import {NamespaceSteps} from "../../steps/setup/namespace-steps";
-import {ApplicationSteps} from "../../steps/application-steps";
-import {NamespaceStubs} from "../../stubs/namespace-stubs";
-import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
+import {NamespaceSteps} from "../../../steps/setup/namespace-steps";
+import {ApplicationSteps} from "../../../steps/application-steps";
+import {NamespaceStubs} from "../../../stubs/namespace-stubs";
+import {ModalDialogSteps} from "../../../steps/modal-dialog-steps";
 
 describe('Namespaces', () => {
 

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -195,4 +195,9 @@ export class MainMenuSteps {
         this.clickOnMenuSetup();
         this.getSubmenuAutocomplete().click();
     }
+
+    static clickOnNamespaces() {
+        this.clickOnMenuSetup();
+        this.getSubMenuButton('sub-menu-namespaces').click();
+    }
 }

--- a/e2e-tests/steps/setup/namespace-steps.js
+++ b/e2e-tests/steps/setup/namespace-steps.js
@@ -1,10 +1,16 @@
-export class NamespaceSteps {
+import {BaseSteps} from "../base-steps";
+
+export class NamespaceSteps extends BaseSteps {
     static visit() {
         cy.visit('/namespaces');
     }
 
     static getNamespacesView() {
-        return cy.get('#wb-namespaces');
+        return this.getByTestId('namespaces-page')
+    }
+
+    static getNamespacesContent() {
+        return this.getNamespacesView().getByTestId('namespaces-content');
     }
 
     // ------ Generic ------

--- a/packages/legacy-workbench/src/js/angular/namespaces/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/namespaces/plugin.js
@@ -19,7 +19,8 @@ PluginRegistry.add('main.menu', {
             href: 'namespaces',
             order: 30,
             parent: 'Setup',
-            guideSelector: 'sub-menu-namespaces'
+            guideSelector: 'sub-menu-namespaces',
+            testSelector: 'sub-menu-namespaces'
         }
     ]
 });

--- a/packages/legacy-workbench/src/pages/namespaces.html
+++ b/packages/legacy-workbench/src/pages/namespaces.html
@@ -10,9 +10,9 @@
 
 
 <div class="ot-loader ot-main-loader" onto-loader size="50" ng-show="loader"></div>
-<div id="wb-namespaces" ng-hide="loader">
+<div id="wb-namespaces" ng-hide="loader" data-test="namespaces-page">
     <div core-errors></div>
-    <div ng-show="getActiveRepository()">
+    <div ng-show="getActiveRepository()" data-test="namespaces-content">
         <div class="clearfix mb-2">
             <form novalidate name="form" class="form-inline pull-right add-namespace-form" ng-show="canWriteActiveRepo()">
                 <div class="form-group" style="width: 130px;">


### PR DESCRIPTION
## What
Added tests to verify the initial state of the Namespaces view.

## Why
To ensure that the view loads correctly and prevent navigation issues during the view migration process.

## How
Added a test for the view that verifies:
- Access via the navigation menu;
- Direct access via URL;
- Proper initialization and rendering in the expected initial state.

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
