### PR TITLE
GDB-12728: The user guide crashes when clicking the Previous button

### DIFF
--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/create-repository/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/create-repository/plugin.js
@@ -30,6 +30,7 @@ PluginRegistry.add('guide.step', [
                         class: 'create-gdb-repository-guide-dialog',
                         url: 'repository/create',
                         elementSelector: GuideUtils.getGuideElementSelector('createGraphDBRepository'),
+                        disablePreviousFlow: false,
                         onNextClick: GuideUtils.clickOnGuideElement('createGraphDBRepository')
                     }, options)
                 }, {
@@ -39,6 +40,7 @@ PluginRegistry.add('guide.step', [
                         class: 'gdb-repository-id-input-guide-dialog',
                         url: 'repository/create/graphdb',
                         elementSelector: repositoryIdInputSelector,
+                        disablePreviousFlow: false,
                         onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(repositoryIdInputSelector, repositoryId))
                     }, options)
                 }
@@ -52,6 +54,7 @@ PluginRegistry.add('guide.step', [
                         url: 'repository/create/graphdb',
                         class: 'gdb-repository-ruleset-select-guide-dialog',
                         elementSelector: GuideUtils.getGuideElementSelector('graphDBRepositoryRulesetSelect'),
+                        disablePreviousFlow: false,
                         show: () => () => {
                             GuideUtils.validateTextInput(repositoryIdInputSelector, repositoryId);
                         }
@@ -68,6 +71,7 @@ PluginRegistry.add('guide.step', [
                                    extraContent: 'guide.step_plugin.create_repository.enable-fts.extra-content',
                                    extraContentClass: 'alert alert-help text-left',
                                    elementSelector: GuideUtils.getGuideElementSelector('enable-fts-search'),
+                                   disablePreviousFlow: false,
                                    onNextValidate: () => Promise.resolve(GuideUtils.isChecked(GuideUtils.getGuideElementSelector('enable-fts-search', 'input')))
                                }, options)
                            });
