### PR TITLE
GDB-12633 SPARQL editor copied query urls not working

### DIFF
--- a/e2e-tests/e2e-legacy/sparql-editor/saved-query/share-query.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/saved-query/share-query.spec.js
@@ -46,7 +46,7 @@ describe('Share saved queries', () => {
     });
 
     // FIX: Skipped because the functionality is not working. There is a bug in the application https://graphwise.atlassian.net/browse/GDB-12633
-    it.skip('Should be able to open a share link in a new editor tab', () => {
+    it('Should be able to open a share link in a new editor tab', () => {
         // Given I have created a query
         YasguiSteps.getTabs().should('have.length', 1);
         const savedQueryName = SavedQuery.generateQueryName();

--- a/packages/legacy-workbench/package-lock.json
+++ b/packages/legacy-workbench/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
                 "ontotext-graphql-playground-component": "^0.0.8",
-                "ontotext-yasgui-web-component": "1.3.24",
+                "ontotext-yasgui-web-component": "1.3.25",
                 "shepherd.js": "^11.2.0",
                 "single-spa-angularjs": "^4.3.1"
             },
@@ -5635,9 +5635,10 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.24",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.24.tgz",
-            "integrity": "sha512-Ai3Orjhp7fCf5Y6oJHxdhY0f8/ubti1A6R/NWpDQlz1s7fakQJdgKyPLS7uc1dZxtl6O+5G4g6hJhVornKuSEw==",
+            "version": "1.3.25",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.25.tgz",
+            "integrity": "sha512-HR09J00bEOpqC0MQlmXIXOAyjYNUI75Yx+uRAo2+p29+RvZ3jEV/l09DrfXcljbt/bJzhlcSNb6yIQmTzrCujQ==",
+            "license": "MIT",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/packages/legacy-workbench/package.json
+++ b/packages/legacy-workbench/package.json
@@ -75,7 +75,7 @@
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
         "ontotext-graphql-playground-component": "^0.0.8",
-        "ontotext-yasgui-web-component": "1.3.24",
+        "ontotext-yasgui-web-component": "1.3.25",
         "shepherd.js": "^11.2.0",
         "single-spa-angularjs": "^4.3.1"
     },

--- a/packages/root-config/src/ontotext-root-config.js
+++ b/packages/root-config/src/ontotext-root-config.js
@@ -94,10 +94,3 @@ bootstrapWorkbench()
     console.error('Error during bootstrap of workbench', error);
   });
 
-// window.addEventListener("single-spa:routing-event", (evt) => {
-//     console.log("single-spa finished mounting/unmounting applications!");
-//     console.log(evt.detail.originalEvent); // PopStateEvent
-//     console.log(evt.detail.newAppStatuses); // { app1: MOUNTED, app2: NOT_MOUNTED }
-//     console.log(evt.detail.appsByNewStatus); // { MOUNTED: ['app1'], NOT_MOUNTED: ['app2'] }
-//     console.log(evt.detail.totalAppChanges); // 2
-// });


### PR DESCRIPTION
## What
Fixed component not loading again after unmount/mount

## Why
The problem happens because SingleSpa refires a `popstate` event if the URL changes, even if only the query parameters have changed. This causes AngularJS to redraw which unmount/mounts the StencilJS components.
With the latest release of `ontotext-yasgui-web-component`, there is reinitialization of the component after it was mounted again

How
- Updated `ontotext-yasgui-web-component`

## Testing
n/a

## Screenshots
n/a

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
