### PR TITLE
GDB-12689 - Remove underlines from anchors in autocomplete toastr

### DIFF
--- a/packages/root-config/src/styles/partials/anchor/_anchor.scss
+++ b/packages/root-config/src/styles/partials/anchor/_anchor.scss
@@ -1,9 +1,9 @@
 a {
-  &:hover:not(.btn, .nav-link, .menu-element-root, .nodes-list .data-value),
-  &:active:not(.btn, .nav-link, .menu-element-root, .nodes-list .data-value),
-  &[href^="http"]:not(.nodes-list .data-value),
-  &[href^="http"]:hover,
-  &[href^="http"]:active {
+  &:hover:not(.btn, .nav-link, .menu-element-root, .nodes-list .data-value, .no-underline),
+  &:active:not(.btn, .nav-link, .menu-element-root, .nodes-list .data-value, .no-underline),
+  &[href^="http"]:not(.nodes-list .data-value, .no-underline),
+  &[href^="http"]:hover:not(.no-underline),
+  &[href^="http"]:active:not(.no-underline) {
     text-decoration-line: underline !important;
     text-decoration-style: solid !important;
     text-decoration-thickness: var(--link-decoration-thickness) !important;

--- a/packages/shared-components/src/components/onto-search-resource-input/onto-search-resource-input.tsx
+++ b/packages/shared-components/src/components/onto-search-resource-input/onto-search-resource-input.tsx
@@ -213,7 +213,7 @@ export class OntoSearchResourceInput {
     if (this.inputValue.length > 0 && !this.isAutocompleteEnabled && !this.autocompleteWarningShown) {
       this.autocompleteWarningShown = true;
       const message = TranslationService.translate('rdf_search.toasts.autocomplete_is_off');
-      this.toastrService.warning(`<a style="font-weight: 500">${message}</a>`,
+      this.toastrService.warning(`<a class="no-underline" style="font-weight: 500">${message}</a>`,
         {
           onClick: navigateTo('autocomplete'),
           removeOnClick: true


### PR DESCRIPTION
## What
The autocomplete warning toastr will not have an underline on hover.

## Why
Incorrect styling not matching the pre-migration state.

## How
I added a class exception to the _anchor.scss and a class to the anchor element.

## Testing
N/A

## Screenshots
<img width="476" height="150" alt="image" src="https://github.com/user-attachments/assets/7b5dbdd6-f735-4852-a61b-56485f414a66" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