@@ -79,6 +83,7 @@ PluginRegistry.add('guide.step', [
                     url: 'repository/create/graphdb',
                     class: 'create-repository-button-guide-dialog',
                     elementSelector: GuideUtils.getGuideElementSelector('graphDBRepositoryCrateButton'),
+                    disablePreviousFlow: false,
                     show: () => () => {
                         GuideUtils.validateTextInput(repositoryIdInputSelector, repositoryId);
                     },

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/create-similarity-index/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/create-similarity-index/plugin.js
@@ -19,6 +19,7 @@ PluginRegistry.add('guide.step', [
                         class: 'similarity-index-guide-dialog',
                         url: 'similarity',
                         elementSelector: GuideUtils.getGuideElementSelector('create-similarity-index'),
+                        disableNextFlow: true,
                         onNextClick: () => {
                         }
                     }, options)
@@ -38,6 +39,8 @@ PluginRegistry.add('guide.step', [
                         class: 'create-similarity-index-guide-dialog',
                         url: 'similarity/index/create',
                         elementSelector: GuideUtils.getGuideElementSelector('create-similarity-index-btn'),
+                        disablePreviousFlow: false,
+                        disableNextFlow: true,
                         onNextClick: () => {
                         }
                     }, options)

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/execute-sparql-query/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/execute-sparql-query/plugin.js
@@ -22,7 +22,6 @@ PluginRegistry.add('guide.step', [
                         ...(options.mainAction ? {} : {title: SPARQL_EDITOR_DEFAULT_TITLE}),
                         url: 'sparql',
                         elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_VISUAL_BUTTON_SELECTOR,
-                        disablePreviousFlow: true,
                         class: 'visual-sparql-results-button-guide-dialog',
                         scrollToHandler: GuideUtils.scrollToTop,
                         onNextClick: () => GuideUtils.clickOnElement(GuideUtils.CSS_SELECTORS.SPARQL_VISUAL_BUTTON_SELECTOR)(),
@@ -47,7 +46,6 @@ PluginRegistry.add('guide.step', [
                         content: 'guide.step_plugin.execute-sparql-query.run-sparql-query.content',
                         url: 'sparql',
                         elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_RUN_BUTTON_SELECTOR,
-                        disablePreviousFlow: true,
                         class: 'yasgui-run-button-guide-dialog',
                         onNextClick: (guide) => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(SPARQL_DIRECTIVE_SELECTOR)
                             .then((yasgui) => {
@@ -91,7 +89,6 @@ PluginRegistry.add('guide.step', [
                         url: 'sparql',
                         elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
                         class: 'yasgui-query-editor-guide-dialog',
-                        disablePreviousFlow: true,
                         queryAsHtmlCodeElement: '<div class="shepherd-code">' + code.outerHTML + copy.outerHTML + '</div>',
                         beforeShowPromise: () => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(SPARQL_DIRECTIVE_SELECTOR)
                             .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
@@ -185,7 +182,6 @@ PluginRegistry.add('guide.step', [
                     options: {
                         query,
                         queryExtraContent: queryDef.queryExtraContent,
-                        disablePreviousFlow: false,
                         beforeShowPromise: () => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(SPARQL_DIRECTIVE_SELECTOR)
                             .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
                             .then(() => GuideUtils.deferredShow(500)())
@@ -231,7 +227,6 @@ PluginRegistry.add('guide.step', [
                 steps.push({
                     guideBlockName: 'sparql-editor-run-button',
                     options: {
-                        disablePreviousFlow: false,
                         initPreviousStep: (services, stepId) => {
                             const previousStep = services.ShepherdService.getPreviousStepFromHistory(stepId);
                             return previousStep.options.initPreviousStep(services, previousStep.options.id)

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/ask-ttyg-agent/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/ask-ttyg-agent/plugin.js
@@ -38,7 +38,6 @@ PluginRegistry.add('guide.step', [
                             // Remove the "keydown" listener of element. It is important when step is hidden.
                             $(elementSelector).off('keydown');
                         },
-                        disablePreviousFlow: true,
                         disableNextFlow: true
                     }, options)
                 },
@@ -74,7 +73,6 @@ PluginRegistry.add('guide.step', [
                             class: 'explain-answer-guide-dialog',
                             url: 'ttyg',
                             elementSelector,
-                            disablePreviousFlow: true,
                             disableNextFlow: true
                         }, options)
                     },
@@ -110,7 +108,6 @@ PluginRegistry.add('guide.step', [
                             content: 'guide.step_plugin.ask-ttyg-agent.explore-sparql',
                             class: 'explore-sparql-guide-dialog',
                             url: 'ttyg',
-                            disablePreviousFlow: true,
                             disableNextFlow: true,
                             elementSelector
                         }, options)
@@ -139,8 +136,7 @@ PluginRegistry.add('guide.step', [
                                         // Using a timeout because the library executes logic to show the step in a then clause which causes current and next steps to show
                                         setTimeout(() => guide.show(stepId + 3))
                                     })
-                            },
-                            disablePreviousFlow: true
+                            }
                         }, options)
                     },
                     {

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/configure-agent/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/configure-agent/plugin.js
@@ -10,7 +10,10 @@ PluginRegistry.add('guide.step', [
                 return methods.map((method) => {
                     return {
                         guideBlockName: method.guideBlockName,
-                        options: angular.extend({}, method.options)
+                        options: {
+                            disablePreviousFlow: false,
+                            ...method.options
+                        }
                     };
                 });
             };
@@ -37,7 +40,7 @@ PluginRegistry.add('guide.step', [
                         content: 'guide.step_plugin.configure-agent.name-input',
                         class: 'input-agent-name-guide-dialog',
                         url: 'ttyg',
-                        disablePreviousFlow: true,
+                        disablePreviousFlow: false,
                         beforeShowPromise: () => GuideUtils.waitFor(GuideUtils.getGuideElementSelector('agent-form'), 5)
                             .catch((error) => {
                                 services.toastr.error(services.$translate.instant('guide.unexpected.error.message'));
@@ -61,6 +64,7 @@ PluginRegistry.add('guide.step', [
                         class: 'input-model-guide-dialog',
                         url: 'ttyg',
                         elementSelector: GuideUtils.getGuideElementSelector('model'),
+                        disablePreviousFlow: false,
                         onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(GuideUtils.getGuideElementSelector('model'), options.model, false))
                     }, options)
                 })
@@ -74,11 +78,13 @@ PluginRegistry.add('guide.step', [
                         class: 'input-user-instructions-guide-dialog',
                         url: 'ttyg',
                         elementSelector: GuideUtils.getGuideElementSelector('user-instructions'),
+                        disablePreviousFlow: false,
                         onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(GuideUtils.getGuideElementSelector('user-instructions'), options.userInstructions, false))
                     }, options)
                 })
             }
-
+            // Removes the "Previous" button from the first method control step, because there is no previous step in the form.
+            steps[1].options.disablePreviousFlow = true;
             return steps;
         }
     }

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/fts-search-method/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/fts-search-method/plugin.js
@@ -29,8 +29,7 @@ PluginRegistry.add('guide.step', [
                     options: angular.extend({}, {
                         content: 'guide.step_plugin.fts-search-method.content',
                         url: 'ttyg',
-                        class: 'info-fts-search-guide-dialog',
-                        disablePreviousFlow: true
+                        class: 'info-fts-search-guide-dialog'
                     }, options)
                 },
                 {

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/similarity-search-method/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/similarity-search-method/plugin.js
@@ -29,8 +29,7 @@ PluginRegistry.add('guide.step', [
                     options: angular.extend({}, {
                         content: 'guide.step_plugin.similarity-search-method.content',
                         url: 'ttyg',
-                        class: 'info-similarity-search-guide-dialog',
-                        disablePreviousFlow: true
+                        class: 'info-similarity-search-guide-dialog'
                     }, options)
                 },
                 {

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/sparql-search-method/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/sparql-search-method/plugin.js
@@ -29,8 +29,7 @@ PluginRegistry.add('guide.step', [
                     options: angular.extend({}, {
                         content: `guide.step_plugin.sparql-search-method.content`,
                         class: 'info-sparql-search-guide-dialog',
-                        url: 'ttyg',
-                        disablePreviousFlow: true
+                        url: 'ttyg'
                     }, options)
                 },
                 {

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/create-ttyg-agent/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/create-ttyg-agent/plugin.js
@@ -45,6 +45,7 @@ PluginRegistry.add('guide.step', [
                         class: 'save-agent-guide-dialog',
                         url: 'ttyg',
                         elementSelector: GuideUtils.getGuideElementSelector('save-agent-settings'),
+                        disablePreviousFlow: false,
                         disableNextFlow: true
                     }, options)
                 },

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/edit-ttyg-agent/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/edit-ttyg-agent/plugin.js
@@ -54,7 +54,6 @@ PluginRegistry.add('guide.step', [
                         class: 'edit-agent-btn-guide-dialog',
                         url: 'ttyg',
                         elementSelector: GuideUtils.getGuideElementSelector('edit-current-agent'),
-                        disablePreviousFlow: true,
                         disableNextFlow: true
                     }, options)
                 },
@@ -69,6 +68,7 @@ PluginRegistry.add('guide.step', [
                         class: 'save-agent-guide-dialog',
                         url: 'ttyg',
                         elementSelector: GuideUtils.getGuideElementSelector('save-agent-settings'),
+                        disablePreviousFlow: false,
                         disableNextFlow: true
                     }, options)
                 },

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/select-ttyg-agent/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/select-ttyg-agent/plugin.js
@@ -53,7 +53,6 @@ PluginRegistry.add('guide.step', [
                                 }
                             }
                         },
-                        disablePreviousFlow: true,
                         disableNextFlow: true,
                         hide: () => () => {
                             options.observer.disconnect();
@@ -75,8 +74,7 @@ PluginRegistry.add('guide.step', [
                                     // Using a timeout because the library executes logic to show the step in a then clause which causes current and next steps to show
                                     setTimeout(() => guide.show(stepId + 2))
                                 })
-                        },
-                        disablePreviousFlow: true
+                        }
                     }, options)
                 },
                 {

--- a/packages/legacy-workbench/src/js/angular/guides/steps/core/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/core/plugin.js
@@ -8,6 +8,7 @@ const BASIC_STEP = {
     maxWaitTime: 3,
     canBePaused: true,
     onNextClick: undefined,
+    disablePreviousFlow: true,
     onNextValidate: () => Promise.resolve(true),
     onPreviousClick: undefined,
     skipPoint: false,
@@ -121,7 +122,6 @@ PluginRegistry.add('guide.step', [
             };
             return angular.extend({}, BASIC_STEP, {
                 initPreviousStep: services.GuideUtils.defaultInitPreviousStep,
-                disablePreviousFlow: true,
                 onNextValidate: () => Promise.resolve(!services.GuideUtils.isVisible(options.elementSelectorToWait))
             }, options, notOverridable);
         }
@@ -134,7 +134,6 @@ PluginRegistry.add('guide.step', [
             };
             return angular.extend({}, BASIC_STEP, {
                 initPreviousStep: services.GuideUtils.defaultInitPreviousStep,
-                disablePreviousFlow: true,
                 onNextValidate: () => Promise.resolve(services.GuideUtils.isVisible(options.elementSelectorToWait))
             }, options, notOverridable);
         }


### PR DESCRIPTION
## What
The user guide crashes when clicking the "Previous" button on certain steps.

## Why
The previous flow is too complex because showing a previous step requires restoring the application's state before the step is displayed. This is not a trivial task, as the required state may depend not only on the immediately previous step, but also on earlier steps in the flow. If the "Previous" button is clicked and the necessary state can't be restored, the guide crashes, the element where the dialog should appear may no longer exist.

## How
There is a flag that controls whether the "Previous" button is shown. The default behavior was to always show the button, this has now been changed to hide it by default.

The functionality is still available and can be enabled where it's safe and useful, for example, in form steps where the user may want to go back and change an input field.

After this change, all steps will no longer show the "Previous" button by default, except for the "create-repository" steps.

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
