### PR TITLE
GDB-12731: Free Access login button not functioning

### DIFF
--- a/packages/shared-components/cypress/e2e/header/header.cy.js
+++ b/packages/shared-components/cypress/e2e/header/header.cy.js
@@ -144,7 +144,7 @@ describe('Header', () => {
       // When, I click it
       HeaderSteps.clickLoginButton();
       // Then, I should still not see the search
-      BaseSteps.getRedirectUrl().should('have.text', 'redirect to /login')
+      BaseSteps.getRedirectUrl().should('have.text', 'redirect to login')
 
       // When I deactivate free access
       HeaderSteps.deactivateFreeAccess();

--- a/packages/shared-components/src/components/onto-user-login/onto-user-login.tsx
+++ b/packages/shared-components/src/components/onto-user-login/onto-user-login.tsx
@@ -10,7 +10,7 @@ export class OntoUserLogin {
   render() {
     return (
       <section class="onto-user-login">
-        <button onClick={navigateTo('/login')}>
+        <button onClick={navigateTo('login')}>
           <i class="icon-arrow-right"></i>
           <translate-label
             class="user-login-label"


### PR DESCRIPTION
## What
When Free Access is enabled and the user clicks the login button, the login page does not open when GraphDB is running under a context path. Additionally, errors appear in the console.

## Why
The login link started with a leading /, which breaks navigation when the application is served under a context path.

## How
The leading / was removed from the login URL to support relative navigation under any context path.

## Screenshots
N/A

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
