### PR TITLE
GDB-12378: All repositories are displayed by default

### DIFF
--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -511,10 +511,6 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         return $repositories.getReadableRepositories();
     };
 
-    $scope.getAllAccessibleRepositories = function () {
-        return $repositories.getAllAccessibleRepositories();
-    };
-
     $scope.getWritableRepositories = function () {
         return $repositories.getWritableRepositories();
     };

--- a/packages/legacy-workbench/src/js/angular/core/services/repositories.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/repositories.service.js
@@ -277,18 +277,12 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
             return this.getRepositories().find((repository) => repository.id === repositoryId);
         };
 
-        this.getReadableRepositories = function () {
-            return _.filter(this.getRepositories(), function (repo) {
-                return $jwtAuth.canReadRepo(repo);
-            });
-        };
-
         this.getReadableGraphdbRepositories = function () {
             return this.getReadableRepositories()
                 .filter((repo) => repo.type === 'graphdb');
         };
 
-        this.getAllAccessibleRepositories = function () {
+        this.getReadableRepositories = function () {
             return _.filter(this.getRepositories(), function (repo) {
                 return $jwtAuth.canReadRepo(repo) || $jwtAuth.hasGraphqlReadRights(repo);
             });
@@ -546,7 +540,7 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
         });
 
         $rootScope.$watch(() => {
-            const currentRepos = that.getAllAccessibleRepositories();
+            const currentRepos = that.getReadableRepositories();
             return JSON.stringify(currentRepos);
         }, (newVal, oldVal) => {
             if (newVal !== oldVal) {

--- a/packages/legacy-workbench/src/js/angular/core/templates/core-errors.html
+++ b/packages/legacy-workbench/src/js/angular/core/templates/core-errors.html
@@ -31,7 +31,7 @@
                     </button>
                 </div>
                 <ul class="list-group limit-height clearfix two-columns repos" ng-mouseleave="hidePopoverForRepo($event)">
-                    <li ng-repeat="repository in getAllAccessibleRepositories() | orderBy: ['type === \'system\'', 'location', 'id']"
+                    <li ng-repeat="repository in getAccessibleRepositories() | orderBy: ['type === \'system\'', 'location', 'id']"
                         ng-if="repository.id !== getActiveRepository() || repository.location !== getActiveRepositoryObject().location"
                         class="list-group-item list-group-item-action repository"
                         ng-class="{'remote': !repository.local}"

--- a/packages/legacy-workbench/src/js/angular/security/templates/user.html
+++ b/packages/legacy-workbench/src/js/angular/security/templates/user.html
@@ -283,7 +283,7 @@
                                 </thead>
                                 <tbody>
                                     <div>
-                                        <tr ng-repeat="repository in getAllAccessibleRepositories() | orderBy: ['location', 'id']">
+                                        <tr ng-repeat="repository in getReadableRepositories() | orderBy: ['location', 'id']">
                                             <td class="repository-name">{{repository.id}}<small><em ng-if="(hasGraphqlPermission(repository) || hasGraphqlPermission('*')) && (hasReadPermission(repository) || hasReadPermission('*') || hasWritePermission(repository) || hasWritePermission('*'))" class="fa-kit fa-gdb-graphql graphql-icon text-info" gdb-tooltip="{{'security.tooltip.graphql' | translate}}"></em> &middot; {{repository.location ? repository.location : 'repo.local' | translate}}</small></td>
                                             <td class="text-xs-center read-rights">
                                                 <span ng-click="setGrantedAuthorities()">

--- a/packages/legacy-workbench/src/template.html
+++ b/packages/legacy-workbench/src/template.html
@@ -57,11 +57,11 @@
                 <em ng-class="'icon-repo-' + getActiveRepositoryObject().type"></em>
                 {{getActiveRepository()}}{{ getActiveRepositoryShortLocation() }}
             </span>
-            <span class="no-selected-repository" ng-if="!getActiveRepository() && getAllAccessibleRepositories().length">{{'choose.repo' | translate}}</span>
-            <span class="no-repositories" ng-if="!getActiveRepository() && !getAllAccessibleRepositories().length">{{'no.accessible.repos.warning' | translate}}</span>
+            <span class="no-selected-repository" ng-if="!getActiveRepository() && getReadableRepositories().length">{{'choose.repo' | translate}}</span>
+            <span class="no-repositories" ng-if="!getActiveRepository() && !getReadableRepositories().length">{{'no.accessible.repos.warning' | translate}}</span>
         </button>
         <ul class="dropdown-menu dropdown-menu-right pre-scrollable" aria-labelledby="dropdownMenuButton">
-            <li ng-repeat="repository in getAllAccessibleRepositories() | orderBy: ['location', 'id']"
+            <li ng-repeat="repository in getReadableRepositories() | orderBy: ['location', 'id']"
                 ng-if="!isRepoActive(repository)"
                 ng-mouseover="handlePopovers(repository)" popover-popup-delay="500"
                 popover-trigger="mouseenter" popover-placement="left-bottom"


### PR DESCRIPTION
## What
All repositories are displayed by default even when "Show remote locations" is not clicked

## Why
After the introduction of GraphQL functionality, the template responsible for displaying repositories in the core error directive was changed. As a result, it started showing all repositories without filtering by location (local or remote).

## How
The directive was updated to use a method that filters the displayed repositories based on whether "Show remote locations" is selected.

## Screenshots
Before
<img width="320" height="307" alt="image" src="https://github.com/user-attachments/assets/478bebd0-afe8-4248-a83d-3776ae390dd6" /><img width="320" height="307" alt="image" src="https://github.com/user-attachments/assets/2d710cd5-0edc-49ff-86f1-4113450d5131" />
After
<img width="320" height="307" alt="image" src="https://github.com/user-attachments/assets/e97e7ad1-e5b5-4fd0-b072-481cd963aadf" /> <img width="320" height="307" alt="image" src="https://github.com/user-attachments/assets/f01a3337-4083-43fc-b10b-3b011b4e4b80" />



## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
