### PR TITLE
GDB-12874: Add a guide step for RDF Rank

### DIFF
--- a/packages/legacy-workbench/src/css/rdfrank.css
+++ b/packages/legacy-workbench/src/css/rdfrank.css
@@ -16,3 +16,20 @@
     padding-top: calc((100vh - 300px) / 2);
     background-color: rgba(255,255,255,0.66);
 }
+
+/**
+   Fixes Sonar issue: "Label elements should have a text label and an associated control."
+   https://sonarcloud.io/organizations/ontotext-ad/rules?open=Web%3AS6853&rule_key=Web%3AS6853&tab=why
+
+   The issue occurs because Bootstrap Toggle expects an empty <label> to follow the <input> element.
+   Adding a zero-width whitespace (&#8203;) to the <label> tag resolves the Sonar warning,
+   but it visually breaks the toggle's layout. The additional CSS at the bottom is applied to fix
+   the visual misalignment caused by this change.
+ */
+#toggleIncludeExplicit label, #toggleIncludeImplicit label, #toggleFilterMode label  {
+    vertical-align: middle;
+    display: inline-block;
+    height: 1.2em;
+    line-height: 1.2em;
+    margin-bottom: -2px;
+}

--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -3338,6 +3338,7 @@
     "guide.step_plugin.class-relationships-class-list-intro.content": "The left panel shows all classes, sorted by number of links, displaying both incoming and outgoing connections.",
     "guide.step_plugin.class-relationships-class-list-background-intro.content": "A <b>green background</b> behind a class name in the list indicates that it is currently shown in the diagram.",
     "guide.step_plugin.class-relationships-class-list-selection.content": "Use the <b>+ / –</b> icons next to each class name to add or remove it from the diagram display.",
+    "guide.step_plugin.rdf-rank-compute-fill.content": "Click on <b>Compute Full</b> to start the RDF Rank computation.",
     "guide.confirm.cancel.message": "Are you sure you want to stop the guide?",
     "guide.unexpected.error.message": "The guide was cancelled due to an unexpected error. Please run the guide again and if the problem persists contact the support.",
     "guide.start.unexpected.error.message": "The guide cannot be started due to an unexpected error. Please try running the guide again and if the problem persists contact the support.",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -3336,6 +3336,7 @@
     "guide.step_plugin.class-relationships-class-list-intro.content": "Le panneau de gauche montre toutes les classes, triées par nombre de liens, affichant les connexions entrantes et sortantes.",
     "guide.step_plugin.class-relationships-class-list-background-intro.content": "Un <b>arrière-plan vert</b> derrière un nom de classe dans la liste indique qu'elle est actuellement affichée dans le diagramme.",
     "guide.step_plugin.class-relationships-class-list-selection.content": "Utilisez les icônes <b>+ / –</b> à côté de chaque nom de classe pour l'ajouter ou la retirer de l'affichage du diagramme.",
