### PR TITLE
(cherry-pick) GDB-12592 - Add Model info to TTYG view

### DIFF
--- a/src/css/ttyg/agent-list.css
+++ b/src/css/ttyg/agent-list.css
@@ -49,6 +49,7 @@
     padding: 6px 8px;
     display: flex;
     justify-content: space-between;
+    flex-direction: column;
 }
 
 .agent-list-component .agent-item.selected {
@@ -56,7 +57,9 @@
 }
 
 .agent-list-component .agent-item .agent-info {
-    width: 92%;
+    display: flex;
+    flex-direction: row;
+    width: 100%;
 }
 
 .agent-list-component .agent-item:hover {
@@ -64,7 +67,13 @@
     cursor: pointer;
 }
 
-.agent-list-component .agent-item .related-repository {
+.agent-list-component .agent-item .repository-model-group {
+    display: flex;
+    justify-content: space-between;
+}
+
+.agent-list-component .agent-item .repository-model-group .related-repository,
+.agent-list-component .agent-item .repository-model-group .model-name {
     color: var(--gray-color-dark);
 }
 

--- a/src/css/ttyg/agent-select-menu.css
+++ b/src/css/ttyg/agent-select-menu.css
@@ -27,6 +27,7 @@
     white-space: nowrap;
     padding-top: 4px;
     padding-bottom: 4px;
+    padding-right: 15px;
 }
 
 .agent-select-menu .dropdown-menu li.selected,
@@ -60,6 +61,7 @@
 .agent-select-menu .agent-option {
     padding-left: 10px;
     padding-right: 10px;
+    white-space: nowrap;
 }
 
 .agent-select-menu .agent-option .agent-name,
@@ -88,6 +90,22 @@
 }
 
 .agent-select-menu .agent-option .agent-with-deleted-repository,
-.agent-select-menu .selected-agent-option .agent-with-deleted-repository{
+.agent-select-menu .selected-agent-option .agent-with-deleted-repository {
     flex: 0 1 auto;
+}
+
+.agent-select-menu .dropdown-toggle-btn .selected-agent-option .model-name {
+    margin-left: auto;
+    text-align: right;
+    flex-shrink: 0;
+}
+
+.agent-select-menu .agent-option .model-name {
+    margin-left: auto;
+    text-align: right;
+    flex-shrink: 0;
+}
+
+.agent-select-menu .agent-menu-item {
+    display: flex;
 }

--- a/src/css/ttyg/agent-settings-modal.css
+++ b/src/css/ttyg/agent-settings-modal.css
@@ -23,6 +23,20 @@
     font-weight: var(--field-label-weight);
 }
 
