### PR TITLE
GDB-12654 Fix broken toasts without ssl

### DIFF
--- a/e2e-tests/e2e-legacy/home/rdf-resource-search.spec.js
+++ b/e2e-tests/e2e-legacy/home/rdf-resource-search.spec.js
@@ -14,7 +14,6 @@ describe('RDF resource search', () => {
         cy.createRepository({id: repositoryId});
         cy.initializeRepository(repositoryId);
         cy.enableAutocomplete(repositoryId);
-        BrowserStubs.stubCryptoUUID();
     });
 
     afterEach(() => {

--- a/e2e-tests/stubs/browser-stubs.js
+++ b/e2e-tests/stubs/browser-stubs.js
@@ -18,14 +18,4 @@ export class BrowserStubs {
             cy.spy(win.singleSpa, 'navigateToUrl').as(BrowserStubs.NAVIGATE_TO_URL_ALIAS(true))
         })
     }
-
-    /**
-     * Stubs `window.crypto.randomUUID` to return a specified UUID, because in headless mode the window cripto not exist.
-     * @param uuid The UUID string to return each time `crypto.randomUUID()` is called.
-     */
-    static stubCryptoUUID(uuid = '999e8888-e77b-66d3-a456-426655440999') {
-        cy.on('window:before:load', (win) => {
-            win.crypto.randomUUID = () => uuid;
-        });
-    }
 }

--- a/packages/api/src/services/monitoring/test/monigoring.service.spec.ts
+++ b/packages/api/src/services/monitoring/test/monigoring.service.spec.ts
@@ -7,7 +7,6 @@ import {OperationSummaryMapper} from '../mapper/operation-summary-mapper';
 
 describe('MonitoringService', () => {
   let monitoringService: MonitoringService;
-  window.crypto.randomUUID = jest.fn();
 
   beforeEach(() => {
     monitoringService = new MonitoringService();

--- a/packages/api/src/services/toastr/test/onto-toastr.service.spec.ts
+++ b/packages/api/src/services/toastr/test/onto-toastr.service.spec.ts
@@ -2,7 +2,6 @@ import {OntoToastrService} from '../onto-toastr.service';
 
 describe('OntoToastrService', () => {
   let service: OntoToastrService;
-  window.crypto.randomUUID = jest.fn();
 
   beforeEach(() => {
     service = new OntoToastrService();

--- a/packages/api/src/services/utils/generator-utils.ts
+++ b/packages/api/src/services/utils/generator-utils.ts
@@ -3,7 +3,7 @@
  */
 export class GeneratorUtils {
   /**
-   * Generates a random UUID (Universally Unique Identifier) using the browser's crypto API.
+   * Generates a pseudo random UUID (Universally Unique Identifier).
    *
    * This method creates a version 4 UUID, which is based on random numbers.
    * The generated UUID follows the RFC 4122 standard format.
@@ -13,7 +13,28 @@ export class GeneratorUtils {
    * and y is one of 8, 9, a, or b.
    */
   static uuid(): string {
-    return window.crypto.randomUUID();
+    const HEX_RADIX = 16;
+    const UUID_V4_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
+    const VARIANT_BITMASK = 0x3;
+    const VARIANT_VALUE = 0x8;
+
+    let timestamp = new Date().getTime();
+    let performanceNow = (performance?.now() ?? 0) * 1000;
+
+    return UUID_V4_TEMPLATE.replace(/[xy]/g, (char) => {
+      let random = Math.random() * HEX_RADIX;
+
+      if (timestamp > 0) {
+        random = (timestamp + random) % HEX_RADIX | 0;
+        timestamp = Math.floor(timestamp / HEX_RADIX);
+      } else {
+        random = (performanceNow + random) % HEX_RADIX | 0;
+        performanceNow = Math.floor(performanceNow / HEX_RADIX);
+      }
+
+      const value = char === 'x' ? random : (random & VARIANT_BITMASK) | VARIANT_VALUE;
+      return value.toString(HEX_RADIX);
+    });
   }
 
   /**

--- a/packages/api/src/services/utils/test/generator-utils.spec.ts
+++ b/packages/api/src/services/utils/test/generator-utils.spec.ts
@@ -12,4 +12,13 @@ describe('Generator Utils', () => {
     const str2 = 'hello universe';
     expect(GeneratorUtils.hashCode(str1)).not.toEqual(GeneratorUtils.hashCode(str2));
   });
+
+  test('should generate a valid UUID', () => {
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+    expect(uuidRegex.test(GeneratorUtils.uuid())).toEqual(true);
+  });
+
+  test('should generate a different UUID for each call', () => {
+    expect(GeneratorUtils.uuid()).not.toEqual(GeneratorUtils.uuid());
+  });
 });

--- a/packages/shared-components/cypress/e2e/operations-notification/operations-notification.cy.js
+++ b/packages/shared-components/cypress/e2e/operations-notification/operations-notification.cy.js
@@ -19,12 +19,6 @@ const assertRedirectLink = (index, textValue) => {
 }
 
 describe('onto-operations-notification', () => {
-  beforeEach(() => {
-    cy.on('window:before:load', (win) => {
-      win.crypto.randomUUID = () => '123e4567-e89b-12d3-a456-426655440000';
-    });
-  });
-
   it('should display operations notification', () => {
     // Given, I am on the operations notification page and I have added mock operations
     OperationsNotificationSteps.visit();

--- a/packages/shared-components/cypress/e2e/rdf-search/rdf-search.cy.js
+++ b/packages/shared-components/cypress/e2e/rdf-search/rdf-search.cy.js
@@ -3,11 +3,6 @@ import {BaseSteps} from "../../steps/base-steps";
 import {NavbarSteps} from "../../steps/navbar/navbar-steps";
 
 describe('RDF Search', () => {
-  beforeEach(() => {
-    cy.on('window:before:load', (win) => {
-      win.crypto.randomUUID = () => new Date().toISOString();
-    })
-  })
 
   it('should display RDF search', () => {
     // Given, I visit the RDF search page

--- a/packages/shared-components/cypress/e2e/toastr/toastr.cy.js
+++ b/packages/shared-components/cypress/e2e/toastr/toastr.cy.js
@@ -10,12 +10,6 @@ const assertToastMessage = (toastClass, toastIconClass) => {
 }
 
 describe('OntoToastr', () => {
-  beforeEach(() => {
-    cy.on('window:before:load', (win) => {
-      win.crypto.randomUUID = () => '123e4567-e89b-12d3-a456-426655440000';
-    });
-  });
-
   it('should display different toast types', () => {
     // Given I visit the onto-toastr page
     ToastrSteps.visit();


### PR DESCRIPTION
## What
Fix missing toast messages, when using GDB without ssl

## Why
They are not being displayed due to an error

## How
Replaced `window.crypto.randomUUID` with a custom generator for ids. When GDB is deployed without SSL and not on a local machine, there is no `window.crypto`, which results in an error, when opening migration toasts

## Testing
jest

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
