### PR TITLE
feat(GDB-12742) Respect return URL on repo create

### DIFF
--- a/e2e-tests/cypress-flaky.config.js
+++ b/e2e-tests/cypress-flaky.config.js
@@ -1,6 +1,7 @@
-const {defineConfig} = require('cypress');
+import { defineConfig } from 'cypress';
+import setupPlugins from './plugins/index.js';
 
-module.exports = defineConfig({
+export default defineConfig({
     projectId: 'v35btb',
     fixturesFolder: 'fixtures',
     screenshotsFolder: 'report/screenshots',
@@ -16,12 +17,12 @@ module.exports = defineConfig({
         // We've imported your old cypress plugins here.
         // You may want to clean this up later by importing these.
         setupNodeEvents(on, config) {
-            return require('./plugins')(on, config);
+            return setupPlugins(on, config);
         },
         baseUrl: 'http://localhost:9000',
         specPattern: 'e2e-flaky/**/*.{js,jsx,ts,tsx}',
         supportFile: 'support/e2e.js',
-        reporter: "cypress-multi-reporters",
+        reporter: 'cypress-multi-reporters',
         reporterOptions: {
             configFile: 'cypress-reporter-config.json'
         }

--- a/e2e-tests/cypress-legacy.config.js
+++ b/e2e-tests/cypress-legacy.config.js
@@ -1,8 +1,15 @@
-const {defineConfig} = require('cypress');
+import { defineConfig } from 'cypress';
+import setupPlugins from './plugins/index.js';
 
 const isCoverage = process.env.COVERAGE === 'true';
 
-module.exports = defineConfig({
+const loadCodeCoverage = async (on, config) => {
+    const mod = await import('@bahmutov/cypress-code-coverage/plugin');
+    const plugin = ('default' in mod) ? mod.default : mod;
+    plugin(on, config);
+};
+
+export default defineConfig({
     projectId: 'v35btb',
     fixturesFolder: 'fixtures',
     screenshotsFolder: 'report/screenshots',
@@ -19,10 +26,10 @@ module.exports = defineConfig({
         },
         // We've imported your old cypress plugins here.
         // You may want to clean this up later by importing these.
-        setupNodeEvents(on, config) {
-            require('./plugins')(on, config);
+        async setupNodeEvents(on, config) {
+            setupPlugins(on, config);
             if (isCoverage) {
-                require('@bahmutov/cypress-code-coverage/plugin')(on, config)
+                await loadCodeCoverage(on, config);
             }
             return config;
         },

--- a/e2e-tests/cypress.config.js
+++ b/e2e-tests/cypress.config.js
@@ -1,6 +1,7 @@
-const {defineConfig} = require('cypress');
+import { defineConfig } from 'cypress';
+import setupPlugins from './plugins/index.js';
 
-module.exports = defineConfig({
+export default defineConfig({
     projectId: 'v35btb',
     fixturesFolder: 'fixtures',
     screenshotsFolder: 'report/screenshots',
@@ -20,7 +21,7 @@ module.exports = defineConfig({
         // We've imported your old cypress plugins here.
         // You may want to clean this up later by importing these.
         setupNodeEvents(on, config) {
-            return require('./plugins')(on, config);
+            return setupPlugins(on, config);
         },
         baseUrl: 'http://localhost:9000',
         specPattern: './**/*.{js,jsx,ts,tsx}',

--- a/e2e-tests/eslint.config.js
+++ b/e2e-tests/eslint.config.js
@@ -25,7 +25,10 @@ export default [
                 afterEach: 'readonly',
                 before: 'readonly',
                 after: 'readonly',
-                expect: 'readonly'
+                expect: 'readonly',
+
+                // Node.js globals for scripts
+                process: 'readonly',
             }
         },
         rules: {

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -2,6 +2,7 @@
   "name": "graphdb-workbench-tests",
   "version": "3.1.0-plugins1",
   "description": "Cypress tests for GraphDB workbench",
+  "type": "module",
   "scripts": {
     "prepack": "npm shrinkwrap",
     "postpack": "mv npm-shrinkwrap.json package-lock.json",

--- a/e2e-tests/plugins/index.js
+++ b/e2e-tests/plugins/index.js
@@ -11,17 +11,20 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-const deleteSync = require('del').deleteSync;
+import { deleteSync } from 'del';
+import failed from 'cypress-failed-log/src/failed.js';
+import installLogsPrinter from 'cypress-terminal-report/src/installLogsPrinter.js';
+
 const retryTracker = {};
 
-module.exports = (on, config) => {
+export default (on, config) => {
     // `on` is used to hook into various events Cypress emits
     // `config` is the resolved Cypress config
     on('task', {
-        failed: require('cypress-failed-log/src/failed')()
+        failed: failed()
     });
 
-    require('cypress-terminal-report/src/installLogsPrinter')(on, {
+    installLogsPrinter(on, {
         logToFilesOnAfterRun: true,
         printLogsToConsole: 'onFail',
         outputRoot: config.projectRoot + '/logs/',
@@ -95,5 +98,6 @@ module.exports = (on, config) => {
         printGroup('[FAIL] Broken tests', broken);
         console.log('====================================================================================================\n');
     });
+
     return config;
 };

--- a/e2e-tests/steps/home-steps.js
+++ b/e2e-tests/steps/home-steps.js
@@ -15,7 +15,7 @@ class HomeSteps extends BaseSteps {
 
     static visitInProdMode() {
         cy.visit('/', {
-            onBeforeLoad: (win) => {
+            onBeforeLoad: () => {
                 EnvironmentStubs.stubWbProdMode();
             }
         });
@@ -23,7 +23,7 @@ class HomeSteps extends BaseSteps {
 
     static visitInDevMode() {
         cy.visit('/', {
-            onBeforeLoad: (win) => {
+            onBeforeLoad: () => {
                 EnvironmentStubs.stubWbDevMode();
             }
         });
@@ -135,10 +135,16 @@ class HomeSteps extends BaseSteps {
     static selectSPARQLQueryToExecute(query) {
         cy.contains('ul.saved-queries li', query)
             .should('be.visible')
-            .trigger('hover')
+            .as('savedQueryItem');
+
+        cy.get('@savedQueryItem')
+            .trigger('hover');
+
+        cy.get('@savedQueryItem')
             .find('.execute-saved-query')
-            .click({force: true});
+            .click({ force: true });
     }
+
 
     static verifyQueryLink(queryName, modifiesRepoModal) {
         HomeSteps.selectSPARQLQueryToExecute(queryName);
@@ -188,7 +194,7 @@ class HomeSteps extends BaseSteps {
                 HomeSteps.getCreateRepositoryLink()
                     .click()
                     .url()
-                    .should('eq', Cypress.config("baseUrl") + '/repository/create?previous=home');
+                    .should('eq', Cypress.config("baseUrl") + '/repository/create?previous=%2F');
             });
         cy.get('.big-logo').click();
     }
@@ -205,9 +211,8 @@ class HomeSteps extends BaseSteps {
     }
 
     static getAutocompleteInput() {
-        const input = cy.get('.home-rdf-resource-search search-resource-input .view-res-input');
-        input.should('be.visible');
-        return input;
+        return cy.get('.home-rdf-resource-search search-resource-input .view-res-input')
+            .should('be.visible');
     }
 
     static shouldHaveAutocompleteResult(uri) {
@@ -220,9 +225,9 @@ class HomeSteps extends BaseSteps {
     }
 
     static getAutocompleteResultElement(uri) {
-        const element = cy.get("#auto-complete-results-wrapper p").contains(uri);
-        element.trigger('mouseover');
-        return element;
+        return cy.get('#auto-complete-results-wrapper p')
+            .contains(uri)
+            .trigger('mouseover');
     }
 
     static verifyAutocompleteResourceLink(uri) {

--- a/e2e-tests/support/e2e.js
+++ b/e2e-tests/support/e2e.js
@@ -24,14 +24,16 @@ import 'cypress-file-upload';
 import {LicenseStubs} from "../stubs/license-stubs";
 import {SecurityStubs} from "../stubs/security-stubs";
 // https://github.com/bahmutov/cypress-code-coverage
-require('@bahmutov/cypress-code-coverage/support');
+import '@bahmutov/cypress-code-coverage/support';
 
 // Configures an environment variable with the key used for common actions (cmd on mac, ctrl on other OS).
 // This variable must be used in all actions that type e.g. ctrl-a to select text.
 Cypress.env('modifierKey', Cypress.platform === 'darwin' ? '{cmd}' : '{ctrl}');
 
-require('cypress-failed-log');
-require('cypress-terminal-report/src/installLogsCollector')();
+import 'cypress-failed-log';
+import * as ctr from 'cypress-terminal-report/src/installLogsCollector';
+const installLogsCollector = ('default' in ctr) ? ctr.default : ctr;
+installLogsCollector();
 
 // We don't want any tests to hit real Google
 beforeEach(() => {

--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -38,7 +38,7 @@ import {
     RepositoryContextService,
     RepositoryService,
     ServiceProvider,
-    SecurityContextService
+    SecurityContextService,
 } from "@ontotext/workbench-api";
 import {EventConstants} from "./utils/event-constants";
 import {CookieConsent} from "./models/cookie-policy/cookie-consent";
@@ -70,7 +70,7 @@ angular
         'pageslide-directive',
         'graphdb.core.services.workbench-context',
         'graphdb.framework.core.services.rdf4j.repositories',
-        'rzSlider'
+        'rzSlider',
     ])
     .controller('mainCtrl', mainCtrl)
     .controller('homeCtrl', homeCtrl)
@@ -104,7 +104,6 @@ function homeCtrl($scope,
                   WorkbenchContextService,
                   RDF4JRepositoriesService,
                   toastr) {
-
     $scope.doClear = false;
 
     // =========================
@@ -119,15 +118,15 @@ function homeCtrl($scope,
         $scope.activeRepositorySizeError = undefined;
 
         ServiceProvider.get(RepositoryService).getRepositorySizeInfo(repo)
-            .then(function (repositorySizeInfo) {
+            .then(function(repositorySizeInfo) {
                 $scope.activeRepositorySize = repositorySizeInfo;
             })
-            .catch(function (e) {
+            .catch(function(e) {
                 $scope.activeRepositorySizeError = e.data.message;
             });
     };
 
-    $scope.onKeyDown = function (event) {
+    $scope.onKeyDown = function(event) {
         if (event.keyCode === 27) {
             $scope.doClear = true;
         }
@@ -167,7 +166,7 @@ function homeCtrl($scope,
 
     $scope.$on('$destroy', () => subscriptions.forEach((subscription) => subscription()));
 
-    $scope.$on('$routeChangeSuccess', function ($event, current, previous) {
+    $scope.$on('$routeChangeSuccess', function($event, current, previous) {
         if (previous) {
             // If previous is defined we got here through navigation, hence security is already
             // initialized and its safe to refresh the repository info.
@@ -180,7 +179,6 @@ function homeCtrl($scope,
             }
         }
     });
-
 }
 
 mainCtrl.$inject = ['$scope', '$menuItems', '$jwtAuth', '$http', 'toastr', '$location', '$repositories', '$licenseService', '$rootScope',
@@ -220,7 +218,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         const routes = PluginRegistry.get('route');
         const menuItems = PluginRegistry.get('main.menu');
 
-        angular.forEach(routes, function (route) {
+        angular.forEach(routes, function(route) {
             const menuItem = menuItems.flatMap((mi) => mi.items)
                 .filter((menuItem) => menuItem.role?.includes('ROLE_'))
                 .find((menuItem) => route.url.includes(menuItem.href));
@@ -233,24 +231,24 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
             restrictedPages.setPageRestriction(route.url, isAccessToPageRestricted);
         });
         securityContextService.updateRestrictedPages(restrictedPages);
-    }
+    };
 
     const startGuide = (guideId) => {
         // Check to see if $translate service is ready with the language before starting the guide as the steps are translated ahead on time. Will retry 20 times (1 second).
-        const timer = $interval(function () {
+        const timer = $interval(function() {
             if ($translate.use()) {
-                GuidesService.autoStartGuide(guideId)
+                GuidesService.autoStartGuide(guideId);
                 $interval.cancel(timer);
             }
         }, 50, 20);
-    }
+    };
 
     $scope.onRdfResourceSearch = () => {
         if (isHomePage()) {
             $scope.hideRdfResourceSearch = true;
             $('#search-resource-input-home input').focus();
             toastr.info(decodeHTML($translate.instant('search.resource.current.page.msg')), $translate.instant('search.resources.msg'), {
-                allowHtml: true
+                allowHtml: true,
             });
         }
     };
@@ -259,31 +257,31 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         return $location.url() === '/';
     };
 
-    $scope.isMenuCollapsedOnLoad = function () {
+    $scope.isMenuCollapsedOnLoad = function() {
         return $('.main-menu').hasClass('collapsed');
     };
 
-    $scope.checkMenu = debounce(function () {
+    $scope.checkMenu = debounce(function() {
         const collapsed = $scope.isMenuCollapsedOnLoad();
         if ($scope.menuCollapsed !== collapsed) {
             $scope.menuCollapsed = collapsed;
         }
     }, 0, {trailing: true});
 
-    const deregisterMenuWatcher = $scope.$watch(function () {
+    const deregisterMenuWatcher = $scope.$watch(function() {
         return $scope.isMenuCollapsedOnLoad();
-    }, function (newValue, oldValue) {
+    }, function(newValue, oldValue) {
         if (newValue !== oldValue || typeof newValue === 'undefined') {
             // Trigger debounced check on both collapse and expand
             $scope.checkMenu();
         }
     });
 
-    $scope.showLabel = function (item) {
+    $scope.showLabel = function(item) {
         return item.children ? true : !$scope.menuCollapsed;
     };
 
-    const setYears = function () {
+    const setYears = function() {
         const date = new Date();
         $scope.currentYear = date.getFullYear();
         $scope.previousYear = 2002; // Peio says this is 2002 or 2003, in other words the year of the earliest file.
@@ -291,7 +289,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 
     setYears();
 
-    $('#repositorySelectDropdown').on('hide.bs.dropdown', function (e) {
+    $('#repositorySelectDropdown').on('hide.bs.dropdown', function(e) {
         if (GuidesService.isActive()) {
             if ($('#repositorySelectDropdown.autoCloseOff').length > 0) {
                 e.preventDefault();
@@ -299,7 +297,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         }
     });
 
-    $scope.$on("$routeChangeSuccess", function ($event, current, previous) {
+    $scope.$on("$routeChangeSuccess", function($event, current, previous) {
         $scope.clicked = false;
         $scope.hideRdfResourceSearch = false;
         if (previous) {
@@ -319,40 +317,36 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
     }
 
     const subscribeToCookieConsentChanged = () => {
-        document.body.addEventListener(COOKIE_CONSENT_CHANGED_EVENT, updateCookieConsentHandler)
+        document.body.addEventListener(COOKIE_CONSENT_CHANGED_EVENT, updateCookieConsentHandler);
         return () => document.body.removeEventListener(COOKIE_CONSENT_CHANGED_EVENT, updateCookieConsentHandler);
-    }
+    };
 
-    let cookieConsentChangedSubscription;
-    if (cookieConsentChangedSubscription) {
-        cookieConsentChangedSubscription();
-    }
-    cookieConsentChangedSubscription = subscribeToCookieConsentChanged();
+    const cookieConsentChangedSubscription = subscribeToCookieConsentChanged();
 
-    $scope.resumeGuide = function () {
+    $scope.resumeGuide = function() {
         $rootScope.$broadcast('guideResume');
     };
 
-    $rootScope.$on('guideReset', function () {
+    $rootScope.$on('guideReset', function() {
         $scope.guidePaused = false;
         $rootScope.guidePaused = false;
     });
 
-    $rootScope.$on('guideStarted', function () {
+    $rootScope.$on('guideStarted', function() {
         $scope.guidePaused = false;
         $rootScope.guidePaused = false;
     });
 
-    $rootScope.$on('guidePaused', function () {
+    $rootScope.$on('guidePaused', function() {
         $scope.guidePaused = true;
         $rootScope.guidePaused = true;
     });
 
-    $rootScope.$on('$translateChangeSuccess', function () {
-        $scope.menu.forEach(function (menu) {
+    $rootScope.$on('$translateChangeSuccess', function() {
+        $scope.menu.forEach(function(menu) {
             menu.label = $translate.instant(menu.labelKey);
             if (menu.children) {
-                menu.children.forEach(function (child) {
+                menu.children.forEach(function(child) {
                     child.label = $translate.instant(child.labelKey);
                 });
             }
@@ -364,27 +358,28 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
     });
 
     //Copy to clipboard popover options
-    $scope.copyToClipboard = function (uri) {
+    $scope.copyToClipboard = function(uri) {
         ModalService.openCopyToClipboardModal(uri);
     };
 
-    $scope.goToAddRepo = function () {
-        $location.path('repository/create').search({previous: 'home'});
+    $scope.goToAddRepo = function() {
+        const returnTo = $location.url();
+        $location.path('repository/create').search({previous: returnTo});
     };
 
-    $scope.goToEditRepo = function (repository) {
+    $scope.goToEditRepo = function(repository) {
         $location.path(`repository/edit/${repository.id}`).search({previous: 'home', location: repository.location});
     };
 
-    $scope.getLocationFromUri = function (location) {
+    $scope.getLocationFromUri = function(location) {
         return $repositories.getLocationFromUri(location);
     };
 
-    $scope.$on("$locationChangeSuccess", function () {
+    $scope.$on("$locationChangeSuccess", function() {
         $scope.showFooter = true;
     });
 
-    $scope.$on("repositoryIsSet", function () {
+    $scope.$on("repositoryIsSet", function() {
         $scope.setRestricted();
         LocalStorageAdapter.clearClassHieararchyState();
     });
@@ -397,7 +392,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 
     $scope.sesameVersion = productInfo.sesame;
 
-    $scope.select = function (index, event, clicked) {
+    $scope.select = function(index, event, clicked) {
         if ($('.main-menu').hasClass('collapsed')) {
             if (!$(event.target).parents(".menu-element").children('.menu-element-root').hasClass('active')) {
                 if (!$(event.target).parents(".menu-element").hasClass('open') && clicked) {
@@ -432,7 +427,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
                     $scope.selected = index;
                 }
             } else {
-                $timeout(function () {
+                $timeout(function() {
                     $(event.target).parents(".menu-element").children('.menu-element-root').addClass('active');
                 }, 50);
                 $scope.selected = index;
@@ -440,7 +435,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         }
     };
 
-    $('body').bind('click', function (e) {
+    $('body').bind('click', function(e) {
         if (!$(e.target).parents(".main-menu").length && $('.main-menu').hasClass('collapsed')) {
             $scope.clicked = false;
             $scope.selected = -1;
@@ -449,13 +444,13 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 
     $scope.resolveUrl = (productVersion, endpointPath) => DocumentationUrlResolver.getDocumentationUrl(productVersion, endpointPath);
 
-    $scope.isCurrentPath = function (path) {
+    $scope.isCurrentPath = function(path) {
         return $location.path() === '/' + path;
     };
 
-    $scope.isCurrentSubmenuChildPath = function (submenu) {
+    $scope.isCurrentSubmenuChildPath = function(submenu) {
         if (submenu.children.length !== 0) {
-            return submenu.children.some(function (child) {
+            return submenu.children.some(function(child) {
                 return $scope.isCurrentPath(child.href);
             });
         }
@@ -466,7 +461,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
     if ($location.path() === '/') {
         $scope.selected = -1;
     } else {
-        $timeout(function () {
+        $timeout(function() {
             const route = $location.path().replace('/', '');
             const elem = $('a[href^="' + route + '"]');
             $scope.selected = elem.closest('.menu-element').index() - 1;
@@ -477,56 +472,56 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
     $scope.popoverTemplate = 'js/angular/templates/repositorySize.html';
 
     $scope.securityEnabled = true;
-    $scope.isSecurityEnabled = function () {
+    $scope.isSecurityEnabled = function() {
         return $jwtAuth.isSecurityEnabled();
     };
-    $scope.isFreeAccessEnabled = function () {
+    $scope.isFreeAccessEnabled = function() {
         return $jwtAuth.isFreeAccessEnabled();
     };
-    $scope.hasExternalAuthUser = function () {
+    $scope.hasExternalAuthUser = function() {
         return $jwtAuth.hasExternalAuthUser();
     };
-    $scope.isDefaultAuthEnabled = function () {
+    $scope.isDefaultAuthEnabled = function() {
         return $jwtAuth.isDefaultAuthEnabled();
     };
 
-    $scope.isUserLoggedIn = function () {
+    $scope.isUserLoggedIn = function() {
         return $scope.userLoggedIn;
     };
 
-    $scope.hasActiveLocation = function () {
+    $scope.hasActiveLocation = function() {
         return $repositories.hasActiveLocation();
     };
 
-    $scope.getActiveLocation = function () {
+    $scope.getActiveLocation = function() {
         return $repositories.getActiveLocation();
     };
 
-    $scope.isLoadingLocation = function () {
+    $scope.isLoadingLocation = function() {
         return $repositories.isLoadingLocation();
     };
 
-    $scope.getRepositories = function () {
+    $scope.getRepositories = function() {
         return $repositories.getRepositories();
     };
 
-    $scope.getReadableRepositories = function () {
+    $scope.getReadableRepositories = function() {
         return $repositories.getReadableRepositories();
     };
 
-    $scope.getWritableRepositories = function () {
+    $scope.getWritableRepositories = function() {
         return $repositories.getWritableRepositories();
     };
 
-    $scope.getActiveRepository = function () {
+    $scope.getActiveRepository = function() {
         return $repositories.getActiveRepository();
     };
 
-    $scope.canWriteRepoInLocation = function (repository) {
+    $scope.canWriteRepoInLocation = function(repository) {
         return $jwtAuth.canWriteRepo(repository);
     };
 
-    $scope.canWriteActiveRepo = function (noSystem) {
+    $scope.canWriteActiveRepo = function(noSystem) {
         const activeRepository = $repositories.getActiveRepositoryObject();
         if (activeRepository) {
             // If the parameter noSystem is true then we don't allow write access to the SYSTEM repository
@@ -536,11 +531,11 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         return false;
     };
 
-    $scope.getActiveRepositoryObject = function () {
+    $scope.getActiveRepositoryObject = function() {
         return $repositories.getActiveRepositoryObject();
     };
 
-    $scope.getActiveRepositoryShortLocation = function () {
+    $scope.getActiveRepositoryShortLocation = function() {
         const repo = $repositories.getActiveRepositoryObject();
         if (repo) {
             const location = repo.location;
@@ -552,19 +547,19 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         return '';
     };
 
-    $scope.isActiveRepoOntopType = function () {
+    $scope.isActiveRepoOntopType = function() {
         return $repositories.isActiveRepoOntopType();
     };
 
-    $scope.isActiveRepoFedXType = function () {
+    $scope.isActiveRepoFedXType = function() {
         return $repositories.isActiveRepoFedXType();
     };
 
-    $scope.isLicensePresent = function () {
+    $scope.isLicensePresent = function() {
         return $licenseService.isLicensePresent();
     };
 
-    $scope.isLicenseValid = function () {
+    $scope.isLicenseValid = function() {
         return $licenseService.isLicenseValid();
     };
 
@@ -572,7 +567,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
      *  Sets attrs property in the directive
      * @param attrs
      */
-    $scope.setAttrs = function (attrs) {
+    $scope.setAttrs = function(attrs) {
         $scope.attrs = attrs;
     };
 
@@ -583,7 +578,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
      *  If on the other hand attribute "ontop" or "fedx" is found and such repo, proper message about the
      * restrictions related with repository of type Ontop or FedX will be shown to the user
      */
-    $scope.setRestricted = function () {
+    $scope.setRestricted = function() {
         if ($scope.attrs) {
             $scope.isRestricted =
                 $scope.attrs.hasOwnProperty('license') && !$licenseService.isLicenseValid() ||
@@ -593,7 +588,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         }
     };
 
-    $scope.toHumanReadableType = function (type) {
+    $scope.toHumanReadableType = function(type) {
         switch (type) {
             case 'graphdb':
                 return 'Graphdb';
@@ -608,7 +603,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         }
     };
 
-    $scope.setRepository = function (repository) {
+    $scope.setRepository = function(repository) {
         $repositories.setRepository(repository);
     };
 
@@ -638,7 +633,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
             // otherwise show login screen if security is on
             $rootScope.redirectToLogin().then(() => {
                 toastr.success('Signed out');
-            })
+            });
         }
     }
 
@@ -680,60 +675,60 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         }
     };
 
-    $scope.isAdmin = function () {
+    $scope.isAdmin = function() {
         return $scope.hasRole(UserRole.ROLE_ADMIN);
     };
 
-    $scope.isUser = function () {
+    $scope.isUser = function() {
         return $scope.hasRole(UserRole.ROLE_USER);
     };
 
-    $scope.hasRole = function (role) {
+    $scope.hasRole = function(role) {
         if (!angular.isUndefined(role)) {
             return $jwtAuth.hasRole(role);
         }
         return true;
     };
 
-    $scope.hasPermission = function () {
+    $scope.hasPermission = function() {
         return $rootScope.hasPermission();
     };
 
-    $scope.canReadRepo = function (repo) {
+    $scope.canReadRepo = function(repo) {
         return $jwtAuth.canReadRepo(repo);
     };
 
-    $scope.checkForWrite = function (role, repo) {
+    $scope.checkForWrite = function(role, repo) {
         return $jwtAuth.checkForWrite(role, repo);
     };
 
-    $scope.hasAuthority = function () {
+    $scope.hasAuthority = function() {
         return $jwtAuth.hasAuthority();
-    }
+    };
 
-    $scope.hasGraphqlRightsOverCurrentRepo = function () {
+    $scope.hasGraphqlRightsOverCurrentRepo = function() {
         return $jwtAuth.hasGraphqlRightsOverCurrentRepo();
-    }
+    };
 
-    $scope.setPopoverRepo = function (repository) {
+    $scope.setPopoverRepo = function(repository) {
         $scope.popoverRepo = repository;
     };
 
     // When the dropdown list is open, the popover of the already selected repo should disappear on mouseover on any of the listed options
-    $scope.handlePopovers = function (repository) {
+    $scope.handlePopovers = function(repository) {
         $scope.setPopoverRepo(repository);
         $scope.closeActiveRepoPopover();
     };
 
-    $scope.isRepoActive = function (repository) {
+    $scope.isRepoActive = function(repository) {
         return $repositories.isRepoActive(repository);
     };
 
-    $scope.getRepositorySize = function () {
+    $scope.getRepositorySize = function() {
         $scope.repositorySize = {};
         if ($scope.popoverRepo) {
             $scope.repositorySize.loading = true;
-            RepositoriesRestService.getSize($scope.popoverRepo).then(function (res) {
+            RepositoriesRestService.getSize($scope.popoverRepo).then(function(res) {
                 $scope.repositorySize = res.data;
             });
         }
@@ -745,10 +740,10 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
      */
     let popoverTimer;
 
-    $scope.openActiveRepoPopover = function () {
+    $scope.openActiveRepoPopover = function() {
         if ($scope.getActiveRepository()) {
             $scope.cancelPopoverOpen();
-            popoverTimer = $timeout(function () {
+            popoverTimer = $timeout(function() {
                 $scope.isActiveRepoPopoverOpen = true;
             }, 1000);
         }
@@ -757,18 +752,18 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
     /**
      * Cancels the popover timer.
      */
-    $scope.cancelPopoverOpen = function () {
+    $scope.cancelPopoverOpen = function() {
         $timeout.cancel(popoverTimer);
-    }
+    };
 
-    $scope.closeActiveRepoPopover = function () {
+    $scope.closeActiveRepoPopover = function() {
         $scope.isActiveRepoPopoverOpen = false;
     };
 
-    const closeActiveRepoPopoverEventHandler = function (event) {
+    const closeActiveRepoPopoverEventHandler = function(event) {
         const popoverElement = document.querySelector('.popover');
         if ($scope.isActiveRepoPopoverOpen && popoverElement && !popoverElement.contains(event.target)) {
-            $timeout(function () {
+            $timeout(function() {
                 $scope.isActiveRepoPopoverOpen = false;
             }, 0);
         }
@@ -776,40 +771,40 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 
     document.addEventListener('click', closeActiveRepoPopoverEventHandler);
 
-    $scope.getDegradedReason = function () {
+    $scope.getDegradedReason = function() {
         return $repositories.getDegradedReason();
     };
 
-    $scope.canManageRepositories = function () {
+    $scope.canManageRepositories = function() {
         return $jwtAuth.hasRole(UserRole.ROLE_REPO_MANAGER) && !$repositories.getDegradedReason();
     };
 
-    $scope.getSavedQueries = function () {
+    $scope.getSavedQueries = function() {
         SparqlRestService.getSavedQueries()
-            .success(function (data) {
+            .success(function(data) {
                 $scope.sampleQueries = data;
             })
-            .error(function (data) {
+            .error(function(data) {
                 const msg = getError(data);
                 toastr.error(msg, $translate.instant('query.editor.get.saved.queries.error'));
             });
     };
 
-    $scope.goToSparqlEditor = function (query) {
+    $scope.goToSparqlEditor = function(query) {
         $location.path('/sparql').search({savedQueryName: query.name, owner: query.owner, execute: true});
     };
 
-    $scope.declineTutorial = function () {
+    $scope.declineTutorial = function() {
         LocalStorageAdapter.set(LSKeys.TUTORIAL_STATE, 1);
         $scope.tutorialState = false;
     };
 
-    $scope.showTutorial = function () {
+    $scope.showTutorial = function() {
         $scope.tutorialState = true;
         LocalStorageAdapter.remove(LSKeys.TUTORIAL_STATE);
     };
 
-    $scope.initTutorial = function () {
+    $scope.initTutorial = function() {
         if (!$scope.tutorialState && $location.path() !== '/') {
             return;
         }
@@ -818,29 +813,29 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
                 "title": $translate.instant("main.info.title.welcome.page"),
                 "info": '<p>' + decodeHTML($translate.instant('main.info.welcome.page')) + '</p>'
                     + '<p>' + decodeHTML($translate.instant('main.info.welcome.page.guides')) + '</p>'
-                    + '<p>' + decodeHTML($translate.instant('main.info.welcome.page.footer')) + '</p>'
+                    + '<p>' + decodeHTML($translate.instant('main.info.welcome.page.footer')) + '</p>',
             },
             {
                 "title": $translate.instant('main.info.title.create.repo.page'),
-                "info": decodeHTML($translate.instant('main.info.create.repo.page', {link: "<a href=\"https://graphdb.ontotext.com/documentation/" + productInfo.productShortVersion + "/configuring-a-repository.html\" target=\"_blank\">"}))
+                "info": decodeHTML($translate.instant('main.info.create.repo.page', {link: "<a href=\"https://graphdb.ontotext.com/documentation/" + productInfo.productShortVersion + "/configuring-a-repository.html\" target=\"_blank\">"})),
             },
             {
                 "title": $translate.instant('main.info.title.load.sample.dataset'),
-                "info": $translate.instant('main.info.load.sample.dataset')
+                "info": $translate.instant('main.info.load.sample.dataset'),
             },
             {
                 "title": $translate.instant('main.info.title.run.sparql.query'),
-                "info": decodeHTML($translate.instant('main.info.run.sparql.query'))
+                "info": decodeHTML($translate.instant('main.info.run.sparql.query')),
             },
             {
                 "title": $translate.instant('menu.rest.api.label'),
-                "info": decodeHTML($translate.instant('main.info.rest.api'))
-            }
+                "info": decodeHTML($translate.instant('main.info.rest.api')),
+            },
         ];
         $scope.activePage = 0;
         $(".pages-wrapper .page-slide").css("opacity", 100);
         const widthOfParentElm = $(".main-container")[0].offsetWidth + 200;
-        $timeout(function () {
+        $timeout(function() {
             const $pageSlider = $(".pages-wrapper .page-slide");
             $pageSlider.css("left", widthOfParentElm + "px");
             $($pageSlider[$scope.activePage]).css("left", 0 + "px");
@@ -848,11 +843,11 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         }, 50);
     };
 
-    $scope.getTutorialPageHtml = function (page) {
+    $scope.getTutorialPageHtml = function(page) {
         return $sce.trustAsHtml(page.info);
     };
 
-    $scope.checkSubMenuPosition = function (index) {
+    $scope.checkSubMenuPosition = function(index) {
         if (index === 0) {
             $('.main-menu.collapsed .sub-menu').removeClass('align-bottom');
         } else {
@@ -866,7 +861,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 
     collapsedMenuLogicOnInit();
 
-    $(window).resize(function () {
+    $(window).resize(function() {
         collapseMenuLogicOnResize();
         if ($scope.tutorialState && $location.path() === '/') {
             $scope.initTutorial();
@@ -931,7 +926,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         }
     }
 
-    $scope.slideToPage = function (index) {
+    $scope.slideToPage = function(index) {
         const widthOfParentElm = $(".main-container")[0].offsetWidth;
         const $pageSlider = $(".pages-wrapper .page-slide");
         $pageSlider.css("opacity", "0").delay(200).css("left", widthOfParentElm + "px");
@@ -939,7 +934,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         $($pageSlider[$scope.activePage]).css("opacity", "100").css("left", 0 + "px");
     };
 
-    $scope.slideNext = function () {
+    $scope.slideNext = function() {
         let nextPageIndex = ++$scope.activePage;
         if (nextPageIndex >= $scope.tutorialInfo.length) {
             nextPageIndex = 0;
@@ -948,7 +943,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         $($(".btn-toolbar.pull-right .btn-group .btn")[$scope.activePage]).focus();
     };
 
-    $scope.toggleNavigation = function () {
+    $scope.toggleNavigation = function() {
         const $mainMenu = $('.main-menu');
         const $activeSubmenu = $('.sub-menu li.active');
         if (!$mainMenu.hasClass('collapsed')) {
@@ -980,7 +975,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         }
     };
 
-    $scope.$on('onToggleNavWidth', function (e, isCollapsed) {
+    $scope.$on('onToggleNavWidth', function(e, isCollapsed) {
         $scope.menuState = isCollapsed;
         if (isCollapsed) {
             LocalStorageAdapter.set(LSKeys.MENU_STATE, 'collapsedMenu');
@@ -989,7 +984,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         }
         if ($scope.tutorialState && $location.path() === '/') {
             const withOfParentElm = $(".pages-wrapper")[0].offsetWidth + 200;
-            $timeout(function () {
+            $timeout(function() {
                 const $pageSlider = $(".pages-wrapper .page-slide");
                 $pageSlider.css("left", withOfParentElm + "px");
                 $($pageSlider[$scope.activePage]).css("left", 0 + "px");
@@ -1001,7 +996,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         $scope.getSavedQueries();
     }
 
-    $scope.$on('securityInit', function (scope, securityEnabled, userLoggedIn, freeAccess) {
+    $scope.$on('securityInit', function(scope, securityEnabled, userLoggedIn, freeAccess) {
         $scope.securityEnabled = securityEnabled;
         $scope.userLoggedIn = userLoggedIn;
 
@@ -1014,7 +1009,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
             setPrincipal()
                 .then(() => {
                     // Update Restricted Pages permissions on securityInit
-                    updatePermissions()
+                    updatePermissions();
 
                     // Added timeout because, when the 'securityInit' event is fired after user logged-in.
                     // The authentication headers are still not set correctly when a request that loads saved queries is called and the $unauthorizedInterceptor rejects the request.
@@ -1024,7 +1019,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
             $licenseService.checkLicenseStatus()
                 .then(() => {
                     $scope.licenseIsSet = true;
-                    TrackingService.applyTrackingConsent()
+                    TrackingService.applyTrackingConsent();
                 })
                 .catch((error) => {
                     $scope.licenseIsSet = false;
@@ -1040,49 +1035,49 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         }
     });
 
-    $scope.isTrackingAllowed = function () {
+    $scope.isTrackingAllowed = function() {
         if (!$scope.licenseIsSet) {
             return;
         }
         return TrackingService.isTrackingAllowed();
     };
 
-    $scope.getProductType = function () {
+    $scope.getProductType = function() {
         return $licenseService.productType();
     };
 
-    $scope.isEnterprise = function () {
+    $scope.isEnterprise = function() {
         return $scope.getProductType() === "enterprise";
     };
 
-    $scope.isFreeEdition = function () {
+    $scope.isFreeEdition = function() {
         return $scope.getProductType() === "free";
     };
 
-    $scope.checkEdition = function (editions) {
-        if (editions == null) {
+    $scope.checkEdition = function(editions) {
+        if (editions === null) {
             return true;
         }
         return _.indexOf(editions, $scope.getProductType()) >= 0;
     };
 
-    $scope.showLicense = function () {
+    $scope.showLicense = function() {
         return $licenseService.showLicense();
     };
 
-    $scope.getLicense = function () {
+    $scope.getLicense = function() {
         return $licenseService.license();
     };
 
-    $scope.getLicenseErrorMsg = function () {
+    $scope.getLicenseErrorMsg = function() {
         return $licenseService.licenseErrorMsg();
-    }
+    };
 
-    $scope.isLicenseHardcoded = function () {
+    $scope.isLicenseHardcoded = function() {
         return $licenseService.isLicenseHardcoded();
     };
 
-    $scope.getHumanReadableSeconds = function (s, preciseSeconds) {
+    $scope.getHumanReadableSeconds = function(s, preciseSeconds) {
         const days = Math.floor(s / 86400);
         const hours = Math.floor((s % 86400) / 3600);
         const minutes = Math.floor((s % 3600) / 60);
@@ -1113,7 +1108,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
         return message.replace(/( 0[a-z])+$/, "");
     };
 
-    $scope.getHumanReadableTimestamp = function (time) {
+    $scope.getHumanReadableTimestamp = function(time) {
         const now = Date.now();
         const delta = (now - time) / 1000;
         if (delta < 60) {
@@ -1208,8 +1203,8 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
 repositorySizeCtrl.$inject = ['$scope', '$http', 'RepositoriesRestService'];
 
 function repositorySizeCtrl($scope, $http, RepositoriesRestService) {
-    $scope.getRepositorySize = function (repository) {
-        RepositoriesRestService.getSize(repository).then(function (res) {
+    $scope.getRepositorySize = function(repository) {
+        RepositoriesRestService.getSize(repository).then(function(res) {
             $scope.size = res.data;
         });
     };
@@ -1223,19 +1218,19 @@ function uxTestCtrl($scope, $repositories, toastr, ModalService) {
         {name: 'white', shade: 'light'},
         {name: 'red', shade: 'dark'},
         {name: 'blue', shade: 'dark'},
-        {name: 'yellow', shade: 'light'}
+        {name: 'yellow', shade: 'light'},
     ];
     $scope.myColor = $scope.colors[2];
 
     $scope.specialValue = {
         "id": "12345",
-        "value": "green"
+        "value": "green",
     };
 
     $scope.checkedItem = {name: 'black', shade: 'dark'};
 
     $scope.toggleOn = true;
-    $scope.toggleSwitch = function () {
+    $scope.toggleSwitch = function() {
         $scope.toggleOn = !$scope.toggleOn;
     };
 
@@ -1244,16 +1239,16 @@ function uxTestCtrl($scope, $repositories, toastr, ModalService) {
 
     $scope.onopen = $scope.onclose = () => angular.noop();
     $scope.openInfoPanel = false;
-    $scope.showInfoPanel = function () {
+    $scope.showInfoPanel = function() {
         $scope.openInfoPanel = true;
     };
-    $scope.closeInfoPanel = function () {
+    $scope.closeInfoPanel = function() {
         $scope.openInfoPanel = false;
     };
 
     $scope.slideOpen = false;
 
-    $scope.toggleSlide = function () {
+    $scope.toggleSlide = function() {
         $scope.slideOpen = !$scope.slideOpen;
     };
 
@@ -1264,33 +1259,33 @@ function uxTestCtrl($scope, $repositories, toastr, ModalService) {
         options: {
             floor: 0,
             ceil: 100,
-            step: 1
-        }
+            step: 1,
+        },
     };
 
-    $scope.openModal = function () {
+    $scope.openModal = function() {
         const modal = ModalService.openSimpleModal({
             title: 'Confirm',
             message: 'Lorem ipsum dolor sit amet.',
-            warning: true
+            warning: true,
         });
 
-        modal.result.then(function () {
+        modal.result.then(function() {
             modal.dismiss('cancel');
         });
     };
 
-    $scope.demoToast = function (alertType, secondArg = true) {
+    $scope.demoToast = function(alertType, secondArg = true) {
         toastr[alertType]('Consectetur adipiscing elit. Sic transit gloria mundi.',
             secondArg ? 'Lorem ipsum dolor sit amet' : undefined,
             {timeOut: 300000, extendedTimeOut: 300000});
     };
 
-    $scope.clearToasts = function () {
+    $scope.clearToasts = function() {
         toastr.clear();
     };
 
-    $scope.clearRepo = function () {
+    $scope.clearRepo = function() {
         $repositories.setRepository('');
     };
 }

--- a/packages/legacy-workbench/src/js/angular/repositories/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/controllers.js
@@ -2,7 +2,7 @@ import {
     FILENAME_PATTERN,
     NUMBER_PATTERN,
     REPOSITORY_TYPES,
-    STATIC_RULESETS
+    STATIC_RULESETS,
 } from "./repository.constants";
 import {decodeHTML} from "../../../app";
 import './controllers/manage-remote-location-dialog.controller';
@@ -10,7 +10,7 @@ import {RemoteLocationType} from "../models/repository/remote-location.model";
 
 const ENTITY_INDEX_SIZE_MIN = 10000;
 
-export const getFileName = function (path) {
+export const getFileName = function(path) {
     let lastIdx = path.lastIndexOf('/');
     if (lastIdx === -1) {
         lastIdx = path.lastIndexOf('\\');
@@ -22,12 +22,12 @@ export const getFileName = function (path) {
     return name;
 };
 
-const parseNumberParamsIfNeeded = function (params) {
+const parseNumberParamsIfNeeded = function(params) {
     if (!params) {
         return;
     }
 
-    Object.keys(params).forEach(key => {
+    Object.keys(params).forEach((key) => {
         const param = params[key];
         if (param && typeof param.value === 'string') {
             const possibleNumber = parseFloat(params[key].value);
@@ -40,13 +40,13 @@ const parseNumberParamsIfNeeded = function (params) {
     });
 };
 
-const parseMemberParamIfNeeded = function (param) {
+const parseMemberParamIfNeeded = function(param) {
     if (param && param.member) {
         param.member.value = [];
     }
 };
 
-const getShaclOptionsClass = function () {
+const getShaclOptionsClass = function() {
     const optionsModule = document.getElementById('shaclOptions');
 
     if (optionsModule) {
@@ -70,7 +70,7 @@ const numberParamToErrorKey = {
     entityIndexSize: 'invalid.entity.index.size',
 };
 
-const getNumberFormatError = function (params, $translate) {
+const getNumberFormatError = function(params, $translate) {
     if (!params) {
         return '';
     }
@@ -85,10 +85,10 @@ const getNumberFormatError = function (params, $translate) {
         : '';
 };
 
-const getDocBase = function (productInfo) {
+const getDocBase = function(productInfo) {
     return `https://graphdb.ontotext.com/documentation/${productInfo.productShortVersion}`;
 };
-const filterLocations = function (result) {
+const filterLocations = function(result) {
     return result.filter((location) => location.isGraphDBLocation() && !location.errorMsg && !location.degradedReason);
 };
 
@@ -97,7 +97,7 @@ const filterLocations = function (result) {
  * @param {*} $repositories the repositories service
  * @return {[] | Promise} returns the locations as array or a promise of the array
  */
-const getFilteredLocations = function ($repositories) {
+const getFilteredLocations = function($repositories) {
     // Don't allow the user to create repository on location with error or degradeded reason
     return $repositories.getLocations().then((locations) => filterLocations(locations));
 };
@@ -127,7 +127,6 @@ LocationsAndRepositoriesCtrl.$inject = ['$scope', '$rootScope', '$uibModal', 'to
 
 function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $repositories, ModalService, AuthTokenService, LocationsRestService,
     LocalStorageAdapter, $interval, $translate, $q, GuidesService) {
-
     $scope.RemoteLocationType = RemoteLocationType;
     $scope.loader = true;
     /**
@@ -135,7 +134,7 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
      */
     $scope.locations = [];
 
-    $scope.isLocationInactive = function (location) {
+    $scope.isLocationInactive = function(location) {
         return !location.active || !$scope.hasActiveLocation();
     };
 
@@ -165,52 +164,52 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
         return locationTypes.some((locationType) => $scope.getLocalLocation(local, locationType).length > 0);
     };
 
-    $scope.hasActiveLocation = function () {
+    $scope.hasActiveLocation = function() {
         return $repositories.hasActiveLocation();
     };
 
-    $scope.getActiveLocation = function () {
+    $scope.getActiveLocation = function() {
         return $repositories.getActiveLocation();
     };
 
-    $scope.getLocationError = function () {
+    $scope.getLocationError = function() {
         return $repositories.getLocationError();
     };
 
-    $scope.getDegradedReason = function () {
+    $scope.getDegradedReason = function() {
         return $repositories.getDegradedReason();
     };
 
-    $scope.getRepositories = function () {
+    $scope.getRepositories = function() {
         return $repositories.getRepositories();
     };
 
-    $scope.isRepoActive = function (repo) {
+    $scope.isRepoActive = function(repo) {
         return $repositories.isRepoActive(repo);
     };
 
     //Delete location
-    $scope.deleteLocation = function (uri) {
+    $scope.deleteLocation = function(uri) {
         ModalService.openSimpleModal({
             title: $translate.instant('location.confirm.detach'),
             message: $translate.instant('location.confirm.detach.warning', {uri: uri}),
-            warning: true
+            warning: true,
         }).result
-            .then(function () {
+            .then(function() {
                 $scope.loader = true;
                 $repositories.deleteLocation(uri).finally(() => getLocations());
             });
     };
 
     //Add new location
-    $scope.addLocationHttp = function (dataAddLocation) {
+    $scope.addLocationHttp = function(dataAddLocation) {
         $scope.loader = true;
         LocationsRestService.addLocation(dataAddLocation)
-            .success(function () {
+            .success(function() {
                 //Reload locations and repositories
                 $repositories.init();
             })
-            .error(function (data) {
+            .error(function(data) {
                 const msg = getError(data);
                 toastr.error(msg, $translate.instant('common.error'));
             })
@@ -241,10 +240,10 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
             resolve: {
                 data: () => {
                     return {
-                        remoteLocation
+                        remoteLocation,
                     };
-                }
-            }
+                },
+            },
         }).result.then((dataAddLocation) => {
                 if (remoteLocation) {
                     $scope.editLocationHttp(dataAddLocation);
@@ -255,14 +254,14 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
     };
 
     //Edit location
-    $scope.editLocationHttp = function (dataEditLocation) {
+    $scope.editLocationHttp = function(dataEditLocation) {
         $scope.loader = true;
         LocationsRestService.editLocation(dataEditLocation)
-            .success(function () {
+            .success(function() {
                 //Reload locations and repositories
                 $repositories.init();
             })
-            .error(function (data) {
+            .error(function(data) {
                 const msg = getError(data);
                 toastr.error(msg, $translate.instant('common.error'));
             })
@@ -270,18 +269,18 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
     };
 
     //Change repository
-    $scope.setRepository = function (repo) {
+    $scope.setRepository = function(repo) {
         $repositories.setRepository(repo);
     };
 
     //Delete repository
-    $scope.deleteRepository = function (repository) {
+    $scope.deleteRepository = function(repository) {
         ModalService.openSimpleModal({
             title: $translate.instant('common.confirm.delete'),
             message: decodeHTML($translate.instant('delete.repo.warning.msg', {repositoryId: repository.id})),
-            warning: true
+            warning: true,
         }).result
-            .then(function () {
+            .then(function() {
                 $scope.loader = true;
                 $repositories.deleteRepository(repository)
                     .finally(() => {
@@ -292,19 +291,19 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
             });
     };
 
-    $scope.restartRepository = function (repository) {
+    $scope.restartRepository = function(repository) {
         ModalService.openSimpleModal({
             title: $translate.instant('confirm.restart.repo'),
             message: decodeHTML($translate.instant('confirm.restart.repo.warning.msg', {repositoryId: repository.id})),
-            warning: true
+            warning: true,
         }).result
-            .then(function () {
+            .then(function() {
                 $scope.loader = true;
                 $repositories.restartRepository(repository).finally(() => getLocations());
             });
     };
 
-    $scope.toggleDefaultRepository = function (repositoryId) {
+    $scope.toggleDefaultRepository = function(repositoryId) {
         if ($scope.getDefaultRepository() === repositoryId) {
             // unset
             $repositories.setDefaultRepository(null);
@@ -314,7 +313,7 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
         }
     };
 
-    $scope.getDefaultRepository = function () {
+    $scope.getDefaultRepository = function() {
         return $repositories.getDefaultRepository();
     };
 
@@ -341,7 +340,7 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
      };
      */
 
-    $scope.getRepositoryDownloadLink = function (repository) {
+    $scope.getRepositoryDownloadLink = function(repository) {
         let url = `rest/repositories/${repository.id}${(repository.type === REPOSITORY_TYPES.ontop ? '/download-zip'
             : '/download-ttl')}?location=${repository.location}`;
         const token = AuthTokenService.getAuthToken();
@@ -352,30 +351,30 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
     };
 
     ///Copy to clipboard popover options
-    $scope.copyToClipboard = function (uri) {
+    $scope.copyToClipboard = function(uri) {
         ModalService.openCopyToClipboardModal(uri);
     };
 
-    $scope.fromFile = function () {
+    $scope.fromFile = function() {
         const modalInstance = $uibModal.open({
             templateUrl: 'js/angular/templates/modal/upload-repository-config.html',
-            controller: 'UploadRepositoryConfigCtrl'
+            controller: 'UploadRepositoryConfigCtrl',
         });
-        modalInstance.result.then(function () {
+        modalInstance.result.then(function() {
             $repositories.init();
         });
     };
 
     //Delete repository
-    $scope.openActiveLocationSettings = function () {
+    $scope.openActiveLocationSettings = function() {
         $uibModal.open({
             templateUrl: 'js/angular/settings/modal/location-settings.html',
-            controller: 'ActiveLocationSettingsCtrl'
+            controller: 'ActiveLocationSettingsCtrl',
         });
     };
 
     getLocations();
-    const timer = $interval(function () {
+    const timer = $interval(function() {
         if (GuidesService.isActive() && !$rootScope.guidePaused) {
             // Don't refresh list while a guide is active
             return;
@@ -386,7 +385,7 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
         getLocations();
     }, 5000);
 
-    $scope.$on('$destroy', function () {
+    $scope.$on('$destroy', function() {
         $interval.cancel(timer);
         // If there is a getLocations request in progress, abort it so the service can properly clear flags
         if (getLocationsAbortRequestPromise) {
@@ -397,7 +396,7 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
     function removeCachedGraphsOnDelete(repo) {
         const cashedDependenciesGraphPrefix = `dependencies-selectedGraph-${repo.id}`;
         const cashedClassHierarchyGraphPrefix = `classHierarchy-selectedGraph-${repo.id}`;
-        angular.forEach(LocalStorageAdapter.keys(), function (key) {
+        angular.forEach(LocalStorageAdapter.keys(), function(key) {
             // remove everything but the hide prefixes setting, it should always persist
             if (key.startsWith(cashedClassHierarchyGraphPrefix) || key.startsWith(cashedDependenciesGraphPrefix)) {
                 LocalStorageAdapter.remove(key);
@@ -405,7 +404,7 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
         });
     }
 
-    $scope.getRepositoriesFromLocation = function (locationId) {
+    $scope.getRepositoriesFromLocation = function(locationId) {
         return $repositories.getRepositoriesFromLocation(locationId);
     };
 }
@@ -413,31 +412,31 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
 UploadRepositoryConfigCtrl.$inject = ['$scope', '$uibModalInstance', 'Upload', 'toastr', '$translate'];
 
 function UploadRepositoryConfigCtrl($scope, $uibModalInstance, Upload, toastr, $translate) {
-    $scope.upload = function (files) {
+    $scope.upload = function(files) {
         if (files && files.length) {
             $scope.uploadFile = files[0];
         }
     };
-    $scope.ok = function () {
+    $scope.ok = function() {
         if ($scope.uploadFile) {
             $scope.uploadFileLoader = true;
             Upload.upload({
                 url: 'rest/repositories',
                 method: 'POST',
-                data: {config: $scope.uploadFile}
+                data: {config: $scope.uploadFile},
             })
-                .success(function () {
+                .success(function() {
                     $scope.uploadFileLoader = false;
                     $uibModalInstance.close();
                 })
-                .error(function (data) {
+                .error(function(data) {
                     const msg = getError(data);
                     toastr.error(msg, $translate.instant('common.error'));
                     $scope.uploadFileLoader = false;
                 });
         }
     };
-    $scope.cancel = function () {
+    $scope.cancel = function() {
         $uibModalInstance.dismiss('cancel');
     };
 }
@@ -445,23 +444,22 @@ function UploadRepositoryConfigCtrl($scope, $uibModalInstance, Upload, toastr, $
 AddLocationCtrl.$inject = ['$scope', '$uibModalInstance', 'toastr', 'productInfo', '$translate'];
 
 function AddLocationCtrl($scope, $uibModalInstance, toastr, productInfo, $translate) {
-
     $scope.newLocation = {
         'uri': '',
         'authType': 'none',
         'username': '',
         'password': '',
-        'active': false
+        'active': false,
     };
     $scope.docBase = getDocBase(productInfo);
 
-    $scope.isValidLocation = function () {
+    $scope.isValidLocation = function() {
         return ($scope.newLocation.uri.length < 6 ||
                 $scope.newLocation.uri.indexOf('http:') === 0 || $scope.newLocation.uri.indexOf('https:') === 0)
             && $scope.newLocation.uri.indexOf('/repositories') <= -1;
     };
 
-    $scope.ok = function () {
+    $scope.ok = function() {
         if (!$scope.newLocation) {
             toastr.error($translate.instant('location.cannot.be.empty.error'));
             return;
@@ -469,7 +467,7 @@ function AddLocationCtrl($scope, $uibModalInstance, toastr, productInfo, $transl
         $uibModalInstance.close($scope.newLocation);
     };
 
-    $scope.cancel = function () {
+    $scope.cancel = function() {
         $uibModalInstance.dismiss('cancel');
     };
 }
@@ -477,15 +475,14 @@ function AddLocationCtrl($scope, $uibModalInstance, toastr, productInfo, $transl
 EditLocationCtrl.$inject = ['$scope', '$uibModalInstance', 'location', 'productInfo'];
 
 function EditLocationCtrl($scope, $uibModalInstance, location, productInfo) {
-
     $scope.editedLocation = _.cloneDeep(location);
     $scope.docBase = getDocBase(productInfo);
 
-    $scope.ok = function () {
+    $scope.ok = function() {
         $uibModalInstance.close($scope.editedLocation);
     };
 
-    $scope.cancel = function () {
+    $scope.cancel = function() {
         $uibModalInstance.dismiss('cancel');
     };
 }
@@ -494,7 +491,7 @@ ChooseRepositoryCtrl.$inject = ['$scope', '$location'];
 
 function ChooseRepositoryCtrl($scope, $location) {
     $scope.repositoryTypes = REPOSITORY_TYPES;
-    $scope.chooseRepositoryType = function (repoType) {
+    $scope.chooseRepositoryType = function(repoType) {
         $location.path(`${$location.path()}/${repoType}`);
     };
 }
@@ -517,7 +514,7 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
         params: {},
         title: '',
         type: '',
-        location: ''
+        location: '',
     };
 
     getFilteredLocations($repositories)
@@ -525,7 +522,7 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
             $scope.locations = locations;
         });
 
-    $scope.changedLocation = function () {
+    $scope.changedLocation = function() {
         $scope.$broadcast('changedLocation');
     };
 
@@ -569,8 +566,8 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
         }
     }
 
-    $scope.getConfig = function (repoType) {
-        RepositoriesRestService.getRepositoryConfiguration(repoType).then(function (resp) {
+    $scope.getConfig = function(repoType) {
+        RepositoriesRestService.getRepositoryConfiguration(repoType).then(function(resp) {
             const data = resp.data;
             $scope.repositoryInfo.params = data.params;
             $scope.repositoryInfo.type = data.type;
@@ -580,11 +577,11 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
             // The clean way is the "autofocus" attribute and we use it but it doesn't seem to
             // work in all browsers because of the way dynamic content is handled so give it another
             // try here.
-            $timeout(function () {
+            $timeout(function() {
                 // Focus the ID field
                 angular.element(document).find('#id').focus();
             }, 50);
-        }).catch(function (data) {
+        }).catch(function(data) {
             const msg = getError(data);
             toastr.error(msg, $translate.instant('common.error'));
             $scope.loader = false;
@@ -599,26 +596,26 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
         $location.path('/repository/create');
     }
 
-    $scope.hasActiveLocation = function () {
+    $scope.hasActiveLocation = function() {
         return $repositories.hasActiveLocation();
     };
 
-    $scope.activeLocation = function () {
+    $scope.activeLocation = function() {
         return $repositories.getActiveLocation();
     };
 
     let isInvalidPieFile = false;
-    $scope.uploadRuleset = function (files) {
+    $scope.uploadRuleset = function(files) {
         if (files && files.length) {
             $scope.uploadFile = files[0];
             $scope.uploadFileLoader = true;
             Upload.upload({
                 url: 'rest/repositories/ruleset/upload',
-                data: {ruleset: $scope.uploadFile, location: $scope.repositoryInfo.location}
-            }).progress(function (evt) {
+                data: {ruleset: $scope.uploadFile, location: $scope.repositoryInfo.location},
+            }).progress(function(evt) {
                 /*						var progressPercentage = parseInt(100.0 * evt.loaded / evt.total);
                  console.log('progress: ' + progressPercentage + '% ' + evt.config.file.name);*/
-            }).success(function (data) {
+            }).success(function(data) {
                 if (!data.success) {
                     toastr.error(data.errorMessage);
                     isInvalidPieFile = true;
@@ -639,7 +636,7 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
                     $scope.repositoryInfo.params.ruleset.value = $scope.rulesetPie;
                 }
                 $scope.uploadFileLoader = false;
-            }).error(function (data) {
+            }).error(function(data) {
                 const msg = getError(data);
                 toastr.error(msg, $translate.instant('common.error'));
                 $scope.uploadFile = '';
@@ -649,28 +646,31 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
         }
     };
 
-    $scope.noMembersError = function () {
+    $scope.noMembersError = function() {
         toastr.error($translate.instant('fedx.create.repo.no.members.warning'));
     };
 
-    $scope.goBackToPreviousLocation = function () {
-        if (angular.isDefined($routeParams.previous)) {
-            delete $location.$$search.previous;
-            $location.path('/');
+    $scope.goBackToPreviousLocation = function() {
+        const previous = $location.search().previous;
+        if (previous) {
+            $location.search('previous', null);
+            const isAbsolute = typeof previous === 'string' && previous.charAt(0) === '/';
+            const target = isAbsolute ? previous : '/' + previous;
+            $location.url(target);
         } else {
             $location.path('/repository');
         }
     };
 
-    $scope.createRepoHttp = function () {
+    $scope.createRepoHttp = function() {
         $scope.loader = true;
         RepositoriesRestService.createRepository($scope.repositoryInfo)
-            .then(function () {
+            .then(function() {
                 toastr.success($translate.instant('created.repo.success.msg', {repoId: $scope.repositoryInfo.id}));
                 return $repositories.init();
             })
             .then(() => $scope.goBackToPreviousLocation())
-            .catch(function (error) {
+            .catch(function(error) {
                 const msg = getError(error.data);
                 toastr.error(msg, $translate.instant('common.error'));
             })
@@ -679,7 +679,7 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
             });
     };
 
-    $scope.createRepo = function () {
+    $scope.createRepo = function() {
         if (!$scope.repositoryInfo.id) {
             toastr.error($translate.instant('empty.repoid.warning'));
             return;
@@ -697,14 +697,14 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
             $scope.noMembersError();
         } else if (numberFormatError) {
             toastr.error(numberFormatError);
-        } else if ($scope.isInvalidEntityIndexSizeMin){
+        } else if ($scope.isInvalidEntityIndexSizeMin) {
             toastr.error($translate.instant('repo.error.entityIndex.min'));
         } else {
             $scope.createRepoHttp();
         }
     };
 
-    $scope.rulesetWarning = function () {
+    $scope.rulesetWarning = function() {
         const pp = $scope.repositoryInfo.params;
         if (pp === undefined || pp.ruleset === undefined || pp.disableSameAs === undefined) {
             return '';
@@ -721,7 +721,7 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
         }
     };
 
-    $scope.getShaclOptionsClass = function () {
+    $scope.getShaclOptionsClass = function() {
         return getShaclOptionsClass();
     };
     //TODO - check if repositoryID exist
@@ -740,25 +740,24 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
 EditRepositoryFileCtrl.$inject = ['$scope', '$uibModalInstance', 'RepositoriesRestService', 'file', 'toastr', '$translate', 'dialogTitle', 'location'];
 
 function EditRepositoryFileCtrl($scope, $uibModalInstance, RepositoriesRestService, file, toastr, $translate, dialogTitle, location) {
-
     $scope.dialogTitle = dialogTitle ? dialogTitle : $translate.instant('update.file.content.header');
     if (file) {
-        RepositoriesRestService.getRepositoryFileContent(file, location).success(function (data) {
+        RepositoriesRestService.getRepositoryFileContent(file, location).success(function(data) {
             $scope.fileContent = data;
-        }).error(function (data) {
+        }).error(function(data) {
             const msg = getError(data);
             toastr.error(msg, $translate.instant('common.error'));
         });
     }
 
-    $scope.ok = function () {
+    $scope.ok = function() {
         $uibModalInstance.close({
             content: $scope.fileContent,
-            fileLocation: file
+            fileLocation: file,
         });
     };
 
-    $scope.cancel = function () {
+    $scope.cancel = function() {
         $uibModalInstance.dismiss('cancel');
     };
 }
@@ -767,7 +766,6 @@ EditRepositoryCtrl.$inject = ['$rootScope', '$scope', '$routeParams', 'toastr', 
     '$translate', 'MonitoringRestService'];
 
 function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositories, $location, ModalService, RepositoriesRestService, $translate, MonitoringRestService) {
-
     $scope.rulesets = STATIC_RULESETS.slice();
     $scope.repositoryTypes = REPOSITORY_TYPES;
     $scope.entityIndexSizeMin = ENTITY_INDEX_SIZE_MIN;
@@ -784,7 +782,7 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
     $scope.repositoryType = '';
     $scope.saveRepoId = $scope.params.repositoryId;
     $scope.pageTitle = $translate.instant('view.edit.repo.title', {repositoryId: $scope.params.repositoryId});
-    $scope.hasActiveLocation = function () {
+    $scope.hasActiveLocation = function() {
         return $repositories.hasActiveLocation();
     };
 
@@ -799,7 +797,7 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
         const repositoryInfo = repositoryInfoResponse.data;
         if (angular.isDefined(repositoryInfo.params.ruleset)) {
             let ifRulesetExists = false;
-            angular.forEach($scope.rulesets, function (item) {
+            angular.forEach($scope.rulesets, function(item) {
                 if (item.id === repositoryInfo.params.ruleset.value) {
                     ifRulesetExists = true;
                 }
@@ -816,7 +814,7 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
         $scope.loader = false;
     };
 
-    $scope.$watch($scope.hasActiveLocation, function () {
+    $scope.$watch($scope.hasActiveLocation, function() {
         if ($scope.hasActiveLocation) {
             // Should get locations before getting repository info
             let repositoryInfoResponse;
@@ -851,7 +849,7 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
                 toastr.error(toastrMsg, $translate.instant('common.error'), {allowHtml: true});
 
                 if (status === 404) {
-                    setTimeout(function () {
+                    setTimeout(function() {
                         $scope.loader = false;
                         $location.path('repository');
                     }, 1000);
@@ -862,31 +860,31 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
         }
     });
 
-    $scope.setRepositoryType = function (type) {
+    $scope.setRepositoryType = function(type) {
         $scope.repositoryType = type;
     };
 
-    $scope.noMembersError = function () {
+    $scope.noMembersError = function() {
         toastr.error($translate.instant('fedx.create.repo.no.members.warning'));
     };
 
-    $scope.editRepoHttp = function () {
+    $scope.editRepoHttp = function() {
         $scope.loader = true;
         RepositoriesRestService.editRepository($scope.repositoryInfo.saveId, $scope.repositoryInfo)
-            .success(function () {
+            .success(function() {
                 toastr.success($translate.instant('edit.repo.success.msg', {saveId: $scope.repositoryInfo.saveId}));
                 $repositories.init().finally(() => $scope.goBackToPreviousLocation());
                 if ($scope.repositoryInfo.saveId === $scope.repositoryInfo.id && $scope.repositoryInfo.restartRequested) {
                     $repositories.restartRepository($scope.repositoryInfo);
                 }
-            }).error(function (data) {
+            }).error(function(data) {
             const msg = getError(data);
             toastr.error(msg, $translate.instant('common.error'));
             $scope.loader = false;
         });
     };
 
-    $scope.editRepository = function () {
+    $scope.editRepository = function() {
         $scope.isInvalidRepoName = !FILENAME_PATTERN.test($scope.repositoryInfo.id);
         $scope.isInvalidEntityIndexSizeMin = $scope.repositoryInfo.params.entityIndexSize?.value < ENTITY_INDEX_SIZE_MIN;
         const numberFormatError = getNumberFormatError($scope.repositoryInfo.params, $translate);
@@ -904,33 +902,33 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
             $scope.noMembersError();
         } else if (numberFormatError) {
             toastr.error(numberFormatError);
-        } else if ($scope.isInvalidEntityIndexSizeMin){
+        } else if ($scope.isInvalidEntityIndexSizeMin) {
             toastr.error($translate.instant('repo.error.entityIndex.min'));
         } else {
             ModalService.openSimpleModal({
                 title: $translate.instant('common.confirm.save'),
                 message: modalMsg,
-                warning: true
+                warning: true,
             }).result
-                .then(function () {
+                .then(function() {
                     $scope.editRepoHttp();
                 });
         }
     };
 
-    $scope.editRepositoryId = function () {
-        let msg = decodeHTML($translate.instant('edit.repo.id.warning.msg'));
+    $scope.editRepositoryId = function() {
+        const msg = decodeHTML($translate.instant('edit.repo.id.warning.msg'));
 
         ModalService.openSimpleModal({
             title: $translate.instant('confirm.enable.edit'),
             message: msg,
-            warning: true
-        }).result.then(function () {
+            warning: true,
+        }).result.then(function() {
             $scope.canEditRepoId = true;
         });
     };
 
-    $scope.goBackToPreviousLocation = function () {
+    $scope.goBackToPreviousLocation = function() {
         if (angular.isDefined($routeParams.previous)) {
             delete $location.$$search.previous;
             $location.path('/');
@@ -939,7 +937,7 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
         }
     };
 
-    $scope.getShaclOptionsClass = function () {
+    $scope.getShaclOptionsClass = function() {
         return getShaclOptionsClass();
     };
 


### PR DESCRIPTION
## WHAT
- Make repo create flow return to the actual originating route via previous query param.

## WHY
Users were sent to generic paths after creating/canceling, instead of going back to where they started—hurting UX.

## HOW
- goToAddRepo - capture the current $location.url() and pass it as previous when navigating to repository/create
- goBackToPreviousLocation - read previous, remove it, navigate to it, else default to /repository
- Add trailing commas in arrays/objects/imports, ensure semicolons, normalize function() spacing, replace let with const where applicable and remove stray blank lines across touched files.


## Checklist
- [X] Branch name
- [X] Target branch
- [X] Commit messages
- [X] Squash commits
- [X] MR name
- [X] MR Description
- [ ] Tests
