### PR TITLE
GDB-12980: Change default scrollTo strategy to prevent screen flashing

### DIFF
--- a/packages/legacy-workbench/src/js/angular/guides/model/guides.js
+++ b/packages/legacy-workbench/src/js/angular/guides/model/guides.js
@@ -3,3 +3,6 @@ export const GuideLevel = Object.freeze({
     INTERMEDIATE: 1,
     ADVANCED: 2
 });
+
+export const SMOOTH = 'smooth';
+export const NEAREST = 'nearest';

--- a/packages/legacy-workbench/src/js/angular/guides/tour-lib-services/shepherd.service.js
+++ b/packages/legacy-workbench/src/js/angular/guides/tour-lib-services/shepherd.service.js
@@ -5,6 +5,7 @@ import {
     navigate,
     getPathName
 } from '@ontotext/workbench-api';
+import {NEAREST, SMOOTH} from "../model/guides";
 
 export const GUIDE_ID = 'shepherd.guide_id';
 export const GUIDE_CURRENT_STEP_ID = 'shepherd.guide.current.step.id';
@@ -212,7 +213,11 @@ function ShepherdService($translate, LocalStorageAdapter, LSKeys, $interpolate, 
             confirmCancel: this._confirmGuideCancel,
             defaultStepOptions: {
                 classes: 'shadow-md bg-purple-dark',
-                scrollTo: true
+                scrollTo: {
+                    behavior: SMOOTH,
+                    block: NEAREST,
+                    inline: NEAREST
+                }
             }
         });
     };


### PR DESCRIPTION
## What
Changed the default scrollTo configuration to use a smoother and less disruptive alignment.

## Why
The previous strategy scrolled elements to the top of the viewport, which often caused the screen to flash or jump abruptly. This degraded the user experience during guides.

## How
- Updated `scrollTo.behavior` to smooth for natural animated scrolling;
- Updated block and inline to nearest, ensuring minimal movement while keeping the element visible.

(cherry picked from commit db0834581ba9493227f549e7a33bb342560a4524)

## Screenshots
## Before
<img width="320" alt="image" src="https://github.com/user-attachments/assets/44e829f2-cad2-42f5-81d6-2bef0c8d6b6f" />

#### After click "Next" button

<img width="320" alt="image" src="https://github.com/user-attachments/assets/2c580110-cf3b-409c-b052-b96abc21a89e" />

## After
<img width="320" alt="image" src="https://github.com/user-attachments/assets/56944a09-d086-439a-bea6-3dfa113181ac" />

#### After click "Next" button

<img width="320" alt="image" src="https://github.com/user-attachments/assets/d8411aa3-64bc-4973-9462-f276eafdd1c0" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
