### PR TITLE
GDB-12802 improve ttyg agent settings form validation

### DIFF
--- a/packages/legacy-workbench/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -379,9 +379,19 @@ function AgentSettingsModalController(
 
     /**
      * Checks the status of the autocomplete index.
+     * @param {AdditionalExtractionMethodFormModel|undefined} method - The extraction method to check the autocomplete
+     * index for. This function can be called in the visibilitychange handler, so the method might not be defined.
+     * If not provided, it will check the 'Autocomplete IRI discovery search' method from the additional extraction
+     * methods.
      */
-    $scope.checkAutocompleteIndexEnabled = () => {
-        if (!$scope.agentFormModel.repositoryId) {
+    $scope.checkAutocompleteIndexEnabled = (method) => {
+        if (!method) {
+            method = $scope.agentFormModel.additionalExtractionMethods.additionalExtractionMethods
+                .find((extractionMethod) => extractionMethod.method === AdditionalExtractionMethod.AUTOCOMPLETE_IRI_DISCOVERY_SEARCH);
+        }
+        // If the method is not selected, we don't need to check the autocomplete index status.
+        // Also, if the repository id is not set, we can't check the autocomplete index status.
+        if (method && !method.selected || !$scope.agentFormModel.repositoryId) {
             return;
         }
         const selectedRepositoryInfo = getSelectedRepositoryInfo();
@@ -704,7 +714,7 @@ function AgentSettingsModalController(
             // clear the validation status if method is deselected.
             $scope.agentSettingsForm.$setValidity('autocompleteDisabled', true);
         }
-        $scope.checkAutocompleteIndexEnabled();
+        $scope.checkAutocompleteIndexEnabled(extractionMethod);
     }
 
     const refreshValidations = (clearIndexSelection = false, clearRetrievalConnectorSelection = false) => {

--- a/packages/legacy-workbench/src/js/angular/ttyg/templates/autocomplete-iri-discovery-search.html
+++ b/packages/legacy-workbench/src/js/angular/ttyg/templates/autocomplete-iri-discovery-search.html
@@ -25,7 +25,7 @@
            <div ng-if="extractionMethod.expanded" class="extraction-method-options"
                 ng-class="{'has-error': (extractionMethod.selected && agentSettingsForm.$error.autocompleteDisabled) || agentSettingsForm.repositoryId.$invalid}">
                <button ng-if="agentFormModel.repositoryId" class="btn btn-link btn-sm pull-right"
-                       ng-click="checkAutocompleteIndexEnabled()"
+                       ng-click="checkAutocompleteIndexEnabled(extractionMethod)"
                        ng-disabled="disabled"
                        gdb-tooltip="{{'ttyg.agent.create_agent_modal.form.additional_query_methods.method.autocomplete_iri_discovery_search.btn.reload.tooltip' | translate}}">
                    <i class="fa fa-arrows-rotate"></i>


### PR DESCRIPTION
**This also should be fixing** https://graphwise.atlassian.net/browse/GDB-12800

## What
User might not be able to save a TTYG agent due to agent settings form validation error which is not shown.

## Why
When user switches browser tabs while the agent settings modal is opened and returns back to the same tab, a request for autocomplete status check is made then the autocompleteDisabled validation is set in the form's ng model. This request and the validation in the model needs to be done only if the respective autocomplete_iri_discovery_search method is enabled. Otherwise it makes it unclear for the user why the form remains invalid and agent settings can't be saved.

## How
Made sure that the autocomplete status check is not performed and the autocompleteDisabled validation status is not set if the autocomplete_iri_discovery_search method is disabled.

## Testing
Can't write test for this because it requires switching browser tabs

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
