### PR TITLE
GDB-12739: "Copy to Editor" Button Not Working in SPARQL Editor Step

### DIFF
--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/execute-sparql-query/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/execute-sparql-query/plugin.js
@@ -1,3 +1,10 @@
+const createCopyToEditorListener = (YasguiComponentDirectiveUtil, sparqlDirectiveSelector, query) => {
+    return (event) => {
+        event.preventDefault();
+        YasguiComponentDirectiveUtil.setQuery(sparqlDirectiveSelector, query).then(() => {});
+    }
+}
+
 PluginRegistry.add('guide.step', [
     {
         guideBlockName: 'execute-sparql-query',
@@ -13,7 +20,8 @@ PluginRegistry.add('guide.step', [
 
             const code = document.createElement('code');
             const copy = document.createElement('button');
-            copy.className = 'btn btn-sm btn-secondary';
+            const copyToEditorButtonClass = 'guide-copy-to-editor-query-button';
+            copy.className = `btn btn-sm btn-secondary ${copyToEditorButtonClass}`;
             copy.innerText = $translate.instant('guide.step_plugin.execute-sparql-query.copy-to-editor.button');
             copy.setAttribute('ng-click', 'copyQuery()');
 
@@ -37,6 +45,9 @@ PluginRegistry.add('guide.step', [
                 queries[index] = query;
                 code.innerText = query;
                 options.queryAsHtmlCodeElement = '<div class="shepherd-code">' + code.outerHTML + copy.outerHTML + '</div>';
+
+                const copyToEditorListener = createCopyToEditorListener(YasguiComponentDirectiveUtil, SPARQL_DIRECTIVE_SELECTOR, query);
+                let stepHTMLElement;
 
                 steps.push({
                     guideBlockName: 'input-element',
@@ -86,8 +97,14 @@ PluginRegistry.add('guide.step', [
                         },
                         scrollToHandler: GuideUtils.scrollToTop,
                         extraContent: queryDef.queryExtraContent,
-                        onScope: (scope) => {
-                            scope.copyQuery = () => YasguiComponentDirectiveUtil.setQuery(SPARQL_DIRECTIVE_SELECTOR, query).then(() => {});
+                        show: (_guide) => () => {
+                            stepHTMLElement = _guide.currentStep.el.querySelector(`.${copyToEditorButtonClass}`);
+                            stepHTMLElement.addEventListener('click', copyToEditorListener);
+                        },
+                        hide: () => () => {
+                            if (stepHTMLElement) {
+                                stepHTMLElement.removeEventListener('click', copyToEditorListener);
+                            }
                         }
                     }, options)
                 });

--- a/packages/legacy-workbench/src/js/angular/guides/tour-lib-services/shepherd.service.js
+++ b/packages/legacy-workbench/src/js/angular/guides/tour-lib-services/shepherd.service.js
@@ -921,20 +921,6 @@ function ShepherdService($translate, LocalStorageAdapter, LSKeys, $interpolate, 
         this._addTotalProgress(currentStep, currentStepElement);
 
         this._addTypeIcon(currentStepElement, stepDescription);
-
-        // We have some Angular bits on the elements and this is needed to make them work
-        const scope = angular.element(currentStepElement).scope();
-        // After the migration, the scope here is always undefined.
-        // This broke the "copy query to editor" functionality in the execute-sparql-query plugin.
-        // Note: The scope is used only in the execute-sparql-query plugin.
-        // TODO: To restore this functionality, it needs to be reimplemented in a way that does not depend on AngularJS.
-        if (scope) {
-            if (this._isFunction(stepDescription.onScope)) {
-                // Step definitions may want to add functions to the scope
-                stepDescription.onScope(scope);
-            }
-            setTimeout(() => scope.$apply(() => $compile(currentStepElement)(scope)));
-        }
     };
 
     this._toParagraph = (text, textClass) => {


### PR DESCRIPTION
## What
The "Copy to Editor" button does not function as expected during the guide step that introduces the SPARQL editor.

## Why
The original implementation of the "Copy to Editor" functionality relied on Angular's scope. However, this approach does not work reliably in a single-spa environment.

## How
The "Copy to Editor" functionality was updated to use explicit event listeners instead of relying on Angular scope:
- On step show: A click event listener is registered on the "Copy to Editor" button.
- On step hide: The listener is properly removed to prevent memory leaks or unexpected behavior.

When the button is clicked, the listener explicitly fills the query editor with the query content defined in the guide step.

## Screenshots
N/A

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
