### PR TITLE
GDB-12845: Extend repositories-select-repository step

### DIFF
--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/select-repository/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/select-repository/plugin.js
@@ -74,7 +74,7 @@ PluginRegistry.add('guide.step', [
         guideBlockName: 'repositories-select-repository',
         getSteps: (options, services) => {
             const GuideUtils = services.GuideUtils;
-            const repositoryId = getRepositoryName(services, options);
+            const repositoryId = options.repositoryIdToSelect ?? getRepositoryName(services, options);
             const selectRepositoryRowSelector = GuideUtils.getGuideElementSelector(`repository-${repositoryId}`);
             const selectRepositoryButtonWrapperSelector = `${selectRepositoryRowSelector} ${GuideUtils.getGuideElementSelector('select-repository-button-wrapper')}`;
             const selectRepositoryButtonSelector = `${selectRepositoryButtonWrapperSelector} ${GuideUtils.getGuideElementSelector('select-repository-button')}`;


### PR DESCRIPTION
## What
Extended the repositories-select-repository step with a new option: repositoryIdToSelect. If this option is present, it will be used to select the repository in the selector.

## Why
This allows guides to select repositories that differ from the ones defined in the guide's main configuration.

## How
Updated the repository selection logic to consider the repositoryIdToSelect property when present. If it's defined, it will be used; otherwise, the repository defined in the guide configuration will be used.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