+.agent-settings-modal .agent-settings-form .llm-model .page-info-icon .icon-info {
+    vertical-align: baseline;
+    font-size: 1rem;
+    color: var(--primary-color-dark);
+}
+
+.agent-settings-modal .agent-settings-form .provider-name {
+    padding-left: 5px;
+}
+
+.agent-settings-modal .agent-settings-form .llm-model {
+    padding-left: 0;
+}
+
 .agent-settings-modal .agent-settings-form [type="checkbox"],
 .agent-settings-modal .agent-settings-form [type="checkbox"] + label {
     cursor: pointer;

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -463,8 +463,8 @@
                     },
                     "model": {
                         "label": "Model",
-                        "tooltip": "The model to use for this agent. More powerful models will provide better results.",
-                        "hint": "Check out the available OpenAI models <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">here</a>."
+                        "hint": "The default model is an admin-set property. Check with them for other available models.",
+                        "link_text": " Learn how to configure the model in the GraphDB documentation."
                     },
                     "temperature": {
                         "label": "Temperature",

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -462,8 +462,8 @@
                     },
                     "model": {
                         "label": "Modèle",
-                        "tooltip": "Le modèle à utiliser pour cet agent. Des modèles plus puissants fourniront de meilleurs résultats.",
-                        "hint": "Découvrez les modèles OpenAI disponibles <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">ici</a>."
+                        "hint": "Le modèle par défaut est une propriété définie par l'administrateur. Consultez-le pour connaître les autres modèles disponibles.",
+                        "link_text": " Apprenez à configurer le modèle dans la documentation de GraphDB."
                     },
                     "temperature": {
                         "label": "Température",

--- a/src/js/angular/rest/ttyg.rest.service.js
+++ b/src/js/angular/rest/ttyg.rest.service.js
@@ -9,6 +9,7 @@ TTYGRestService.$inject = ['$http'];
 const CONVERSATIONS_ENDPOINT = 'rest/chat/conversations';
 const AGENTS_ENDPOINT = 'rest/chat/agents';
 const EXPLAIN_RESPONSE_ENDPOINT = `${CONVERSATIONS_ENDPOINT}/explain`;
+const PROVIDER_ENDPOINT = 'rest/ttyg/provider';
 
 const DEVELOPMENT = false;
 

--- a/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -9,6 +9,7 @@ import {REPOSITORY_PARAMS} from "../../models/repository/repository";
 import {TTYGEventName} from "../services/ttyg-context.service";
 import {AGENT_OPERATION, TTYG_ERROR_MSG_LENGTH} from "../services/constants";
 import {mapUriAsNtripleAutocompleteResponse} from "../../rest/mappers/autocomplete-mapper";
+import {DocumentationUrlResolver} from "../../utils/documentation-url-resolver";
 
 angular
     .module('graphdb.framework.ttyg.controllers.agent-settings-modal', [
@@ -41,7 +42,8 @@ AgentSettingsModalController.$inject = [
     'TTYGService',
     'ExtractionMethodTemplates',
     'AutocompleteService',
-    'AutocompleteRestService'];
+    'AutocompleteRestService',
+    'productInfo'];
 
 function AgentSettingsModalController(
     $scope,
@@ -60,7 +62,8 @@ function AgentSettingsModalController(
     TTYGService,
     ExtractionMethodTemplates,
     AutocompleteService,
-    AutocompleteRestService) {
+    AutocompleteRestService,
+    productInfo) {
 
     // =========================
     // Private variables
@@ -221,16 +224,11 @@ function AgentSettingsModalController(
         additionalExtractionPanelToggleHandlers[extractionMethod.method](extractionMethod);
     };
 
-    /**
-     * Resolves the hint message for the agent model property. This is needed because the hint contains a html link that
-     * should be properly rendered.
-     * @return {*}
-     */
-    $scope.getModelHelpMessage = () => {
-        // The hint contains a html link which should be properly rendered.
-        const message = decodeHTML($translate.instant('ttyg.agent.create_agent_modal.form.model.hint'));
-        return $sce.trustAsHtml(message);
-    };
+    $scope.helpInfoForModel = {
+        ttygHelpInfo: getModelHelpMessage(),
+        linkText: $translate.instant('ttyg.agent.create_agent_modal.form.model.link_text'),
+        documentationUrl: DocumentationUrlResolver.getDocumentationUrl(productInfo.productShortVersion, 'talk-to-graph.html#prerequisites-and-configuration')
+    }
 
     /**
      * Resolves the hint for the FTS search missing message. This is needed because the hint contains a html link that
@@ -459,6 +457,18 @@ function AgentSettingsModalController(
     // =========================
     // Private functions
     // =========================
+
+    /**
+     * Resolves the hint message for the agent model property.
+     * This is needed because the hint contains a html link that
+     * should be properly rendered.
+     * @return {*}
+     */
+    function getModelHelpMessage() {
+        // The hint contains a html link which should be properly rendered.
+        const message = decodeHTML($translate.instant('ttyg.agent.create_agent_modal.form.model.hint'));
+        return $sce.trustAsHtml(message);
+    }
 
     /**
      * Mapping of agent operations to their respective handlers.

--- a/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -4,6 +4,7 @@ import 'angular/ttyg/directives/agent-list.directive';
 import 'angular/ttyg/directives/agent-select-menu.directive';
 import 'angular/ttyg/directives/no-agents-view.directive';
 import 'angular/ttyg/directives/show-tooltip-on-overflow.directive';
+import 'angular/ttyg/directives/help-info-popover.directive';
 import 'angular/ttyg/controllers/agent-settings-modal.controller';
 import 'angular/core/services/ttyg.service';
 import 'angular/ttyg/services/ttyg-context.service';
@@ -33,7 +34,8 @@ const modules = [
     'graphdb.framework.ttyg.directives.agent-select-menu',
     'graphdb.framework.ttyg.directives.no-agents-view',
     'graphdb.framework.ttyg.directives.show-tooltip-on-overflow',
-    'graphdb.framework.ttyg.controllers.agent-settings-modal'
+    'graphdb.framework.ttyg.controllers.agent-settings-modal',
+    'graphdb.framework.core.directives.help-info-popover',
 ];
 
 angular

--- a/src/js/angular/ttyg/directives/agent-list.directive.js
+++ b/src/js/angular/ttyg/directives/agent-list.directive.js
@@ -37,7 +37,7 @@ function AgentListComponent(TTYGContextService, ModalService, $translate) {
             $scope.selectedAgentsFilter = undefined;
 
             /**
-             * An event instance holding the agent to be deleted and if the progres is ongoing.
+             * An event instance holding the agent to be deleted and if the progress is ongoing.
              * @type {agentId: string, inProgress: boolean}
              */
             $scope.deletingAgent = undefined;

--- a/src/js/angular/ttyg/directives/help-info-popover.directive.js
+++ b/src/js/angular/ttyg/directives/help-info-popover.directive.js
@@ -1,0 +1,54 @@
+/**
+ * @name helpInfoPopover
+ * @restrict E
+ * @scope
+ *
+ * @description
+ * Custom element directive for showing a help info popover on hover. The content is
+ * passed in through the `helpInfo` attribute and rendered using an external template.
+ *
+ * @param {Object} helpInfo - The help information to be displayed in the popover.
+ *
+ * @example
+ * <help-info-popover help-info="myHelpData"></help-info-popover>
+ *
+ * @returns {Object} Directive definition object
+ */
+angular.module('graphdb.framework.core.directives.help-info-popover', [])
+    .directive('helpInfoPopover', function() {
+        return {
+            restrict: 'E',
+            scope: {
+                helpInfo: '=',
+            },
+            templateUrl: 'js/angular/ttyg/templates/modal/helpInfoPopoverTemplate.html',
+            link: function($scope, element) {
+                // Track whether the popover is open
+                $scope.isPopoverOpen = false;
+
+                const mouseEnterHandler = () => {
+                    $scope.$apply(() => {
+                        $scope.isPopoverOpen = true;
+                    });
+                };
+
+                const mouseLeaveHandler = () => {
+                    $scope.$apply(() => {
+                        $scope.isPopoverOpen = false;
+                    });
+                };
+
+                // =========================
+                // Events
+                // =========================
+                element.on('mouseenter', mouseEnterHandler);
+                element.on('mouseleave', mouseLeaveHandler);
+
+                // Clean up the event listeners on scope destroy
+                $scope.$on('$destroy', function() {
+                    element.off('mouseenter', mouseEnterHandler);
+                    element.off('mouseleave', mouseLeaveHandler);
+                });
+            }
+        };
+    });

--- a/src/js/angular/ttyg/services/ttyg-context.service.js
+++ b/src/js/angular/ttyg/services/ttyg-context.service.js
@@ -395,7 +395,7 @@ function TTYGContextService(EventEmitterService) {
         toggleExplainResponse,
         getExplainResponse,
         addExplainResponseCache,
-        onExplainResponseCacheUpdated,
+        onExplainResponseCacheUpdated
     };
 }
 
@@ -555,5 +555,5 @@ export const TTYGEventName = {
      */
     GO_TO_SPARQL_EDITOR: "openQueryInSparqlEditor",
 
-    CAN_MODIFY_AGENT_UPDATED: "canModifyAgentUpdated"
+    CAN_MODIFY_AGENT_UPDATED: "canModifyAgentUpdated",
 };

--- a/src/js/angular/ttyg/templates/agent-list.html
+++ b/src/js/angular/ttyg/templates/agent-list.html
@@ -33,15 +33,8 @@
                         </i>
                         {{agent.name}}
                     </div>
-                    <div class="related-repository">
-                        <i ng-if="!agent.isRepositoryDeleted" class="fa-kit fa-gdb-repo-graphdb"></i>
-                        <i ng-if="agent.isRepositoryDeleted"
-                           class="fa fa-triangle-exclamation text-warning agent-with-deleted-repository"
-                           gdb-tooltip="{{'ttyg.agent.deleted_repository' | translate}}">
-                        </i>
-                        {{agent.repositoryId}}
-                    </div>
-                </div>
+
+
                 <div class="btn-group">
                     <button class="btn btn-link secondary btn-sm open-agent-actions-btn"
                             data-toggle="dropdown" aria-expanded="false"
@@ -72,6 +65,18 @@
                             <span>{{'ttyg.agent.btn.delete_agent.label' | translate}}</span>
                         </button>
                     </div>
+                </div>
+                </div>
+                <div class="repository-model-group">
+                    <div class="related-repository">
+                        <i ng-if="!agent.isRepositoryDeleted" class="fa-kit fa-gdb-repo-graphdb"></i>
+                        <i ng-if="agent.isRepositoryDeleted"
+                           class="fa fa-triangle-exclamation text-warning agent-with-deleted-repository"
+                           gdb-tooltip="{{'ttyg.agent.deleted_repository' | translate}}">
+                        </i>
+                        {{agent.repositoryId}}
+                    </div>
+                    <div class="model-name">{{agent.model}}</div>
                 </div>
             </div>
 

--- a/src/js/angular/ttyg/templates/agent-select-menu.html
+++ b/src/js/angular/ttyg/templates/agent-select-menu.html
@@ -12,6 +12,7 @@
                gdb-tooltip="{{'ttyg.agent.deleted_repository' | translate}}">
             </i>
             <span class="repository-id">{{selectedAgent.repositoryId}}</span>
+            <span class="model-name">{{selectedAgent.model}}</span>
         </div>
         <span ng-if="selectedAgent && selectedAgent.isDeleted" class="text-warning">
             <i class="fa fa-triangle-exclamation"></i>
@@ -37,6 +38,7 @@
                 </i>
                 <span class="repository-id">{{agentOption.data.agent.repositoryId}}</span>
             </a>
+            <span class="model-name">{{agentOption.data.agent.model}}</span>
         </li>
     </ul>
 </div>

--- a/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -37,6 +37,54 @@
                 {{'required.field' | translate}}
             </div>
         </div>
+
+        <div class="form-row clearfix">
+            <div class="form-group llm-model col-md-4">
+                <label for="model">{{'ttyg.agent.create_agent_modal.form.model.label' | translate}}</label>
+                <help-info-popover help-info="helpInfoForModel"></help-info-popover>
+                <input type="text" class="form-control" id="model" name="model" ng-model="agentFormModel.model" guide-selector="model"
+                       required autocomplete="off">
+                <div class="alert alert-danger"
+                     ng-if="agentSettingsForm.model.$touched && agentSettingsForm.model.$invalid">
+                    {{'required.field' | translate}}
+                </div>
+            </div>
+            <div class="form-group temperature col-md-4">
+                <label for="temperature">
+                    <span uib-popover="{{'ttyg.agent.create_agent_modal.form.temperature.tooltip' | translate}}"
+                          popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.temperature.label' | translate}}</span>
+                    <i class="fa fa-triangle-exclamation text-warning high-temperature-warning"
+                       ng-if="showHighTemperatureWarning"
+                       uib-popover="{{'ttyg.agent.create_agent_modal.form.temperature.high_temperature_warning' | translate}}"
+                       popover-trigger="mouseenter"></i>
+                </label>
+                <input type="text" id="temperature" name="temperature" readonly
+                       class="form-control" ng-class="{'has-warning': showHighTemperatureWarning}"
+                       ng-model="agentFormModel.temperature.value">
+                <input id="temperatureSlider" name="temperature" type="range"
+                       min="{{agentFormModel.temperature.minValue}}"
+                       max="{{agentFormModel.temperature.maxValue}}" step="{{agentFormModel.temperature.step}}"
+                       ng-change="onTemperatureChange()"
+                       ng-model="agentFormModel.temperature.value"/>
+            </div>
+            <div class="form-group top-p col-md-4">
+                <label for="topP" uib-popover="{{'ttyg.agent.create_agent_modal.form.top_p.tooltip' | translate}}"
+                       popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.top_p.label' |
+                translate}}</label>
+                <input type="text" class="form-control" id="topP" name="topP" readonly
+                       ng-model="agentFormModel.topP.value">
+                <input id="topPSlider" name="topP" type="range" min="{{agentFormModel.topP.minValue}}"
+                       max="{{agentFormModel.topP.maxValue}}" step="{{agentFormModel.topP.step}}"
+                       ng-model="agentFormModel.topP.value"/>
+            </div>
+            <!--            Hidden for now because currently this property doesn't work in openai, but in the future it will -->
+            <!--            <div class="form-group seed col-md-4 pr-0">-->
+            <!--                <label for="seed">{{'ttyg.agent.create_agent_modal.form.seed.label' | translate}}</label>-->
+            <!--                <input type="number" class="form-control" id="seed" name="seed" min="0" ng-model="agentFormModel.seed"-->
+            <!--                       placeholder="{{'ttyg.agent.create_agent_modal.form.seed.hint' | translate}}">-->
+            <!--            </div>-->
+        </div>
+
         <div class="form-group extraction-methods-group">
             <label for="extractionMethods"
                    uib-popover="{{'ttyg.agent.create_agent_modal.form.extraction_method.tooltip' | translate}}"
@@ -331,58 +379,6 @@
                     <div ng-include="'js/angular/ttyg/templates/' + ExtractionMethodTemplates[extractionMethod.method] + '.html'"></div>
                 </div>
             </div>
-        </div>
-
-
-        <div class="form-row clearfix">
-            <div class="form-group gpt-model col-md-4">
-                <label for="model" uib-popover="{{'ttyg.agent.create_agent_modal.form.model.tooltip' | translate}}"
-                       popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.model.label' |
-                    translate}}</label>
-                <input type="text" class="form-control" id="model" name="model" ng-model="agentFormModel.model" guide-selector="model"
-                       required autocomplete="off">
-                <small id="modelHelp" class="form-text text-muted"
-                       ng-bind-html="getModelHelpMessage()">
-                </small>
-                <div class="alert alert-danger"
-                     ng-if="agentSettingsForm.model.$touched && agentSettingsForm.model.$invalid">
-                    {{'required.field' | translate}}
-                </div>
-            </div>
-            <div class="form-group temperature col-md-4">
-                <label for="temperature">
-                    <span uib-popover="{{'ttyg.agent.create_agent_modal.form.temperature.tooltip' | translate}}"
-                          popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.temperature.label' | translate}}</span>
-                    <i class="fa fa-triangle-exclamation text-warning high-temperature-warning"
-                       ng-if="showHighTemperatureWarning"
-                       uib-popover="{{'ttyg.agent.create_agent_modal.form.temperature.high_temperature_warning' | translate}}"
-                       popover-trigger="mouseenter"></i>
-                </label>
-                <input type="text" id="temperature" name="temperature" readonly
-                       class="form-control" ng-class="{'has-warning': showHighTemperatureWarning}"
-                       ng-model="agentFormModel.temperature.value">
-                <input id="temperatureSlider" name="temperature" type="range"
-                       min="{{agentFormModel.temperature.minValue}}"
-                       max="{{agentFormModel.temperature.maxValue}}" step="{{agentFormModel.temperature.step}}"
-                       ng-change="onTemperatureChange()"
-                       ng-model="agentFormModel.temperature.value"/>
-            </div>
-            <div class="form-group top-p col-md-4">
-                <label for="topP" uib-popover="{{'ttyg.agent.create_agent_modal.form.top_p.tooltip' | translate}}"
-                       popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.top_p.label' |
-                    translate}}</label>
-                <input type="text" class="form-control" id="topP" name="topP" readonly
-                       ng-model="agentFormModel.topP.value">
-                <input id="topPSlider" name="topP" type="range" min="{{agentFormModel.topP.minValue}}"
-                       max="{{agentFormModel.topP.maxValue}}" step="{{agentFormModel.topP.step}}"
-                       ng-model="agentFormModel.topP.value"/>
-            </div>
-            <!--            Hidden for now because currently this property doesn't work in openai, but in the future it will -->
-            <!--            <div class="form-group seed col-md-4 pr-0">-->
-            <!--                <label for="seed">{{'ttyg.agent.create_agent_modal.form.seed.label' | translate}}</label>-->
-            <!--                <input type="number" class="form-control" id="seed" name="seed" min="0" ng-model="agentFormModel.seed"-->
-            <!--                       placeholder="{{'ttyg.agent.create_agent_modal.form.seed.hint' | translate}}">-->
-            <!--            </div>-->
         </div>
 
         <div class="form-group user-instructions">

