### PR TITLE
(cherry-pick) GDB-12692 - Introduce copy Agent functionality and tests

### DIFF
--- a/src/css/ttyg/agent-settings-modal.css
+++ b/src/css/ttyg/agent-settings-modal.css
@@ -23,6 +23,15 @@
     font-weight: var(--field-label-weight);
 }
 
+.agent-settings-modal .agent-settings-form .external-config-btn {
+    all: unset;
+    cursor: pointer;
+    color: inherit;
+    font: inherit;
+    padding: 0 8px;
+    margin: 8px 0 24px 8px;
+}
+
 .agent-settings-modal .agent-settings-form .llm-model .page-info-icon .icon-info {
     vertical-align: baseline;
     font-size: 1rem;

--- a/src/css/ttyg/external-integration-configuration-modal.css
+++ b/src/css/ttyg/external-integration-configuration-modal.css
@@ -1,0 +1,23 @@
+.modal-body .form-control {
+    background-color: #FFFFFF;
+}
+
+.modal-body .form-horizontal {
+    margin-top: 16px;
+}
+
+form.form-horizontal .form-group label.control-label[for="agentId"],
+form.form-horizontal .form-group label.control-label[for="queryMethods"],
+form.form-horizontal .form-group label.control-label[for="difyExtension"] {
+    font-weight: 500;
+}
+
+.input-group-addon copy-to-clipboard {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+copy-to-clipboard .custom-link-icon {
+    color: var(--primary-color-dark);
+}

--- a/src/i18n/locale-en.json
+++ b/src/i18n/locale-en.json
@@ -457,6 +457,10 @@
                         "placeholder": "Enter а user friendly name",
                         "tooltip": "A descriptive name that helps you identify this agent."
                     },
+                    "external_config": {
+                        "label": "External integration configuration",
+                        "tooltip": "Show URLs for the agent’s external access and integration"
+                    },
                     "repository": {
                         "label": "Repository ID",
                         "tooltip": "The ID of the repository that will be used to retrieve information from GraphDB. Ontop and FedX repositories are not supported."
@@ -697,6 +701,17 @@
                     }
                 }
             },
+            "external_integration_config_modal": {
+                "title": "Agent endpoints and external access",
+                "label": "Access {{agentName}} query methods via OpenAPI endpoints",
+                "agent_id_label": "Agent ID",
+                "query_methods": "Query methods via OpenAPI endpoints",
+                "dify_extension": "Dify extension",
+                "copy_tooltip": "Copy",
+                "agent_copied_tooltip": "Agent ID copied",
+                "openAPI_copied_tooltip": "OpenAPI endpoints link copied",
+                "dify_extension_copied_tooltip": "Dify extension link copied"
+            },
             "agent_select_menu": {
                 "no_selection_label": "Select an agent",
                 "deleted_agent": "[deleted agent]",
@@ -721,6 +736,7 @@
                     "tooltip": "Edit agent settings",
                     "tooltip_disabled": "You do not have permission to edit the agent"
                 },
+                "external_integration": "External integration",
                 "clone_agent": {
                     "label": "Clone",
                     "tooltip": "Clone Agent"

--- a/src/i18n/locale-fr.json
+++ b/src/i18n/locale-fr.json
@@ -456,6 +456,10 @@
                         "placeholder": "Entrez un nom convivial",
                         "tooltip": "Un nom descriptif qui vous aide à identifier cet agent."
                     },
+                    "external_config": {
+                        "label": "Configuration de l'intégration externe",
+                        "tooltip": "Afficher les URL pour l'accès externe et l'intégration de l'agent"
+                    },
                     "repository": {
                         "label": "ID du dépôt",
                         "tooltip": "L'ID du référentiel qui sera utilisé pour récupérer les informations de GraphDB. Les référentiels Ontop et FedX ne sont pas pris en charge."
@@ -696,6 +700,17 @@
                     }
                 }
             },
