### PR TITLE
GDB-12608 - Allow repo restart in cluster

### DIFF
--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -2363,7 +2363,6 @@
     "delete.repo.warning.msg": "<p>Are you sure you want to delete the repository <strong>{{repositoryId}}</strong>?</p><p><span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>All data in the repository will be lost.</p>",
     "confirm.restart.repo": "Confirm restart",
     "confirm.restart.repo.warning.msg": "<p>Are you sure you want to restart the repository <strong>{{repositoryId}}</strong>?</p><p><span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>The repository will be shut down immediately and all running queries and updates will be cancelled.</p>",
-    "restart.repo.in.cluster.tooltip": "Restarting a repository is not supported in a cluster environment. To apply configuration changes, restart all cluster nodes.",
     "location.cannot.be.empty.error": "Location cannot be empty",
     "required.field": "This field is required",
     "invalid.field.value": "Invalid field value. The value should match the pattern '{{pattern}}'",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -2361,7 +2361,6 @@
     "delete.repo.warning.msg": "<p>Vous êtes sûr de vouloir supprimer le dépôt <strong>{{repositoryId}}</strong>?</p><p><span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>Toutes les données du dépôt seront perdues.</p>",
     "confirm.restart.repo": "Confirmer le redémarrage",
     "confirm.restart.repo.warning.msg": "<p>Vous êtes sûr de vouloir redémarrer le dépôt <strong>{{repositoryId}}</strong>?</p><p><span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>Le dépôt sera arrêté immédiatement et toutes les requêtes et mises à jour en cours seront annulées.</p>",
-    "restart.repo.in.cluster.tooltip": "Le redémarrage d'un dépôt n'est pas pris en charge dans un environnement de cluster. Pour appliquer les modifications de configuration, redémarrez tous les nœuds du cluster.",
     "location.cannot.be.empty.error": "L'emplacement ne peut pas être vide",
     "required.field": "Ce champ est requis",
     "invalid.field.value": "Valeur de champ invalide. La valeur doit correspondre au modèle '{{pattern}}'.",

--- a/src/js/angular/repositories/controllers.js
+++ b/src/js/angular/repositories/controllers.js
@@ -7,7 +7,6 @@ import {
 import {decodeHTML} from "../../../app";
 import './controllers/manage-remote-location-dialog.controller';
 import {RemoteLocationType} from "../models/repository/remote-location.model";
-import 'angular/rest/cluster.rest.service';
 
 const ENTITY_INDEX_SIZE_MIN = 10000;
 
@@ -111,7 +110,6 @@ const modules = [
     'toastr',
     'ngFileUpload',
     'graphdb.framework.repositories.controllers.manage-remote-location-dialog',
-    'graphdb.framework.rest.cluster.service'
 ];
 
 angular.module('graphdb.framework.repositories.controllers', modules)
@@ -125,14 +123,13 @@ angular.module('graphdb.framework.repositories.controllers', modules)
     .controller('UploadRepositoryConfigCtrl', UploadRepositoryConfigCtrl);
 
 LocationsAndRepositoriesCtrl.$inject = ['$scope', '$rootScope', '$uibModal', 'toastr', '$repositories', 'ModalService', 'AuthTokenService', 'LocationsRestService',
-    'LocalStorageAdapter', '$interval', '$translate', '$q', 'GuidesService', 'ClusterRestService'];
+    'LocalStorageAdapter', '$interval', '$translate', '$q', 'GuidesService'];
 
 function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $repositories, ModalService, AuthTokenService, LocationsRestService,
-    LocalStorageAdapter, $interval, $translate, $q, GuidesService, ClusterRestService) {
+    LocalStorageAdapter, $interval, $translate, $q, GuidesService) {
 
     $scope.RemoteLocationType = RemoteLocationType;
     $scope.loader = true;
-    $scope.isInCluster = false;
     /**
      * @type {RemoteLocationModel[]}
      */
@@ -151,19 +148,6 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
                 return locations;
             })
             .finally(() => $scope.loader = false);
-    }
-
-    function getAndSetClusterStatus() {
-        ClusterRestService.getNodeStatus().then(() => {
-            // If the endpoint returns a success response, that means we have a cluster
-            $scope.isInCluster = true;
-        }).catch((error) => {
-            if (error.status === 404) {
-                $scope.isInCluster = false;
-            } else {
-                console.error('An unexpected error occurred:', error);
-            }
-        });
     }
 
     $scope.getLocalLocation = (local, locationType) => {
@@ -391,7 +375,6 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
     };
 
     getLocations();
