### PR TITLE
3.1 clean up tsd files generated by stenciljs

### DIFF
--- a/packages/shared-components/stencil.config.ts
+++ b/packages/shared-components/stencil.config.ts
@@ -5,6 +5,7 @@ const path = `${__dirname}/src/pages/fake-server.js`;
 
 export const config: Config = {
   namespace: 'shared-components',
+  sourceMap: false,
   outputTargets: [
     {
       type: 'dist',

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -32,7 +32,10 @@ module.exports = (env, argv) => merge(commonConfig(env, argv), {
                 },
               {
                 from: 'packages/shared-components/dist',
-                to: 'shared-components'
+                to: 'shared-components',
+                globOptions: {
+                    ignore: ['**/.stencil/**']
+                }
               },
               {
                 from: 'packages/api/dist',


### PR DESCRIPTION
Remove the .stencil folder after build. This contains ts.d files that are not needed in a production build, but we can't find a way to disable stencil to output them. Effectively this removes the folder which brakes windows distribution because of the quite long file paths.
<img width="455" height="641" alt="image" src="https://github.com/user-attachments/assets/a05449c2-5272-40c3-a6bf-96397fab4de7" />

Also disabled source map files generation for the web components due to the same reason -> too long names 
