### PR TITLE
GDB-12631 Fix tooltip in the YASGUI components getting destroyed

### DIFF
--- a/packages/shared-components/src/utils/tooltip-util.ts
+++ b/packages/shared-components/src/utils/tooltip-util.ts
@@ -9,6 +9,7 @@ export class TooltipUtil {
   private static readonly ATTR_PLACEMENT = 'tooltip-placement';
   private static readonly ATTR_TRIGGER = 'tooltip-trigger';
   private static readonly ATTR_APPEND_TO = 'tooltip-append-to';
+  private static readonly TOOLTIP_CLASS = 'onto-tooltip';
 
   /**
    * Returns the Tippy instance associated with an element, if it exists.
@@ -26,6 +27,7 @@ export class TooltipUtil {
    * @returns The newly created Tippy Instance.
    */
   static createTooltip(target: HTMLElement): Instance {
+    target.classList.add(TooltipUtil.TOOLTIP_CLASS);
     return tippy(target, TooltipUtil.getConfig(target));
   }
 
@@ -68,7 +70,7 @@ export class TooltipUtil {
    */
   static destroyTooltip(target: HTMLElement): void {
     const tip = TooltipUtil.getTooltipInstance(target);
-    if (tip && !tip.state?.isDestroyed) {
+    if (target.classList.contains(TooltipUtil.TOOLTIP_CLASS) && tip && !tip.state?.isDestroyed) {
       tip.destroy();
     }
   }


### PR DESCRIPTION
## What
Fix tooltip in the YASGUI components getting destroyed

## Why
The `onto-tooltip` component uses the same library as the YASGUI - `tippy.js`. The problem is that the `onto-tooltip` does not differentiate from tooltip created by it and other and listens globally on document mouseout to destroy them, which destroys all instances created by `tippy.js`

How
- added a class to the host element, when the tooltip is created
- added a condition to only destroy tooltips with the specified class

## Testing
Added tests for `TooltipUtil`

## Screenshots
![image](https://github.com/user-attachments/assets/211b2141-b8a7-4f14-a0f8-e946998aefaf)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [X] Tests