-    getAndSetClusterStatus();
     const timer = $interval(function () {
         if (GuidesService.isActive() && !$rootScope.guidePaused) {
             // Don't refresh list while a guide is active

--- a/src/pages/repositories.html
+++ b/src/pages/repositories.html
@@ -120,11 +120,8 @@
                                                     <em class="icon-download"></em>
                                             </a>
                                             <button class="btn btn-link p-0 restart-repository-btn" type="button"
-                                                    gdb-tooltip="{{isInCluster
-                                                    ? ('restart.repo.in.cluster.tooltip' | translate)
-                                                    : ('restart.repo.label' | translate) + ' ' + repository.id}}"
+                                                    gdb-tooltip="{{('restart.repo.label' | translate) + ' ' + repository.id}}"
                                                     tooltip-placement="top"
-                                                    ng-disabled="isInCluster"
                                                     ng-click="restartRepository(repository)">
                                                     <span class="icon-reload"></span>
                                             </button>

--- a/src/pages/repository.html
+++ b/src/pages/repository.html
@@ -418,14 +418,12 @@
                     <div ng-if="repositoryInfo.type !== 'ontop'" class="pt-1"></div>
                     <div class="form-group row" ng-if="repositoryInfo.type !== 'ontop' && editRepoPage">
                         <div class="checkbox col-xs-12">
-                            <label gdb-tooltip="{{isRepoInCluster && !repositoryInfo.location
-                            ? ('restart.repo.in.cluster.tooltip' | translate)
-                            : ('restart.repo.check.tooltip' | translate)}}">
+                            <label gdb-tooltip="{{'restart.repo.check.tooltip' | translate}}">
                                 <input id="restartRepo" name="restartRepo"
                                        type="checkbox"
                                        ng-model="repositoryInfo.restartRequested"
                                        ng-checked="repositoryInfo.restartRequested || repositoryInfo.saveId !== repositoryInfo.id"
-                                       ng-disabled="(repositoryInfo.saveId !== repositoryInfo.id) || (isRepoInCluster && !repositoryInfo.location)"/>
+                                       ng-disabled="repositoryInfo.saveId !== repositoryInfo.id"/>
                                 {{'restart.repo.label' | translate}}
                             </label>
                         </div>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -2363,7 +2363,6 @@
     "delete.repo.warning.msg": "<p>Are you sure you want to delete the repository <strong>{{repositoryId}}</strong>?</p><p><span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>All data in the repository will be lost.</p>",
     "confirm.restart.repo": "Confirm restart",
     "confirm.restart.repo.warning.msg": "<p>Are you sure you want to restart the repository <strong>{{repositoryId}}</strong>?</p><p><span class=\"icon-2x icon-warning\" style=\"color: var(--primary-color-dark)\"></span>The repository will be shut down immediately and all running queries and updates will be cancelled.</p>",
-    "restart.repo.in.cluster.tooltip": "Restarting a repository is not supported in a cluster environment. To apply configuration changes, restart all cluster nodes.",
     "location.cannot.be.empty.error": "Location cannot be empty",
     "required.field": "This field is required",
     "invalid.field.value": "Invalid field value. The value should match the pattern '{{pattern}}'",

--- a/test-cypress/integration/repository/repositories.spec.js
+++ b/test-cypress/integration/repository/repositories.spec.js
@@ -510,19 +510,19 @@ describe('Repositories', () => {
         ModalDialogSteps.verifyDialogBody('Changing the repository ID is a dangerous operation since it renames the repository folder and enforces repository shutdown.');
     });
 
-    it('should NOT allow restart of LOCAL repository from EDIT PAGE, if node is in cluster', () => {
+    it('should allow restart of LOCAL repository from EDIT PAGE, if node is in cluster', () => {
         // Given I create a repository
         cy.createRepository({id: repositoryId});
         // When I set the node in a cluster
         GlobalOperationsStatusesStub.stubGlobalOperationsStatusesResponse(repositoryId);
         // Then go to the local repository's edit page
         RepositorySteps.visitEditPage(repositoryId);
-        // I expect the repository restart checkbox button to be disabled
+        // I expect the repository restart checkbox button to be enabled
         RepositorySteps.getEditViewRestartButton().should('be.visible');
-        RepositorySteps.getEditViewRestartButton().should('be.disabled');
+        RepositorySteps.getEditViewRestartButton().should('not.be.disabled');
     });
 
-    it('should NOT allow restart of LOCAL repositories from REPOSITORIES PAGE, if node is in cluster', () => {
+    it('should allow restart of LOCAL repositories from REPOSITORIES PAGE, if node is in cluster', () => {
         // Given I create a repository
         cy.createRepository({id: repositoryId});
         // When I set the node in a cluster
@@ -530,9 +530,9 @@ describe('Repositories', () => {
         ClusterStubs.stubClusterNodeStatus();
         // Then go to the repositories page
         RepositorySteps.visit();
-        // I expect the local repository's restart button to be disabled
+        // I expect the local repository's restart button to be enabled
         RepositorySteps.getRepositoryRestartButton(repositoryId).should('be.visible');
-        RepositorySteps.getRepositoryRestartButton(repositoryId).should('be.disabled');
+        RepositorySteps.getRepositoryRestartButton(repositoryId).should('not.be.disabled');
     });
 
     it('should ALLOW restart of REMOTE repositories from REPOSITORIES PAGE, if node is in cluster', () => {


### PR DESCRIPTION
## What
Repo restart in cluster will be allowed from the repositories view and inside edit repository view.

## Why
The backend can now handle repo restart in a cluster setting, so the restriction is no longer necessary.

## How
I essentially reverted the changes from https://github.com/Ontotext-AD/graphdb-workbench/pull/1714. Only the tests remain.

## Testing
Edited existing tests to verify the reverse scenario.

## Screenshots
Restart icon not disabled
![Screenshot from 2025-07-01 11-22-31](https://github.com/user-attachments/assets/2be86d9c-2462-42e1-ac22-352ec0eb587d)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
