### PR TITLE
GDB-10641 Fix microfrontends mount and unmount in single spa

### DIFF
--- a/packages/api/src/services/security/authentication.service.ts
+++ b/packages/api/src/services/security/authentication.service.ts
@@ -36,15 +36,6 @@ export class AuthenticationService implements Service {
   }
 
   /**
-   * Checks if the user is logged in based on the provided configuration and user details.
-   * @returns {boolean} True if the user is authenticated, false otherwise.
-   */
-  isLoggedIn(): boolean {
-    const config = this.getSecurityConfig();
-    return !!(config?.enabled && config?.userLoggedIn);
-  }
-
-  /**
    * Check if the user is authenticated.
    * A user is considered authenticated, if security is disabled, if he is external, or if there is an
    * auth token in the store

--- a/packages/shared-components/src/components/onto-header/onto-header.tsx
+++ b/packages/shared-components/src/components/onto-header/onto-header.tsx
@@ -136,8 +136,8 @@ export class OntoHeader {
             totalTripletsFormatter={this.totalTripletsFormatter}
             canWriteRepo={this.canWriteRepo}>
           </onto-repository-selector>
-          {this.securityConfig?.enabled && this.securityConfig?.userLoggedIn ? <onto-user-menu user={this.user} securityConfig={this.securityConfig}></onto-user-menu> : ''}
-          {this.securityConfig?.enabled && !this.securityConfig?.userLoggedIn && (this.currentRoute !== 'login') ? <onto-user-login></onto-user-login> : ''}
+          {this.authService.isAuthenticated() ? <onto-user-menu user={this.user} securityConfig={this.securityConfig}></onto-user-menu> : ''}
+          {this.securityConfig?.enabled && !this.authService.isAuthenticated() && (this.currentRoute !== 'login') ? <onto-user-login></onto-user-login> : ''}
           <onto-language-selector dropdown-alignment="right"></onto-language-selector>
         </div>
       </Host>


### PR DESCRIPTION
## What
Fix microfrontends mounting and unmounting in single spa

## Why
The angularjs microfrontend wasn't being completely cleaned when unmounted. This resulted in errors, when trying to mount it again

## How
Instead of cleaning and re-creating the instance, we now store the reference to the DOM element and attach/remove it on mount/unmount. This way we don't re-create it in a corrupt environment, and there are no errors

- Removed `isLoggedIn` in favour of `isAuthenticated`. The authenticated user no longer comes from the legacy workbench and conditions for displaying the header and navbar failed

- Re-added `loadRepositories` on user change. This is needed to populate repositories after login

TODO: The legacy workbench is currently unaware of the newly logged-in user, since it happens in the migrated login. This will be addressed with the security related tasks

## Testing
jest

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
