### PR TITLE
GDB-12738 - Skip test with new API key property name

### DIFF
--- a/e2e-tests/e2e-legacy/ttyg/ttyg-initial-state-with-selected-repository.spec.js
+++ b/e2e-tests/e2e-legacy/ttyg/ttyg-initial-state-with-selected-repository.spec.js
@@ -10,10 +10,12 @@ function verifyStateWithSelectedRepository() {
     TTYGViewSteps.getApiKeyMessage().should('be.visible');
     TTYGViewSteps.getMissingApiKeyToastMessage()
         .should('be.visible')
-        .and('contain', 'Set the config property graphdb.openai.api-key to your OpenAI API key');
+        .and('contain', 'Set the config property \'graphdb.llm.api-key\' to your LLM API key.');
 }
 
-describe('TTYG initial state with selected repository', () => {
+// TODO: skipped until BE releases an updated version with the new API key.
+//  https://graphwise.atlassian.net/browse/GDB-12738
+describe.skip('TTYG initial state with selected repository', () => {
     let repositoryId;
 
     beforeEach(() => {


### PR DESCRIPTION
## What
Both tests in ttyg-initial-state-with-selected-repository.spec.js skipped. API key in test was updated.

## Why
The BE has updated the API key name and the Workbench still expects the old one. This fails the BE builds. Hence, the test is skipped until the BE releases successfully.

## How
I skipped the test and updated the property.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
