### PR TITLE
GDB-12542: favicon is missing

### DIFF
--- a/packages/root-config/src/index.ejs
+++ b/packages/root-config/src/index.ejs
@@ -25,8 +25,8 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <base href="/">
     <link rel="stylesheet" href="css/splash-screen.css?v=<%= buildVersion %>">
-    <link rel="icon" type="image/png" href="/assets/images/favicon.png" />
-    <link rel="apple-touch-icon-precomposed" href="/assets/images/favicon.png">
+    <link rel="icon" type="image/png" href="assets/images/favicon.png" />
+    <link rel="apple-touch-icon-precomposed" href="assets/images/favicon.png">
     <title>GraphDB Workbench</title>
 
     <!--


### PR DESCRIPTION
## What
The favicon was not visible when the Workbench was accessed under a context path.

## Why
Because of an incorrect relative path to the icon.

## How
The path to the favicon has been corrected.

## Screenshots
Before
<img width="510" height="274" alt="image" src="https://github.com/user-attachments/assets/b84039ee-ae96-4d2d-94c0-02f548f5a3fd" />

After
<img width="320" height="274" alt="image" src="https://github.com/user-attachments/assets/bd833b44-2fed-4f85-a4c7-f011ce9ae771" />


## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
