### PR TITLE
GDB-12921 Remove access to REST API for free access user

### DIFF
--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -214,6 +214,9 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         const securityContextService = ServiceProvider.get(SecurityContextService);
         const restrictedPages = securityContextService.getRestrictedPages();
 
+        const isAdministratorUser = $jwtAuth.isAdmin();
+        const hasAuthority = (role) => $scope.principal.authorities.indexOf(role) !== -1;
+
         const routes = PluginRegistry.get('route');
         const menuItems = PluginRegistry.get('main.menu');
 
@@ -226,7 +229,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
                 return;
             }
 
-            const isAccessToPageRestricted = !$jwtAuth.isAdmin() && $scope.principal.authorities.indexOf(menuItem.role) === -1;
+            const isAccessToPageRestricted = !isAdministratorUser && !hasAuthority(menuItem.role);
             restrictedPages.setPageRestriction(route.url, isAccessToPageRestricted);
         });
         securityContextService.updateRestrictedPages(restrictedPages);

--- a/packages/legacy-workbench/src/js/angular/stats/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/stats/plugin.js
@@ -46,7 +46,8 @@ PluginRegistry.add('main.menu', {
             order: 1,
             parent: 'Help',
             guideSelector: 'sub-menu-rest-api',
-            testSelector: 'sub-menu-rest-api'
+            testSelector: 'sub-menu-rest-api',
+            role: 'ROLE_USER',
         }, {
             label: 'Documentation',
             labelKey: 'menu.documentation.label',


### PR DESCRIPTION
## What
Remove access to REST API for free access user

## Why
Users with free access should not have access to the REST API menu item and page

How
- added role `ROLE_USER` to the menu item

## Testing

## Screenshots
<img width="261" height="293" alt="image" src="https://github.com/user-attachments/assets/821a3149-7183-4385-86cb-d06b8e3f507f" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
