### PR TITLE
Remove the .stencil folder after build

### DIFF
--- a/packages/shared-components/stencil.config.ts
+++ b/packages/shared-components/stencil.config.ts
@@ -5,10 +5,11 @@ const path = `${__dirname}/src/pages/fake-server.js`;
 
 export const config: Config = {
   namespace: 'shared-components',
+  sourceMap: false,
   outputTargets: [
     {
       type: 'dist',
-      esmLoaderPath: '../loader',
+      esmLoaderPath: '../loader'
     },
     // {
     //   type: 'dist-custom-elements',

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -32,7 +32,10 @@ module.exports = (env, argv) => merge(commonConfig(env, argv), {
                 },
               {
                 from: 'packages/shared-components/dist',
-                to: 'shared-components'
+                to: 'shared-components',
+                globOptions: {
+                    ignore: ['**/.stencil/**']
+                }
               },
               {
                 from: 'packages/api/dist',


### PR DESCRIPTION
Remove the .stencil folder after build. This contains ts.d files that are not needed in a production build, but we can't find a way to disable stencil to output them. This effectively removes the folder which brakes windows distribution because of the quite long file paths.
<img width="457" height="644" alt="image" src="https://github.com/user-attachments/assets/6d1c113a-e4c3-4c47-8c89-628ea5d96b68" />

Also disabled source map files generation for the web components due to the same reason -> too long names