### PR TITLE
GDB-12487 - Fix movie guide step 31 when side-panel won't open

### DIFF
--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/class-hierarchy/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/class-hierarchy/plugin.js
@@ -87,11 +87,19 @@ PluginRegistry.add('guide.step', [
     {
         guideBlockName: 'class-hierarchy-instances',
         getSteps: (options, services) => {
+            let element;
             const GuideUtils = services.GuideUtils;
             const RoutingUtil = services.RoutingUtil;
             options.title = 'guide.step_plugin.class-hierarchy-instances.title';
             const closeButtonSelector = GuideUtils.getGuideElementSelector('close-info-panel');
             const clasInstanceSelector = GuideUtils.getGuideElementSelector('class-' + options.iri);
+            const handleDoubleClick = () => (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                // Ensure the side panel always appears
+                return reloadAndOpenInfoPanel({RoutingUtil, GuideUtils}, clasInstanceSelector);
+            };
+            let dblClickHandler = handleDoubleClick();
             const steps = [
                 {
                     guideBlockName: 'clickable-element',
@@ -111,7 +119,21 @@ PluginRegistry.add('guide.step', [
                             }
 
                             return Promise.resolve();
-                        }
+                        },
+                        show: () => () => {
+                            // Add a "dblclick" listener to the element.
+                            // We have to open side panel info manually when a selected node is clicked.
+                            element = document.querySelector(clasInstanceSelector);
+                            if (element) {
+                                element.addEventListener('dblclick', dblClickHandler, true);
+                            }
+                        },
+                        hide: () => () => {
+                            if (element) {
+                                element.removeEventListener('dblclick', dblClickHandler);
+                                element = null;
+                            }
+                        },
                     }, options)
                 },
                 {


### PR DESCRIPTION
## What
Movie guide step 31 won't break on double click.

## Why
Double click would make the next step not appear properly (the sidepanel would remain closed).

## How
I added an event listener for `dblclick` to make sure the sidepanel is opened on double click.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
