### PR TITLE
GDB-12760: Repository selector does not update after login

### DIFF
--- a/e2e-tests/e2e-security/setup/users-and-access/user-and-access.spec.js
+++ b/e2e-tests/e2e-security/setup/users-and-access/user-and-access.spec.js
@@ -60,4 +60,28 @@ describe('User and Access', () => {
         // Then: I should see the error message, because import view is available only for write access, repositoryId2 has only graphql rights.
         ErrorSteps.verifyError('Some functionalities are not available because you do not have the required repository permissions.')
     });
+
+    it('should restrict the repositories depending on whether free access is enabled and whether the user is logged in', () => {
+        // Given: There at least two repositories.
+        // When: I enable the security
+        UserAndAccessSteps.toggleSecurity();
+        LoginSteps.loginWithUser('admin', 'root');
+        // And: turn on Free Access
+        UserAndAccessSteps.toggleFreeAccess();
+        // And: set rights for the second repository when free access is ON
+        UserAndAccessSteps.clickFreeWriteAccessRepo(repositoryId2);
+        ModalDialogSteps.clickOKButton();
+
+        // When: I logout
+        LoginSteps.logout();
+        // Then: I should see only repositoryId2, as it is the only one configured for free access
+        RepositorySelectorSteps.getRepositorySelectorButton(repositoryId1).should('not.exist');
+        RepositorySelectorSteps.getRepositorySelectorButton(repositoryId2).should('exist');
+
+        // When: I log in again with a user who has access to all repositories
+        LoginSteps.loginWithUser('admin', 'root');
+        // Then: I should see both repositories in the repository selector, because the user has access to all repositories
+        RepositorySelectorSteps.getRepositorySelectorButton(repositoryId1).should('exist');
+        RepositorySelectorSteps.getRepositorySelectorButton(repositoryId2).should('exist');
+    });
 });

--- a/packages/shared-components/src/components/onto-header/onto-header.tsx
+++ b/packages/shared-components/src/components/onto-header/onto-header.tsx
@@ -155,6 +155,7 @@ export class OntoHeader {
     this.subscribeToActiveRepoLoadingChange();
     this.subscribeToNavigationEnd();
     this.subscribeToLanguageChanged();
+    this.subscribeToAuthenticatedUserChange();
   }
 
   private subscribeToRepositoryListChanged(): () => void {
@@ -181,7 +182,7 @@ export class OntoHeader {
         this.currentRepository ? this.startOperationPolling() : this.stopOperationPolling();
         this.shouldShowSearch = this.shouldShowRdfSearch();
         this.loadNamespaces();
-        this.repositoryItems = this.getRepositoriesDropdownItems();
+        this.updateRepositoryItems();
       })
     );
   }
@@ -194,6 +195,12 @@ export class OntoHeader {
     this.subscriptions.add(this.securityContextService.onSecurityConfigChanged((config) => {
       this.securityConfig = config;
     }));
+  }
+
+  private subscribeToAuthenticatedUserChange() {
+    this.subscriptions.add(this.securityContextService.onAuthenticatedUserChanged(() => {
+      this.updateRepositoryItems();
+    }))
   }
 
   private subscribeToActiveRepositoryLocationChange() {
@@ -242,6 +249,10 @@ export class OntoHeader {
 
   private initOnRepositoryListChanged(repositories: RepositoryList): void {
     this.repositoryList = repositories;
+    this.updateRepositoryItems();
+  }
+
+  private updateRepositoryItems() {
     this.repositoryItems = this.getRepositoriesDropdownItems();
   }
 


### PR DESCRIPTION
## What
The repositories displayed in the repository selector component are not consistent with the current security state (e.g., whether security is enabled or disabled, free access is on or off, or whether a user is logged in).

## Why
The repository selector is only updated when it is initialized or when a repository is created or deleted. Since the visible repositories are filtered based on the security state and user access rights, this becomes an issue. When the authenticated user changes (e.g., on login/logout), the selector is not regenerated, resulting in outdated or incorrect repository visibility.

## How
A listener for authenticated user change events was added. The selector now re-renders the repository list based on the current user's access rights or free access status.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
