### PR TITLE
GDB-12173 Add initial state tests for the Plugins view

### DIFF
--- a/e2e-tests/e2e-legacy/setup/plugins/plugins-with-repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/plugins/plugins-with-repository.spec.js
@@ -1,0 +1,38 @@
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {PluginsSteps} from "../../../steps/setup/plugins-steps";
+
+describe('Plugins with selected repository', () => {
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'plugins-init-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Plugins page via URL with a repository selected
+        PluginsSteps.visit();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation bar', () => {
+        // Given, I visit the Plugins page via the navigation menu with a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnPlugins();
+        // Then,
+        verifyInitialStateWithSelectedRepository();
+    });
+
+    const verifyInitialStateWithSelectedRepository = () => {
+        PluginsSteps.getPluginsView().should('be.visible');
+        PluginsSteps.getSearchPluginBar().should('be.visible');
+        PluginsSteps.getPluginsList().should('exist');
+    };
+})

--- a/e2e-tests/e2e-legacy/setup/plugins/plugins-without-repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/plugins/plugins-without-repository.spec.js
@@ -1,0 +1,28 @@
+import {ErrorSteps} from "../../../steps/error-steps";
+import HomeSteps from "../../../steps/home-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {PluginsSteps} from "../../../steps/setup/plugins-steps";
+
+describe('Plugins without selected repository', () => {
+    it('Should display the correct initial state when navigating via URL', () => {
+        // Given, I visit the Plugins page via URL without a repository selected
+        PluginsSteps.visit();
+        // Then,
+        verifyInitialStateWithoutSelectedRepository();
+    });
+
+    it('Should display the correct initial state when navigating via the navigation menu', () => {
+        // Given, I visit the Plugins page via the navigation menu without a repository selected
+        HomeSteps.visit();
+        MainMenuSteps.clickOnPlugins();
+        // Then,
+        verifyInitialStateWithoutSelectedRepository()
+    });
+
+    const verifyInitialStateWithoutSelectedRepository = () => {
+        ErrorSteps.verifyNoConnectedRepoMessage();
+        PluginsSteps.getPluginsView().should('be.visible');
+        PluginsSteps.getSearchPluginBar().should('not.be.visible');
+        PluginsSteps.getPluginsList().should('not.exist');
+    };
+})

--- a/e2e-tests/e2e-legacy/setup/plugins/plugins.spec.js
+++ b/e2e-tests/e2e-legacy/setup/plugins/plugins.spec.js
@@ -1,6 +1,6 @@
-import {PluginsSteps} from "../../steps/setup/plugins-steps";
-import {PluginsStubs} from "../../stubs/setup/plugins-stubs";
-import {LicenseStubs} from "../../stubs/license-stubs";
+import {PluginsSteps} from "../../../steps/setup/plugins-steps";
+import {PluginsStubs} from "../../../stubs/setup/plugins-stubs";
+import {LicenseStubs} from "../../../stubs/license-stubs";
 
 describe('Plugins view', () => {
 

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -200,4 +200,9 @@ export class MainMenuSteps {
         this.clickOnMenuSetup();
         this.getSubMenuButton('sub-menu-namespaces').click();
     }
+
+    static clickOnPlugins() {
+        this.clickOnMenuSetup();
+        this.getSubMenuButton('sub-menu-plugins').click();
+    }
 }

--- a/e2e-tests/steps/setup/plugins-steps.js
+++ b/e2e-tests/steps/setup/plugins-steps.js
@@ -1,10 +1,20 @@
-export class PluginsSteps {
+import {BaseSteps} from "../base-steps";
+
+export class PluginsSteps extends BaseSteps {
     static visit() {
         cy.visit('/plugins');
     }
 
     static getPluginsView() {
         return cy.get('#plugins');
+    }
+
+    static getSearchPluginBar() {
+        return this.getPluginsView().getByTestId('search-plugins-bar');
+    }
+
+    static getPluginsList() {
+        return this.getPluginsView().getByTestId('plugins-list');
     }
 
     static waitUntilPluginsPageIsLoaded() {

--- a/packages/legacy-workbench/src/js/angular/plugins/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/plugins/plugin.js
@@ -20,7 +20,8 @@ PluginRegistry.add('main.menu', {
             order: 25,
             parent: 'Setup',
             role: "IS_AUTHENTICATED_FULLY",
-            guideSelector: 'sub-menu-plugins'
+            guideSelector: 'sub-menu-plugins',
+            testSelector: 'sub-menu-plugins'
         }
     ]
 });

--- a/packages/legacy-workbench/src/pages/plugins.html
+++ b/packages/legacy-workbench/src/pages/plugins.html
@@ -15,7 +15,9 @@
     <div core-errors write ontop fedx license></div>
 
     <!--search box-->
-    <div class="search-bar" ng-show="plugins.length > 0 && !loader">
+    <div class="search-bar"
+         ng-show="plugins.length > 0 && !loader"
+         data-test="search-plugins-bar">
             <span class="pull-left" id="searchbox-plugins">
                 <input type="text" class="form-control plugins-filter" placeholder="{{'search.plugins.placeholder' | translate}}"
                        ng-model="searchPluginsTerm" gdb-tooltip="{{'common.search.btn' | translate}}"
@@ -26,6 +28,7 @@
 
     <table ng-if="isLicenseValid() && canWriteActiveRepo() && !isRestricted"
            id="wb-plugins-pluginInPlugins"
+           data-test="plugins-list"
            class="table table-hover" aria-describedby="Plugins table">
         <tbody>
         <tr ng-repeat="(key, plugin) in displayedPlugins" class="wb-plugins-row plugin" loader-post-repeat-directive>


### PR DESCRIPTION
## What
Added tests to verify the initial state of the Plugins view.

## Why
To ensure that the view loads correctly and prevent navigation issues during the view migration process.

## How
Added a test for the view that verifies:
- Access via the navigation menu;
- Direct access via URL;
- Proper initialization and rendering in the expected initial state.

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
