### PR TITLE
fix(GDB-12625) Enable write checks in GraphQL endpoint creation template

### DIFF
--- a/packages/legacy-workbench/src/js/angular/graphql/templates/create-graphql-endpoint.html
+++ b/packages/legacy-workbench/src/js/angular/graphql/templates/create-graphql-endpoint.html
@@ -7,7 +7,7 @@
         <page-info-tooltip></page-info-tooltip>
     </h1>
 
-    <div class="core-errors-container" core-errors></div>
+    <div class="core-errors-container" core-errors write></div>
 
     <div class="create-graphql-endpoint-container">
 


### PR DESCRIPTION
## What:
Added the write attribute to the core-errors-container directive in create-graphql-endpoint.html.

## Why:
This change triggers the write-permission check for the selected repository. If the user lacks write rights, the component will now display the appropriate banner with a description of the problem.

## How:
Updated the template line

## Screenshots
![image](https://github.com/user-attachments/assets/96f0d2fd-8ad4-445d-9ecb-4184144939b5)


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
