### PR TITLE
fix(GDB-12680): hide RDF Search icon for users with only GQL rights

### DIFF
--- a/packages/shared-components/src/components/onto-header/onto-header.tsx
+++ b/packages/shared-components/src/components/onto-header/onto-header.tsx
@@ -329,7 +329,8 @@ export class OntoHeader {
   // ========================
   private shouldShowRdfSearch(): boolean {
     return !!this.currentRepository &&
-      (!this.isActiveLocationLoading || getPathName() === '/repository');
+      (!this.isActiveLocationLoading || getPathName() === '/repository') &&
+      this.authService.canReadRepo(this.currentRepository);
   }
 
   private readonly showViewResourceMessage= (event:MouseEvent) => {


### PR DESCRIPTION
## WHAT
Updated the shouldShowRdfSearch() method in onto-header.tsx to add an extra permission check.

## WHY
Users who have only GQL rights on a repository should not see the RDF Search icon, since they lack the necessary read permissions to use it.

## HOW
Added this.authService.canReadRepo(this.currentRepository) to the existing conditions in shouldShowRdfSearch(), so the icon is only shown when the user can actually read the repository.

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
