### PR TITLE
(cherry-pick) GDB-12815 - Fix inconsistent values on field sliders

### DIFF
--- a/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -712,6 +712,13 @@ function AgentSettingsModalController(
         }
     };
 
+    const refreshSliderById = (elementId, value) => {
+        const slider = document.getElementById(elementId);
+        if (slider) {
+            slider.value = value;
+        }
+    };
+
     // =========================
     // Subscriptions
     // =========================
@@ -733,6 +740,10 @@ function AgentSettingsModalController(
     const init = () => {
         // Delay the validation status setting because angular form ngmodel is not present immediately
         setTimeout(setExtractionMethodValidityStatus, 0);
+        $uibModalInstance.rendered.then(() => {
+            refreshSliderById('temperatureSlider', $scope.agentFormModel.temperature.value);
+            refreshSliderById('topPSlider', $scope.agentFormModel.topP.value);
+        });
     };
     init();
 }


### PR DESCRIPTION
## What
The "Temperature" and "Top P" sliders will show correct values, consistent with the model.

## Why
The sliders would always load at value 1 when the Create/Edit Agent modal was opened. This was due to the model and sliders not being available at the same time when the controller is initialized.

## How
I added a delay to re-render the sliders with the correct values.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
