### PR TITLE
GDB-12500 - Save selected agent to local store and select first in dropdown

### DIFF
--- a/e2e-tests/e2e-legacy/ttyg/agent-select-menu.spec.js
+++ b/e2e-tests/e2e-legacy/ttyg/agent-select-menu.spec.js
@@ -35,8 +35,8 @@ describe('TTYG agent select menu', () => {
         TTYGViewSteps.visit();
         // And: The agent dropdown menu is not visible
         TTYGViewSteps.getAgentsDropdownMenu().should('not.be.visible');
-        // And: No agent is currently selected
-        TTYGViewSteps.getAgentsMenuToggleButton().should('contain', 'Select an agent');
+        // And: The first agent is selected
+        TTYGViewSteps.getAgentsMenuToggleButton().should('contain', 'agent-1');
 
         // When: I open the agent selection menu
         TTYGViewSteps.openAgentsMenu();
@@ -48,7 +48,7 @@ describe('TTYG agent select menu', () => {
         // When: I attempt to select an incompatible agent from the menu
         TTYGViewSteps.selectAgent(0);
         // Then: The incompatible agent should not be selected
-        TTYGViewSteps.getAgentsMenuToggleButton().should('contain', 'Select an agent');
+        TTYGViewSteps.getAgentsMenuToggleButton().should('contain', 'agent-1');
         // And: The dropdown menu should remain open
         TTYGViewSteps.getAgentsDropdownMenu().should('be.visible');
     });

--- a/e2e-tests/e2e-legacy/ttyg/edit-agent.spec.js
+++ b/e2e-tests/e2e-legacy/ttyg/edit-agent.spec.js
@@ -43,11 +43,11 @@ describe('TTYG edit an agent', () => {
         // and save the agent.
         TTYGStubs.stubAgentEdit();
         TtygAgentSettingsModalSteps.saveAgent();
-        cy.wait('@edit-agent');
+        cy.wait('@edit-agent').then((interception) => {
+            expect(interception.request.body.additionalExtractionMethods[0].method).to.equal('iri_discovery_search');
+        });
         // Then I expect the agent to be saved
         ToasterSteps.verifySuccess('The agent \'agent-1\' was saved successfully.');
-        TTYGViewSteps.editCurrentAgent();
-        TtygAgentSettingsModalSteps.getIriDiscoverySearchCheckbox().should('be.checked');
     });
 
 
@@ -76,13 +76,16 @@ describe('TTYG edit an agent', () => {
         // When I save the agent
         TTYGStubs.stubAgentEdit();
         TtygAgentSettingsModalSteps.saveAgent();
-        cy.wait('@edit-agent');
+        cy.wait('@edit-agent').then((interception) => {
+            const additionalMethod = interception.request.body.additionalExtractionMethods[0];
+            expect(additionalMethod).to.not.be.undefined;
+            expect(additionalMethod.method).to.equal('autocomplete_iri_discovery_search');
+            expect(additionalMethod.limit).to.equal(2);
+        });
         // Then I expect the agent to be saved
         ToasterSteps.verifySuccess('The agent \'Test autocomplete extraction agent\' was saved successfully.');
         TTYGViewSteps.editCurrentAgent();
-        TtygAgentSettingsModalSteps.getAutocompleteSearchCheckbox().should('be.checked');
         TtygAgentSettingsModalSteps.toggleAutocompleteSearchPanel();
-        TtygAgentSettingsModalSteps.getAutocompleteMaxResults().should('have.value', '2');
 
         // When: I select a repository with disabled autocomplete
         AutocompleteStubs.stubAutocompleteEnabled(false);


### PR DESCRIPTION
## What
The first agent in the TTYG agent select dropdown will be selected on page load. If the user selects another agent, it will be remembered the next time the page is loaded.

## Why
The improvement reduces steps needed to be taken in order to ask a question.

## How
I save the user selected agent to the local store, otherwise if local store is empty, I load the first option from the dropdown. When a chat is loaded, the last agent used in the chat will be selected, as per the original functionality, regardless what is in local store.

## Testing
Test expectations edited to fit the default first option selected.

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
