### PR TITLE
GDB-11410: Fixes the RDF resource search component

### DIFF
--- a/e2e-tests/steps/base-steps.js
+++ b/e2e-tests/steps/base-steps.js
@@ -14,4 +14,8 @@ export class BaseSteps {
   static getByTestId(testId) {
     return cy.getByTestId(testId);
   }
+
+  static typeEscapeKey() {
+    cy.get('body').type('{esc}');
+  }
 }

--- a/e2e-tests/steps/home-steps.js
+++ b/e2e-tests/steps/home-steps.js
@@ -3,26 +3,17 @@ import {RepositoryErrorsWidgetSteps} from "./widgets/repository-errors-widget-st
 import {ActiveRepositoryWidgetSteps} from "./widgets/active-repository-widget-steps";
 import {SavedSparqlQueriesWidgetSteps} from "./widgets/saved-sparql-queries-widget-steps";
 import {RepositorySteps} from "./repository-steps";
+import {BaseSteps} from "./base-steps";
 
-class HomeSteps {
+class HomeSteps extends BaseSteps {
 
     static visit() {
         cy.visit('/');
         HomeSteps.getTutorialPanel().should('be.visible');
     }
 
-    static visitAndWaitLoader(stubNewWindow) {
-        if (stubNewWindow) {
-            cy.visit('/', {
-                onBeforeLoad (win) {
-                    cy.stub(win, 'open').as('window.open');
-                }
-            });
-        } else {
-            cy.visit('/');
-        }
-
-        cy.window();
+    static visitAndWaitLoader() {
+        cy.visit('/');
         return cy.get('.ot-loader-new-content').should('not.exist');
     }
 
@@ -233,19 +224,40 @@ class HomeSteps {
         cy.wait('@getAutocompleteStatus').then(callback);
     }
 
-    static openRdfSearchBox() {
-        cy.get('.search-rdf-btn').click();
-        cy.get('.search-rdf-input').should('be.visible');
-        cy.get('.search-rdf-input search-resource-input .view-res-input').should('be.visible')
-            .and('be.focused');
+    static getRdfResourceSearchComponent() {
+        return this.getByTestId('search-rdf-resource-component');
     }
 
-    static doNotOpenRdfSearchBoxButFocusResourceSearch() {
-        cy.get('.search-rdf-btn').click();
-        cy.get('.search-rdf-input').should('not.exist');
-        cy.get('.search-rdf-input search-resource-input .view-res-input').should('not.exist');
-        cy.get('#search-resource-input-home > #search-resource-box > input').should('be.visible')
-            .and('be.focused');
+    static getRdfResourceSearchInput() {
+        return this.getRdfResourceSearchComponent().getByTestId('rdf-resource-input');
+    }
+
+    static getAutocompleteResultsContainer() {
+        return this.getRdfResourceSearchComponent().getByTestId('auto-complete-results');
+    }
+
+    static getAutocompleteSuggestion() {
+        return this.getAutocompleteResultsContainer().getByTestId('autocomplete-suggestion');
+    }
+
+    static getAutocompleteSuggestionByPartialText(partialText) {
+        return this.getAutocompleteSuggestion().contains(partialText);
+    }
+
+    static getTableDisplayButton() {
+        return this.getRdfResourceSearchComponent().getByTestId('display-table-button');
+    }
+
+    static getVisualDisplayButton() {
+        return this.getRdfResourceSearchComponent().getByTestId('display-visual-button');
+    }
+
+    static getRdfResourceSearchCloseButton() {
+        return this.getRdfResourceSearchComponent().getByTestId('rdf-resource-clear-button');
+    }
+
+    static closeRdfResourceSearchBox() {
+        this.getRdfResourceSearchCloseButton().click();
     }
 
     static getViewResourceAsLabel() {

--- a/e2e-tests/steps/rdf-resource-search-steps.js
+++ b/e2e-tests/steps/rdf-resource-search-steps.js
@@ -1,0 +1,55 @@
+import {BaseSteps} from "./base-steps";
+
+export class RdfResourceSearchSteps extends BaseSteps {
+
+    static getComponent() {
+        return this.getByTestId('onto-rdf-search-component');
+    }
+
+    static getShowViewResourceMessageButton() {
+        return this.getByTestId('onto-show-view-resource-message');
+    }
+
+    static clickOnShowViewResourceMessageButton() {
+        this.getShowViewResourceMessageButton().click();
+    }
+
+    static getOpenButton() {
+        return this.getByTestId('onto-open-rdf-search-button');
+    }
+
+    static clickOnRDFResourceSearch() {
+        this.getOpenButton().click();
+    }
+
+    static getRDFResourceSearchInput() {
+        return this.getComponent().getByTestId('rdfSearchContext');
+    }
+
+    static getCloseButton() {
+        return this.getComponent().getByTestId('onto-rdf-resource-search-close-btn');
+    }
+
+    static getAutocompleteResults() {
+        return this.getComponent().getByTestId('onto-autocomplete-results');
+    }
+
+    static getAutocompleteSuggestionByPartialText(partialText) {
+        return this.getAutocompleteResults().getByTestId('onto-autocomplete-suggestion').contains(partialText);
+    }
+
+    static clickOnAutocompleteSuggestionByPartialText(partialText) {
+        return this.getAutocompleteSuggestionByPartialText(partialText).click();
+    }
+
+    static openRdfSearchBox() {
+        RdfResourceSearchSteps.clickOnRDFResourceSearch();
+        RdfResourceSearchSteps.getRDFResourceSearchInput()
+            .should('be.visible')
+            .and('be.focused');
+    }
+
+    static closeRDFSearchBox() {
+        this.getCloseButton().click();
+    }
+}

--- a/e2e-tests/stubs/browser-stubs.js
+++ b/e2e-tests/stubs/browser-stubs.js
@@ -1,5 +1,5 @@
 export class BrowserStubs {
-    static WINDOW_OPEN_ALIAS = (isDefinition) => {
+    static WINDOW_OPEN_ALIAS = (isDefinition = false) => {
         return isDefinition ? 'windowOpen' : '@windowOpen';
     }
 
@@ -17,5 +17,15 @@ export class BrowserStubs {
         cy.window().then((win) => {
             cy.spy(win.singleSpa, 'navigateToUrl').as(BrowserStubs.NAVIGATE_TO_URL_ALIAS(true))
         })
+    }
+
+    /**
+     * Stubs `window.crypto.randomUUID` to return a specified UUID, because in headless mode the window cripto not exist.
+     * @param uuid The UUID string to return each time `crypto.randomUUID()` is called.
+     */
+    static stubCryptoUUID(uuid = '999e8888-e77b-66d3-a456-426655440999') {
+        cy.on('window:before:load', (win) => {
+            win.crypto.randomUUID = () => uuid;
+        });
     }
 }

--- a/packages/legacy-workbench/src/js/angular/core/templates/search-resource-input.html
+++ b/packages/legacy-workbench/src/js/angular/core/templates/search-resource-input.html
@@ -2,9 +2,10 @@
 
 <div id="search-resource-box" class="input-group btn-group" ng-class="{'input-group-lg': !radioButtons}" style="white-space: nowrap">
     <input type="text" class="form-control view-res-input" placeholder="{{placeholder}}" ng-model="searchInput"
+           data-test="rdf-resource-input"
            ng-change="onChange()"
            ng-keydown="onKeyDown($event)">
-    <button ng-if="clearInputIcon && showClearInputIcon" class="btn btn-link clear-icon"
+    <button ng-if="clearInputIcon && showClearInputIcon" class="btn btn-link clear-icon" data-test="rdf-resource-clear-button"
             gdb-tooltip="{{'clear.tooltip' | translate}}" tooltip-placement="bottom">
         <i class="icon-close" aria-hidden="true" ng-click="clearInput()"></i>
     </button>
@@ -19,21 +20,30 @@
         </button>
     </span>
     <span ng-if="radioButtons" class="input-group-btn">
-        <button class="btn btn-secondary display-type-table-btn" ng-model="searchType" uib-btn-radio="searchDisplayType.table" ng-click="changeSearchType(searchDisplayType.table)">
+        <button class="btn btn-secondary display-type-table-btn"
+                ng-model="searchType"
+                uib-btn-radio="searchDisplayType.table"
+                data-test="display-table-button"
+                ng-click="changeSearchType(searchDisplayType.table)">
             {{textButtonLabel | translate}}
         </button>
-        <button class="btn btn-secondary display-type-visual-btn" ng-model="searchType" uib-btn-radio="searchDisplayType.visual" ng-click="changeSearchType(searchDisplayType.visual)">
+        <button class="btn btn-secondary display-type-visual-btn"
+                ng-model="searchType"
+                uib-btn-radio="searchDisplayType.visual"
+                data-test="display-visual-button"
+                ng-click="changeSearchType(searchDisplayType.visual)">
             {{visualButtonLabel | translate}}
         </button>
     </span>
 </div>
 <span class="autocomplete-hint text-muted">{{'query.editor.autocomplete.hint' | translate}}</span>
-<div id="auto-complete-results-wrapper" ng-if="isAutocompleteEnabled">
+<div id="auto-complete-results-wrapper" ng-if="isAutocompleteEnabled" data-test="auto-complete-results">
     <div ng-repeat="autoCompleteUriResult in autoCompleteUriResults track by $index"
          id="{{'auto_' + $index}}"
          ng-click="searchRdfResourceByEvent(autoCompleteUriResult, $event)"
          ng-class="{active: activeSearchElm === $index, selected: selectedElementIndex === $index}"
          ng-mousemove="setActiveClassOnMouseMove($index)"
+         data-test="autocomplete-suggestion"
          class="result-item" guide-selector="autocomplete-{{autoCompleteUriResult.value}}">
         <p ng-bind-html="getResultItemHtml(autoCompleteUriResult)"></p>
     </div>

--- a/packages/legacy-workbench/src/pages/home.html
+++ b/packages/legacy-workbench/src/pages/home.html
@@ -54,6 +54,7 @@
                             empty="empty"
                             radio-buttons="true"
                             clear-input-icon="true"
+                            data-test="search-rdf-resource-component"
                             id="search-resource-input-home">
                     </search-resource-input>
                 </div>

--- a/packages/shared-components/cypress/steps/base-steps.js
+++ b/packages/shared-components/cypress/steps/base-steps.js
@@ -18,4 +18,8 @@ export class BaseSteps {
   static getByTestId(testId) {
     return cy.getByTestId(testId);
   }
+
+  static typeEscapeKey() {
+    cy.get('body').type('{esc}');
+  }
 }

--- a/packages/shared-components/src/components/onto-header/onto-header.tsx
+++ b/packages/shared-components/src/components/onto-header/onto-header.tsx
@@ -111,9 +111,11 @@ export class OntoHeader {
           <onto-search-icon
             class="rdf-search-button"
             onClick={this.showViewResourceMessage}
+            data-test='onto-show-view-resource-message'
             style={{display: this.shouldShowSearch && this.isHomePage ? 'block' : 'none'}}>
           </onto-search-icon>
           <onto-rdf-search
+            data-test='onto-open-rdf-search-button'
             style={{display: this.shouldShowSearch && !this.isHomePage ? 'block' : 'none'}}>
           </onto-rdf-search>
           {this.activeOperations?.allRunningOperations.getItems().length

--- a/packages/shared-components/src/components/onto-rdf-search/onto-rdf-search.tsx
+++ b/packages/shared-components/src/components/onto-rdf-search/onto-rdf-search.tsx
@@ -66,15 +66,20 @@ export class OntoRdfSearch {
 
   render() {
     return (
-      <section ref={(ref) => this.rdfSearchRef = ref} class="onto-rdf-search" onKeyDown={this.onKeyDown()}>
+      <section ref={(ref) => this.rdfSearchRef = ref}
+               class="onto-rdf-search"
+               onKeyDown={this.onKeyDown()}
+               data-test='onto-rdf-search-component'>
         <section class={`search-area ${this.isOpen ? 'visible' : 'invisible'}`}>
           <i onClick={this.setIsOpen(false)}
              tooltip-content={TranslationService.translate('rdf_search.tooltips.close_search_area')}
              tooltip-placement={OntoTooltipPlacement.BOTTOM}
+             data-test='onto-rdf-resource-search-close-btn'
              class="fa-light fa-xmark-large close-btn"></i>
           <onto-search-resource-input buttonConfig={this.buttonConfig}
                                       preserveSearch={true}
                                       isHidden={!this.isOpen}
+                                      data-test='onto-rdf-resource-search-input'
                                       context={this.RDF_CONTEXT}></onto-search-resource-input>
         </section>
         {!this.isOpen ? <onto-search-icon onClick={this.setIsOpen(true)}></onto-search-icon> : ''}

--- a/packages/shared-components/src/components/onto-search-icon/onto-search-icon.scss
+++ b/packages/shared-components/src/components/onto-search-icon/onto-search-icon.scss
@@ -1,4 +1,4 @@
-i {
+.onto-search-icon {
   cursor: pointer;
   color: var(--primary-color, #9e2b0a);
   transition: all 0.15s ease-out;

--- a/packages/shared-components/src/components/onto-search-icon/onto-search-icon.tsx
+++ b/packages/shared-components/src/components/onto-search-icon/onto-search-icon.tsx
@@ -5,8 +5,7 @@ import {OntoTooltipPlacement} from "../onto-tooltip/models/onto-tooltip-placemen
 
 @Component({
   tag: 'onto-search-icon',
-  styleUrl: 'onto-search-icon.scss',
-  scoped: true
+  styleUrl: 'onto-search-icon.scss'
 })
 export class OntoSearchIcon {
   @State() private tooltipLabel: string;
@@ -30,7 +29,7 @@ export class OntoSearchIcon {
     return (
       <i tooltip-content={this.tooltipLabel}
          tooltip-placement={OntoTooltipPlacement.BOTTOM}
-         class="fa-light fa-magnifying-glass"></i>
+         class="onto-search-icon fa-light fa-magnifying-glass"></i>
     );
   }
 

--- a/packages/shared-components/src/components/onto-search-resource-input/onto-search-resource-input.tsx
+++ b/packages/shared-components/src/components/onto-search-resource-input/onto-search-resource-input.tsx
@@ -118,6 +118,7 @@ export class OntoSearchResourceInput {
                    placeholder={`${TranslationService.translate('rdf_search.labels.search')}...`}
                    ref={(ref) => this.inputRef = ref}
                    onKeyDown={this.onKeyDown}
+                   data-test={this.context}
                    onInput={this.handleInput}/>
             {this.inputValue?.length ?
               <i onClick={this.clearInput}
@@ -133,10 +134,11 @@ export class OntoSearchResourceInput {
           ))}
         </div>
         <span class="hint">{TranslationService.translate('rdf_search.labels.hint')}</span>
-        <section class="autocomplete-results-wrapper">
+        <section class="autocomplete-results-wrapper" data-test='onto-autocomplete-results'>
           {this.searchResult?.getSuggestions().getItems().map((suggestion) => (
             <p key={suggestion.getId()}
                onClick={this.onSuggestionClick(suggestion)}
+               data-test='onto-autocomplete-suggestion'
                onMouseMove={this.hoverSuggestion(suggestion)}
                class={`${suggestion.isHovered() ? 'hovered' : ''} ${suggestion.isSelected() ? 'selected' : ''}`}
                innerHTML={suggestion.getDescription()}></p>


### PR DESCRIPTION
## What
Enable and fix the RDF resource search spec, which was previously disabled due to the migration.

## Why
The test was broken as a result of the migration.

## How
- Removed .skip from the test
- Extracted RDF selectors into two separate steps:
 - One interacting with the legacy RDF resource search component on the Home page;
 - Another interacting with the newly implemented component in the shared-components project.
- Updated the test to use the new steps.

## Screenshots
N/A

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [X] Tests
