### PR TITLE
fix(GDB-12626) Only skip header injection when OpenID URIs are defined and match

### DIFF
--- a/packages/api/src/interceptor/auth/auth-request-interceptor.ts
+++ b/packages/api/src/interceptor/auth/auth-request-interceptor.ts
@@ -59,8 +59,16 @@ export class AuthRequestInterceptor extends HttpInterceptor<HttpRequest> {
     if (!openIdConfig) {
       return true;
     }
-    const openIDUrls = [openIdConfig?.openIdKeysUri, openIdConfig?.openIdTokenUrl];
-    const isOpenIdUrl = openIDUrls.some((url) => url && request.url.indexOf(url) > -1);
-    return !isOpenIdUrl;
+
+    const openIdKeysUri = openIdConfig?.openIdKeysUri;
+    const openIdTokenUrl = openIdConfig?.openIdTokenUrl;
+
+    if (openIdKeysUri && openIdTokenUrl) {
+      const openIDUrls = [openIdConfig?.openIdKeysUri, openIdConfig?.openIdTokenUrl];
+      const isOpenIdUrl = openIDUrls.some((url) => url && request.url.indexOf(url) > -1);
+      return !isOpenIdUrl;
+    }
+
+    return true;
   }
 }

--- a/packages/legacy-workbench/src/js/angular/core/interceptors/authentication.interceptor.js
+++ b/packages/legacy-workbench/src/js/angular/core/interceptors/authentication.interceptor.js
@@ -11,10 +11,15 @@ angular.module('graphdb.framework.core.interceptors.authentication', [
                     const headers = config.headers || {};
 
                     // When using OpenID, during authentication process, the additional headers modification must be skipped
-                    const openIDUrls = [AuthTokenService.OPENID_CONFIG.openIdKeysUri, AuthTokenService.OPENID_CONFIG.openIdTokenUrl];
-                    const isOpenIdUrl = openIDUrls.some((url) => config.url.indexOf(url) > -1);
-                    if (isOpenIdUrl) {
-                        return config;
+                    const openIdKeysUri = AuthTokenService.OPENID_CONFIG.openIdKeysUri;
+                    const openIdTokenUrl = AuthTokenService.OPENID_CONFIG.openIdTokenUrl;
+
+                    if (openIdKeysUri && openIdTokenUrl) {
+                        const openIDUrls = [openIdKeysUri, openIdTokenUrl];
+                        const isOpenIdUrl = openIDUrls.some((url) => config.url && config.url.indexOf(url) > -1);
+                        if (isOpenIdUrl) {
+                            return config;
+                        }
                     }
 
                     // Angular doesn't send this header by default, and we need it to detect XHR requests


### PR DESCRIPTION
## What:
Add guards in both the new (shouldProcess) and legacy (authentication.interceptor.js) interceptors so that OpenID URL checks run only when both openIdKeysUri and openIdTokenUrl are present.

## Why:
When both URIs were undefined, the some(...indexOf(...)) check produced a false‐positive match, causing the XHR detection header (X-Requested-With) to be omitted. That omission triggered the browser’s native authentication popup (the reported bug).

## How:
- Extract openIdKeysUri and openIdTokenUrl into separate constants.
- Wrap the URL‐matching logic in an if (openIdKeysUri && openIdTokenUrl) { … } block so it only executes when both values exist.
- Default to injecting headers normally (returning true or falling through) whenever either URI is missing.

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