--- a/src/js/angular/ttyg/templates/modal/helpInfoExternalLink.html
+++ b/src/js/angular/ttyg/templates/modal/helpInfoExternalLink.html
@@ -1,0 +1,8 @@
+<div class="help-info">
+    <div ng-if="helpInfo.ttygHelpInfo">
+        <span ng-bind-html="helpInfo.ttygHelpInfo"></span>
+        <br><br>
+        <a href="{{helpInfo.documentationUrl}}" target="_blank">{{helpInfo.linkText}}</a>
+        <i class="fa fa-arrow-up-right-from-square"></i>
+    </div>
+</div>

--- a/src/js/angular/ttyg/templates/modal/helpInfoPopoverTemplate.html
+++ b/src/js/angular/ttyg/templates/modal/helpInfoPopoverTemplate.html
@@ -1,0 +1,9 @@
+<span class="btn btn-link page-info-icon"
+      uib-popover-template="'js/angular/ttyg/templates/modal/helpInfoExternalLink.html'"
+      popover-trigger="'none'"
+      popover-placement="bottom-right"
+      popover-is-open="isPopoverOpen"
+      popover-append-to-body="false"
+      popover-scope="helpInfo">
+    <i class="icon-info"></i>
+</span>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -463,8 +463,8 @@
                     },
                     "model": {
                         "label": "Model",
-                        "tooltip": "The model to use for this agent. More powerful models will provide better results.",
-                        "hint": "Check out the available OpenAI models <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">here</a>."
+                        "hint": "The default model is an admin-set property. Check with them for other available models.",
+                        "link_text": " Learn how to configure the model in the GraphDB documentation."
                     },
                     "temperature": {
                         "label": "Temperature",

--- a/test-cypress/integration/ttyg/create-agent.spec.js
+++ b/test-cypress/integration/ttyg/create-agent.spec.js
@@ -105,12 +105,12 @@ describe('TTYG create new agent', () => {
 
         // Validate the other agent settings
 
-        // gpt model
-        TtygAgentSettingsModalSteps.getGptModelField().should('have.value', 'gpt-4o');
-        TtygAgentSettingsModalSteps.clearGptModel();
+        // LLM model
+        TtygAgentSettingsModalSteps.getLLMModelField().should('have.value', 'gpt-4o');
+        TtygAgentSettingsModalSteps.clearLLMModel();
         TtygAgentSettingsModalSteps.getSaveAgentButton().should('be.disabled');
-        TtygAgentSettingsModalSteps.getGptModelError().should('be.visible').and('contain', 'This field is required');
-        TtygAgentSettingsModalSteps.typeGptModel('gpt-4o');
+        TtygAgentSettingsModalSteps.getLLMModelError().should('be.visible').and('contain', 'This field is required');
+        TtygAgentSettingsModalSteps.typeLLMModel('gpt-4o');
 
         // temperature
         TtygAgentSettingsModalSteps.setTemperature('0.2');
@@ -480,7 +480,7 @@ describe('TTYG create new agent', () => {
         TtygAgentSettingsModalSteps.setTemperature('1.2');
         TtygAgentSettingsModalSteps.getTemperatureSliderField().should('have.value', '1.2');
         // Then I should see a warning message
-        TtygAgentSettingsModalSteps.getTemperatureWarning().should('be.visible');
+        TtygAgentSettingsModalSteps.scrollToTemperatureWarning().should('be.visible');
         TtygAgentSettingsModalSteps.getTemperatureField().should('have.class', 'has-warning');
         // When I change the temperature to value below 1.0
         TtygAgentSettingsModalSteps.setTemperature('0.9');

--- a/test-cypress/steps/ttyg/ttyg-agent-settings-modal.steps.js
+++ b/test-cypress/steps/ttyg/ttyg-agent-settings-modal.steps.js
@@ -321,27 +321,27 @@ export class TtygAgentSettingsModalSteps extends ModalDialogSteps {
         this.getRetrievalConnectorField().find('option:selected').should('have.text', connectorName);
     }
 
-    // GPT model
+    // LLM model
 
-    static getGptModelFormGroup() {
-        return this.getDialog().find('.gpt-model');
+    static getLLMModelFormGroup() {
+        return this.getDialog().find('.llm-model');
     }
 
-    static getGptModelField() {
-        return this.getGptModelFormGroup().find('input');
+    static getLLMModelField() {
+        return this.getLLMModelFormGroup().find('input');
     }
 
-    static clearGptModel() {
-        this.getGptModelField().clear();
+    static clearLLMModel() {
+        this.getLLMModelField().clear();
         cy.realPress('Tab');
     }
 
-    static getGptModelError() {
-        return this.getGptModelFormGroup().find('.alert-danger');
+    static getLLMModelError() {
+        return this.getLLMModelFormGroup().find('.alert-danger');
     }
 
-    static typeGptModel(value) {
-        return this.getGptModelField().type(value);
+    static typeLLMModel(value) {
+        return this.getLLMModelField().type(value);
     }
 
     // temperature
@@ -364,6 +364,10 @@ export class TtygAgentSettingsModalSteps extends ModalDialogSteps {
 
     static getTemperatureWarning() {
         return this.getTemperatureFormGroup().find('.high-temperature-warning');
+    }
+
+    static scrollToTemperatureWarning() {
+        return this.getTemperatureWarning().scrollIntoView();
     }
 
     // Top P


### PR DESCRIPTION
## What
The user will be able to see which Model for each agent in several places in the TTYG view. The Agent Create/Edit modal also has an updated modal for the Model.

## Why
This is part of a new requirement, and will allow the user to see more about the TTYG configuration.

## How
I added the information to the agent select dropdown, to the agent management panel and to the agent create/edit dialog.

## Testing
Due to the rearrangement of the Agent modal, one test had to be edited to scroll for an element.

## Screenshots
<img width="272" height="792" alt="image" src="https://github.com/user-attachments/assets/2c9fd0ba-b80c-44dc-b5b4-277f0da9f099" />
<img width="566" height="408" alt="image" src="https://github.com/user-attachments/assets/48a210bf-4996-43c4-8798-4bbafe6af244" />

Info icon in Create/Edit agent modal:
<img width="1027" height="131" alt="image" src="https://github.com/user-attachments/assets/df743b38-4dee-45a8-a121-18be73e3d5d7" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
