### PR TITLE
GDB-12840 - Prevent negative and non-number values in Context size field TTYG

### DIFF
--- a/packages/legacy-workbench/src/css/ttyg/agent-settings-modal.css
+++ b/packages/legacy-workbench/src/css/ttyg/agent-settings-modal.css
@@ -46,6 +46,18 @@
     padding-right: 3.5em;
 }
 
+/* Hide number arrows in Chrome, Edge, Safari */
+.agent-settings-modal .agent-settings-form .context-size .input-with-unit input::-webkit-outer-spin-button,
+.agent-settings-modal .agent-settings-form .context-size .input-with-unit input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+/* Hide number arrows in Firefox */
+.agent-settings-modal .agent-settings-form .context-size .input-with-unit input[type=number] {
+    -moz-appearance: textfield;
+}
+
 .agent-settings-modal .agent-settings-form .context-size .input-with-unit .token-unit-label {
     position: absolute;
     right: 0.5em;

--- a/packages/legacy-workbench/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/packages/legacy-workbench/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -72,8 +72,9 @@
                         <i class="fa fa-arrow-rotate-left"></i>
                     </button>
                     <div class="input-with-unit">
-                        <input type="text" id="contextSize" name="contextSize"
+                        <input type="number" id="contextSize" name="contextSize"
                                class="form-control"
+                               min="1"
                                ng-model="agentFormModel.contextSize"
                                required autocomplete="off">
                         <span class="token-unit-label">


### PR DESCRIPTION
## What
The user will only be able to type positive numbers bigger than 0 in the TTYG Context size field.

## Why
The field allowed values which the backend couldn't handle.

## How
I change the input type and the minimum allowed value.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
