### PR TITLE
GDB-12677: Wrong Redirection to Login Page in Free Access

### DIFF
--- a/e2e-tests/e2e-security/setup/users-and-access/user-and-access.spec.js
+++ b/e2e-tests/e2e-security/setup/users-and-access/user-and-access.spec.js
@@ -1,0 +1,63 @@
+import {RepositoriesStubs} from "../../../stubs/repositories/repositories-stubs";
+import {UserAndAccessSteps} from "../../../steps/setup/user-and-access-steps";
+import {LoginSteps} from "../../../steps/login-steps";
+import {ModalDialogSteps} from "../../../steps/modal-dialog-steps";
+import ImportSteps from "../../../steps/import/import-steps";
+import {MainMenuSteps} from "../../../steps/main-menu-steps";
+import {RepositorySelectorSteps} from "../../../steps/repository-selector-steps";
+import {ErrorSteps} from "../../../steps/error-steps";
+
+describe('User and Access', () => {
+
+    let repositoryId1;
+    let repositoryId2;
+    const graphqlUser = 'graphqlUser';
+
+    beforeEach(() => {
+        cy.viewport(1280, 1000);
+        RepositoriesStubs.spyGetRepositories();
+        repositoryId1 = 'user-access-repo1-' + Date.now();
+        repositoryId2 = 'user-access-repo2-' + Date.now();
+        cy.createRepository({id: repositoryId1});
+        cy.createRepository({id: repositoryId2});
+        cy.presetRepository(repositoryId1);
+        UserAndAccessSteps.visit();
+        // Users table should be visible
+        UserAndAccessSteps.getUsersTable().should('be.visible');
+    });
+
+    afterEach(() => {
+        cy.loginAsAdmin().then(() => {
+            cy.deleteRepository(repositoryId1, true);
+            cy.deleteRepository(repositoryId2, true);
+            cy.deleteUser(graphqlUser, true);
+            cy.switchOffFreeAccess(true);
+            cy.switchOffSecurity(true);
+        });
+
+    });
+
+    it('should restrict page when free access in on', () => {
+        // Given: There at least two repositories.
+        // When: I enable the security
+        UserAndAccessSteps.toggleSecurity();
+        LoginSteps.loginWithUser('admin', 'root');
+        // And: turn on Free Access
+        UserAndAccessSteps.getFreeAccessSwitchInput().should('not.be.checked');
+        UserAndAccessSteps.toggleFreeAccess();
+        // And: set graphql rights for the second repository when free access is ON
+        UserAndAccessSteps.clickFreeWriteAccessRepo(repositoryId2);
+        UserAndAccessSteps.clickFreeGraphqlAccessRepo(repositoryId2);
+        ModalDialogSteps.clickOKButton();
+
+        // When: I logout
+        LoginSteps.logout();
+        // And: repository with graphql rights is selected
+        RepositorySelectorSteps.selectRepository(repositoryId2);
+        // And: I click on the Import menu.
+        MainMenuSteps.clickOnMenuImport();
+
+        // Then: I should see the error message, because import view is available only for write access, repositoryId2 has only graphql rights.
+        ErrorSteps.verifyError('Some functionalities are not available because you do not have the required repository permissions.')
+    });
+});

--- a/e2e-tests/steps/error-steps.js
+++ b/e2e-tests/steps/error-steps.js
@@ -1,14 +1,11 @@
 export class ErrorSteps {
-    static getErrorElement() {
-        return cy.get('.idError');
-    }
-
-    static verifyError(errorMessage) {
-        ErrorSteps.getErrorElement().contains(errorMessage);
-    }
 
     static getRepositoryErrors() {
         return cy.get('.card.repository-errors')
+    }
+
+    static verifyError(errorMessage) {
+        ErrorSteps.getRepositoryErrors().contains(errorMessage);
     }
 
     static getNoConnectedRepoMessage() {

--- a/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
@@ -274,26 +274,30 @@ angular.module('graphdb.framework.core.services.jwtauth', [
 
             this.toggleFreeAccess = function (enabled, authorities, appSettings, updateFreeAccess) {
                 if (enabled !== this.freeAccess || updateFreeAccess) {
-                    if (enabled) {
-                        this.freeAccessPrincipal = {authorities: authorities, appSettings: appSettings};
-                    } else {
-                        this.freeAccessPrincipal = undefined;
-                    }
                     SecurityService.setFreeAccess({
                         enabled: enabled ? 'true' : 'false',
                         authorities: authorities,
                         appSettings: appSettings
-                    }).then(() => {
-                        this.freeAccess = enabled;
-                        if (updateFreeAccess) {
-                            toastr.success($translate.instant('jwt.auth.free.access.updated.msg'));
-                        } else {
-                            toastr.success($translate.instant('jwt.auth.free.access.status', {status: ($translate.instant(enabled ? 'enabled.status' : 'disabled.status'))}));
-                        }
-                    }).catch((err) => {
-                        toastr.error(err.data, $translate.instant('common.error'));
-                    });
-                    this.broadcastSecurityInit(this.securityEnabled, this.hasExplicitAuthentication(), this.freeAccess)
+                    })
+                        .then(() => {
+                            this.freeAccess = enabled;
+                            return enabled ? SecurityService.getFreeAccess() : {}
+                        })
+                        .then((freeAccess) => {
+                            this.freeAccessPrincipal = {
+                                authorities: freeAccess.authorities,
+                                appSettings: freeAccess.appSettings
+                            };
+                            if (updateFreeAccess) {
+                                toastr.success($translate.instant('jwt.auth.free.access.updated.msg'));
+                            } else {
+                                toastr.success($translate.instant('jwt.auth.free.access.status', {status: ($translate.instant(enabled ? 'enabled.status' : 'disabled.status'))}));
+                            }
+                        })
+                        .finally(() => this.broadcastSecurityInit(this.securityEnabled, this.hasExplicitAuthentication(), this.freeAccess))
+                        .catch((err) => {
+                            toastr.error(err.data, $translate.instant('common.error'));
+                        });
                 }
             };
 


### PR DESCRIPTION
GDB-12677: Wrong Redirection to Login Page in Free Access

## What
The user is redirected to the login page even when they have the appropriate rights to see the page.

Steps to reproduce:
- Enable security;
- Enable Free Access;
- In the settings dialog, grant GraphQL rights only to a specific repository;
- Select the repository with GraphQL only rights (IMPORTANT);
- Log out.

Actual behavior: The login page is loaded instead.
Expected behavior: The Import view should be shown.

## Why
The issue arises because authority formats are mismatched.

When the Free Access configuration dialog is closed, the application stores the user's authorities in the wrong format. Because of this:
- When the user clicks the Import menu, the frontend believes the user has permission and tries to load the view;
- However, the backend evaluates the request using a different authority format and returns a 401 Unauthorized error;
- As a result, the user is redirected to the login page, even though they technically have the correct rights.

## How
Add backend call to fetch updated free access data and refresh workbench state accordingly.

## Screenshots
N/A

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [] Tests