+    "guide.step_plugin.rdf-rank-compute-fill.content": "Cliquez sur <b>Calculer tout</b> pour lancer le calcul du RDF Rank.",
     "guide.confirm.cancel.message": "Êtes-vous sûr de vouloir arrêter le guide?",
     "guide.unexpected.error.message": "Le guide a été annulé en raison d'une erreur inattendue. Veuillez exécuter à nouveau le guide et si le problème persiste, contactez le support.",
     "guide.start.unexpected.error.message": "Le guide ne peut pas être démarré en raison d'une erreur inattendue. Veuillez réessayer d'exécuter le guide et si le problème persiste, contactez le support.",

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/main-menu/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/main-menu/plugin.js
@@ -107,6 +107,16 @@ PluginRegistry.add('guide.step', [
                     viewName = 'menu.similarity.label';
                     helpInfo = 'guide.step-help-info.create-similarity-index';
                     break;
+                case "rdf-rank":
+                    menuSelector = 'menu-setup';
+                    menuTitle = 'menu.setup.label';
+                    menuDialogClass = 'menu-setup-guide-dialog';
+                    submenuSelector = 'sub-menu-rdf-rank';
+                    submenuTitle = 'view.rdf.rank.title';
+                    submenuDialogClass = 'sub-menu-rdf-rank-guide-dialog';
+                    viewName = 'view.rdf.rank.title';
+                    helpInfo = 'view.rdf.rank.helpInfo';
+                    break;
             }
 
             const mainMenuClickElementPostSelector = submenuSelector ? ' div' : ' a';
@@ -116,19 +126,20 @@ PluginRegistry.add('guide.step', [
             if (options.showIntro && options.mainAction) {
                 steps.push({
                     guideBlockName: 'info-message',
-                    options: angular.extend({}, {
+                    options: {
                         content: 'guide.step-intro.' + options.mainAction,
                         extraContent: helpInfo,
                         extraContentClass: 'alert alert-help text-left',
-                        skipPoint: true
-                    }, options)
+                        skipPoint: true,
+                        ...options
+                    }
                 });
             }
 
             // Main menu element
             steps.push({
                 guideBlockName: 'clickable-element',
-                options: angular.extend({}, {
+                options: {
                     content: 'guide.step-menu.click-menu',
                     menuLabelKey: menuTitle,
                     class: menuDialogClass,
@@ -148,14 +159,15 @@ PluginRegistry.add('guide.step', [
                         }
 
                         return Promise.resolve();
-                    }
-                }, options)
+                    },
+                    ...options
+                }
             });
 
             if (submenuSelector) {
                 steps.push({
                     guideBlockName: 'clickable-element',
-                    options: angular.extend({}, {
+                    options: {
                         content: 'guide.step-menu.click-menu',
                         menuLabelKey: submenuTitle,
                         class: submenuDialogClass,
@@ -170,8 +182,9 @@ PluginRegistry.add('guide.step', [
                             }
 
                             return Promise.resolve();
-                        }
-                    }, options)
+                        },
+                        ...options
+                    }
                 });
             }
             return steps;

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/rdf-rank/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/rdf-rank/plugin.js
@@ -1,0 +1,24 @@
+const RDF_RANK_DEFAULT_TITLE = 'view.rdf.rank.title'
+
+PluginRegistry.add('guide.step', [
+    {
+        guideBlockName: 'rdf-rank-compute-fill',
+        getSteps: (options, services) => {
+            const GuideUtils = services.GuideUtils;
+            const computeRDFRankButtonSelector = GuideUtils.getGuideElementSelector('compute-rdf-rank-btn');
+            return [{
+                guideBlockName: 'clickable-element',
+                options: {
+                    url: 'rdfrank',
+                    content: 'guide.step_plugin.rdf-rank-compute-fill.content',
+                    elementSelector: computeRDFRankButtonSelector,
+                    // If mainAction is set the title will be set automatically
+                    ...(options.mainAction ? {} : {title: RDF_RANK_DEFAULT_TITLE}),
+                    onNextClick: computeRDFRankButtonSelector,
+                    ...options
+                }
+            }]
+        }
+    }
+]);
+

--- a/packages/legacy-workbench/src/pages/rdfrank.html
+++ b/packages/legacy-workbench/src/pages/rdfrank.html
@@ -55,7 +55,9 @@
 					<button ng-disabled="currentRankStatus == rdfStatus.COMPUTING"
 							ng-click="computeRank()"
 							data-test="compute-rdf-rank-btn"
-							class="btn btn-primary compute-rdf-rank-btn">{{'compute.full.btn' | translate}}</button>
+							class="btn btn-primary compute-rdf-rank-btn"
+							guide-selector="compute-rdf-rank-btn">{{'compute.full.btn' | translate}}
+					</button>
                     <button ng-hide="currentRankStatus != rdfStatus.OUTDATED"
 							ng-click="computeIncrementalRank()" class="btn btn-primary">{{'compute.incremental.btn' | translate}}</button>
 				</p>
@@ -67,8 +69,8 @@
 				<h3 class="d-inline-block mr-1">{{'filtering.header' | translate}}</h3>
 				<span class="tag {{filteringEnabled ? 'tag-primary' : 'tag-default'}}">{{filteringEnabled ? 'common.on.btn' : 'common.off.btn' | translate}}</span>
                 <span gdb-tooltip="{{'click.to' | translate}} {{filteringEnabled ? 'disable' : 'enable' | translate}} {{'filtering' | translate}}" tooltip-placement="top" ng-click="toggleFiltering()" class="switch rdf-rank-filter-switch">
-                    <input type="checkbox" class="switch" ng-checked="filteringEnabled"/>
-                    <label for="toggleFilterMode"></label>
+                    <input id="toggleFilterModeInput" type="checkbox" class="switch" ng-checked="filteringEnabled"/>
+                    <label for="toggleFilterModeInput">&#8203;</label>
                 </span>
 			</div>
 
@@ -80,8 +82,8 @@
 						{{'include.explicit.header' | translate}}
 						<span class="tag {{includeExplicit ? 'tag-primary' : 'tag-default'}}">{{includeExplicit ? 'yes' : 'no' | translate}}</span>
                         <span gdb-tooltip="{{'click.to' | translate}} {{includeExplicit ? 'exclude' : 'include' | translate}} {{'explicit.statements' | translate}}" tooltip-placement="top" ng-click="toggleIncludeExplicit()" class="switch">
-	                    <input type="checkbox" class="switch" ng-checked="includeExplicit"/>
-	                    <label for="toggleIncludeExplicit"></label>
+	                    <input id="toggleIncludeExplicitInput" type="checkbox" class="switch" ng-checked="includeExplicit"/>
+	                    <label for="toggleIncludeExplicitInput">&#8204;</label>
 	                </span>
 					</div>
 
@@ -89,8 +91,8 @@
 						{{'include.implicit.header' | translate}}
 						<span class="tag {{includeImplicit ? 'tag-primary' : 'tag-default'}}">{{includeImplicit ? 'yes' : 'no' | translate}}</span>
 						<span gdb-tooltip="{{'click.to' | translate}} {{includeImplicit ? 'exclude' : 'include' | translate}} {{'implicit.statements' | translate}}" tooltip-placement="top" ng-click="toggleIncludeImplicit()" class="switch">
-	                    <input type="checkbox" class="switch" ng-checked="includeImplicit"/>
-	                    <label for="toggleIncludeImplicit"></label>
+	                    <input id="toggleIncludeImplicitInput" type="checkbox" class="switch" ng-checked="includeImplicit"/>
+	                    <label for="toggleIncludeImplicitInput">&#8204;</label>
 	                </span>
 					</div>
 				</div>


### PR DESCRIPTION
## What
Added a new step: rdf-rank-compute-fill.

## Why
This enhances the guides with the opportunity to teach users how to trigger the computation of the RDF Rank values.

## How
- Implemented a new step that selects the "Compute Full" button.
- Extended the "click-main-menu" step to support the RDF Rank submenu.

## Screenshots
<img width="543" height="439" alt="image" src="https://github.com/user-attachments/assets/c99cf375-f5e9-469e-a394-65148a017b18" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
