### PR TITLE
Cherry-pick GDB-12988 Fix wrong position on create agent step

### DIFF
--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/create-ttyg-agent/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/create-ttyg-agent/plugin.js
@@ -10,12 +10,12 @@ PluginRegistry.add('guide.step', [
                   options: {
                       content: 'guide.step_plugin.create-ttyg-agent.intro',
                       // If mainAction is set the title will be set automatically
-                      ...(options.mainAction ? {} : { title: TTYG_CREATE_AGENT_DEFAULT_TITLE }),
-                      ...options
-                  }
+                      ...(options.mainAction ? {} : {title: TTYG_CREATE_AGENT_DEFAULT_TITLE}),
+                      ...options,
+                  },
               },
-          ]
-      }
+          ];
+      },
     },
     {
         guideBlockName: 'ttyg-create-agent-click',
@@ -23,21 +23,28 @@ PluginRegistry.add('guide.step', [
             const GuideUtils = services.GuideUtils;
             return [
                 {
+                    guideBlockName: 'wait-for-element-to-hide',
+                    options: angular.extend({}, {
+                        elementSelectorToHide: GuideUtils.getElementSelector('.ttyg-page-loader'),
+                        timeToWait: 10,
+                    }, options),
+                },
+                {
                     guideBlockName: 'clickable-element',
                     options: {
                         content: 'guide.step_plugin.create-ttyg-agent.create-agent',
                         // If mainAction is set the title will be set automatically
-                        ...(options.mainAction ? {} : { title: TTYG_CREATE_AGENT_DEFAULT_TITLE }),
+                        ...(options.mainAction ? {} : {title: TTYG_CREATE_AGENT_DEFAULT_TITLE}),
                         class: 'create-agent-btn',
                         maxWaitTime: 10,
                         disableNextFlow: true,
                         ...options,
                         url: 'ttyg',
                         elementSelector: GuideUtils.getGuideElementSelector('create-agent-btn'),
-                    }
-                }
-            ]
-        }
+                    },
+                },
+            ];
+        },
     },
     {
       guideBlockName: 'ttyg-create-agent-save',
@@ -50,17 +57,17 @@ PluginRegistry.add('guide.step', [
                   options: {
                       content: 'guide.step_plugin.create-ttyg-agent.save-agent-settings',
                       // If mainAction is set the title will be set automatically
-                      ...(options.mainAction ? {} : { title: TTYG_CREATE_AGENT_DEFAULT_TITLE }),
+                      ...(options.mainAction ? {} : {title: TTYG_CREATE_AGENT_DEFAULT_TITLE}),
                       class: 'save-agent',
                       disablePreviousFlow: false,
                       disableNextFlow: true,
                       ...options,
                       url: 'ttyg',
-                      elementSelector: GuideUtils.getGuideElementSelector('save-agent-settings')
-                  }
-              }
-          ]
-      }
+                      elementSelector: GuideUtils.getGuideElementSelector('save-agent-settings'),
+                  },
+              },
+          ];
+      },
     },
     {
         guideBlockName: 'create-ttyg-agent',
@@ -74,35 +81,35 @@ PluginRegistry.add('guide.step', [
                     options: {
                         showIntro: true,
                         ...options,
-                        menu: 'ttyg'
-                    }
+                        menu: 'ttyg',
+                    },
                 },
                 {
-                    guideBlockName: 'end-on-api-key-error'
+                    guideBlockName: 'end-on-api-key-error',
                 },
                 {
                     guideBlockName: 'ttyg-create-agent-intro-message',
-                    options: {...options}
+                    options: {...options},
                 },
                 {
-                    guideBlockName: 'ttyg-create-agent-click', options: {...options}
+                    guideBlockName: 'ttyg-create-agent-click', options: {...options},
                 },
                 {
                     guideBlockName: 'configure-agent',
                     // Set name field as mandatory for creation
-                    options: { ...options, editName: true }
+                    options: {...options, editName: true},
                 },
                 {
-                    guideBlockName: 'ttyg-create-agent-save', options: {...options}
+                    guideBlockName: 'ttyg-create-agent-save', options: {...options},
                 },
                 {
                     guideBlockName: 'wait-for-element-to-hide',
                     options: angular.extend({}, {
                         elementSelectorToHide: GuideUtils.getElementSelector('.agent-settings-modal'),
-                        timeToWait: 10
-                    }, options)
-                }
+                        timeToWait: 10,
+                    }, options),
+                },
             ];
-        }
-    }
+        },
+    },
 ]);


### PR DESCRIPTION
## What
Fix wrong position of create agent step

## Why
It was positioning the dialog in the top left corner

## How
Added `wait-for-element-to-hide` step, before the create agent step. We wait for the container of the spinner to hide, since it is the element, which has a `display none` applied to it. This way the button is visible, when it is time to position the step on top of it

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
