### PR TITLE
GDB-12787 Fix error in console when logging out

### DIFF
--- a/e2e-tests/e2e-security/setup/users-and-access/turn-on-security-and-password-change.spec.js
+++ b/e2e-tests/e2e-security/setup/users-and-access/turn-on-security-and-password-change.spec.js
@@ -74,4 +74,14 @@ describe('Turn on Security', () => {
     UserAndAccessSteps.typeConfirmPasswordField(newPassword);
     UserAndAccessSteps.confirmUserEdit();
   });
+
+  it('should show toaster when after logging out', () => {
+      UserAndAccessSteps.visit();
+      LoginSteps.loginWithUser('admin', 'root');
+      // Log out
+      LoginSteps.logout();
+      cy.url().should('include', '/login');
+      // Verify toaster message
+      ToasterSteps.verifySuccess('Signed out');
+  })
 });

--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -606,7 +606,6 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 
     function logout() {
         $jwtAuth.clearAuthentication();
-        toastr.success('Signed out');
         if ($jwtAuth.freeAccess) {
             // if it's free access check if we still can access the current repo
             // if not, a new default repo will be set or the current repo will be unset
@@ -614,7 +613,9 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
             $jwtAuth.updateReturnUrl();
         } else if ($jwtAuth.isSecurityEnabled()) {
             // otherwise show login screen if security is on
-            $rootScope.redirectToLogin();
+            $rootScope.redirectToLogin().then(() => {
+                toastr.success('Signed out');
+            })
         }
     }
 


### PR DESCRIPTION
## What
Fix the error in the console when logging out, and show the toaster, which caused the error

## Why
The redirect to the login (which happens 2 times) breaks the toaster, and it shows an error in the console and does not show in the view

How
- moved the toaster trigger in the `redirectToLogin` promise chain

## Testing
added in the security suite

## Screenshots
<img width="908" height="1239" alt="image" src="https://github.com/user-attachments/assets/c0f15218-2482-4cb3-b39e-ff8918c3da5d" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
