### PR TITLE
GDB-11410 Fix user-import-data test

### DIFF
--- a/e2e-tests/e2e-legacy/import/import-user-data.spec.js
+++ b/e2e-tests/e2e-legacy/import/import-user-data.spec.js
@@ -7,7 +7,6 @@ const RDF_TEXT_SNIPPET = '@prefix ab:<http://learningsparql.com/ns/addressbook#>
     'ab:richard ab:homeTel "(229)276-5135".\n' +
     'ab:richard ab:email "richard491@hotmail.com".';
 
-// TODO: Fix me. Broken due to migration (Error: unknown)
 describe('Import user data', () => {
 
     let repositoryId;

--- a/e2e-tests/steps/import/import-steps.js
+++ b/e2e-tests/steps/import/import-steps.js
@@ -263,7 +263,7 @@ class ImportSteps {
     }
 
     static deleteUploadedFile(index) {
-        this.getResource(index).find('.import-resource-action-remove-btn').click();
+        this.getResource(index).find('.import-resource-action-remove-btn').invoke('show').trigger('click');
     }
 
     static importFile(index) {


### PR DESCRIPTION
## What
Fix user-import-data test

## Why
It was flaky

How
Forced the `remove` button to be shown, before being clicked. Previously the button was there, it was visible, but the click command did not open the confirmation dialog

## Testing
cypress

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
