### PR TITLE
GDB-10616 - Handle new SPARQL "LLM Explain" button

### DIFF
--- a/packages/legacy-workbench/src/js/angular/core/directives/yasgui-component/yasgui-component-directive.util.js
+++ b/packages/legacy-workbench/src/js/angular/core/directives/yasgui-component/yasgui-component-directive.util.js
@@ -10,8 +10,7 @@ const HIGHLIGHT_TAB_NAME_COLORS = ['var(--primary-color)', '', 'var(--primary-co
  */
 const COLOR_CHANGES_INTERVAL = 400;
 
-export const YasguiComponentDirectiveUtil = (function () {
-
+export const YasguiComponentDirectiveUtil = (function() {
     const getOntotextYasguiElementController = (directiveSelector) => {
         const elementById = angular.element(document.querySelector(directiveSelector));
         const directiveElement = angular.element(elementById);
@@ -57,7 +56,7 @@ export const YasguiComponentDirectiveUtil = (function () {
                     iteration -= waitTime;
                     if (iteration < 0) {
                         clearInterval(interval);
-                        console.log('YASGUI component is not found', directiveSelector);
+                        console.warn('YASGUI component is not found', directiveSelector);
                         reject(new Error('Element is not found: ' + directiveSelector));
                     }
                 }
@@ -147,17 +146,17 @@ export const YasguiComponentDirectiveUtil = (function () {
         getOntotextYasguiElementAsync,
         executeSparqlQuery,
         setQuery,
-        highlightTabName
+        highlightTabName,
     };
 })();
 
 export class YasqeButtonsBuilder {
-
     constructor() {
         this.createSavedQueryVisibility = false;
         this.showSavedQueriesVisibility = false;
         this.shareQueryVisibility = false;
         this.includeInferredStatementsVisibility = false;
+        this.explainQueryVisibility = false;
     }
 
     addCreateSavedQuery() {
@@ -180,6 +179,11 @@ export class YasqeButtonsBuilder {
         return this;
     }
 
+    addExplainQuery() {
+        this.explainQueryVisibility = true;
+        return this;
+    }
+
     /**
      *
      * @return {YasqeActionButtonDefinition[]}
@@ -188,17 +192,21 @@ export class YasqeButtonsBuilder {
         return [
             {
                 name: YasqeButtonName.CREATE_SAVED_QUERY,
-                visible: this.createSavedQueryVisibility
+                visible: this.createSavedQueryVisibility,
             }, {
                 name: YasqeButtonName.SHOW_SAVED_QUERIES,
-                visible: this.showSavedQueriesVisibility
+                visible: this.showSavedQueriesVisibility,
             }, {
                 name: YasqeButtonName.SHARE_QUERY,
-                visible: this.shareQueryVisibility
+                visible: this.shareQueryVisibility,
             }, {
                 name: YasqeButtonName.INCLUDE_INFERRED_STATEMENTS,
-                visible: this.includeInferredStatementsVisibility
-            }
+                visible: this.includeInferredStatementsVisibility,
+            },
+            {
+                name: YasqeButtonName.EXPLAIN_QUERY,
+                visible: this.explainQueryVisibility,
+            },
         ];
     }
 }
@@ -207,9 +215,10 @@ export const YasqeButtonName = {
     CREATE_SAVED_QUERY: 'createSavedQuery',
     SHOW_SAVED_QUERIES: 'showSavedQueries',
     SHARE_QUERY: 'shareQuery',
+    EXPLAIN_QUERY: 'aiExplain',
     EXPANDS_RESULTS: 'expandResults',
     INFER_STATEMENTS: 'inferStatements',
-    INCLUDE_INFERRED_STATEMENTS: 'includeInferredStatements'
+    INCLUDE_INFERRED_STATEMENTS: 'includeInferredStatements',
 };
 
 export const DISABLE_YASQE_BUTTONS_CONFIGURATION = new YasqeButtonsBuilder().build();


### PR DESCRIPTION
## What
Yasgui version increased. New version includes a new button in SPARQL view to explain query with the configured LLM. 

## Why
The button encourages users to try the LLM explain feature.

## How
I added the button in the `Button builder`, so that its visibility can be set.

## TODO
YASGUI must be published with these changes. The MR there is https://github.com/Ontotext-AD/ontotext-yasgui/pull/288

## Testing
N/A

## Screenshots
N/A

## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
