### PR TITLE
GDB-13029 fix operations requests for free access users

### DIFF
--- a/packages/api/src/services/security/authentication.service.ts
+++ b/packages/api/src/services/security/authentication.service.ts
@@ -7,6 +7,7 @@ import {SecurityContextService} from './security-context.service';
 import {Repository} from '../../models/repositories';
 import {RepositoryService, RepositoryStorageService} from '../repository';
 import {RoutingService} from '../routing/routing.service';
+import {AuthenticationStorageService} from './authentication-storage.service';
 
 /**
  * Service responsible for handling authentication-related operations.
@@ -26,14 +27,27 @@ export class AuthenticationService implements Service {
     ServiceProvider.get(EventService).emit(new Logout());
   }
 
-  // TODO: get security config and authenticated user synchronously from context
   /**
-   * Checks if the user is authenticated based on the provided configuration and user details.
+   * Checks if the user is logged in based on the provided configuration and user details.
    * @returns {boolean} True if the user is authenticated, false otherwise.
    */
-  isAuthenticated(): boolean {
+  isLoggedIn(): boolean {
     const config = this.getSecurityConfig();
     return !!(config?.enabled && config?.userLoggedIn);
+  }
+
+  /**
+   * Check if the user is authenticated.
+   * A user is considered authenticated, if security is disabled, if he is external, or if there is an
+   * auth token in the store
+   */
+  isAuthenticated() {
+    const config = this.getSecurityConfig();
+    const user = this.getAuthenticatedUser();
+    return !config?.enabled
+      || user?.external
+      // eslint-disable-next-line eqeqeq
+      || ServiceProvider.get(AuthenticationStorageService).getAuthToken().getValue() != null;
   }
 
   /**

--- a/packages/api/src/services/security/test/authentication.service.spec.ts
+++ b/packages/api/src/services/security/test/authentication.service.spec.ts
@@ -38,7 +38,7 @@ describe('AuthenticationService', () => {
     const securityConfig = {enabled: true, userLoggedIn: true} as unknown as SecurityConfig;
     ServiceProvider.get(SecurityContextService).updateSecurityConfig(securityConfig);
     // Then, I expect to be authenticated
-    expect(authService.isAuthenticated()).toEqual(true);
+    expect(authService.isLoggedIn()).toEqual(true);
   });
 
   test('isAuthenticated should return false if the user is not authenticated', () => {
@@ -47,14 +47,14 @@ describe('AuthenticationService', () => {
     ServiceProvider.get(SecurityContextService).updateSecurityConfig(enabledSecurityConfig);
     // When, I check, if I am authenticated
     // Then, I expect, not to be authenticated
-    expect(authService.isAuthenticated()).toEqual(false);
+    expect(authService.isLoggedIn()).toEqual(false);
 
     // Given, I have disabled security
     const disabledSecurityConfig = {enabled: false} as unknown as SecurityConfig;
     ServiceProvider.get(SecurityContextService).updateSecurityConfig(disabledSecurityConfig);
     // When, I check, if I am authenticated
     // Then, I expect, not to be authenticated
-    expect(authService.isAuthenticated()).toEqual(false);
+    expect(authService.isLoggedIn()).toEqual(false);
   });
 
   test('hasFreeAccess should return true if free access is enabled', () => {

--- a/packages/shared-components/src/components/onto-header/onto-header.tsx
+++ b/packages/shared-components/src/components/onto-header/onto-header.tsx
@@ -104,6 +104,7 @@ export class OntoHeader {
     this.setupTotalRepositoryFormater();
     this.subscribeToEvents();
     this.currentRoute = getCurrentRoute();
+    this.startOperationPolling();
   }
 
   render() {
@@ -147,10 +148,10 @@ export class OntoHeader {
   // Subscriptions
   // ========================
   private subscribeToEvents(): void {
+    this.subscribeToSecurityContextChange();
     this.subscribeToRepositoryListChanged();
     this.subscribeToLicenseChange();
     this.subscribeToRepositoryChange();
-    this.subscribeToSecurityContextChange();
     this.subscribeToActiveRepositoryLocationChange();
     this.subscribeToActiveRepoLoadingChange();
     this.subscribeToNavigationEnd();
@@ -179,7 +180,6 @@ export class OntoHeader {
     this.subscriptions.add(
       this.repositoryContextService.onSelectedRepositoryChanged((repository) => {
         this.currentRepository = repository;
-        this.currentRepository ? this.startOperationPolling() : this.stopOperationPolling();
         this.shouldShowSearch = this.shouldShowRdfSearch();
         this.loadNamespaces();
         this.updateRepositoryItems();
@@ -307,10 +307,18 @@ export class OntoHeader {
   private startOperationPolling() {
     clearInterval(this.pollingInterval);
     this.pollingInterval = WindowService.getWindow().setInterval(() => {
+      if (!this.authService.isAuthenticated()) {
+        this.activeOperations = undefined;
+        return;
+      }
 
       if (this.skipUpdateActiveOperationsTimes > 0) {
         // Requested to skip this run, the number of skips is a Fibonacci sequence when errors are consecutive.
         this.skipUpdateActiveOperationsTimes--;
+        return;
+      }
+
+      if (!this.currentRepository) {
         return;
       }
 


### PR DESCRIPTION
## What
Fix operations requests handling for users with free access, ensuring proper operation polling.

## Why
Because they are not supposed to be requested, when a user is not authenticated

## How
Updated the `isAuthenticated` method to `isLoggedIn` in `authentication.service.ts` and adjusted the operation polling logic in `onto-header.tsx` to account for free access scenarios.

## Testing
jest

## Screenshots
<img width="1793" height="1041" alt="image" src="https://github.com/user-attachments/assets/a74aa0c9-752b-4f65-848e-16cf4d88c3dc" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
