### PR TITLE
GDB-12614 fix endpoint management filtering

### DIFF
--- a/src/js/angular/graphql/controllers/graphql-endpoint-management-view.controller.js
+++ b/src/js/angular/graphql/controllers/graphql-endpoint-management-view.controller.js
@@ -388,6 +388,7 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
      */
     const onEndpointsInfoLoaded = (endpointsInfoList) => {
         $scope.endpointsInfoList = endpointsInfoList;
+        $scope.endpointsInfoList.filter($scope.filterTerm);
         if ($scope.endpointsInfoList && $scope.endpointsInfoList.endpoints.length > 0) {
             $scope.hasEndpoints = true;
             // Find out the default endpoint. If there is no default endpoint in the list, then create a new one dummy

--- a/src/js/angular/models/graphql/graphql-endpoints-info.js
+++ b/src/js/angular/models/graphql/graphql-endpoints-info.js
@@ -223,7 +223,7 @@ export class GraphqlEndpointsInfoList {
         this._endpoints = this._originalEndpointsList
             .filter((endpoint) => {
                 return endpoint.endpointId.toLowerCase().includes(filterTerm.toLowerCase()) ||
-                    endpoint.label.toLowerCase().includes(filterTerm.toLowerCase());
+                    endpoint.label?.toLowerCase().includes(filterTerm.toLowerCase());
             });
     }
 


### PR DESCRIPTION
## What
Fix endpoint management filtering

## Why
Filtering wasn't always applied. Also, if applied, it was reset after a few seconds

## How
Added optional chaining to the filter function, which compares labels, since they are optional. Added filtering to `onEndpointsInfoLoaded` to keep the same filters applied, after endpoints are polled.

## Testing
n/a

## Screenshots
![Screenshot from 2025-07-01 14-46-37](https://github.com/user-attachments/assets/4f992d65-2974-4606-93a7-f49dc44b164b)
![Screenshot from 2025-07-01 14-46-46](https://github.com/user-attachments/assets/71496c11-be2c-4234-b6b7-62fdb89a9827)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
