### PR TITLE
GDB-12669 Fix unnecessary namespaces requests

### DIFF
--- a/packages/api/src/services/security/authentication.service.ts
+++ b/packages/api/src/services/security/authentication.service.ts
@@ -71,6 +71,14 @@ export class AuthenticationService implements Service {
     return !!this.getSecurityConfig()?.enabled;
   }
 
+  /**
+   * Checks if the current user has read permissions for the specified repository.
+   * This method evaluates if the user can read the repository based on security configuration,
+   * user authentication status, and user roles.
+   *
+   * @param {Repository} repository - The repository to check read permissions for.
+   * @returns {boolean} True if the user has read permissions for the repository, false otherwise.
+   */
   canReadRepo(repository?: Repository): boolean {
     if (!repository || repository.id === '') {
       return false;
@@ -95,11 +103,43 @@ export class AuthenticationService implements Service {
     return true;
   }
 
+  /**
+   * Checks if the current user has GraphQL read permissions for the specified repository.
+   * This method determines if the user can execute GraphQL read operations on the repository.
+   *
+   * @param {Repository} repository - The repository to check GraphQL read permissions for.
+   * @returns {boolean} True if the user has GraphQL read permissions for the repository, false otherwise.
+   */
   canReadGqlRepo(repository: Repository): boolean {
     if (!repository || repository.id === '') {
       return false;
     }
     return this.hasGraphqlAuthority(Rights.READ, repository);
+  }
+
+  /**
+   * Checks if the current user has GraphQL write permissions for the specified repository.
+   * This method determines if the user can execute GraphQL write operations on the repository.
+   *
+   * @param {Repository} repository - The repository to check GraphQL write permissions for.
+   * @returns {boolean} True if the user has GraphQL write permissions for the repository, false otherwise.
+   */
+  canWriteGqlRepo(repository: Repository): boolean {
+    if (!repository || repository.id === '') {
+      return false;
+    }
+    return this.hasGraphqlAuthority(Rights.WRITE, repository);
+  }
+
+  /**
+   * Checks if the current user has any GraphQL permissions (read or write) for the specified repository.
+   * This is a convenience method that combines the results of canReadGqlRepo and canWriteGqlRepo.
+   *
+   * @param {Repository} repository - The repository to check GraphQL permissions for.
+   * @returns {boolean} True if the user has any GraphQL permissions for the repository, false otherwise.
+   */
+  hasGqlRights(repository: Repository): boolean {
+    return this.canReadGqlRepo(repository) || this.canWriteGqlRepo(repository);
   }
 
   private hasGraphqlAuthority(action: string, repo: Repository): boolean {

--- a/packages/shared-components/src/components/onto-header/onto-header.tsx
+++ b/packages/shared-components/src/components/onto-header/onto-header.tsx
@@ -280,11 +280,12 @@ export class OntoHeader {
   };
 
   private loadNamespaces() {
-    if (this.currentRepository) {
-      // TODO: check why loaction not used maybe it is added in autorization interceptor
-      this.namespacesService.getNamespaces(this.currentRepository.id)
-        .then((namespaces) => this.namespaceContextService.updateNamespaces(namespaces))
+    if (!this.currentRepository || !this.authService.canReadRepo(this.currentRepository)) {
+      return;
     }
+    // TODO: check why loaction not used maybe it is added in autorization interceptor
+    this.namespacesService.getNamespaces(this.currentRepository.id)
+      .then((namespaces) => this.namespaceContextService.updateNamespaces(namespaces));
   }
 
   // ========================


### PR DESCRIPTION
## What
Fix unnecessary namespaces requests

## Why
They are triggered and, whenever a user does not have rights, they return 403. The user sees the permissions banner, when he shouldn't

## How
- Added a check, if the user has read repository rights in the header. This way the request is not made for the RDF search
- Refactored the main angularjs controller to use the new auth service for resolving the permissions. Since it uses the new context services, the timing is different, than before. Whenever the legacy service tries to resolve GQL rights for the current user, `this.principal` is not yet defined, which causes the request to be made again

## Testing
n/a

## Screenshots
![image](https://github.com/user-attachments/assets/1cd63e9a-8572-4e1a-9158-7e2ddd996111)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
