### PR TITLE
GDB-12630 - Hide empty dropdown in GQL endpoint create view

### DIFF
--- a/src/js/angular/graphql/templates/create-graphql-endpoint.html
+++ b/src/js/angular/graphql/templates/create-graphql-endpoint.html
@@ -11,7 +11,7 @@
 
     <div class="create-graphql-endpoint-container">
 
-        <div class="content">
+        <div class="content" ng-if="selectedSourceRepository">
             <div class="toolbar">
                 <div class="form-inline">
                     <label


### PR DESCRIPTION
## What
When opening `/graphql/endpoint/create` without a repository selected, the **Source repository** dropdown will not be visible until a repository is selected.

## Why
The dropdown would appear with empty options when no repository was selected.

## How
I added a condition to show the dropdown when a repository is selected.

## Testing
N/A

## Screenshots
Before:
![Screenshot from 2025-07-02 16-48-20](https://github.com/user-attachments/assets/edbf33f3-dd1e-4f7c-8e1e-c5fc72456f28)

After: 
![Screenshot from 2025-07-02 16-47-57](https://github.com/user-attachments/assets/030237fb-a9ec-4c62-9f82-7868629ee57c)


## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
