### PR TITLE
GDB-12799 show menu and header correctly for free access user

### DIFF
--- a/packages/api/src/services/security/test/authentication.service.spec.ts
+++ b/packages/api/src/services/security/test/authentication.service.spec.ts
@@ -1,5 +1,5 @@
 import {AuthenticationService} from '../authentication.service';
-import {AuthenticatedUser, Authority, SecurityConfig} from '../../../models/security';
+import {AuthenticatedUser, Authority, AuthorityList, SecurityConfig} from '../../../models/security';
 import {MapperProvider, ServiceProvider} from '../../../providers';
 import {AuthenticationStorageService} from '../authentication-storage.service';
 import {AuthenticatedUserMapper} from '../mappers/authenticated-user.mapper';
@@ -30,31 +30,31 @@ describe('AuthenticationService', () => {
 
   test('isAuthenticated should return true if the user is authenticated', () => {
     // When, I have an enabled security and logged user
-    const securityConfig = {enabled: true, userLoggedIn: true} as unknown as SecurityConfig;
+    const securityConfig = {enabled: true, userLoggedIn: true, freeAccess: {authorities: new AuthorityList()}} as unknown as SecurityConfig;
     ServiceProvider.get(SecurityContextService).updateSecurityConfig(securityConfig);
     // Then, I expect to be authenticated
-    expect(authService.isAuthenticated()).toEqual(true);
+    expect(authService.isLoggedIn()).toEqual(true);
   });
 
   test('isAuthenticated should return false if the user is not authenticated', () => {
     // Given, I have enabled security
-    const enabledSecurityConfig = {enabled: true} as unknown as SecurityConfig;
+    const enabledSecurityConfig = {enabled: true, freeAccess: {authorities: new AuthorityList()}} as unknown as SecurityConfig;
     ServiceProvider.get(SecurityContextService).updateSecurityConfig(enabledSecurityConfig);
     // When, I check, if I am authenticated
     // Then, I expect, not to be authenticated
-    expect(authService.isAuthenticated()).toEqual(false);
+    expect(authService.isLoggedIn()).toEqual(false);
 
     // Given, I have disabled security
     const disabledSecurityConfig = {enabled: false} as unknown as SecurityConfig;
     ServiceProvider.get(SecurityContextService).updateSecurityConfig(disabledSecurityConfig);
     // When, I check, if I am authenticated
     // Then, I expect, not to be authenticated
-    expect(authService.isAuthenticated()).toEqual(false);
+    expect(authService.isLoggedIn()).toEqual(false);
   });
 
   test('hasFreeAccess should return true if free access is enabled', () => {
     // Given, I have a security config with enabled free access
-    const securityConfigWithFreeAccess = {enabled: true, freeAccessActive: true} as unknown as SecurityConfig;
+    const securityConfigWithFreeAccess = {enabled: true, freeAccess: {enabled: true} } as unknown as SecurityConfig;
     ServiceProvider.get(SecurityContextService).updateSecurityConfig(securityConfigWithFreeAccess);
     // When, I check, if free access is enabled
     // Then, I expect, to have free access
@@ -63,7 +63,7 @@ describe('AuthenticationService', () => {
 
   test('hasFreeAccess should return false if free access is disabled', () => {
     // Given, I have a security config with disabled free access
-    const securityConfigWithFreeAccess = {enabled: true, freeAccessActive: false} as unknown as SecurityConfig;
+    const securityConfigWithFreeAccess = {enabled: true, freeAccess: {enabled: false}} as unknown as SecurityConfig;
     ServiceProvider.get(SecurityContextService).updateSecurityConfig(securityConfigWithFreeAccess);
     // When, I check, if free access is enabled
     // Then, I expect, not to have free access
@@ -144,7 +144,7 @@ describe('AuthenticationService', () => {
     securityContextService.updateAuthenticatedUser(userWithRole);
 
     // And, I have a security config with disabled free access
-    const securityConfigWithFreeAccess = {enabled: true, freeAccess: {enabled: false}} as unknown as SecurityConfig;
+    const securityConfigWithFreeAccess = {enabled: true, freeAccess: {enabled: false, authorities: new AuthorityList()}} as unknown as SecurityConfig;
     securityContextService.updateSecurityConfig(securityConfigWithFreeAccess);
 
     // When, I check, if the user has a higher role
@@ -173,7 +173,7 @@ describe('AuthenticationService', () => {
 
   test('canReadRepo should return false when security is enabled but user is not authenticated', () => {
     // Given, I have enabled security
-    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityConfig = {enabled: true, freeAccess: {authorities: new AuthorityList()}} as unknown as SecurityConfig;
     securityContextService.updateSecurityConfig(securityConfig);
 
     // When, I check if I can read a repository
@@ -208,7 +208,7 @@ describe('AuthenticationService', () => {
 
   test('canReadRepo should return true when user has ROLE_REPO_MANAGER', () => {
     // Given, I have enabled security
-    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityConfig = {enabled: true, freeAccess: {authorities: new AuthorityList()}} as unknown as SecurityConfig;
     const securityContextService = ServiceProvider.get(SecurityContextService);
     securityContextService.updateSecurityConfig(securityConfig);
 
@@ -231,7 +231,7 @@ describe('AuthenticationService', () => {
 
   test('canReadRepo should return false when user tries to access SYSTEM repository', () => {
     // Given, I have enabled security
-    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityConfig = {enabled: true, freeAccess: {authorities: new AuthorityList()}} as unknown as SecurityConfig;
     const securityContextService = ServiceProvider.get(SecurityContextService);
     securityContextService.updateSecurityConfig(securityConfig);
 
@@ -267,7 +267,7 @@ describe('AuthenticationService', () => {
 
   test('canReadRepo should return true when user has READ rights on a non-SYSTEM repository', () => {
     // Given, I have enabled security
-    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityConfig = {enabled: true, freeAccess: {authorities: new AuthorityList()}} as unknown as SecurityConfig;
     const securityContextService = ServiceProvider.get(SecurityContextService);
     securityContextService.updateSecurityConfig(securityConfig);
 
@@ -292,7 +292,7 @@ describe('AuthenticationService', () => {
 
   test('canReadRepo should return false when user does not have READ rights on repository', () => {
     // Given, I have enabled security
-    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityConfig = {enabled: true, freeAccess: {authorities: new AuthorityList()}} as unknown as SecurityConfig;
     const securityContextService = ServiceProvider.get(SecurityContextService);
     securityContextService.updateSecurityConfig(securityConfig);
 
@@ -312,7 +312,7 @@ describe('AuthenticationService', () => {
 
   test('canReadRepo should return true for authenticated users with base READ rights for a specific repository location', () => {
     // Given, I have enabled security
-    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityConfig = {enabled: true, freeAccess: {authorities: new AuthorityList()}} as unknown as SecurityConfig;
     const securityContextService = ServiceProvider.get(SecurityContextService);
     securityContextService.updateSecurityConfig(securityConfig);
 
@@ -369,7 +369,7 @@ describe('AuthenticationService', () => {
     );
     securityContextService.updateAuthenticatedUser(regularUser);
 
-    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityConfig = {enabled: true, freeAccess: {authorities: new AuthorityList()}} as unknown as SecurityConfig;
     securityContextService.updateSecurityConfig(securityConfig);
 
     jest.spyOn(windowMock.PluginRegistry, 'get').mockReturnValue([]);
@@ -383,7 +383,7 @@ describe('AuthenticationService', () => {
       {authorities: [Authority.ROLE_USER]} as unknown as AuthenticatedUser
     );
     securityContextService.updateAuthenticatedUser(regularUser);
-    const securityConfig = {enabled: true} as unknown as SecurityConfig;
+    const securityConfig = {enabled: true, freeAccess: {authorities: new AuthorityList()}} as unknown as SecurityConfig;
     securityContextService.updateSecurityConfig(securityConfig);
 
     const activeRoute = new RouteItemModel({

--- a/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
@@ -214,7 +214,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                         } else {
                             that.getAuthenticatedUserFromBackend();
                         }
-                        that.broadcastSecurityInit(that.securityEnabled, that.hasExplicitAuthentication(), that.hasOverrideAuth)
+                        that.broadcastSecurityInit(that.securityEnabled, that.hasExplicitAuthentication(), that.freeAccess);
                     } else {
                         AuthTokenService.clearAuthToken();
                         const overrideAuthData = res.data.overrideAuth;
@@ -230,7 +230,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                          } else {
                             return SecurityService.getAdminUser().then(function (res) {
                                 that.principal = {username: 'admin', appSettings: res.appSettings, authorities: res.grantedAuthorities, grantedAuthoritiesUiModel: res.grantedAuthoritiesUiModel};
-                                that.broadcastSecurityInit(that.securityEnabled, true, that.hasOverrideAuth)
+                                that.broadcastSecurityInit(that.securityEnabled, true, false);
                             });
                         }
                     }

--- a/packages/root-config/src/bootstrap/bootstrap.js
+++ b/packages/root-config/src/bootstrap/bootstrap.js
@@ -1,9 +1,9 @@
 import {languageBootstrap} from './language/language-bootstrap';
 import {licenseBootstrap} from './license/license-bootstrap';
-import {productInfoBootstrap} from './product-info/product-info-bootstrap';
+import {loadProductInfoLocal} from './product-info/product-info-bootstrap';
 import {autoCompleteBootstrap} from './autocomplete/autocomplete';
 import {securityBootstrap} from './security/security-bootstrap';
-import {repositoryBootstrap} from './repository/repository-bootstrap';
+import {loadRepositories, repositoryBootstrap} from './repository/repository-bootstrap';
 
 import {
   ServiceProvider,
@@ -16,7 +16,6 @@ import {defineCustomElements} from '../../../shared-components/loader';
 
 const bootstrapPromises = [
   ...licenseBootstrap,
-  ...productInfoBootstrap,
   ...autoCompleteBootstrap,
 ];
 
@@ -39,7 +38,9 @@ const executePromises = (bootstrapFns) => {
 const loadEssentials = () => {
   return Promise.all([
     executePromises(languageBootstrap),
-    securityBootstrap.loadSecurityConfig()
+    securityBootstrap.loadSecurityConfig(),
+    loadRepositories(),
+    loadProductInfoLocal()
   ]);
 };
 

--- a/packages/root-config/src/bootstrap/product-info/product-info-bootstrap.js
+++ b/packages/root-config/src/bootstrap/product-info/product-info-bootstrap.js
@@ -1,6 +1,6 @@
 import {ServiceProvider, ProductInfoService, ProductInfoContextService} from '@ontotext/workbench-api';
 
-const loadProductInfoLocal = () => {
+export const loadProductInfoLocal = () => {
   return ServiceProvider.get(ProductInfoService).getProductInfoLocal()
     .then((productInfo) => {
       ServiceProvider.get(ProductInfoContextService).updateProductInfo(productInfo);
@@ -9,5 +9,3 @@ const loadProductInfoLocal = () => {
       throw new Error('Could not load local product info', error);
     });
 };
-
-export const productInfoBootstrap = [loadProductInfoLocal];

--- a/packages/root-config/src/bootstrap/repository/repository-bootstrap.js
+++ b/packages/root-config/src/bootstrap/repository/repository-bootstrap.js
@@ -7,7 +7,7 @@ import {
   RepositoryLocationContextService
 } from '@ontotext/workbench-api';
 
-const loadRepositories = () => {
+export const loadRepositories = () => {
   return ServiceProvider.get(RepositoryService).getRepositories()
     .then((repositories) => {
       const repositoryContextService = ServiceProvider.get(RepositoryContextService);
@@ -30,4 +30,4 @@ const loadActiveRepositoryLocation = () => {
     });
 };
 
-export const repositoryBootstrap = [loadRepositories, loadActiveRepositoryLocation];
+export const repositoryBootstrap = [loadActiveRepositoryLocation];

--- a/packages/shared-components/cypress/e2e/layout/layout.cy.js
+++ b/packages/shared-components/cypress/e2e/layout/layout.cy.js
@@ -20,14 +20,12 @@ describe('Layout', () => {
     const setupMenuIndex = 4;
     const helpMenuIndex = 6;
 
-    // When I open monitoring, setup and help menus, so submenus can be visible
-    NavbarSteps.openSubmenus(monitoringMenuIndex);
-    NavbarSteps.openSubmenus(setupMenuIndex);
-    NavbarSteps.openSubmenus(helpMenuIndex);
     // And, I enable security
     LayoutSteps.enableSecurityUserLoggedIn();
     // And I set the authenticated user role to admin
     LayoutSteps.setAdminRole();
+    // And I open setup menu so submenus can be visible
+    NavbarSteps.openSubmenus(setupMenuIndex);
 
     // Then I should see submenus for admin role
     const adminRoleSetupSubmenuItems = [
@@ -47,6 +45,8 @@ describe('Layout', () => {
     ]
     assertSubmenuItems(setupMenuIndex, adminRoleSetupSubmenuItems);
 
+    // And I open monitoring menu so submenus can be visible
+    NavbarSteps.openSubmenus(monitoringMenuIndex);
     const adminMonitoringMenuItems = [
       'Queries and Updates',
       'Backup and Restore',
@@ -54,6 +54,8 @@ describe('Layout', () => {
     ]
     assertSubmenuItems(monitoringMenuIndex, adminMonitoringMenuItems);
 
+    // And I open help menu so submenus can be visible
+    NavbarSteps.openSubmenus(helpMenuIndex);
     const adminHelpSubmenuItems = [
       'Interactive guides',
       'REST API',
@@ -66,6 +68,8 @@ describe('Layout', () => {
 
     // When I set the authenticated user role to user
     LayoutSteps.setUserRole();
+    // And I open setup menu so submenus can be visible
+    NavbarSteps.openSubmenus(setupMenuIndex);
 
     // Then I should see 9 sub menu items for Setup
     const userRoleSetupSubmenuItems = [
@@ -81,12 +85,16 @@ describe('Layout', () => {
     ]
     assertSubmenuItems(setupMenuIndex, userRoleSetupSubmenuItems);
 
+    // And I open monitoring menu so submenus can be visible
+    NavbarSteps.openSubmenus(monitoringMenuIndex);
     const userMonitoringMenuItems = [
       'Queries and Updates',
       'Backup and Restore',
     ]
     assertSubmenuItems(monitoringMenuIndex, userMonitoringMenuItems);
 
+    // And I open help menu so submenus can be visible
+    NavbarSteps.openSubmenus(helpMenuIndex);
     const userHelpSubmenuItems = [
       'Interactive guides',
       'REST API',
@@ -98,6 +106,9 @@ describe('Layout', () => {
 
     // When I set the authenticated user role to repo manager
     LayoutSteps.setRepoManagerRole();
+
+    // And I open setup menu so submenus can be visible
+    NavbarSteps.openSubmenus(setupMenuIndex);
 
     // Then I should see 10 sub menu items for Setup
     const repoManagerRoleSetupSubmenuItems = [

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -44,7 +44,7 @@ export class OntoLayout {
   @State() securityConfig: SecurityConfig;
   @State() isLowResolution = false;
   @State() hasPermission: boolean = true;
-  @State() showFooter = this.isAuthenticatedFully();
+  @State() showHeader = this.isAuthenticatedFully();
   @State() isVisible: boolean;
 
   // ========================
@@ -98,7 +98,7 @@ export class OntoLayout {
           <slot name="default"></slot>
         </div>
         <header class="wb-header">
-          {this.isVisible && <onto-header></onto-header>}
+          {this.showHeader && <onto-header></onto-header>}
         </header>
 
         <nav class="wb-navbar">
@@ -113,7 +113,7 @@ export class OntoLayout {
           <onto-permission-banner></onto-permission-banner>
         )}
         <footer class="wb-footer">
-          {this.isVisible && <onto-footer></onto-footer>}
+          <onto-footer></onto-footer>
         </footer>
         <onto-tooltip></onto-tooltip>
         <onto-toastr></onto-toastr>
@@ -218,19 +218,19 @@ export class OntoLayout {
   private updateVisibility() {
     if (!this.authenticationService.isSecurityEnabled()) {
       this.isVisible = true;
-      this.showFooter = true;
+      this.showHeader = true;
     } else {
       const hasAuth = !!this.authenticatedUser && !!this.securityConfig;
-      const isAuthenticated = this.authenticationService.isAuthenticated() || this.authenticationService.hasFreeAccess();
+      const isAuthenticated = this.authenticationService.isLoggedIn() || this.authenticationService.hasFreeAccess();
 
       this.isVisible = hasAuth && isAuthenticated;
-      this.showFooter = isAuthenticated;
+      this.showHeader = isAuthenticated;
     }
   }
 
   private isAuthenticatedFully() {
     const authService = ServiceProvider.get(AuthenticationService);
-    return !authService.isSecurityEnabled() || authService.isAuthenticated() || authService.hasFreeAccess();
+    return !authService.isSecurityEnabled() || authService.isLoggedIn() || authService.hasFreeAccess();
   }
 
   private shouldShowMenu(role: Authority): boolean {

--- a/packages/shared-components/src/pages/header/index.html
+++ b/packages/shared-components/src/pages/header/index.html
@@ -15,8 +15,8 @@
 
   <script type="module" src="/build/shared-components.esm.js"></script>
   <script nomodule src="/build/shared-components.js"></script>
-  <script src="./main.js" defer></script>
   <script src="../js/main.js" defer></script>
+  <script src="./main.js" defer></script>
   <link rel="stylesheet" href="../css/bootstrap.min.css">
   <link rel="stylesheet" href="/pages/css/fontawesome.min.css">
   <link rel="stylesheet" href="/pages/css/light.min.css">

--- a/packages/shared-components/src/pages/header/main.js
+++ b/packages/shared-components/src/pages/header/main.js
@@ -33,3 +33,8 @@ const setInvalidLicense = () => {
     }
   )
 }
+
+setSecurityConfig({
+  enabled: false,
+  freeAccess: {enabled: false, authorities: {hasAuthority: () => false}}
+})

--- a/packages/shared-components/src/pages/layout/main.js
+++ b/packages/shared-components/src/pages/layout/main.js
@@ -10,7 +10,8 @@ const setUserRole = (role) => {
 const setSecurity = (enabled, userLoggedIn) => {
   setSecurityConfig({
     enabled: enabled,
-    userLoggedIn: userLoggedIn
+    userLoggedIn: userLoggedIn,
+    freeAccess: {enabled: false, authorities: {hasAuthority: () => false}}
   });
 }
 

--- a/packages/shared-components/src/pages/operations-notification/main.js
+++ b/packages/shared-components/src/pages/operations-notification/main.js
@@ -1,1 +1,4 @@
-
+setSecurityConfig({
+  enabled: false,
+  freeAccess: {enabled: false, authorities: {hasAuthority: () => false}}
+});


### PR DESCRIPTION
## What
Fix menu and header visualization for free access users

## Why
- Header wasn't being shown to free access user
- Free access user wasn't seeing repositories, which he has access to
- Footer wasn't being shown on the login screen

## How
- Changed bootstrap to load repositories and product info initially. This solves missing repositories in the selector and missing info in the footer
- Added checks for free access authorities
- Replaced legacy `freeAccessActive` with the config `freeAccess.enabled`. This is needed for correct resolving of conditions in the layout
- Made the footer visible always and corrected the condition for the header

## Testing
n/a

## Screenshots
<img width="1850" height="921" alt="image" src="https://github.com/user-attachments/assets/7d552b92-b4f6-4d12-b5ee-3c511bbe8174" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
