### PR TITLE
GDB-12652: Suggestions not displayed after page refresh

### DIFF
--- a/packages/api/src/models/rdf-search/autocomplete-search-result.ts
+++ b/packages/api/src/models/rdf-search/autocomplete-search-result.ts
@@ -27,8 +27,7 @@ export class AutocompleteSearchResult extends Model<AutocompleteSearchResult> {
    * Sets the hovered state of the first suggestion to true, if present.
    */
   hoverFirstSuggestion() {
-    this.hoverSuggestion(this.getSuggestions().getItems()[0]);
-    return this.copy();
+    return this.hoverSuggestion(this.getSuggestions().getItems()[0]);
   }
 
   /**


### PR DESCRIPTION
## What
When a user types a value into the RDF Resource Search component, suggestions are correctly displayed based on the entered value. The input value is persisted, and suggestions should be displayed every time the component is opened—even after a page refresh.

However, after refreshing the page, while the persisted input value is restored, the suggestions are not consistently displayed

## Why
The RDF Resource Search component subscribes to an "autocomplete enabled" event. There's a race condition in how this subscription is registered. When the page loads, results are fetched from GraphDB. If the subscription is registered after the results are loaded, the component might not be properly initialized.

In some cases, when the subscription is registered, the autocomplete state may not yet be initialized. This can result in the callback receiving a false value for autocomplete, which incorrectly triggers the clearing of the results.

## How
The results fetching logic has been changed: results are now fetched when the component is opened. This ensures that:
- All results are fresh and synchronized with the input;
- Results are cleared when the component is closed to free memory.

## Testing
This merge request stabilizes an existing flaky test.

## Screenshots

before
![image](https://github.com/user-attachments/assets/d1e11821-dc61-4380-96d3-5eb23031507b)


after
![image](https://github.com/user-attachments/assets/64233c9d-1d20-484d-9818-fcfb2d5cb4fe)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
