### PR TITLE
GDB-12690 - Remove underlines from anchors in cluster operations dropdown

### DIFF
--- a/packages/shared-components/src/components/onto-operations-notification/onto-operations-notification.tsx
+++ b/packages/shared-components/src/components/onto-operations-notification/onto-operations-notification.tsx
@@ -75,7 +75,7 @@ export class OntoOperationsNotification {
                 <section class="operations-statuses-content">
                   {this.activeOperations.allRunningOperations.getItems().map((operation) => (
                     <li key={operation.id}>
-                      <a class={`operation-status-content onto-btn ${operationStatusToWarningClass[operation.status]}`}
+                      <a class={`operation-status-content onto-btn no-underline ${operationStatusToWarningClass[operation.status]}`}
                          target="_blank"
                          onClick={navigateTo(operation.href)}>
                         <i class={operationGroupToIcon[operation.group]}></i>


### PR DESCRIPTION
## What
The cluster status dropdown won't have underlines for the statuses on hover.

## Why
Incorrect styling not matching the pre-migration state.

## How
I added a class exception to the _anchor.scss.

## Testing
N/A

## Screenshots
<img width="323" height="143" alt="image" src="https://github.com/user-attachments/assets/61c8dcf4-d549-4d67-ae3a-9ce3336ddc03" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
