### PR TITLE
GDB-12815 - Fix inconsistent values on field sliders

### DIFF
--- a/packages/legacy-workbench/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -743,6 +743,13 @@ function AgentSettingsModalController(
         }
     };
 
+    const refreshSliderById = (elementId, value) => {
+        const slider = document.getElementById(elementId);
+        if (slider) {
+            slider.value = value;
+        }
+    };
+
     // =========================
     // Subscriptions
     // =========================
@@ -769,6 +776,10 @@ function AgentSettingsModalController(
         }
         // Delay the validation status setting because angular form ngmodel is not present immediately
         setTimeout(setExtractionMethodValidityStatus, 0);
+        $uibModalInstance.rendered.then(() => {
+            refreshSliderById('temperatureSlider', $scope.agentFormModel.temperature.value);
+            refreshSliderById('topPSlider', $scope.agentFormModel.topP.value);
+        });
     };
     init();
 }


### PR DESCRIPTION
## What
The "Temperature" and "Top P" sliders will show correct values, consistent with the model.

## Why
The sliders would always load at value 1 when the Create/Edit Agent modal was opened. This was due to the model and sliders not being available at the same time when the controller is initialized.

## How
I added a delay to re-render the sliders with the correct values.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
