### PR TITLE
GDB-12924: Clear auth token on 401

### DIFF
--- a/packages/api/src/interceptor/auth/unauthorized-interceptor.ts
+++ b/packages/api/src/interceptor/auth/unauthorized-interceptor.ts
@@ -1,0 +1,24 @@
+import {HttpInterceptor} from '../../models/interceptor/http-interceptor';
+import {navigate} from '../../services/utils';
+import {WindowService} from '../../services/window';
+
+export class UnauthorizedInterceptor extends HttpInterceptor<Response> {
+  process(data: Response): Promise<Response> {
+    // If backend returns 401, it means that the user is not authenticated.
+    // Se we have to remove the JWT token from local storage
+    if (localStorage.getItem('ontotext.gdb.auth.jwt')) {
+      localStorage.removeItem('ontotext.gdb.auth.jwt');
+      navigate('login');
+      // There is scenario when 401 is thrown during bootstrap and
+      // when user is logged the workbench is not properly loaded
+      // For example if languages are not loaded.
+      // So we need to reload the page to ensure that everything is loaded properly.
+      WindowService.getWindow().location.reload();
+    }
+    return Promise.reject(data);
+  }
+
+  shouldProcess(data: Response): boolean {
+    return 401 === data.status;
+  }
+}

--- a/packages/api/src/interceptor/interceptors.ts
+++ b/packages/api/src/interceptor/interceptors.ts
@@ -2,6 +2,7 @@ import {HttpInterceptor} from '../models/interceptor/http-interceptor';
 import {HttpRequest} from '../models/http/http-request';
 import {ModelList} from '../models/common';
 import {AuthRequestInterceptor} from './auth/auth-request-interceptor';
+import {UnauthorizedInterceptor} from './auth/unauthorized-interceptor';
 
 /**
  * An array of HTTP request interceptors to be used in the application.
@@ -16,4 +17,5 @@ export const REQUEST_INTERCEPTORS = new ModelList<HttpInterceptor<HttpRequest>>(
  */
 export const RESPONSE_INTERCEPTORS = new ModelList<HttpInterceptor<Response>> ([
   // Response interceptors go here
+  new UnauthorizedInterceptor()
 ]);


### PR DESCRIPTION
## What
When the backend is restarted, existing JWT tokens become invalid. This caused issues where a logged-in user would see a broken workbench.

## Why
When the page is reloaded, the backend returns 401 because an invalid JWT token is used. In the new REST services, there is no interceptor that removes the token from storage, so the workbench keeps using it. As a result, the backend always returns 401 and the user cannot use the system until the JWT token is manually deleted from local storage.

## How
The fix ensures that on a 401 response:
- The JWT token is removed from local storage;
- The user is redirected to the login page;
- The page is reloaded to guarantee proper bootstrap after re-authentication.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
