### PR TITLE
GDB-12584: Fix cluster node link not opening in new tab

### DIFF
--- a/packages/legacy-workbench/src/pages/cluster-management/clusterInfo.html
+++ b/packages/legacy-workbench/src/pages/cluster-management/clusterInfo.html
@@ -33,7 +33,7 @@
 </div>
 
 <div id="nodeTooltip" class="nodetooltip" ng-hide="selectedNode == null">
-    <a href="{{selectedNode.endpoint}}" class="break-word"><strong>{{selectedNode.endpoint}}</strong></a>
+    <a href="{{selectedNode.endpoint}}" target="_blank" rel="noopener" class="break-word"><strong>{{selectedNode.endpoint}}</strong></a>
     <hr style="margin-top: 10px; margin-bottom: 10px"/>
     <div class="row">
         <div class="col-sm-6">{{'cluster_management.cluster_status.node.rpc_address' | translate}}</div>


### PR DESCRIPTION
## What
The node tooltip link in the tooltip in the cluster view now opens in a new tab

## Why
Same as other anchor tags which opened in a new tab without target="_blank" on the legacy, now open in tha current tab

## How
- added `target="_blank" rel="noopener"`

## Testing
N/a

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
