### PR TITLE
GDB-12791 Fix wrong redirect from operations notification component

### DIFF
--- a/packages/api/src/models/monitoring/operation-type.ts
+++ b/packages/api/src/models/monitoring/operation-type.ts
@@ -1,7 +1,7 @@
 export enum OperationType {
   UPDATES = 'updates',
   QUERIES = 'queries',
-  IMPORTS = 'imports',
+  IMPORT = 'imports',
   BACKUP_AND_RESTORE = 'backupAndRestore',
   CLUSTER_HEALTH = 'clusterHealth'
 }

--- a/packages/api/src/models/monitoring/operation.ts
+++ b/packages/api/src/models/monitoring/operation.ts
@@ -4,13 +4,13 @@ import {OperationType} from './operation-type';
 import {OperationGroup} from './operation-group';
 
 /** Not all operations have counts as values */
-const OPERATIONS_WITH_COUNT = [OperationType.QUERIES, OperationType.UPDATES, OperationType.IMPORTS];
+const OPERATIONS_WITH_COUNT = [OperationType.QUERIES, OperationType.UPDATES, OperationType.IMPORT];
 
 const OPERATION_TYPE_TO_HREF = {
   [OperationType.UPDATES]: 'monitor/queries',
   [OperationType.QUERIES]: 'monitor/queries',
   [OperationType.BACKUP_AND_RESTORE]: 'monitor/backup-and-restore',
-  [OperationType.IMPORTS]: 'imports',
+  [OperationType.IMPORT]: 'import',
   [OperationType.CLUSTER_HEALTH]: 'cluster'
 };
 
@@ -18,7 +18,7 @@ const OPERATION_TYPE_TO_GROUP = {
   [OperationType.QUERIES]: OperationGroup.QUERY,
   [OperationType.UPDATES]: OperationGroup.QUERY,
   [OperationType.BACKUP_AND_RESTORE]: OperationGroup.BACKUP,
-  [OperationType.IMPORTS]: OperationGroup.IMPORT,
+  [OperationType.IMPORT]: OperationGroup.IMPORT,
   [OperationType.CLUSTER_HEALTH]: OperationGroup.CLUSTER
 };
 

--- a/packages/api/src/services/monitoring/mapper/operation-list.mapper.ts
+++ b/packages/api/src/services/monitoring/mapper/operation-list.mapper.ts
@@ -6,7 +6,7 @@ import {OperationType} from '../../../models/monitoring/operation-type';
 const OPERATION_TYPE_SORT_ORDER = {
   [OperationType.CLUSTER_HEALTH]: 0,
   [OperationType.BACKUP_AND_RESTORE]: 1,
-  [OperationType.IMPORTS]: 2,
+  [OperationType.IMPORT]: 2,
   [OperationType.QUERIES]: 3,
   [OperationType.UPDATES]: 4
 };

--- a/packages/shared-components/cypress/e2e/operations-notification/operations-notification.cy.js
+++ b/packages/shared-components/cypress/e2e/operations-notification/operations-notification.cy.js
@@ -60,7 +60,7 @@ describe('onto-operations-notification', () => {
     OperationsNotificationSteps.getRepositoryItems().should('have.length', 6);
     OperationsNotificationSteps.setMarvelRepo();
 
-    const operationLinks = ['cluster', 'monitor/backup-and-restore', 'imports', 'monitor/queries', 'monitor/queries'];
+    const operationLinks = ['cluster', 'monitor/backup-and-restore', 'import', 'monitor/queries', 'monitor/queries'];
 
     // When, I click on each operation link
     operationLinks.forEach((link, index) => {


### PR DESCRIPTION
## What
Fix wrong redirect to `import` when user clicks on running imports while importing in cluster

## Why
The redirect was wrong to `imports`, rather than `import` when user clicks on running imports

How
- fixed typo

## Testing
Fixed

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
