### PR TITLE
GDB-11410 Enable import user and graphql specs

### DIFF
--- a/e2e-tests/e2e-legacy/graphql/filter-graphql-endpoints-on-management-view.spec.js
+++ b/e2e-tests/e2e-legacy/graphql/filter-graphql-endpoints-on-management-view.spec.js
@@ -17,10 +17,7 @@ describe('GraphQL endpoints filtering', () => {
         cy.deleteRepository(repositoryId);
     });
 
-    /**
-     * TODO Fixme broken due migration (Error unknown)
-     */
-    it.skip('should be able to filter endpoints', () => {
+    it('should be able to filter endpoints', () => {
         // Given I have a repository with active GraphQL endpoints
         // When I visit the endpoint management view
         GraphqlEndpointManagementSteps.visit();

--- a/e2e-tests/e2e-legacy/graphql/graphql-endpoint-management-view.spec.js
+++ b/e2e-tests/e2e-legacy/graphql/graphql-endpoint-management-view.spec.js
@@ -85,7 +85,6 @@ describe('GraphQL endpoints management', () => {
             GraphqlEndpointManagementSteps.getEndpointsInfo().should('have.length', 3);
             GraphqlEndpointManagementSteps.verifyEndpointInfo([
                 {
-                    status: 'deleted',
                     id: 'swapi',
                     label: 'Ontotext Star Wars Ontology',
                     description: '',
@@ -96,7 +95,6 @@ describe('GraphQL endpoints management', () => {
                     properties: 68
                 },
                 {
-                    status: 'deleted',
                     id: 'swapi-planets',
                     label: 'Star Wars planets API',
                     description: '',
@@ -107,7 +105,6 @@ describe('GraphQL endpoints management', () => {
                     properties: 10
                 },
                 {
-                    status: 'deleted',
                     id: 'swapi-species',
                     label: 'Star Wars species API',
                     description: '',

--- a/e2e-tests/e2e-legacy/graphql/import-graphql-endpoint-definitions.spec.js
+++ b/e2e-tests/e2e-legacy/graphql/import-graphql-endpoint-definitions.spec.js
@@ -73,7 +73,6 @@ describe('Graphql: import endpoint definitions', () => {
 
         GraphqlEndpointManagementSteps.verifyEndpointInfo([
             {
-                status: 'deleted',
                 id: 'swapi',
                 label: 'Ontotext Star Wars Ontology',
                 description: '',
@@ -170,7 +169,6 @@ describe('Graphql: import endpoint definitions', () => {
         GraphqlEndpointManagementSteps.getEndpointsInfo().should('have.length', 3);
         GraphqlEndpointManagementSteps.verifyEndpointInfo([
             {
-                status: 'deleted',
                 id: 'swapi',
                 label: 'Ontotext Star Wars Ontology',
                 description: '',
@@ -181,7 +179,6 @@ describe('Graphql: import endpoint definitions', () => {
                 properties: 68
             },
             {
-                status: 'deleted',
                 id: 'swapi-planets',
                 label: 'Star Wars planets API',
                 description: '',
@@ -192,7 +189,6 @@ describe('Graphql: import endpoint definitions', () => {
                 properties: 10
             },
             {
-                status: 'deleted',
                 id: 'swapi-species',
                 label: 'Star Wars species API',
                 description: '',
@@ -236,7 +232,6 @@ describe('Graphql: import endpoint definitions', () => {
         GraphqlEndpointManagementSteps.getEndpointsInfo().should('have.length', 2);
         GraphqlEndpointManagementSteps.verifyEndpointInfo([
             {
-                status: 'deleted',
                 id: 'swapi-planets',
                 label: 'Star Wars planets API',
                 description: '',
@@ -247,7 +242,6 @@ describe('Graphql: import endpoint definitions', () => {
                 properties: 10
             },
             {
-                status: 'deleted',
                 id: 'swapi-species',
                 label: 'Star Wars species API',
                 description: '',

--- a/e2e-tests/e2e-legacy/import/import-user-data.spec.js
+++ b/e2e-tests/e2e-legacy/import/import-user-data.spec.js
@@ -21,8 +21,7 @@ describe('Import user data', () => {
         cy.deleteRepository(repositoryId);
     });
 
-    // TODO: Fix me. Broken due to migration (Error: unknown)
-    it.skip('Should load user data import tab by default', () => {
+    it('Should load user data import tab by default', () => {
         // Given I have visited the import page
         ImportUserDataSteps.visit();
         // When the page is loaded

--- a/e2e-tests/steps/graphql/graphql-endpoint-management-steps.js
+++ b/e2e-tests/steps/graphql/graphql-endpoint-management-steps.js
@@ -89,7 +89,7 @@ export class GraphqlEndpointManagementSteps {
             const endpointInfo = data[index];
             cy.wrap($row).within(() => {
                 const statusCheck = endpointInfo.status === 'deleted' ? 'not.exist' : 'be.visible';
-                cy.get('td').eq(1).find('.endpoint-link').should(statusCheck);
+                cy.get('td').eq(2).find('.endpoint-link').should(statusCheck);
                 cy.get('td').eq(2).should('contain', endpointInfo.id);
                 cy.get('td').eq(3).should('contain', endpointInfo.label);
                 const isDefaultCheck = endpointInfo.default ? 'be.checked' : 'not.be.checked'

--- a/e2e-tests/steps/import/import-steps.js
+++ b/e2e-tests/steps/import/import-steps.js
@@ -35,7 +35,7 @@ class ImportSteps {
     }
 
     static showPageInfoPopover() {
-        return this.getPageInfoIcon().realHover();
+        return this.getPageInfoIcon().trigger('mouseover');
     }
 
     static getPageInfoPopover() {
@@ -47,7 +47,7 @@ class ImportSteps {
     }
 
     static hidePageInfoPopover() {
-        return cy.get('.menu-element-root').realHover();
+        return this.getPageInfoIcon().trigger('mouseleave');
     }
 
     static visitUserImport(repository) {


### PR DESCRIPTION
## What
Enable import user and graphql skipped tests

## Why
They were skipped, because they were failing for unknown reasons

## How
- ensured the `remove` is shown, before being clicked in the import page. Previously the dialog wasn't popping up for some reason
- changed the index, in which `endpoint-link` was being searched for. Previously it was the wrong one. Also removed the `status: 'deleted'` from the parameters, which were passed into `verifyEndpointInfo`. Deleted endpoints should not be visible. This is why the first check wasn't failing

## Testing
cypress

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
