### PR TITLE
fix(GDB-12677) Show restricted access banner instead of redirecting to login page

### DIFF
--- a/packages/legacy-workbench/src/app.js
+++ b/packages/legacy-workbench/src/app.js
@@ -380,7 +380,26 @@ const ngLifecycles = singleSpaAngularJS({
     elementId: 'workbench-app',
     template: `
         <div ng-controller="mainCtrl">
-            <div class="main-container">
+            <div class="container-fluid main-container no-authority-panel" ng-if="hasPermission() && !hasAuthority() && getActiveRepository()">
+                <h1>
+                    {{title}}
+                    <page-info-tooltip></page-info-tooltip>
+                </h1>
+                <div class="mb-2 row">
+                    <div role="alert">
+                        <div class="mb-1 mt-1 ml-1 mr-1">
+                            <div class="card repository-errors">
+                                <div class="alert lead alert-warning">
+                                    <div>{{'core.errors.restricted.warning.msg' | translate}}
+                                        <span>{{'core.errors.no.auth.to.repository.warning.msg' | translate}}</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="main-container" ng-if="hasPermission() && hasAuthority()">
                 <div ng-view></div>
             </div>
         </div>


### PR DESCRIPTION
## WHAT
Reintroduced a conditional block in the Workbench template to display a restricted access warning when the user lacks authority but has permission and an active repository.

## WHY
During the migration from the legacy Workbench to single-spa, the conditional UI check handling restricted repository access was accidentally omitted. As a result, users without proper authority were being redirected to the login page instead of seeing an informative warning.

## HOW
Added back the missing `ng-if="hasPermission() && !hasAuthority() && getActiveRepository()"` container with the appropriate warning banner, preserving the intended UX from the legacy implementation.

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
