### PR TITLE
fix(GDB-12961) Set default npm registry to npmjs.org

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('ontotext-platform@v0.1.49') _
+@Library('ontotext-platform@v0.1.51') _
 pipeline {
     agent {
         label 'aws-large'
@@ -11,12 +11,15 @@ pipeline {
     environment {
         DOCKER_COMPOSE_FILE = "docker-compose-test.yaml"
         SONAR_ENVIRONMENT = "SonarCloud"
+        NPM_CONFIG_REGISTRY = 'https://registry.npmjs.org/'
     }
 
     stages {
         stage('Install') {
             steps {
                 script {
+                    sh 'echo "Registry from env: $NPM_CONFIG_REGISTRY"'
+                    sh 'npm config get registry'
                     sh 'npm run install:ci'
                 }
             }


### PR DESCRIPTION
## WHAT
- Set NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ at pipeline level.
- Update Jenkins shared library to ontotext-platform@v0.1.51.

## WHY
We don’t use a Nexus scope here; public npm should be the default to keep CI stable

## HOW
- Jenkinsfile: add NPM_CONFIG_REGISTRY in environment {} so all npm invocations inherit the public registry unless explicitly overridden by flags or scoped .npmrc.
- Update Jenkins shared library to ontotext-platform@v0.1.51.

<img width="818" height="277" alt="image" src="https://github.com/user-attachments/assets/f9d0c989-f566-4257-b935-c3d1d49ec99f" />

## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
