### PR TITLE
fix(GDB-12688) Treat empty repository ID as “no selection” in JWT auth check

### DIFF
--- a/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
@@ -410,7 +410,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                 }
 
                 // If there is no selected repository, there are no auth restrictions
-                if (!getActiveRepositoryObjectFromStorage()) {
+                if (getActiveRepositoryObjectFromStorage().id === '') {
                     return true;
                 }
 
@@ -425,7 +425,6 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                     // Check if any of the allowed authorities match one of the principal's authorities
                     return auth.some(allowAuth => this.principal.authorities.indexOf(allowAuth) > -1);
                 }
-
                 // If none of the above conditions apply, return true by default
                 return true;
             }


### PR DESCRIPTION
## What:
Update the repository selection guard in jwt-auth.service.js to treat an empty id string as `no repository selected`

## Why:
The method getActiveRepositoryObjectFromStorage() always returns an object (with default {"id":"","location":""}), so the old check if (!getActiveRepositoryObjectFromStorage()) never passed. As a result, GraphQL users without a real repository selected were blocked and saw blank pages.

## How:
Replace the falsy object check with an explicit empty ID check


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
