### PR TITLE
GDB-12826 Fix cluster node recovery label console error

### DIFF
--- a/packages/legacy-workbench/src/js/angular/clustermanagement/services/cluster-drawing.service.js
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/services/cluster-drawing.service.js
@@ -236,19 +236,16 @@ function updateNodesInfoText(nodes) {
         })
         .append('foreignObject')
         .attr('width', function (d) {
-            if (isEmpty(d.recoveryStatus)) {
-                return 0;
+            let shortMessage = '';
+            if (!isEmpty(d.recoveryStatus)) {
+                shortMessage = extractShortMessageFromNode(d);
             }
-            const shortMessage = extractShortMessageFromNode(d);
             const rect = calculateElementSizeByText(shortMessage);
             objectHeight = rect.height;
             objectWidth = rect.width;
             return objectWidth;
         })
         .attr('height', function (d) {
-            if (isEmpty(d.recoveryStatus)) {
-                return 0;
-            }
             return objectHeight;
         })
         .attr('x', function (d) {


### PR DESCRIPTION
## What
Fix console error for cluster node recovery label on initialization

## Why
If there is no recovery status the `objectWidth` prop is not set and so a division with a NaN is triggered

How
- added failback for the message if there is no `recoveryStatus`

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
