### PR TITLE
GDB-12627 Fix visible user menu without rights

### DIFF
--- a/packages/legacy-workbench/src/js/angular/core/services/repositories.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/repositories.service.js
@@ -173,6 +173,7 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
                                         that.repositories.set(key, reposWithHashes);
                                     });
                                     that.resetActiveRepository();
+                                    $rootScope.$broadcast('repositoryIsSet');
                                     loadingDone();
                                     that.checkLocationsDegraded(quick);
                                     // Hack to get the location and repositories into the scope, needed for DefaultAuthoritiesCtrl
@@ -404,12 +405,11 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
             const eventData = {oldRepository: this.repository, newRepository: repo, cancel: false};
             eventEmitterService.emit('repositoryWillChangeEvent', eventData, (eventData) => {
                 if (!eventData.cancel) {
-                    // TODO: Move this in a subscription to updateSelectedRepository, after security is fully migrated.
+                    // TODO: Move this in a subscription to updateSelectedRepository, after views are fully migrated.
                     // If we do this now, we get race conditions, between the context services and the components. Both work
                     // in parallel and it causes issues. Migrated components should load their data after updateApplicationDataState
                     // is called, with DATA_LOADED. This will ensure components start loading their data, after the contexts are updated
                     ServiceProvider.get(SecurityContextService).updateRestrictedPages(new RestrictedPages());
-
                     const repositoryContextService = ServiceProvider.get(RepositoryContextService);
                     // if the current repo is unreadable by the currently logged in user (or free access user)
                     // we unset the repository


### PR DESCRIPTION
## What
Fix visible user menu without rights

## Why
It was being shown to plain users with no rights

## How
Moved the restricted page reset inside `onRepositorySet`. Before there was a race condition between repositories and users requests. Depending on, which is which, the restricted pages banner was shown or not shown. This happened because inside `seRepository` we do not broadcast `repositoryIsSet` anymore, but we use the new context services. Broadcasts happen as many times as they are called, while context services do not broadcast the same value twice. For this reason `setRepository` might not trigger `updateSelectedRepository`. In this case, this is what is supposed to trigger another call to get users and display the banner.

## Testing
n/a

## Screenshots
![Screenshot from 2025-07-04 17-16-27](https://github.com/user-attachments/assets/6f78801d-575a-4f4c-bb7d-3af86f91943b)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
