### PR TITLE
(cherry-pick) GDB-12889 Add copy text to the TTYG user instructions step

### DIFF
--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -3331,7 +3331,7 @@
     "guide.step_plugin.create-similarity-index.wait": "Wait for index to be created",
     "guide.step_plugin.configure-agent.name-input": "Type a name for the agent. You will refer to it later.",
     "guide.step_plugin.configure-agent.model-input": "Here you can type the name of the OpenAI model to be used.<br>Type: \"<b>{{model}}</b>\" to configure the agent to use this model",
-    "guide.step_plugin.configure-agent.user-instructions-input": "Here you can type additional instructions which will be passed to the agent.<br> Type: \"<b>{{userInstructions}}</b>\"",
+    "guide.step_plugin.configure-agent.user-instructions-input": "Those are additional instructions which will be passed to the agent.",
     "guide.step_plugin.class-relationships-intro.content": "This view shows how data instances from different classes are connected based on real RDF statements.",
     "guide.step_plugin.class-relationships-diagram-intro.content": "The diagram shows bundled connections between class pairs. Each connection represents multiple RDF links (subject–predicate–object) between instances of two classes.",
     "guide.step_plugin.class-relationships-digram-thickness-intro.content": "Each connection line varies in <b>thickness</b> based on the number of links, <b>color</b> based on the class with more incoming links, and <b>direction</b> as links may go both ways (from class A to class B and vice versa).",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -3329,7 +3329,7 @@
     "guide.step_plugin.create-similarity-index.wait": "Attendre la création de l'index",
     "guide.step_plugin.configure-agent.name-input": "Saisissez un nom pour l'agent. Vous y ferez référence ultérieurement",
     "guide.step_plugin.configure-agent.model-input": "Vous pouvez saisir ici le nom du modèle OpenAI à utiliser.<br>Type: \"<b>{{model}}</b>\" pour configurer l'agent afin qu'il utilise ce modèle.",
-    "guide.step_plugin.configure-agent.user-instructions-input": "Vous pouvez ici saisir des instructions supplémentaires qui seront transmises à l'agent.<br>Type: \"<b>{{userInstructions}}</b>\"",
+    "guide.step_plugin.configure-agent.user-instructions-input": "Ce sont des instructions supplémentaires qui seront transmises à l'agent.",
     "guide.step_plugin.class-relationships-intro.content": "Cette vue montre comment les instances de données de différentes classes sont connectées basées sur de vraies déclarations RDF.",
     "guide.step_plugin.class-relationships-diagram-intro.content": "Le diagramme montre les connexions groupées entre paires de classes. Chaque connexion représente plusieurs liens RDF (sujet–prédicat–objet) entre instances de deux classes.",
     "guide.step_plugin.class-relationships-digram-thickness-intro.content": "Chaque ligne de connexion varie en <b>épaisseur</b> basée sur le nombre de liens, en <b>couleur</b> basée sur la classe avec le plus de liens entrants, et en <b>direction</b> car les liens peuvent aller dans les deux sens (de la classe A vers la classe B et vice versa).",

--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/configure-agent/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/configure-agent/plugin.js
@@ -138,13 +138,14 @@ PluginRegistry.add('guide.step', [
 
             if (hasUserInstructions) {
                 steps.push({
-                    guideBlockName: 'input-element',
+                    guideBlockName: 'copy-text-element',
                     options: angular.extend({}, {
-                        content: 'guide.step_plugin.configure-agent.user-instructions-input',
+                        extraContent: 'guide.step_plugin.configure-agent.user-instructions-input',
                         class: 'input-user-instructions',
                         url: 'ttyg',
                         elementSelector: GuideUtils.getGuideElementSelector('user-instructions'),
                         disablePreviousFlow: false,
+                        text: options.userInstructions,
                         onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(GuideUtils.getGuideElementSelector('user-instructions'), options.userInstructions, false))
                     }, options)
                 })

--- a/packages/legacy-workbench/src/js/angular/guides/steps/core/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/core/plugin.js
@@ -134,9 +134,9 @@ PluginRegistry.add('guide.step', [
                 {
                     guideBlockName: 'input-element',
                     options: {
+                        ...options,
                         content: 'guide.step_plugin.core-steps.copy-text-element.content',
                         textAsHtmlCodeElement: '<div class="shepherd-code">' + code.outerHTML + copy.outerHTML + '</div>',
-                        ...options,
                         show: (_guide) => () => {
                             stepHTMLElement = _guide.currentStep.el.querySelector(`.${copyToInputQueryButtonClass}`);
                             stepHTMLElement.addEventListener('click', copyToInputListener);


### PR DESCRIPTION
## What
change the step to have a copy text button for the TTYG user instructions step

## Why
Because there is a lot of text which is then validated when next button is clicked

How
- changed `input-element` to `copy-text-element`

(cherry picked from commit 2e633c422ae93a6d446873bbac80a07c88c1513a)

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
