### PR TITLE
GDB-12979: Required to click any connector twice for the form to open

### DIFF
--- a/packages/legacy-workbench/src/pages/connectorsInfo.html
+++ b/packages/legacy-workbench/src/pages/connectorsInfo.html
@@ -46,8 +46,12 @@
                                     </button>
 								</div>
                                 <h5 class="mb-0">
-                                    <a class="collapsed" data-toggle="collapse" data-parent="#accordion-{{keyForDom}}"
-                                       href="#collapse-{{keyForDom}}{{$index}}" aria-expanded="false"
+                                    <a class="collapsed"
+                                       data-toggle="collapse"
+                                       data-parent="#accordion-{{keyForDom}}"
+                                       href=""
+                                       data-target="#collapse-{{keyForDom}}{{$index}}"
+                                       aria-expanded="false"
                                        aria-controls="collapse-{{keyForDom}}{{$index}}">
                                         {{exist.name}}
                                     </a>


### PR DESCRIPTION
## What
Fixed the issue where the connector form required two clicks to open due to Bootstrap collapse and AngularJS interaction.

## Why
The first click triggered a "page flash" caused by Bootstrap’s `href="#collapse-...{{$index}}"` navigation updating the URL fragment and Angular’s digest cycle re-rendering.

## How
- Replaced `href`-based collapse toggle with `data-target` to prevent fragment navigation.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
