### PR TITLE
GDB-12776: There is console log when login page is displayed.

### DIFF
--- a/e2e-tests/e2e-security/setup/home/cookie-policy.spec.js
+++ b/e2e-tests/e2e-security/setup/home/cookie-policy.spec.js
@@ -1,0 +1,64 @@
+import {UserAndAccessSteps} from "../../../steps/setup/user-and-access-steps";
+import {LicenseStubs} from "../../../stubs/license-stubs";
+import {LoginSteps} from "../../../steps/login-steps";
+import {ModalDialogSteps} from "../../../steps/modal-dialog-steps";
+import HomeSteps from "../../../steps/home-steps";
+
+Cypress.env('set_default_user_data', false);
+
+describe('Cookie policy', () => {
+
+    let repository;
+
+    beforeEach(() => {
+        cy.loginAsAdmin().then(() => {
+            cy.switchOffFreeAccess(true);
+            cy.switchOffSecurity(true);
+        });
+        cy.setDefaultUserData(false);
+        LicenseStubs.stubFreeLicense();
+        repository = 'cypress-test-cookie-policy-security-' + Date.now();
+        cy.createRepository({id: repository});
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repository, true);
+        cy.loginAsAdmin().then(() => {
+            cy.switchOffFreeAccess(true);
+            cy.switchOffSecurity(true);
+            cy.setDefaultUserData();
+        });
+    });
+
+    it('should show the consent popup if free access is on and the user is on the login page', () => {
+        // Given: Security is enabled and free access is on
+        UserAndAccessSteps.visitInProdMode();
+        UserAndAccessSteps.toggleSecurity();
+        LoginSteps.loginWithUser('admin', 'root');
+        // And: Free access is enabled
+        UserAndAccessSteps.getFreeAccessSwitchInput().should('not.be.checked');
+        UserAndAccessSteps.toggleFreeAccess();
+        UserAndAccessSteps.clickFreeWriteAccessRepo(repository);
+        ModalDialogSteps.clickOKButton();
+
+        // When: The user visits the login page
+        LoginSteps.visitInProdMode();
+        // Then: The cookie policy popup should be shown
+        HomeSteps.getCookieConsentPopup().should('exist').and('be.visible');
+    });
+
+    it('should not show the consent popup if free access is off and the user is on the login page', () => {
+        // Given: Security is enabled and free access is off
+        UserAndAccessSteps.visitInProdMode();
+        UserAndAccessSteps.toggleSecurity();
+        LoginSteps.loginWithUser('admin', 'root');
+        UserAndAccessSteps.getFreeAccessSwitchInput().should('not.be.checked');
+
+        // When: The user logs out and visits the login page
+        LoginSteps.logout();
+        // Then: The cookie policy popup should not be shown
+        HomeSteps.getCookieConsentPopup().should('not.exist');
+        LoginSteps.visitInProdMode();
+        HomeSteps.getCookieConsentPopup().should('not.exist');
+    });
+});

--- a/e2e-tests/steps/login-steps.js
+++ b/e2e-tests/steps/login-steps.js
@@ -1,6 +1,16 @@
+import {EnvironmentStubs} from "../stubs/environment-stubs";
+
 export class LoginSteps {
     static visitLoginPage() {
         cy.visit('/login');
+    }
+
+    static visitInProdMode() {
+        cy.visit('/login', {
+            onBeforeLoad: (win) => {
+                EnvironmentStubs.stubWbProdMode();
+            }
+        });
     }
 
     static loginWithUser(username, password) {

--- a/e2e-tests/steps/setup/user-and-access-steps.js
+++ b/e2e-tests/steps/setup/user-and-access-steps.js
@@ -1,6 +1,16 @@
+import {EnvironmentStubs} from "../../stubs/environment-stubs";
+
 export class UserAndAccessSteps {
     static visit() {
         cy.visit('/users');
+    }
+
+    static visitInProdMode() {
+        cy.visit('/users', {
+            onBeforeLoad: (win) => {
+                EnvironmentStubs.stubWbProdMode();
+            }
+        });
     }
 
     static getUrl() {

--- a/packages/legacy-workbench/src/js/angular/core/services/tracking/tracking.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/tracking/tracking.service.js
@@ -83,18 +83,20 @@ function TrackingService($window, $jwtAuth, $licenseService, InstallationCookieS
     const getCookieConsent = () => {
         return $jwtAuth.getPrincipal()
             .then((principal) => {
-                const localConsent = LocalStorageAdapter.get(LSKeys.COOKIE_CONSENT);
-
                 // No username => use local storage
-                if (principal && !principal.username) {
-                    if (localConsent) {
-                        return CookieConsent.fromJSON(localConsent);
+                if (!principal || !principal.username) {
+                    if ($jwtAuth.isFreeAccessEnabled()) {
+                        const localConsent = LocalStorageAdapter.get(LSKeys.COOKIE_CONSENT);
+                        if (localConsent) {
+                            return CookieConsent.fromJSON(localConsent);
+                        }
+                        return CookieConsent.NOT_ACCEPTED_WITH_TRACKING;
                     }
-                    return new CookieConsent(undefined, true, true);
+                    return CookieConsent.ACCEPTED_NO_TRACKING;
                 }
 
                 if (!principal.appSettings || !principal.appSettings.COOKIE_CONSENT) {
-                    return new CookieConsent(undefined, true, true);
+                    return CookieConsent.NOT_ACCEPTED_WITH_TRACKING;
                 }
 
                 return CookieConsent.fromJSON(principal.appSettings.COOKIE_CONSENT);

--- a/packages/legacy-workbench/src/js/angular/models/cookie-policy/cookie-consent.js
+++ b/packages/legacy-workbench/src/js/angular/models/cookie-policy/cookie-consent.js
@@ -19,6 +19,22 @@ export class CookieConsent {
     }
 
     /**
+     * Predefined default: policy not accepted, but statistic and third-party cookies are allowed.
+     * Equivalent to: new CookieConsent(undefined, true, true)
+     */
+    static get NOT_ACCEPTED_WITH_TRACKING() {
+        return new CookieConsent(undefined, true, true);
+    }
+
+    /**
+     * Predefined default: policy accepted, no statistic or third-party cookies allowed.
+     * Equivalent to: new CookieConsent(true, false, false)
+     */
+    static get ACCEPTED_NO_TRACKING() {
+        return new CookieConsent(true, false, false);
+    }
+
+    /**
      * Sets the overall cookie policy acceptance status.
      * @param {boolean} consent - The user's decision for the entire cookie policy.
      * @return {CookieConsent} Returns the instance to allow chaining.


### PR DESCRIPTION
## What
A console error occurs when the login page is rendered and free access is turned off.

## Why
When the login page is displayed, the TrackingService attempts to apply tracking consent. This process tries to extract the cookie consent, but in this particular state, there is no principal available, resulting in a NullPointerException.

## How
Updated the functionality to check for a principal before applying tracking consent.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
