### PR TITLE
fix(GDB-12618) Sanitize trailing slash from pathname before SPA bootstrap

### DIFF
--- a/packages/root-config/src/index.ejs
+++ b/packages/root-config/src/index.ejs
@@ -2,6 +2,25 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!--
+      SANITIZE TRAILING SLASH FROM PATHNAME BEFORE SPA BOOTSTRAP
+      This inline script executes immediately upon page load,
+      before any <base> tag or import-map is processed. It detects
+      if the URL’s pathname is longer than 1 character and ends
+      with a “/”, and if so, removes that trailing slash while
+      preserving query strings and hash fragments via
+      history.replaceState.
+    -->
+    <script>
+      (function() {
+        const { pathname, search, hash } = window.location;
+        if (pathname.length > 1 && pathname.endsWith('/')) {
+          const clean = pathname.slice(0, -1) + search + hash;
+          window.history.replaceState({}, '', clean);
+        }
+      })();
+    </script>
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <base href="/">


### PR DESCRIPTION
## WHAT
Added an inline <script> that strips a trailing slash from window.location.pathname before any <base> tag or import-map is applied.

## WHY
To ensure the SPA always loads under a canonical URL without a trailing slash

## HOW
The script runs immediately on page load as an IIFE, checks pathname.endsWith('/') and pathname.length > 1, then uses history.replaceState to rewrite the URL (preserving search and hash) before the rest of the application bootstraps.


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
