### PR TITLE
Cherry-pick GDB-12664 fix missing saved SPARQL queries

### DIFF
--- a/packages/legacy-workbench/src/pages/home.html
+++ b/packages/legacy-workbench/src/pages/home.html
@@ -151,7 +151,7 @@
                  ng-cloak>
                 <div>
                     <ul class="list-group limit-height clearfix {{sampleQueries.length <= 4 ? 'one-column' : 'two-columns'}} saved-queries" ng-show="sampleQueries">
-                        <li ng-repeat="query in sampleQueries" ng-hide="isIgnoreSharedQueries && query.owner != null" class="list-group-item list-group-item-action">
+                        <li ng-repeat="query in sampleQueries" ng-hide="isIgnoreSharedQueries && query.owner != null && query.shared" class="list-group-item list-group-item-action">
                             <span class="help-label execute-saved-query" ng-click="goToSparqlEditor(query)">{{'common.execute' | translate}} <span class="icon-caret-right"></span></span>
                             <samp class="query-name">{{query.name}}</samp>
                             <samp class="text-muted small">{{query.body}}</samp>


### PR DESCRIPTION
## What
Updated the logic for displaying saved SPARQL queries to ensure that shared queries are correctly hidden based on user settings.

## Why
To prevent incorrect visibility of shared queries

## How
Modified the `ng-hide` condition in the `home.html` file to include an additional check for the `shared` property of the query.

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
