### PR TITLE
GDB-12685 - Handle overflowing content in guide steps

### DIFF
--- a/packages/legacy-workbench/src/css/shepherd-custom.css
+++ b/packages/legacy-workbench/src/css/shepherd-custom.css
@@ -32,6 +32,7 @@
     text-align: center;
     min-height: 90px;
     margin-top: 10px;
+    overflow-wrap: break-word;
 }
 
 .shepherd-text ol, .shepherd-text ul {


### PR DESCRIPTION
## What
Long text won't overflow guide step containers.

## Why
One of the steps included a long IRI, which went outside the container.

## How
I handle the overflow in the css file.

## Testing
N/A

## Screenshots
After the fix:
<img width="507" height="239" alt="Screenshot from 2025-08-29 12-40-58" src="https://github.com/user-attachments/assets/043bb50a-8bb7-4587-b318-5257a3a498c5" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
