### PR TITLE
GDB-12885 -  Extract create-repository core steps

### DIFF
--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/create-repository/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/create-repository/plugin.js
@@ -1,95 +1,185 @@
+const REPOSITORIES_CREATE_DEFAULT_TITLE = 'guide.step-action.create-repository';
+
 PluginRegistry.add('guide.step', [
     {
-        guideBlockName: 'create-repository',
+        guideBlockName: 'repositories-create-repository',
         getSteps: (options, services) => {
             const GuideUtils = services.GuideUtils;
-            options.mainAction = 'create-repository';
-
-            const repositoryIdInputSelector = GuideUtils.getGuideElementSelector('graphDBRepositoryIdInput');
-            const repositoryId = options.repositoryId;
-            const steps = [
+            return [
                 {
-                    guideBlockName: 'click-main-menu',
-                    options: angular.extend({}, {
-                        menu: 'repositories',
-                        showIntro: true
-                    }, options)
-                }, {
                     guideBlockName: 'clickable-element',
-                    options: angular.extend({}, {
+                    options: {
                         content: 'guide.step_plugin.create_repository.create_repository_button.content',
+                        // If mainAction is set the title will be set automatically
+                        ...(options.mainAction ? {} : { title: REPOSITORIES_CREATE_DEFAULT_TITLE }),
                         class: 'create-repository',
+                        ...options,
                         url: 'repository',
                         elementSelector: GuideUtils.getGuideElementSelector('createRepository'),
                         onNextClick: GuideUtils.clickOnGuideElement('createRepository')
-                    }, options)
-                }, {
+                    }
+                }
+            ];
+        }
+    },
+    {
+        guideBlockName: 'repositories-create-graphdb',
+        getSteps: (options, services) => {
+            const GuideUtils = services.GuideUtils;
+            return [
+                {
                     guideBlockName: 'clickable-element',
-                    options: angular.extend({}, {
+                    options: {
                         content: 'guide.step_plugin.create_repository.graph_db_repository.content',
+                        // If mainAction is set the title will be set automatically
+                        ...(options.mainAction ? {} : { title: REPOSITORIES_CREATE_DEFAULT_TITLE }),
                         class: 'create-gdb-repository',
+                        ...options,
                         url: 'repository/create',
                         elementSelector: GuideUtils.getGuideElementSelector('createGraphDBRepository'),
                         disablePreviousFlow: false,
                         onNextClick: GuideUtils.clickOnGuideElement('createGraphDBRepository')
-                    }, options)
-                }, {
+                    }
+                }
+            ];
+        }
+    },
+    {
+        guideBlockName: 'repositories-id-input',
+        getSteps: (options, services) => {
+            const GuideUtils = services.GuideUtils;
+            const repositoryIdInputSelector = GuideUtils.getGuideElementSelector('graphDBRepositoryIdInput');
+            return [
+                {
                     guideBlockName: 'input-element',
-                    options: angular.extend({}, {
+                    options: {
                         content: 'guide.step_plugin.create_repository.repository_id.content',
+                        // If mainAction is set the title will be set automatically
+                        ...(options.mainAction ? {} : { title: REPOSITORIES_CREATE_DEFAULT_TITLE }),
                         class: 'gdb-repository-id-input',
+                        ...options,
                         url: 'repository/create/graphdb',
                         elementSelector: repositoryIdInputSelector,
                         disablePreviousFlow: false,
-                        onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(repositoryIdInputSelector, repositoryId))
-                    }, options)
+                        onNextValidate: () =>
+                            Promise.resolve(
+                                GuideUtils.validateTextInput(
+                                    repositoryIdInputSelector,
+                                    options.repositoryId
+                                )
+                            )
+                    }
                 }
             ];
-
-            if (options.rulesetName) {
-                steps.push({
+        }
+    },
+    {
+        guideBlockName: 'repositories-ruleset-dropdown',
+        getSteps: (options, services) => {
+            const GuideUtils = services.GuideUtils;
+            const repositoryIdInputSelector = GuideUtils.getGuideElementSelector('graphDBRepositoryIdInput');
+            return [
+                {
                     guideBlockName: 'clickable-element',
-                    options: angular.extend({}, {
+                    options: {
                         content: 'guide.step_plugin.create_repository.ruleset_dropdown.content',
-                        url: 'repository/create/graphdb',
+                        // If mainAction is set the title will be set automatically
+                        ...(options.mainAction ? {} : { title: REPOSITORIES_CREATE_DEFAULT_TITLE }),
                         class: 'gdb-repository-ruleset-select',
+                        ...options,
+                        url: 'repository/create/graphdb',
                         elementSelector: GuideUtils.getGuideElementSelector('graphDBRepositoryRulesetSelect'),
                         disablePreviousFlow: false,
                         show: () => () => {
-                            GuideUtils.validateTextInput(repositoryIdInputSelector, repositoryId);
+                            GuideUtils.validateTextInput(repositoryIdInputSelector, options.repositoryId);
                         }
-                    }, options)
-                });
+                    }
+                }
+            ];
+        }
+    },
+    {
+        guideBlockName: 'repositories-enable-fts',
+        getSteps: (options, services) => {
+            const GuideUtils = services.GuideUtils;
+            return [
+                {
+                    guideBlockName: 'clickable-element',
+                    options: {
+                        content: 'guide.step_plugin.create_repository.enable-fts.content',
+                        // If mainAction is set the title will be set automatically
+                        ...(options.mainAction ? {} : { title: REPOSITORIES_CREATE_DEFAULT_TITLE }),
+                        class: 'gdb-repository-enable-fts',
+                        extraContent: 'guide.step_plugin.create_repository.enable-fts.extra-content',
+                        extraContentClass: 'alert alert-help text-left',
+                        ...options,
+                        url: 'repository/create/graphdb',
+                        elementSelector: GuideUtils.getGuideElementSelector('enable-fts-search'),
+                        disablePreviousFlow: false,
+                        onNextValidate: () =>
+                            Promise.resolve(
+                                GuideUtils.isChecked(
+                                    GuideUtils.getGuideElementSelector('enable-fts-search', 'input')
+                                )
+                            )
+                    }
+                }
+            ];
+        }
+    },
+    {
+        guideBlockName: 'repositories-save',
+        getSteps: (options, services) => {
+            const GuideUtils = services.GuideUtils;
+            const repositoryIdInputSelector = GuideUtils.getGuideElementSelector('graphDBRepositoryIdInput');
+            return [
+                {
+                    guideBlockName: 'clickable-element',
+                    options: {
+                        content: 'guide.step_plugin.create_repository.save_button.content',
+                        // If mainAction is set the title will be set automatically
+                        ...(options.mainAction ? {} : { title: REPOSITORIES_CREATE_DEFAULT_TITLE }),
+                        class: 'create-repository-button',
+                        ...options,
+                        url: 'repository/create/graphdb',
+                        elementSelector: GuideUtils.getGuideElementSelector('graphDBRepositoryCrateButton'),
+                        disablePreviousFlow: false,
+                        show: () => () => {
+                            GuideUtils.validateTextInput(repositoryIdInputSelector, options.repositoryId);
+                        },
+                        onNextClick: GuideUtils.clickOnGuideElement('graphDBRepositoryCrateButton')
+                    }
+                }
+            ];
+        }
+    },
+    {
+        guideBlockName: 'create-repository',
+        getSteps: (options, services) => {
+            options.mainAction = 'create-repository';
+
+            const steps = [
+                {
+                    guideBlockName: 'click-main-menu',
+                    options: {
+                        menu: 'repositories',
+                        showIntro: true,
+                        ...options
+                    }
+                },
+                { guideBlockName: 'repositories-create-repository', options: { ...options } },
+                { guideBlockName: 'repositories-create-graphdb', options: { ...options } },
+                { guideBlockName: 'repositories-id-input', options: { ...options } }
+            ];
+
+            if (options.rulesetName) {
+                steps.push({ guideBlockName: 'repositories-ruleset-dropdown', options: { ...options } });
             }
-            if(options.fts) {
-                steps.push({
-                               guideBlockName: 'clickable-element',
-                               options: angular.extend({}, {
-                                   content: 'guide.step_plugin.create_repository.enable-fts.content',
-                                   url: 'repository/create/graphdb',
-                                   class: 'gdb-repository-enable-fts',
-                                   extraContent: 'guide.step_plugin.create_repository.enable-fts.extra-content',
-                                   extraContentClass: 'alert alert-help text-left',
-                                   elementSelector: GuideUtils.getGuideElementSelector('enable-fts-search'),
-                                   disablePreviousFlow: false,
-                                   onNextValidate: () => Promise.resolve(GuideUtils.isChecked(GuideUtils.getGuideElementSelector('enable-fts-search', 'input')))
-                               }, options)
-                           });
+            if (options.fts) {
+                steps.push({ guideBlockName: 'repositories-enable-fts', options: { ...options } });
             }
-            steps.push({
-                guideBlockName: 'clickable-element',
-                options: angular.extend({}, {
-                    content: 'guide.step_plugin.create_repository.save_button.content',
-                    url: 'repository/create/graphdb',
-                    class: 'create-repository-button',
-                    elementSelector: GuideUtils.getGuideElementSelector('graphDBRepositoryCrateButton'),
-                    disablePreviousFlow: false,
-                    show: () => () => {
-                        GuideUtils.validateTextInput(repositoryIdInputSelector, repositoryId);
-                    },
-                    onNextClick: GuideUtils.clickOnGuideElement('graphDBRepositoryCrateButton')
-                }, options)
-            });
+
+            steps.push({ guideBlockName: 'repositories-save', options: { ...options } });
 
             return steps;
         }

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/main-menu/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/main-menu/plugin.js
@@ -110,10 +110,10 @@ PluginRegistry.add('guide.step', [
                 case "rdf-rank":
                     menuSelector = 'menu-setup';
                     menuTitle = 'menu.setup.label';
-                    menuDialogClass = 'menu-setup-guide-dialog';
+                    menuDialogClass = 'menu-setup';
                     submenuSelector = 'sub-menu-rdf-rank';
                     submenuTitle = 'view.rdf.rank.title';
-                    submenuDialogClass = 'sub-menu-rdf-rank-guide-dialog';
+                    submenuDialogClass = 'sub-menu-rdf-rank';
                     viewName = 'view.rdf.rank.title';
                     helpInfo = 'view.rdf.rank.helpInfo';
                     break;


### PR DESCRIPTION
## What

- The `create-repository` core steps have been extracted.

- Missed `-guide-dialog` suffix removed.

## Why

- Extracting the steps allows developers to reuse them.

- For some reason IDE didn't show the suffix instance when searching all files for previous MR changes.

## How
Steps extracted in the same file.

## Testing
N/A

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
