### PR TITLE
GDB-12612 Fix broken navigations, when behind context

### DIFF
--- a/packages/shared-components/cypress/e2e/rdf-search/rdf-search.cy.js
+++ b/packages/shared-components/cypress/e2e/rdf-search/rdf-search.cy.js
@@ -74,7 +74,7 @@ describe('RDF Search', () => {
     // Then, I expect to not see the notification anymore
     RdfSearchSteps.getToastNotification().should('not.exist');
     // And, I expect to have been redirected to the setup page
-    RdfSearchSteps.getRedirectUrl().should('have.text', `redirect to /autocomplete`);
+    RdfSearchSteps.getRedirectUrl().should('have.text', `redirect to autocomplete`);
 
     // When, I enable autocomplete
     RdfSearchSteps.enableAutocomplete();

--- a/packages/shared-components/cypress/e2e/user-menu/user-menu.cy.js
+++ b/packages/shared-components/cypress/e2e/user-menu/user-menu.cy.js
@@ -46,7 +46,7 @@ describe('User Menu', () => {
     UserMenuSteps.selectDropdownItem(0)
 
     // Then I should be redirected to the My Settings page
-    UserMenuSteps.getRedirectUrl().should('have.text', `redirect to /settings`);
+    UserMenuSteps.getRedirectUrl().should('have.text', `redirect to settings`);
     // And the dropdown should be closed
     UserMenuSteps.getDropdown().should('not.exist');
   });

--- a/packages/shared-components/src/components/onto-search-resource-input/onto-search-resource-input.tsx
+++ b/packages/shared-components/src/components/onto-search-resource-input/onto-search-resource-input.tsx
@@ -212,7 +212,7 @@ export class OntoSearchResourceInput {
       const message = TranslationService.translate('rdf_search.toasts.autocomplete_is_off');
       this.toastrService.warning(`<a style="font-weight: 500">${message}</a>`,
         {
-          onClick: navigateTo('/autocomplete'),
+          onClick: navigateTo('autocomplete'),
           removeOnClick: true
         });
     }

--- a/packages/shared-components/src/components/onto-user-menu/onto-user-menu.tsx
+++ b/packages/shared-components/src/components/onto-user-menu/onto-user-menu.tsx
@@ -46,7 +46,7 @@ export class OntoUserMenu {
           </button>
           {this.isOpen ?
             <section class='onto-user-menu-dropdown'>
-              <translate-label onClick={navigateTo('/settings')}
+              <translate-label onClick={navigateTo('settings')}
                                labelKey={'user_menu.my_settings'}></translate-label>
               {!this.securityConfig?.hasExternalAuthUser ?
                 <translate-label onClick={this.logout}


### PR DESCRIPTION
## What
Fix broken navigations, when GraphDb is behind a proxy

## Why
Thy are not working

## How
- Changed `navigateTo` parameters to be relative, instead of absolute. This fixes the navigation from the user menu to the settings page and the autocomplete toast message redirect

Fixes: GDB-12616 and GDB-12613 as well

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