+            "external_integration_config_modal": {
+                "title": "Points de terminaison des agents et accès externes",
+                "label": "Accéder aux méthodes de requête {{agentName}} via les points de terminaison OpenAPI",
+                "agent_id_label": "ID d'agent",
+                "query_methods": "Méthodes de requête via les points de terminaison OpenAPI",
+                "dify_extension": "Dify l'extension",
+                "copy_tooltip": "Copie",
+                "agent_copied_tooltip": "ID d'agent copié",
+                "openAPI_copied_tooltip": "Lien vers les points de terminaison OpenAPI copié",
+                "dify_extension_copied_tooltip": "Lien d'extension Dify copié"
+            },
             "agent_select_menu": {
                 "no_selection_label": "Sélectionner un agent",
                 "deleted_agent": "[agent supprimé]",
@@ -720,6 +735,7 @@
                     "tooltip": "Paramètres de l'agent",
                     "tooltip_disabled": "Vous n'avez pas l'autorisation de modifier l'agent."
                 },
+                "external_integration": "Intégration externe",
                 "clone_agent": {
                     "label": "Cloner",
                     "tooltip": "Cloner l'agent"

--- a/src/js/angular/core/directives/copy-to-clipboard/copy-to-clipboard.directive.js
+++ b/src/js/angular/core/directives/copy-to-clipboard/copy-to-clipboard.directive.js
@@ -82,6 +82,10 @@ function copyToClipboard($translate, toastr) {
                     opacity: 1;
                 }
 
+                .custom-link-icon.visible {
+                    opacity: 1 !important;
+                }
+
                 .custom-tooltip-popup {
                     font-family: Arial, sans-serif;
                     position: absolute;
@@ -112,7 +116,7 @@ function copyToClipboard($translate, toastr) {
                 class="btn btn-link btn-sm copy-btn"
                 ng-if="customTooltipStyle"
                 ng-click="copyToClipboard($event)">
-                <i class="fa fa-clone custom-link-icon" aria-hidden="true"></i>
+                <i class="fa fa-clone custom-link-icon" aria-hidden="true" ng-class="{'visible': alwaysShowIcon === 'true'}"></i>
             </button>
         `,
         restrict: 'E',
@@ -121,7 +125,8 @@ function copyToClipboard($translate, toastr) {
             textToCopy: '@',
             customTooltipStyle: '@?',
             targetSelector: '@?',
-            customTooltipText: '@?'
+            customTooltipText: '@?',
+            successMessage: '@?'
         },
         link: function ($scope, element) {
             $scope.copyToClipboard = function() {
@@ -149,7 +154,8 @@ function copyToClipboard($translate, toastr) {
                     if ($scope.customTooltipStyle) {
                         showCustomTooltip();
                     } else {
-                        toastr.success($translate.instant('common.messages.copied_to_clipboard'));
+                        const message = $scope.successMessage || $translate.instant('common.messages.copied_to_clipboard');
+                        toastr.success(message);
                     }
                 }
 

--- a/src/js/angular/rest/locations.rest.service.js
+++ b/src/js/angular/rest/locations.rest.service.js
@@ -7,6 +7,7 @@ LocationsRestService.$inject = ['$http'];
 const LOCATIONS_ENDPOINT = 'rest/locations';
 const ACTIVE_LOCATION_ENDPOINT = `${LOCATIONS_ENDPOINT}/active`;
 const RPC_ADDRESS_ENDPOINT = 'rest/info/rpc-address';
+const EXTERNAL_URL_ENDPOINT = 'rest/info/external-url';
 
 function LocationsRestService($http) {
 
@@ -17,7 +18,8 @@ function LocationsRestService($http) {
         deleteLocation,
         getActiveLocation,
         setDefaultRepository,
-        getLocationRpcAddress
+        getLocationRpcAddress,
+        getExternalUrl
     };
 
     function getLocations(abortRequestPromise) {
@@ -60,5 +62,13 @@ function LocationsRestService($http) {
                 location
             }
         });
+    }
+
+    /**
+     * Calls the backend to fetch the external URL for Copy Agent links.
+     * @returns {Promise<string>} the external URL
+     */
+    function getExternalUrl() {
+        return $http.get(EXTERNAL_URL_ENDPOINT);
     }
 }

--- a/src/js/angular/rest/ttyg.rest.service.js
+++ b/src/js/angular/rest/ttyg.rest.service.js
@@ -9,7 +9,6 @@ TTYGRestService.$inject = ['$http'];
 const CONVERSATIONS_ENDPOINT = 'rest/chat/conversations';
 const AGENTS_ENDPOINT = 'rest/chat/agents';
 const EXPLAIN_RESPONSE_ENDPOINT = `${CONVERSATIONS_ENDPOINT}/explain`;
-const PROVIDER_ENDPOINT = 'rest/ttyg/provider';
 
 const DEVELOPMENT = false;
 
@@ -209,6 +208,7 @@ function TTYGRestService($http) {
         }
         return $http.post(`${AGENTS_ENDPOINT}/explain`, data);
     };
+
 
     return {
         getConversation,

--- a/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -5,6 +5,7 @@ import 'angular/core/services/connectors.service';
 import 'angular/core/services/ttyg.service';
 import 'angular/rest/repositories.rest.service';
 import 'angular/ttyg/controllers/agent-instructions-explain-modal.controller';
+import 'angular/ttyg/services/externalIntegrationModal.service';
 import {REPOSITORY_PARAMS} from "../../models/repository/repository";
 import {TTYGEventName} from "../services/ttyg-context.service";
 import {AGENT_OPERATION, TTYG_ERROR_MSG_LENGTH} from "../services/constants";
@@ -17,6 +18,7 @@ angular
         'graphdb.framework.core.services.connectors',
         'graphdb.framework.rest.repositories.service',
         'graphdb.framework.ttyg.controllers.agent-instructions-explain-modal',
+        'graphdb.framework.ttyg.services.externalIntegrationModal',
         'ngTagsInput'
     ])
     .constant('ExtractionMethodTemplates', {
@@ -43,6 +45,7 @@ AgentSettingsModalController.$inject = [
     'ExtractionMethodTemplates',
     'AutocompleteService',
     'AutocompleteRestService',
+    'ExternalIntegrationModalService',
     'productInfo'];
 
 function AgentSettingsModalController(
@@ -63,6 +66,7 @@ function AgentSettingsModalController(
     ExtractionMethodTemplates,
     AutocompleteService,
     AutocompleteRestService,
+    ExternalIntegrationModalService,
     productInfo) {
 
     // =========================
@@ -349,6 +353,16 @@ function AgentSettingsModalController(
             $scope.extractionMethodLoaderFlags[ExtractionMethod.FTS_SEARCH] = false;
             $scope.agentSettingsForm.$setValidity('FTSDisabled', $scope.ftsEnabled);
         });
+    };
+
+    /**
+     * Opens a modal to copy the external integration for the currently edited agent.
+     *
+     * @function
+     */
+    $scope.openExternalIntegrationConfig = () => {
+        const agent = $scope.agentFormModel;
+        ExternalIntegrationModalService.open(agent);
     };
 
     /**

--- a/src/js/angular/ttyg/controllers/external-integration-configuration-modal.controller.js
+++ b/src/js/angular/ttyg/controllers/external-integration-configuration-modal.controller.js
@@ -1,0 +1,38 @@
+angular
+    .module('graphdb.framework.ttyg.controllers.external-integration-configuration-modal', [])
+    .controller('ExternalIntegrationConfigurationModalController', ExternalIntegrationConfigurationModalController);
+
+ExternalIntegrationConfigurationModalController.$inject = [
+    '$scope',
+    '$uibModalInstance',
+    'ModalService',
+    '$translate',
+    'dialogModel'
+];
+
+function ExternalIntegrationConfigurationModalController($scope, $uibModalInstance, ModalService, $translate, dialogModel) {
+    // =========================
+    // Public variables
+    // =========================
+
+    $scope.externalIntegrationConfiguration = dialogModel.externalIntegrationConfiguration;
+    $scope.difyExtension = dialogModel.difyExtensionUrl;
+    $scope.queryMethods = dialogModel.queryMethodsUrl;
+    $scope.agentId = dialogModel.agentId;
+    $scope.agentName = dialogModel.agentName;
+
+    // =========================
+    // Public functions
+    // =========================
+
+    /**
+     * Closes the modal when the user clicks the close button.
+     */
+    $scope.close = () => {
+        $uibModalInstance.dismiss({});
+    };
+
+    $scope.onCloseExternalIntegrationConfigurationModal = () => {
+        $uibModalInstance.dismiss({});
+    };
+}

--- a/src/js/angular/ttyg/directives/agent-list.directive.js
+++ b/src/js/angular/ttyg/directives/agent-list.directive.js
@@ -1,16 +1,18 @@
 import {decodeHTML} from "../../../../app";
 import {TTYGEventName} from "../services/ttyg-context.service";
+import 'angular/ttyg/services/externalIntegrationModal.service';
 
 const modules = [
+    'graphdb.framework.ttyg.services.externalIntegrationModal'
 ];
 
 angular
     .module('graphdb.framework.ttyg.directives.agent-list', modules)
     .directive('agentList', AgentListComponent);
 
-AgentListComponent.$inject = ['TTYGContextService', 'ModalService', '$translate'];
+AgentListComponent.$inject = ['TTYGContextService', 'ModalService', '$translate', '$uibModal', 'ExternalIntegrationModalService'];
 
-function AgentListComponent(TTYGContextService, ModalService, $translate) {
+function AgentListComponent(TTYGContextService, ModalService, $translate, $uibModal, ExternalIntegrationModalService) {
     return {
         restrict: 'E',
         templateUrl: 'js/angular/ttyg/templates/agent-list.html',
@@ -56,6 +58,18 @@ function AgentListComponent(TTYGContextService, ModalService, $translate) {
              */
             $scope.onEditAgent = (agent) => {
                 TTYGContextService.emit(TTYGEventName.EDIT_AGENT, agent);
+            };
+
+            /**
+             * Opens a modal to copy the external integration for a given agent.
+             *
+             * Used when the agent is already provided.
+             *
+             * @function
+             * @param {AgentModel} agent - The agent for which to configure the integration.
+             */
+            $scope.onExternalIntegration = (agent) => {
+                ExternalIntegrationModalService.open(agent);
             };
 
             /**

--- a/src/js/angular/ttyg/services/externalIntegrationModal.service.js
+++ b/src/js/angular/ttyg/services/externalIntegrationModal.service.js
@@ -1,0 +1,49 @@
+import 'angular/ttyg/controllers/external-integration-configuration-modal.controller';
+import {TTYG_ERROR_MSG_LENGTH} from "./constants";
+
+angular
+    .module('graphdb.framework.ttyg.services.externalIntegrationModal',
+        ['graphdb.framework.ttyg.controllers.external-integration-configuration-modal'])
+    .factory('ExternalIntegrationModalService', ExternalIntegrationModalService)
+
+ExternalIntegrationModalService.$inject = ['$uibModal', 'LocationsRestService', 'toastr'];
+
+function ExternalIntegrationModalService($uibModal, LocationsRestService, toastr) {
+    function buildDialogModel(agent, baseUrl) {
+        return {
+            agentName: agent.name,
+            agentId: agent.id,
+            queryMethodsUrl: `${baseUrl}/rest/llm/tool/ttyg/${agent.id}`,
+            difyExtensionUrl: `${baseUrl}/rest/llm/ttyg/${agent.id}/dify`
+        };
+    }
+
+    function open(agent) {
+        return LocationsRestService.getExternalUrl()
+            .then((response) => {
+                const dialogModel = buildDialogModel(agent, response.data);
+
+                return $uibModal.open({
+                    templateUrl: 'js/angular/ttyg/templates/modal/external-integration-configuration-modal.html',
+                    controller: 'ExternalIntegrationConfigurationModalController',
+                    windowClass: 'external-integration-configuration-modal',
+                    backdrop: 'static',
+                    resolve: {
+                        dialogModel: () => dialogModel
+                    }
+                }).result
+                    .then(() => {
+                        // Modal was closed with success - do nothing
+                    })
+                    .catch(() => {
+                        // Modal was dismissed — do nothing
+                    });
+            })
+            .catch((error) => {
+                // Catches API failure
+                toastr.error(getError(error, 0, TTYG_ERROR_MSG_LENGTH));
+            });
+    }
+
+    return {open};
+}

--- a/src/js/angular/ttyg/templates/agent-list.html
+++ b/src/js/angular/ttyg/templates/agent-list.html
@@ -52,6 +52,13 @@
                             <span>{{'ttyg.agent.btn.edit_agent.label' | translate}}</span>
                         </button>
                         <button ng-if="agent.isCompatible"
+                                class="dropdown-item ext-integration-agent-btn"
+                                type="button"
+                                ng-click="onExternalIntegration(agent)">
+                            <i class="fa-regular fa-plug-circle-plus"></i>
+                            <span>{{'ttyg.agent.btn.external_integration' | translate}}</span>
+                        </button>
+                        <button ng-if="agent.isCompatible"
                                 class="dropdown-item clone-agent-btn"
                                 type="button"
                                 ng-click="onCloneAgent(agent)">

--- a/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -23,6 +23,15 @@
                 {{'required.field' | translate}}
             </div>
         </div>
+        <div>
+            <button class="external-config-btn" ng-click="openExternalIntegrationConfig()"
+                    ng-if="operation !== AGENT_OPERATION.CREATE"
+                    uib-popover="{{'ttyg.agent.create_agent_modal.form.external_config.tooltip' | translate}}"
+                    popover-trigger="mouseenter">
+                <i class="fa-regular fa-plug-circle-plus"></i>
+                {{'ttyg.agent.create_agent_modal.form.external_config.label' | translate}}
+            </button>
+        </div>
         <div class="form-group repository-id">
             <label for="repositoryId"
                    uib-popover="{{'ttyg.agent.create_agent_modal.form.repository.tooltip' | translate}}"

--- a/src/js/angular/ttyg/templates/modal/external-integration-configuration-modal.html
+++ b/src/js/angular/ttyg/templates/modal/external-integration-configuration-modal.html
@@ -1,0 +1,80 @@
+<link href="css/ttyg/external-integration-configuration-modal.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+
+<div class="modal-header">
+  <button type="button" class="close" ng-click="close()"></button>
+  <h4 class="modal-title">{{'ttyg.agent.external_integration_config_modal.title' | translate}}</h4>
+</div>
+
+<div class="modal-body">
+  <h6 class="modal-title">
+    {{ 'ttyg.agent.external_integration_config_modal.label' | translate:{agentName: agentName} }}
+  </h6>
+
+  <form class="form-horizontal">
+    <!-- Agent ID -->
+    <div class="form-group">
+      <label for="agentId" class="control-label">
+        {{ 'ttyg.agent.external_integration_config_modal.agent_id_label' | translate }}
+      </label>
+      <div class="input-group">
+        <input
+            type="text"
+            class="form-control"
+            id="agentId"
+            ng-model="agentId"
+            readonly>
+        <span class="input-group-addon"
+              gdb-tooltip="{{ 'ttyg.agent.external_integration_config_modal.copy_tooltip' | translate }}">
+          <copy-to-clipboard
+              text-to-copy="{{agentId}}"
+              success-message="{{ 'ttyg.agent.external_integration_config_modal.agent_copied_tooltip' | translate }}">
+          </copy-to-clipboard>
+        </span>
+      </div>
+    </div>
+
+    <!-- Query Methods -->
+    <div class="form-group">
+      <label for="queryMethods" class="control-label">
+        {{ 'ttyg.agent.external_integration_config_modal.query_methods' | translate }}
+      </label>
+      <div class="input-group">
+        <input
+            type="text"
+            class="form-control"
+            id="queryMethods"
+            ng-model="queryMethods"
+            readonly>
+        <span class="input-group-addon"
+              gdb-tooltip="{{ 'ttyg.agent.external_integration_config_modal.copy_tooltip' | translate }}">
+          <copy-to-clipboard
+              text-to-copy="{{queryMethods}}"
+              success-message="{{ 'ttyg.agent.external_integration_config_modal.openAPI_copied_tooltip' | translate }}">
+          </copy-to-clipboard>
+        </span>
+      </div>
+    </div>
+
+    <!-- Dify Extension -->
+    <div class="form-group">
+      <label for="difyExtension" class="control-label">
+        {{ 'ttyg.agent.external_integration_config_modal.dify_extension' | translate }}
+      </label>
+      <div class="input-group">
+        <input
+            type="text"
+            class="form-control"
+            id="difyExtension"
+            ng-model="difyExtension"
+            readonly>
+        <span class="input-group-addon"
+              gdb-tooltip="{{ 'ttyg.agent.external_integration_config_modal.copy_tooltip' | translate }}">
+          <copy-to-clipboard
+              text-to-copy="{{difyExtension}}"
+              success-message="{{ 'ttyg.agent.external_integration_config_modal.dify_extension_copied_tooltip' | translate }}">
+          </copy-to-clipboard>
+        </span>
+      </div>
+    </div>
+  </form>
+</div>

--- a/test-cypress/fixtures/locale-en.json
+++ b/test-cypress/fixtures/locale-en.json
@@ -457,6 +457,10 @@
                         "placeholder": "Enter а user friendly name",
                         "tooltip": "A descriptive name that helps you identify this agent."
                     },
+                    "external_config": {
+                        "label": "External integration configuration",
+                        "tooltip": "Show URLs for the agent’s external access and integration"
+                    },
                     "repository": {
                         "label": "Repository ID",
                         "tooltip": "The ID of the repository that will be used to retrieve information from GraphDB. Ontop and FedX repositories are not supported."
@@ -697,6 +701,17 @@
                     }
                 }
             },
+            "external_integration_config_modal": {
+                "title": "Agent endpoints and external access",
+                "label": "Access {{agentName}} query methods via OpenAPI endpoints",
+                "agent_id_label": "Agent ID",
+                "query_methods": "Query methods via OpenAPI endpoints",
+                "dify_extension": "Dify extension",
+                "copy_tooltip": "Copy",
+                "agent_copied_tooltip": "Agent ID copied",
+                "openAPI_copied_tooltip": "OpenAPI endpoints link copied",
+                "dify_extension_copied_tooltip": "Dify extension link copied"
+            },
             "agent_select_menu": {
                 "no_selection_label": "Select an agent",
                 "deleted_agent": "[deleted agent]",
@@ -721,6 +736,7 @@
                     "tooltip": "Edit agent settings",
                     "tooltip_disabled": "You do not have permission to edit the agent"
                 },
+                "external_integration": "External integration",
                 "clone_agent": {
                     "label": "Clone",
                     "tooltip": "Clone Agent"

--- a/test-cypress/integration/ttyg/agent-list.spec.js
+++ b/test-cypress/integration/ttyg/agent-list.spec.js
@@ -2,6 +2,7 @@ import {TTYGViewSteps} from "../../steps/ttyg/ttyg-view-steps";
 import {TTYGStubs} from "../../stubs/ttyg/ttyg-stubs";
 import {RepositoriesStubs} from "../../stubs/repositories/repositories-stubs";
 import {RepositoriesStub} from "../../stubs/repositories-stub";
+import {TtygAgentSettingsModalSteps} from "../../steps/ttyg/ttyg-agent-settings-modal.steps";
 
 describe('TTYG agent list', () => {
     beforeEach(() => {
@@ -89,5 +90,36 @@ describe('TTYG agent list', () => {
         TTYGViewSteps.getDeleteAgentButton(1).should('be.visible');
         TTYGViewSteps.getCloneAgentButton(1).should('be.visible');
         TTYGViewSteps.getEditAgentButton(1).should('be.visible');
+    });
+
+    it('should allow copy of External integration configuration from agent list', () => {
+        TTYGStubs.stubAgentListGet('/ttyg/agent/get-agent-list-autocomplete-query.json');
+        TTYGStubs.getExternalUrl();
+        // Given I have opened the ttyg page
+        TTYGViewSteps.visit();
+        cy.wait('@get-agent-list');
+        // When I select an agent from the sidebar
+        TTYGViewSteps.expandAgentsSidebar();
+        TTYGViewSteps.toggleAgentActionMenu(0);
+        TTYGViewSteps.getExternalIntegrationConfigButton(0).should('be.visible');
+        TTYGViewSteps.openExternalIntegrationConfigButton(0);
+        cy.wait('@external-url');
+        // The url dialog should open
+        TtygAgentSettingsModalSteps.getExternalIntegrationModal().should('be.visible');
+        // The dialog should have all the fields
+        TtygAgentSettingsModalSteps.getAgentUrlField().invoke('val')
+            .then((val) => {
+                expect(val).to.equal('asst_G8EtHyT8kAGeDmCa3Nh6y74v');
+            });
+
+        TtygAgentSettingsModalSteps.getMethodUrlField().invoke('val')
+            .then((val) => {
+                expect(val).to.equal('http://user-pc:7200/rest/llm/tool/ttyg/asst_G8EtHyT8kAGeDmCa3Nh6y74v');
+            });
+
+        TtygAgentSettingsModalSteps.getDifyUrlField().invoke('val')
+            .then((val) => {
+                expect(val).to.equal('http://user-pc:7200/rest/llm/ttyg/asst_G8EtHyT8kAGeDmCa3Nh6y74v/dify');
+            });
     });
 });

--- a/test-cypress/integration/ttyg/edit-agent.spec.js
+++ b/test-cypress/integration/ttyg/edit-agent.spec.js
@@ -106,4 +106,40 @@ describe('TTYG edit an agent', () => {
         // Then: I expect the dialog be disappeared and the disabled message still visible
         TtygAgentSettingsModalSteps.getAutocompleteDisabledMessage().should('be.visible');
     });
+
+    it('should allow copy of External integration configuration', () => {
+        TTYGStubs.stubAgentListGet('/ttyg/agent/get-agent-list-autocomplete-query.json');
+        TTYGStubs.getExternalUrl();
+        // Given I have opened the ttyg page
+        TTYGViewSteps.visit();
+        cy.wait('@get-agent-list');
+        // When I select an agent
+        TTYGViewSteps.expandAgentsSidebar();
+        TTYGViewSteps.openAgentsMenu();
+        TTYGViewSteps.selectAgent(0);
+        TTYGViewSteps.editCurrentAgent();
+
+        // Then I should see the External integration configuration button
+        TtygAgentSettingsModalSteps.getExtIntegrationConfigBtn().should('be.visible');
+        // When I click the button
+        TtygAgentSettingsModalSteps.openExtIntegrationConfig();
+        cy.wait('@external-url');
+        // The url dialog should open
+        TtygAgentSettingsModalSteps.getExternalIntegrationModal().should('be.visible');
+        // The dialog should have all the fields
+        TtygAgentSettingsModalSteps.getAgentUrlField().invoke('val')
+            .then((val) => {
+                expect(val).to.equal('asst_G8EtHyT8kAGeDmCa3Nh6y74v');
+            });
+
+        TtygAgentSettingsModalSteps.getMethodUrlField().invoke('val')
+            .then((val) => {
+                expect(val).to.equal('http://user-pc:7200/rest/llm/tool/ttyg/asst_G8EtHyT8kAGeDmCa3Nh6y74v');
+            });
+
+        TtygAgentSettingsModalSteps.getDifyUrlField().invoke('val')
+            .then((val) => {
+                expect(val).to.equal('http://user-pc:7200/rest/llm/ttyg/asst_G8EtHyT8kAGeDmCa3Nh6y74v/dify');
+            });
+    });
 });

--- a/test-cypress/steps/ttyg/ttyg-agent-settings-modal.steps.js
+++ b/test-cypress/steps/ttyg/ttyg-agent-settings-modal.steps.js
@@ -37,6 +37,30 @@ export class TtygAgentSettingsModalSteps extends ModalDialogSteps {
         return this.getAgentNameFormGroup().find('.alert-danger');
     }
 
+    static getExtIntegrationConfigBtn() {
+        return cy.get('.external-config-btn');
+    }
+
+    static openExtIntegrationConfig() {
+        this.getExtIntegrationConfigBtn().click();
+    }
+
+    static getExternalIntegrationModal() {
+        return cy.get('.external-integration-configuration-modal .modal-content');
+    }
+
+    static getAgentUrlField() {
+        return this.getExternalIntegrationModal().find('#agentId');
+    }
+
+    static getMethodUrlField() {
+        return this.getExternalIntegrationModal().find('#queryMethods');
+    }
+
+    static getDifyUrlField() {
+        return this.getExternalIntegrationModal().find('#difyExtension');
+    }
+
     // Repository ID
 
     static getRepositoryIdFromGroup() {

--- a/test-cypress/steps/ttyg/ttyg-view-steps.js
+++ b/test-cypress/steps/ttyg/ttyg-view-steps.js
@@ -230,9 +230,21 @@ export class TTYGViewSteps {
         return this.getAgent(index).find('.agent-actions-menu .edit-agent-btn');
     }
 
+    static getExternalIntegrationConfigButton(index) {
+        return this.getAgent(index).find('.agent-actions-menu .ext-integration-agent-btn');
+    }
+
+    static openExternalIntegrationConfigButton(index) {
+        return this.getExternalIntegrationConfigButton(index).click();
+    }
+
     static triggerCloneAgentActionMenu(index) {
         this.openAgentActionMenu(index);
         this.getCloneAgentButton(index).click();
+    }
+
+    static toggleAgentActionMenu(index) {
+        this.getOpenAgentActionsButton(index).click();
     }
 
     static getCloneAgentButton(index) {

--- a/test-cypress/stubs/ttyg/ttyg-stubs.js
+++ b/test-cypress/stubs/ttyg/ttyg-stubs.js
@@ -167,4 +167,11 @@ export class TTYGStubs extends Stubs {
             statusCode: 200
         }).as('explain-response');
     }
+
+    static getExternalUrl() {
+        cy.intercept('GET', 'rest/info/external-url', {
+            statusCode: 200,
+            body: 'http://user-pc:7200'
+        }).as('external-url');
+    }
 }


### PR DESCRIPTION
## What
The user will be able to copy the configuration and enabled tools for any agent, using either the Edit agent modal or the action buttons in the agent side-panel list.

## Why
This links will be used to retrieve the configuration and enabled tools for that agent, enabling integration with external systems like Dify via the "Expose GraphDB LLM Tools via OpenAPI for Agent Integration" functionality.

## How
I edited the copyToClipboard to allow custom toastr messages. I created a modal for the agent data to be copied.

## Testing
Tests added.

## Screenshots
<img width="293" height="418" alt="image" src="https://github.com/user-attachments/assets/5f95193c-d3ec-492b-9d39-2f97cdab8f03" />
<img width="1035" height="225" alt="image" src="https://github.com/user-attachments/assets/a56e7c24-55a4-4860-9ee9-664c6964ac3e" />
<img width="723" height="453" alt="image" src="https://github.com/user-attachments/assets/eca754d8-279f-49f4-8d8c-df06c2c8eefc" />
<img width="469" height="100" alt="image" src="https://github.com/user-attachments/assets/dae4b9a3-6bfd-4e78-9590-891551a67a26" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
