### PR TITLE
GDB-12611: Unnecessary authenticated-user request upon login

### DIFF
--- a/packages/api/src/services/utils/routing-utils.ts
+++ b/packages/api/src/services/utils/routing-utils.ts
@@ -40,12 +40,24 @@ export function isHomePage(): boolean {
 }
 
 /**
- * Retrieves the pathname portion of the current URL.
+ * Retrieves the pathname portion of the current URL without the context prefix.
  *
- * @returns {string} The pathname of the current URL, which represents the path segment that comes after the host and before the query string.
+ * @returns {string} The pathname of the current URL, which represents the path segment that comes after the context (if any) and before the query string.
  */
 export function getPathName(): string {
-  return window.location.pathname;
+  return window.location.pathname.substring(getContextName().length - 1);
+}
+
+/**
+ * Returns the context name (base href) from the `<base>` tag in the document.
+ *
+ * This is usually the base path under which the app is deployed, e.g. '/graphdb/'.
+ * If no `<base>` tag is found, returns '/' by default.
+ *
+ * @returns {string} The context path as specified in the base href (always ending with a slash).
+ */
+export function getContextName(): string {
+  return document.querySelector('base')?.getAttribute('href') ?? '/';
 }
 
 /**


### PR DESCRIPTION
## What
An unnecessary authenticated-user request was being made immediately after login when the Workbench is started under a context path.

## Why
There is a subscription to security context changes, which triggers the fetching of the authenticated user details. This request is normally skipped on the login page, as the user is not yet authenticated.

However, the check only verified whether the current route was exactly "login". The route was determined using a utility function that returns the pathname without accounting for the context (base href), which caused the check to fail—leading to the additional request being sent.

The GraphDB server correctly updates the <base href> tag in the index.html to reflect the current context, but this value was not being used in the migrated Workbench code.

## How
Fixes the getPathName utility function to properly remove the context name (as defined in the base href) and return the relative path portion of the URL.

## Additional work
This MR fixes GDB-12612 and GDB-12605, as they share the same root cause.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
