### PR TITLE
GDB-11874 Fix page permissions

### DIFF
--- a/packages/api/src/models/security/restricted-pages.ts
+++ b/packages/api/src/models/security/restricted-pages.ts
@@ -8,7 +8,7 @@ export class RestrictedPages extends Model<RestrictedPages>{
   private pages: Record<string, boolean> = {};
 
   isRestricted(pageUrl: string): boolean {
-    return this.pages[pageUrl];
+    return this.pages[pageUrl] ?? false;
   }
 
   setPageRestriction(pageUrl: string, isRestricted = true): RestrictedPages {

--- a/packages/legacy-workbench/src/app.js
+++ b/packages/legacy-workbench/src/app.js
@@ -191,7 +191,8 @@ const moduleDefinition = function (productInfo, translations) {
             //     });
             // });
 
-            $httpProvider.interceptors.push('$unauthorizedInterceptor');
+            // Disable uauthorizedInterceptor because limitations are implemented with different logic
+            // $httpProvider.interceptors.push('$unauthorizedInterceptor');
             $httpProvider.interceptors.push('$authenticationInterceptor');
 
             // Hack the template request provider to add a version parameter to templates that
@@ -231,7 +232,7 @@ const moduleDefinition = function (productInfo, translations) {
             function updateTitleAndHelpInfo() {
                 // In the new implementation of the language service, the event is triggered too early,
                 // before the route is ready. Therefore, we need to check if the route is ready before translate the title.
-                if(!$route.current) {
+                if (!$route.current) {
                     return;
                 }
                 if ($route.current.title) {
@@ -242,7 +243,7 @@ const moduleDefinition = function (productInfo, translations) {
 
                 $rootScope.helpInfo = $route.current.helpInfo && $sce.trustAsHtml(decodeHTML($translate.instant($route.current.helpInfo)));
                 $rootScope.title = decodeHTML($translate.instant($route.current.title));
-                $rootScope.documentationUrl =  DocumentationUrlResolver.getDocumentationUrl(productInfo.productShortVersion, $route.current.documentationUrl);
+                $rootScope.documentationUrl = DocumentationUrlResolver.getDocumentationUrl(productInfo.productShortVersion, $route.current.documentationUrl);
             }
 
             // Check if theme is set in local storage workbench settings and apply
@@ -272,7 +273,7 @@ const moduleDefinition = function (productInfo, translations) {
                 translateChangeUnsubscribe();
                 // Remove all routes so that when navigating from legacy-workbench to the new workbench and back, the
                 // router will not try to load the route before the app is bootstrapped again.
-                Object.keys($route.routes).forEach(function(route) {
+                Object.keys($route.routes).forEach(function (route) {
                     delete $route.routes[route];
                 });
             })
@@ -380,7 +381,7 @@ const ngLifecycles = singleSpaAngularJS({
     elementId: 'workbench-app',
     template: `
         <div ng-controller="mainCtrl">
-            <div class="container-fluid main-container no-authority-panel" ng-if="hasPermission() && !hasAuthority() && getActiveRepository()">
+            <div class="container-fluid main-container no-authority-panel" ng-if="getActiveRepository() && !hasAuthority()">
                 <h1>
                     {{title}}
                     <page-info-tooltip></page-info-tooltip>
@@ -399,7 +400,7 @@ const ngLifecycles = singleSpaAngularJS({
                     </div>
                 </div>
             </div>
-            <div class="main-container" ng-if="hasPermission() && hasAuthority()">
+            <div class="main-container" ng-if="hasAuthority() || (!getActiveRepository() && !hasAuthority())">
                 <div ng-view></div>
             </div>
         </div>

--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -226,7 +226,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
                 return;
             }
 
-            const isAccessToPageRestricted = $scope.principal.authorities.indexOf(menuItem.role) === -1;
+            const isAccessToPageRestricted = !$jwtAuth.isAdmin() && $scope.principal.authorities.indexOf(menuItem.role) === -1;
             restrictedPages.setPageRestriction(route.url, isAccessToPageRestricted);
         });
         securityContextService.updateRestrictedPages(restrictedPages);

--- a/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
@@ -22,22 +22,12 @@ angular.module('graphdb.framework.core.services.jwtauth', [
     .service('$jwtAuth', ['$http', 'toastr', '$location', '$rootScope', 'SecurityService', '$openIDAuth', '$translate', '$q', '$route', 'AuthTokenService',
         function ($http, toastr, $location, $rootScope, SecurityService, $openIDAuth, $translate, $q, $route, AuthTokenService) {
             const jwtAuth = this;
-
-            $rootScope.deniedPermissions = {};
-            $rootScope.setPermissionDenied = (path) => {
-                if (path === '/login' || !jwtAuth.isAuthenticated()) {
-                    return false;
-                }
-                if(jwtAuth.isAuthenticated() && this.hasGraphqlRightsOverCurrentRepo()) {
-                    return true;
-                }
-
-                $rootScope.deniedPermissions[path] = true;
-                return true;
-            };
             $rootScope.hasPermission = function () {
                 const path = $location.path();
-                return !$rootScope.deniedPermissions[path];
+                const securityContextService = ServiceProvider.get(SecurityContextService);
+                const restrictedPages = securityContextService.getRestrictedPages();
+
+                return restrictedPages.isRestricted(path);
             };
 
             this.updateReturnUrl = () => {
@@ -195,7 +185,7 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                         } else {
                             that.getAuthenticatedUserFromBackend();
                         }
-                        that.broadcastSecurityInit(that.securityEnabled, that.hasExplicitAuthentication(), that.hasOverrideAuth)
+                        that.broadcastSecurityInit(that.securityEnabled, that.hasExplicitAuthentication(), that.freeAccess)
                     } else {
                         AuthTokenService.clearAuthToken();
                         const overrideAuthData = res.data.overrideAuth;
@@ -311,7 +301,6 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                     }
 
                     this.principal = data;
-                    $rootScope.deniedPermissions = {};
                     this.securityInitialized = true;
 
                     const selectedRepo = getActiveRepositoryObjectFromStorage();
@@ -321,8 +310,6 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                         // we unset the repository
                         const repositoryContextService = ServiceProvider.get(RepositoryContextService);
                         repositoryContextService.updateSelectedRepository(undefined);
-                        // reset denied permissions (different repo, different rights)
-                        $rootScope.deniedPermissions = {};
                     }
 
                     this.broadcastSecurityInit(this.securityEnabled, this.hasExplicitAuthentication(), this.freeAccess)

--- a/packages/legacy-workbench/src/js/angular/core/services/repositories.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/repositories.service.js
@@ -421,9 +421,6 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
         this.onRepositorySet = function (newRepository) {
             this.setRepositoryHeaders(newRepository);
             $rootScope.$broadcast('repositoryIsSet', {newRepo: newRepository?.isNew});
-            ServiceProvider.get(SecurityContextService).updateRestrictedPages(new RestrictedPages());
-            // reset denied permissions (different repo, different rights)
-            $rootScope.deniedPermissions = {};
         }
 
         this.getDefaultRepository = function () {

--- a/packages/legacy-workbench/src/js/angular/core/services/repositories.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/repositories.service.js
@@ -15,9 +15,7 @@ import {
     ServiceProvider,
     RepositoryLocationContextService,
     MapperProvider,
-    RepositoryListMapper,
-    SecurityContextService,
-    RestrictedPages
+    RepositoryListMapper
 } from "@ontotext/workbench-api";
 
 const modules = [

--- a/packages/legacy-workbench/src/js/angular/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/plugin.js
@@ -37,7 +37,7 @@ PluginRegistry.add('main.menu', {
                 labelKey: 'menu.lab.label',
                 href: '#',
                 order: 6,
-                role: 'IS_AUTHENTICATED_FULLY',
+                role: 'ROLE_USER',
                 icon: "fa fa-flask",
                 guideSelector: 'menu-lab',
                 testSelector: 'menu-lab',

--- a/packages/legacy-workbench/src/js/angular/settings/app.js
+++ b/packages/legacy-workbench/src/js/angular/settings/app.js
@@ -23,7 +23,7 @@ angular.module('graphdb.framework.settings', [
 config.$inject = ['$httpProvider', '$routeProvider'];
 
 function config($httpProvider) {
-    $httpProvider.interceptors.push('$unauthorizedInterceptor');
+    // $httpProvider.interceptors.push('$unauthorizedInterceptor');
     $httpProvider.interceptors.push('$authenticationInterceptor');
 }
 

--- a/packages/legacy-workbench/src/js/angular/settings/app.js
+++ b/packages/legacy-workbench/src/js/angular/settings/app.js
@@ -23,7 +23,6 @@ angular.module('graphdb.framework.settings', [
 config.$inject = ['$httpProvider', '$routeProvider'];
 
 function config($httpProvider) {
-    // $httpProvider.interceptors.push('$unauthorizedInterceptor');
     $httpProvider.interceptors.push('$authenticationInterceptor');
 }
 

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -108,7 +108,8 @@ export class OntoLayout {
 
         {this.hasPermission ? (
           <div class='main-slot-wrapper'>
-            <slot name="main"></slot></div>
+            <slot name="main"></slot>
+          </div>
         ) : (
           <onto-permission-banner></onto-permission-banner>
         )}
@@ -202,8 +203,7 @@ export class OntoLayout {
   private setPermission(permissions: RestrictedPages) {
     if (permissions) {
       const path = getPathName();
-      // Delegate to legacy, when a user has authority in order to show the authority banner, which is not migrated yet
-      this.hasPermission = !permissions.isRestricted(path) ? true : !this.authenticationService.hasAuthority();
+      this.hasPermission = !permissions.isRestricted(path);
     } else {
       // If the permissions are undefined, the user can access the url
       this.hasPermission = true;

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -189,7 +189,6 @@ export class OntoLayout {
       ServiceProvider.get(EventService).subscribe(EventName.LOGOUT, () => {
         this.setNavbarItemVisibility();
         this.updateVisibility();
-        this.securityContextService.updateRestrictedPages(new RestrictedPages());
       })
     );
     this.subscriptions.add(


### PR DESCRIPTION
## What
Centralize page permissions and base them off of menu declarations

## Why
Page permissions were set based on 403 responses which were not always available on pages where the user does not have permission to view.

How
- added a function to set permissions based on menu item role for each defined route
- removed unauthorized interceptor, because it is no longer needed
- removed `$rootScope.deniedPermissions` and used `SecurityContextService` as single point of truth about permissions
- changed conditions in legacy template to allow the application to show `coreError` directive
- based showing the permission banner in layout on the `SecurityContextService` permissions

## Testing


## Screenshots
* Admin user with no restrictions
<img width="479" height="368" alt="image" src="https://github.com/user-attachments/assets/51366011-939d-495b-97ac-a9c362537c05" />

* Repo manager with some restrictions
<img width="479" height="368" alt="image" src="https://github.com/user-attachments/assets/9ba1b352-d8d7-4f20-b080-3ce91acf04b7" />

* User with more restrictions
<img width="479" height="368" alt="image" src="https://github.com/user-attachments/assets/48256708-e151-4443-80d4-cff76ef86892" />

* Free access user
<img width="479" height="368" alt="image" src="https://github.com/user-attachments/assets/7e8c2b7d-b79c-4f0a-a4ec-3fa0469e1d5b" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
