### PR TITLE
(cherry-pick) GDB-12556 - Reset node edit state on cancel node action

### DIFF
--- a/src/js/angular/clustermanagement/directives/cluster-nodes-configuration.directive.js
+++ b/src/js/angular/clustermanagement/directives/cluster-nodes-configuration.directive.js
@@ -182,6 +182,7 @@ function ClusterNodesConfigurationComponent($translate, $timeout, productInfo, t
             $scope.cancel = () => {
                 $scope.editedNodeIndex = undefined;
                 $scope.addNewLocation = false;
+                resetNodeEditState();
                 ClusterContextService.emitUpdateClusterView();
             };
 


### PR DESCRIPTION
(cherry picked from commit 80fd75ae6c1260cc2ad6a2de97960efec945e110)

## What
Canceling a the replace action for a node will not replace the node with the next one added.

## Why
When the user clicked "Replace node" and then "Cancel", and added a new node to the cluster, the newly added node would still replace the first node (even thought the replace action was canceled). The node would be removed from the cluster.

## How
I reset the edit state on cancel node action.

## Testing
Added test.

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
