### PR TITLE
GDB-13037 fix GDB external plugin tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ coverage/
 # Test environment
 graphdb.license
 /translation-report.json
-/plugins/
+/wb-plugins/

--- a/assets/configuration.default.json
+++ b/assets/configuration.default.json
@@ -1,3 +1,3 @@
 {
-  "pluginsManifestPath": "plugins/plugins-manifest.json"
+  "pluginsManifestPath": "wb-plugins/plugins-manifest.json"
 }

--- a/scripts/copy-plugins.sh
+++ b/scripts/copy-plugins.sh
@@ -8,7 +8,7 @@
 
 copy_plugins() {
     local source_dir="node_modules/graphdb-workbench-plugins/dist"
-    local target_dir="plugins"
+    local target_dir="wb-plugins"
 
     echo "########################   CHECKING FOR PLUGINS   ###########################"
 

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -139,8 +139,8 @@ module.exports = (webpackConfigEnv, argv) => {
                       to: 'assets'
                     },
                     {
-                      from: 'plugins',
-                      to: 'plugins',
+                      from: 'wb-plugins',
+                      to: 'wb-plugins',
                       noErrorOnMissing: true
                     },
                     {


### PR DESCRIPTION
## What
Fix failing tests for external plugins in GDB

## Why
There is an issue in GDB, where `workbench/plugins` is read instead of `/plugins`

## How
Renamed `plugins` to `wb-plugins` as a quick fix to ensure GDB doesn't look in the wrong folder

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
