### PR TITLE
GDB-11430 Implement centralized logging service

### DIFF
--- a/assets/configuration.default.json
+++ b/assets/configuration.default.json
@@ -1,3 +1,7 @@
 {
-  "pluginsManifestPath": "wb-plugins/plugins-manifest.json"
+  "pluginsManifestPath": "wb-plugins/plugins-manifest.json",
+  "loggerConfig": {
+    "minLogLevel": "DEBUG",
+    "loggers": ["console"]
+  }
 }

--- a/packages/api/eslint.config.js
+++ b/packages/api/eslint.config.js
@@ -26,6 +26,6 @@ module.exports = [
         '@typescript-eslint/no-empty-object-type': 'off',
         '@typescript-eslint/consistent-type-definitions': 'off',
       },
-    }
+    },
   ),
 ];

--- a/packages/api/src/models/configuration/configuration.ts
+++ b/packages/api/src/models/configuration/configuration.ts
@@ -1,3 +1,5 @@
+import {LoggerConfig} from '../logging/logger-config';
+
 /**
  * Configurable constants.
  * This is a flat configuration, so downloaded partial configurations could be applied easily.
@@ -7,4 +9,9 @@ export interface Configuration {
    * The path where the plugins manifest is stored.
    */
   pluginsManifestPath: string;
+
+  /**
+   * Logging configuration
+   */
+  loggerConfig: LoggerConfig
 }

--- a/packages/api/src/models/logging/log-level.ts
+++ b/packages/api/src/models/logging/log-level.ts
@@ -1,0 +1,17 @@
+export enum LogLevel {
+  DEBUG = 'DEBUG',
+  INFO = 'INFO',
+  WARN = 'WARN',
+  ERROR = 'ERROR'
+}
+
+export const toNumericLogLevel = (logLevel: LogLevel) => {
+  return LOG_LEVEL_NUMERIC[logLevel];
+};
+
+const LOG_LEVEL_NUMERIC = {
+  [LogLevel.DEBUG]: 0,
+  [LogLevel.INFO]: 1,
+  [LogLevel.WARN]: 2,
+  [LogLevel.ERROR]: 3
+};

--- a/packages/api/src/models/logging/logger-config.ts
+++ b/packages/api/src/models/logging/logger-config.ts
@@ -1,0 +1,21 @@
+import {LoggerType} from './logger-type';
+import {LogLevel} from './log-level';
+
+/**
+ * Configuration interface for logger settings.
+ * Defines the structure for configuring logging behavior including
+ * which loggers to use and the minimum log level to capture.
+ */
+export interface LoggerConfig {
+  /**
+   * Array of logger types to be used for logging operations.
+   * Each logger type represents a different logging destination or format.
+   */
+  loggers: LoggerType[];
+
+  /**
+   * The minimum log level that will be processed and output.
+   * Log messages below this level will be filtered out.
+   */
+  minLogLevel: LogLevel;
+}

--- a/packages/api/src/models/logging/logger-definitions.ts
+++ b/packages/api/src/models/logging/logger-definitions.ts
@@ -1,0 +1,12 @@
+import {LoggerType} from './logger-type';
+import {ConsoleLoggerService} from '../../services/logging/console/console-logger.service';
+import {service} from '../../providers';
+import {Logger} from './logger';
+
+/**
+ * A mapping of available logger types to their corresponding logger service instances.
+ * Adding loggers here will initialize them and make them available for use in the application.
+ **/
+export const LOGGER_DEFINITIONS = new Map<LoggerType, Logger>([
+  [LoggerType.CONSOLE, service(ConsoleLoggerService)],
+]);

--- a/packages/api/src/models/logging/logger-type.ts
+++ b/packages/api/src/models/logging/logger-type.ts
@@ -1,0 +1,3 @@
+export enum LoggerType {
+  CONSOLE = 'console',
+}

--- a/packages/api/src/models/logging/logger.ts
+++ b/packages/api/src/models/logging/logger.ts
@@ -1,0 +1,16 @@
+import {LogLevel} from './log-level';
+
+/**
+ * Interface for logging functionality across the application.
+ * Provides a standardized way to log messages with different severity levels.
+ */
+export interface Logger {
+  /**
+   * Logs a message with the specified level and optional arguments.
+   *
+   * @param level - The severity level of the log message
+   * @param message - The main log message to be recorded
+   * @param args - Additional arguments or context data to include with the log
+   */
+  log(level: LogLevel, message: string, args: unknown[]): void;
+}

--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -44,6 +44,7 @@ export * from './services/app-lifecycle';
 export * from './services/window';
 export * from './services/plugins';
 export * from './services/configuration';
+export * from './services/logging';
 
 // Export utils for external usages.
 export * from './services/utils';

--- a/packages/api/src/services/configuration/test/configuration-context.service.spec.ts
+++ b/packages/api/src/services/configuration/test/configuration-context.service.spec.ts
@@ -1,4 +1,6 @@
 import {ConfigurationContextService} from '../configuration-context.service';
+import {LoggerType} from '../../../models/logging/logger-type';
+import {LogLevel} from '../../../models/logging/log-level';
 
 describe('ConfigurationContextService', () => {
   let configurationContextService: ConfigurationContextService;
@@ -8,7 +10,13 @@ describe('ConfigurationContextService', () => {
   });
 
   test('Should update the application configuration in the context.', () => {
-    const newConfiguration = { pluginsManifestPath: 'plugins/plugins-manifest.json' };
+    const newConfiguration = {
+      pluginsManifestPath: 'plugins/plugins-manifest.json',
+      loggerConfig: {
+        loggers: [LoggerType.CONSOLE],
+        minLogLevel: LogLevel.DEBUG
+      }
+    };
 
     // When I update the application configuration,
     configurationContextService.updateApplicationConfiguration(newConfiguration);

--- a/packages/api/src/services/logging/console/console-logger.service.ts
+++ b/packages/api/src/services/logging/console/console-logger.service.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-console */
+import {Logger} from '../../../models/logging/logger';
+import {LogLevel} from '../../../models/logging/log-level';
+
+/**
+ * Console-based logger implementation that outputs log messages to the browser console.
+ *
+ * This service implements the Logger interface and forwards log messages to the appropriate
+ * console methods based on the log level. Each log level maps to its corresponding console
+ * method for consistent output formatting and browser developer tools integration.
+ */
+export class ConsoleLoggerService implements Logger {
+  /**
+   * Logs a message to the console based on the specified log level.
+   *
+   * @param level - The log level determining which console method to use
+   * @param message - The message to log to the console
+   * @param args - Additional arguments to include in the log output
+   */
+  log(level: LogLevel, message: string, args: unknown[]): void {
+    switch (level) {
+    case LogLevel.DEBUG:
+      console.debug(message, ...args);
+      break;
+    case LogLevel.INFO:
+      console.info(message, ...args);
+      break;
+    case LogLevel.WARN:
+      console.warn(message, ...args);
+      break;
+    case LogLevel.ERROR:
+      console.error(message, ...args);
+      break;
+    default:
+      console.debug(message, ...args);
+    }
+  }
+}

--- a/packages/api/src/services/logging/index.ts
+++ b/packages/api/src/services/logging/index.ts
@@ -1,0 +1,1 @@
+export { Loggers } from './loggers';

--- a/packages/api/src/services/logging/logger-service.ts
+++ b/packages/api/src/services/logging/logger-service.ts
@@ -1,0 +1,103 @@
+import {LOGGER_DEFINITIONS} from '../../models/logging/logger-definitions';
+import {LogLevel, toNumericLogLevel} from '../../models/logging/log-level';
+import {service} from '../../providers';
+import {ConfigurationContextService} from '../configuration/configuration-context.service';
+
+/**
+ * LoggerService provides module-specific logging functionality with configurable log levels and multiple loggers.
+ *
+ * The service automatically formats log messages with timestamp, module name, and log level information.
+ * It supports multiple logger implementations and respects minimum log level configuration based on environment.
+ */
+export class LoggerService {
+  private readonly module: string;
+  private readonly loggers = LOGGER_DEFINITIONS;
+
+  /**
+   * Creates a new LoggerService instance for the specified module.
+   *
+   * @param module - The name of the module this logger instance belongs to
+   */
+  constructor(module: string) {
+    this.module = module;
+  }
+
+  /**
+   * Logs a debug message. Debug messages are only logged in development mode.
+   *
+   * @param message - The debug message to log
+   * @param args - Additional arguments to include in the log output
+   */
+  debug(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.DEBUG, message, args);
+  }
+
+  /**
+   * Logs an error message. Error messages are always logged regardless of environment.
+   *
+   * @param message - The error message to log
+   * @param args - Additional arguments to include in the log output
+   */
+  error(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.ERROR, message, args);
+  }
+
+  /**
+   * Logs an informational message.
+   *
+   * @param message - The informational message to log
+   * @param args - Additional arguments to include in the log output
+   */
+  info(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.INFO, message, args);
+  }
+
+  /**
+   * Logs a warning message.
+   *
+   * @param message - The warning message to log
+   * @param args - Additional arguments to include in the log output
+   */
+  warn(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.WARN, message, args);
+  }
+
+  /**
+   * Internal method that handles the actual logging logic.
+   * Forwards the log message to all configured loggers if the log level meets the minimum threshold.
+   *
+   * @param logLevel - The severity level of the log message
+   * @param message - The message to log
+   * @param args - Additional arguments to include in the log output
+   * @throws {Error} When a configured logger is not found in LOGGER_DEFINITIONS
+   */
+  private log(logLevel: LogLevel, message: string, args: unknown[]): void {
+    const config = this.loadConfiguration();
+    config?.loggers.forEach((loggerKey) => {
+      const logger = this.loggers.get(loggerKey);
+      if (!logger) {
+        throw new Error(`Logger '${loggerKey}' not found`);
+      }
+      if (toNumericLogLevel(config.minLogLevel) <= toNumericLogLevel(logLevel)) {
+        const formattedMessage = this.getFormattedMessage(logLevel, message);
+        logger.log(logLevel, formattedMessage, args);
+      }
+    });
+  }
+
+  /**
+   * Formats a log message with log level, module name, timestamp, and additional arguments.
+   *
+   * @param logLevel - The severity level of the log message
+   * @param message - The base message to format
+   * @returns The formatted log message string
+   */
+  private getFormattedMessage(logLevel: LogLevel, message: string) {
+    return `[${logLevel}] [${this.module}] [${new Date().toLocaleString()}] ${message}`;
+  }
+
+  private loadConfiguration() {
+    const config = service(ConfigurationContextService).getApplicationConfiguration();
+    return config?.loggerConfig;
+  }
+}

--- a/packages/api/src/services/logging/loggers.ts
+++ b/packages/api/src/services/logging/loggers.ts
@@ -1,0 +1,22 @@
+import {LoggerService} from './logger-service';
+
+/**
+ * Static factory class for managing logger instances across different modules.
+ * Implements a singleton pattern to ensure one logger instance per module.
+ */
+export class Loggers {
+  private static readonly loggerInstances = new Map<string, LoggerService>();
+
+  /**
+   * Gets or creates a logger instance for the specified module.
+   *
+   * @param module - The module to get a logger for
+   * @returns LoggerService instance for the module
+   */
+  static getLoggerInstance(module: string): LoggerService {
+    if (!this.loggerInstances.has(module)) {
+      this.loggerInstances.set(module, new LoggerService(module));
+    }
+    return this.loggerInstances.get(module)!;
+  }
+}

--- a/packages/api/src/services/logging/logging.service.ts
+++ b/packages/api/src/services/logging/logging.service.ts
@@ -1,0 +1,17 @@
+import {Loggers} from './loggers';
+
+const MODULE_NAME = 'API';
+
+/**
+ * Logger for the API module.
+ */
+export class LoggingService {
+  /**
+   * Gets the logger instance for the API module.
+   *
+   * @returns LoggerService instance for the API module
+   */
+  static get logger() {
+    return Loggers.getLoggerInstance(MODULE_NAME);
+  }
+}

--- a/packages/api/src/services/logging/test/loggers.spec.ts
+++ b/packages/api/src/services/logging/test/loggers.spec.ts
@@ -1,0 +1,105 @@
+import {Loggers} from '../loggers';
+import {ServiceProvider} from '../../../providers';
+import {ConfigurationContextService} from '../../configuration/configuration-context.service';
+import {LoggerType} from '../../../models/logging/logger-type';
+import {LogLevel} from '../../../models/logging/log-level';
+
+describe('Logging System Integration', () => {
+  let consoleSpy: {
+    debug: jest.SpyInstance;
+    info: jest.SpyInstance;
+    warn: jest.SpyInstance;
+    error: jest.SpyInstance;
+  };
+
+  beforeEach(() => {
+    Loggers['loggerInstances'].clear();
+    ServiceProvider.get(ConfigurationContextService).updateApplicationConfiguration({
+      pluginsManifestPath: 'plugins/plugins-manifest.json',
+      loggerConfig: {
+        loggers: [LoggerType.CONSOLE],
+        minLogLevel: LogLevel.DEBUG
+      }
+    });
+    consoleSpy = {
+      debug: jest.spyOn(console, 'debug').mockImplementation(),
+      info: jest.spyOn(console, 'info').mockImplementation(),
+      warn: jest.spyOn(console, 'warn').mockImplementation(),
+      error: jest.spyOn(console, 'error').mockImplementation()
+    };
+  });
+
+  test('should log from Loggers factory to console output', () => {
+    const apiLogger = Loggers.getLoggerInstance('api');
+    apiLogger.info('Integration test message', {data: 'test'});
+
+    expect(consoleSpy.info).toHaveBeenCalledTimes(1);
+    const loggedMessage = consoleSpy.info.mock.calls[0][0];
+
+    expect(loggedMessage).toContain('[INFO]');
+    expect(loggedMessage).toContain('[api]');
+    expect(loggedMessage).toContain('Integration test message');
+
+    const loggedArgs = consoleSpy.info.mock.calls[0][1];
+    expect(loggedArgs).toEqual({data: 'test'});
+  });
+
+  test('should hide debug logs in prod mode', () => {
+    ServiceProvider.get(ConfigurationContextService).updateApplicationConfiguration({
+      pluginsManifestPath: 'plugins/plugins-manifest.json',
+      loggerConfig: {
+        loggers: [LoggerType.CONSOLE],
+        minLogLevel: LogLevel.INFO
+      }
+    });
+
+    const logger = Loggers.getLoggerInstance('root');
+
+    logger.debug('Debug message');
+    logger.info('Info message');
+    logger.warn('Warn message');
+    logger.error('Error message');
+
+    expect(consoleSpy.debug).not.toHaveBeenCalled();
+    expect(consoleSpy.info).toHaveBeenCalledTimes(1);
+    expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
+    expect(consoleSpy.error).toHaveBeenCalledTimes(1);
+  });
+
+  test('should show debug logs in development mode', () => {
+    Loggers.getLoggerInstance('api').debug('Development debug message');
+    expect(consoleSpy.debug).toHaveBeenCalledTimes(1);
+  });
+
+  test('should hide debug logs in production mode', () => {
+    ServiceProvider.get(ConfigurationContextService).updateApplicationConfiguration({
+      pluginsManifestPath: 'plugins/plugins-manifest.json',
+      loggerConfig: {
+        loggers: [LoggerType.CONSOLE],
+        minLogLevel: LogLevel.INFO
+      }
+    });
+    Loggers.getLoggerInstance('api').debug('Production debug message');
+    expect(consoleSpy.debug).not.toHaveBeenCalled();
+  });
+
+  test('should correctly identify each module in log messages', () => {
+    const moduleTests = [
+      {getter: () => Loggers.getLoggerInstance('legacy'), expectedModule: 'legacy'},
+      {getter: () => Loggers.getLoggerInstance('workbench'), expectedModule: 'workbench'},
+      {getter: () => Loggers.getLoggerInstance('shared-components'), expectedModule: 'shared-components'},
+      {getter: () => Loggers.getLoggerInstance('api'), expectedModule: 'api'},
+      {getter: () => Loggers.getLoggerInstance('root'), expectedModule: 'root'}
+    ];
+
+    moduleTests.forEach(({getter, expectedModule}) => {
+      const logger = getter();
+      logger.info('Module test');
+
+      const loggedMessage = consoleSpy.info.mock.calls[consoleSpy.info.mock.calls.length - 1][0];
+      expect(loggedMessage).toContain(`[${expectedModule}]`);
+    });
+
+    expect(consoleSpy.info).toHaveBeenCalledTimes(5);
+  });
+});

--- a/packages/api/src/services/plugins/plugins.service.ts
+++ b/packages/api/src/services/plugins/plugins.service.ts
@@ -4,6 +4,7 @@ import {PluginsRestService} from './plugins-rest.service';
 import {PluginsManifest, PluginModule} from '../../models/plugins';
 import {WindowService} from '../window';
 import {PluginsManifestMapper} from './mapper/plugins-manifest.mapper';
+import {LoggingService} from '../logging/logging.service';
 
 /**
  * Service responsible for managing plugins in the application.
@@ -12,6 +13,7 @@ import {PluginsManifestMapper} from './mapper/plugins-manifest.mapper';
 export class PluginsService implements Service {
   private readonly pluginsRestService: PluginsRestService;
   private readonly pluginsManifestMapper: PluginsManifestMapper;
+  private readonly logger = LoggingService.logger;
 
   constructor() {
     this.pluginsRestService = ServiceProvider.get(PluginsRestService);
@@ -44,7 +46,7 @@ export class PluginsService implements Service {
     try {
       pluginsManifest = await this.getPluginsManifest();
     } catch (error) {
-      console.warn('Failed to load plugins manifest. Continue with the built-in plugins only.', error);
+      this.logger.warn('Failed to load plugins manifest. Continue with the built-in plugins only.', error);
       // If the manifest cannot be loaded, we will continue with built-in plugins only.
       // This allows the application to function without external plugins.
     }
@@ -57,7 +59,7 @@ export class PluginsService implements Service {
           if (pluginModule.register !== undefined) {
             pluginModule.register(WindowService.getPluginRegistry());
           } else {
-            console.warn('Plugin module is missing the register method. Skipping registration.', pluginModule);
+            this.logger.warn('Plugin module is missing the register method. Skipping registration.', pluginModule);
           }
         });
     }

--- a/packages/api/src/services/plugins/test/plugins.service.spec.ts
+++ b/packages/api/src/services/plugins/test/plugins.service.spec.ts
@@ -4,14 +4,21 @@ import {ResponseMock} from '../../http/test/response-mock';
 import {PluginsManifestResponse} from '../../../models/plugins';
 import {ServiceProvider} from '../../../providers';
 import {ConfigurationContextService} from '../../configuration/configuration-context.service';
+import {LoggerType} from '../../../models/logging/logger-type';
+import {LogLevel} from '../../../models/logging/log-level';
 
 describe('PluginsService', () => {
   let pluginsService: PluginsService;
 
   beforeEach(() => {
-    pluginsService = new PluginsService();
     ServiceProvider.get(ConfigurationContextService).updateApplicationConfiguration({
-      pluginsManifestPath: 'plugins/plugins-manifest.json'});
+      pluginsManifestPath: 'plugins/plugins-manifest.json',
+      loggerConfig: {
+        loggers: [LoggerType.CONSOLE],
+        minLogLevel: LogLevel.DEBUG
+      }
+    });
+    pluginsService = new PluginsService();
   });
 
   it('should retrieve plugins manifest', async () => {

--- a/packages/legacy-workbench/src/app.js
+++ b/packages/legacy-workbench/src/app.js
@@ -22,7 +22,7 @@ import 'angular/core/directives/prop-indeterminate/prop-indeterminate.directive'
 import 'angular/core/directives/page-info-tooltip.directive';
 import 'angular/core/filters/search-filter';
 import 'angular/core/filters/bytes-filter';
-import 'angular/core/services/language.service'
+import 'angular/core/services/language.service';
 import {defineCustomElements as defineYasguiElements} from 'ontotext-yasgui-web-component/loader';
 import {defineCustomElements as defineGraphQlElements} from 'ontotext-graphql-playground-component/loader';
 import {convertToHumanReadable} from "./js/angular/utils/size-util";
@@ -33,8 +33,8 @@ import {ServiceProvider, LanguageContextService} from "@ontotext/workbench-api";
 
 // $translate.instant converts <b> from strings to &lt;b&gt
 // and $sce.trustAsHtml could not recognise that this is valid html
-export const decodeHTML = function (html) {
-    let txt = document.createElement('textarea');
+export const decodeHTML = function(html) {
+    const txt = document.createElement('textarea');
     txt.innerHTML = html;
     return txt.value;
 };
@@ -61,7 +61,7 @@ const modules = [
     'ngCustomElement',
     'graphdb.framework.core.services.language-service',
     'graphdb.framework.core.filters.searchFilter',
-    'graphdb.framework.core.filters.bytes'
+    'graphdb.framework.core.filters.bytes',
 ];
 
 const providers = [
@@ -74,23 +74,22 @@ const providers = [
     '$httpProvider',
     '$templateRequestProvider',
     '$translateProvider',
-    '$languageServiceProvider'
+    '$languageServiceProvider',
 ];
 
 const workbench = angular.module('graphdb.workbench', modules);
 
-const moduleDefinition = function (productInfo, translations) {
+const moduleDefinition = function(productInfo, translations) {
     defineYasguiElements();
     defineGraphQlElements();
 
     workbench.config([...providers,
-        function ($routeProvider, $locationProvider, $menuItemsProvider, toastrConfig, localStorageServiceProvider,
+        function($routeProvider, $locationProvider, $menuItemsProvider, toastrConfig, localStorageServiceProvider,
                   $uibTooltipProvider, $httpProvider, $templateRequestProvider, $translateProvider, $languageServiceProvider) {
-
             if (translations && Object.keys(translations).length > 0) {
                 // If translations data is provided, iterate over the object and register each language key
                 // and its corresponding translation data with $translateProvider.
-                Object.keys(translations).forEach(langKey => {
+                Object.keys(translations).forEach((langKey) => {
                     $translateProvider.translations(langKey, translations[langKey]);
                 });
                 $translateProvider.preferredLanguage($languageServiceProvider.getDefaultLanguage());
@@ -101,7 +100,7 @@ const moduleDefinition = function (productInfo, translations) {
                 // the specified pattern (prefix/suffix).
                 $translateProvider.useStaticFilesLoader({
                     prefix: 'i18n/locale-',
-                    suffix: '.json?v=[AIV]{version}[/AIV]'
+                    suffix: '.json?v=[AIV]{version}[/AIV]',
                 });
                 // load 'en' table on startup
                 $translateProvider.preferredLanguage($languageServiceProvider.getDefaultLanguage());
@@ -113,7 +112,7 @@ const moduleDefinition = function (productInfo, translations) {
                 timeOut: 5000,
                 positionClass: 'toast-bottom-right',
                 tapToDismiss: false,
-                extendedTimeOut: 5000
+                extendedTimeOut: 5000,
             });
 
             localStorageServiceProvider
@@ -121,24 +120,24 @@ const moduleDefinition = function (productInfo, translations) {
                 .setNotify(true, true);
 
             const $route = $routeProvider.$get[$routeProvider.$get.length - 1]({
-                $on: function () {
-                }
+                $on: function() {
+                },
             });
 
             // Handle OAuth returned url, _openid_implicit_ is just a placeholder, the actual URL
             // is defined by the regular expression below.
             $routeProvider.when('_openid_implicit_', {
-                controller: function () {
+                controller: function() {
                 },
-                template: "<div></div>"
+                template: "<div></div>",
             });
 
             // The URL will contain access_token=xxx and id_token=xxx and possibly other parameters,
             // separated by &. Parameters may come in any order.
             $route.routes['_openid_implicit_'].regexp = /[&/](?:id_token=.*&access_token=|access_token=.*&id_token=)/;
 
-            let routes = PluginRegistry.get('route');
-            angular.forEach(routes, function (route) {
+            const routes = PluginRegistry.get('route');
+            angular.forEach(routes, function(route) {
                 $routeProvider.when(route.url, {
                     controller: route.controller,
                     templateUrl: route.templateUrl,
@@ -148,22 +147,22 @@ const moduleDefinition = function (productInfo, translations) {
                     allowAuthorities: route.allowAuthorities,
                     reloadOnSearch: route.reloadOnSearch !== undefined ? route.reloadOnSearch : true,
                     resolve: {
-                        preload: ['$ocLazyLoad', '$q', function ($ocLazyLoad, $q) {
+                        preload: ['$ocLazyLoad', '$q', function($ocLazyLoad, $q) {
                             // some modules define routes to just static pages
                             if (!route.path) {
                                 return $q.defer().resolve();
                             }
-                            return import(`angular/${route.path}`).then(module => {
+                            return import(`angular/${route.path}`).then((module) => {
                                 $ocLazyLoad.inject(route.module)
-                                    .catch(err => {
-                                        console.log(err)
+                                    .catch((err) => {
+                                        console.info(err);
                                     });
-                            }).catch(error => {
+                            }).catch((error) => {
                                 console.error(`Error loading module for path: ${route.path}`, error);
                                 return $q.reject(error);
                             });
-                        }]
-                    }
+                        }],
+                    },
                 });
             });
 
@@ -200,7 +199,7 @@ const moduleDefinition = function (productInfo, translations) {
             // already aren't actually fetched via HTTP so we don't want to add the parameter there.
             const originalTemplateProviderFn = $templateRequestProvider.$get[3];
             if (typeof originalTemplateProviderFn === 'function') {
-                $templateRequestProvider.$get[3] = function (templateCache, http, q) {
+                $templateRequestProvider.$get[3] = function(templateCache, http, q) {
                     const originalHandleRequestFn = originalTemplateProviderFn(templateCache, http, q);
                     return function handleRequestFn(tpl, ignoreRequestError) {
                         if (!templateCache.get(tpl)) {
@@ -209,7 +208,7 @@ const moduleDefinition = function (productInfo, translations) {
                             tpl = tpl + '?v=[AIV]{version}[/AIV]';
                         }
                         return originalHandleRequestFn(tpl, ignoreRequestError);
-                    }
+                    };
                 };
             }
         }]);
@@ -218,14 +217,14 @@ const moduleDefinition = function (productInfo, translations) {
 
     // we need to inject $jwtAuth here in order to init the service before everything else
     workbench.run(['$rootScope', '$route', 'toastr', '$sce', '$translate', '$languageService', 'ThemeService', 'WorkbenchSettingsStorageService', 'LSKeys', 'GuidesService',
-        function ($rootScope, $route, toastr, $sce, $translate, $languageService, ThemeService, WorkbenchSettingsStorageService, LSKeys, GuidesService) {
-            const routeChangeUnsubscribe = $rootScope.$on('$routeChangeSuccess', function () {
+        function($rootScope, $route, toastr, $sce, $translate, $languageService, ThemeService, WorkbenchSettingsStorageService, LSKeys, GuidesService) {
+            const routeChangeUnsubscribe = $rootScope.$on('$routeChangeSuccess', function() {
                 updateTitleAndHelpInfo();
 
                 toastr.clear();
             });
 
-            const translateChangeUnsubscribe = $rootScope.$on('$translateChangeSuccess', function () {
+            const translateChangeUnsubscribe = $rootScope.$on('$translateChangeSuccess', function() {
                 updateTitleAndHelpInfo();
             });
 
@@ -273,14 +272,14 @@ const moduleDefinition = function (productInfo, translations) {
                 translateChangeUnsubscribe();
                 // Remove all routes so that when navigating from legacy-workbench to the new workbench and back, the
                 // router will not try to load the route before the app is bootstrapped again.
-                Object.keys($route.routes).forEach(function (route) {
+                Object.keys($route.routes).forEach(function(route) {
                     delete $route.routes[route];
                 });
-            })
+            });
         }]);
 
-    workbench.filter('titlecase', function () {
-        return function (input) {
+    workbench.filter('titlecase', function() {
+        return function(input) {
             const s = "" + input;
             return s.charAt(0).toUpperCase() + s.slice(1);
         };
@@ -300,12 +299,12 @@ const wbInit = () => {
 
 // Manually load language files
 function initTranslations() {
-    const languages = __LANGUAGES__.availableLanguages.map(lang => lang.key)
+    const languages = __LANGUAGES__.availableLanguages.map((lang) => lang.key);
     const promises = languages.map(loadTranslations);
     const translations = {};
     return Promise.all(promises)
         .then((results) => {
-            results.forEach(result => {
+            results.forEach((result) => {
                 if (result) {
                     translations[result.language] = result.data;
                 }
@@ -322,10 +321,10 @@ function initTranslations() {
 // Helper function to load translations for a given language
 function loadTranslations(language) {
     return $.getJSON(`i18n/locale-${language}.json?v=[AIV]{version}[/AIV]`)
-        .then(function (data) {
+        .then(function(data) {
             return {language, data};
         })
-        .fail(function () {
+        .fail(function() {
             console.error(`Failed to load translation file for: ${language}`);
             return null;
         });
@@ -334,7 +333,7 @@ function loadTranslations(language) {
 // Fetch the product version information before bootstrapping the app
 function loadAppInfo() {
     return new Promise((resolve, reject) => {
-        $.get('rest/info/version?local=1', function (data) {
+        $.get('rest/info/version?local=1', function(data) {
             // Extract major.minor version as short version
             const versionArray = data.productVersion.match(/^(\d+\.\d+)/);
             if (versionArray.length) {
@@ -404,7 +403,7 @@ const ngLifecycles = singleSpaAngularJS({
                 <div ng-view></div>
             </div>
         </div>
-    `
+    `,
 });
 
 export const bootstrap = (props) => {
@@ -418,7 +417,7 @@ export const mount = (props) => {
         .then(() => {
             props.initApplication = () => {
                 return startWorkbench();
-            }
+            };
             return ngLifecycles.mount(props);
         });
 };

--- a/packages/legacy-workbench/src/js/angular/core/services/legacy-logger.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/legacy-logger.service.js
@@ -1,0 +1,18 @@
+import {Loggers} from '@ontotext/workbench-api';
+
+/** Module identifier for legacy module logger */
+const LEGACY_MODULE = 'LEGACY_MODULE';
+
+/**
+ * Service class that provides logging functionality for legacy workbench components.
+ * Acts as a bridge between the legacy AngularJS code and the new logging infrastructure.
+ */
+export class LoggingService {
+    /**
+     * Gets the logger instance specifically configured for legacy module components.
+     * @returns {Logger} Logger instance for the legacy module
+     */
+    static get logger() {
+        return Loggers.getLoggerInstance(LEGACY_MODULE);
+    }
+}

--- a/packages/root-config/src/bootstrap/bootstrap.js
+++ b/packages/root-config/src/bootstrap/bootstrap.js
@@ -15,7 +15,6 @@ import {
 } from '@ontotext/workbench-api';
 import {start} from 'single-spa';
 import {defineCustomElements} from '../../../shared-components/loader';
-
 const bootstrapPromises = [
   ...licenseBootstrap,
   ...autoCompleteBootstrap,

--- a/packages/root-config/src/services/root-logger.service.js
+++ b/packages/root-config/src/services/root-logger.service.js
@@ -1,0 +1,12 @@
+import {Loggers} from '@ontotext/workbench-api';
+
+const MODULE_NAME = 'ROOT_CONFIG';
+
+/**
+ * Service class that provides logging functionality for the root configuration.
+ */
+export class LoggingService {
+  static get logger() {
+    return Loggers.getLoggerInstance(MODULE_NAME);
+  }
+}

--- a/packages/shared-components/src/services/shared-components-logger.service.ts
+++ b/packages/shared-components/src/services/shared-components-logger.service.ts
@@ -1,0 +1,18 @@
+import { Loggers } from '@ontotext/workbench-api';
+
+const MODULE_NAME = 'SharedComponents';
+
+/**
+ * Logger for the Shared Components module.
+ */
+export class SharedComponentsLoggerService {
+  /**
+   * Gets the logger instance for the Shared Components module.
+   *
+   * @returns LoggerService instance for the Shared Components module
+   */
+  static get logger() {
+    return Loggers.getLoggerInstance(MODULE_NAME);
+  }
+}
+

--- a/packages/shared-components/src/services/translation.service.ts
+++ b/packages/shared-components/src/services/translation.service.ts
@@ -2,6 +2,7 @@ import {ServiceProvider, LanguageContextService, TranslationBundle} from '@ontot
 import {TranslationParameter} from '../models/translation/translation-parameter';
 import {TranslationCallback, TranslationObserver} from '../models/translation/translation-observer';
 import {sanitizeHTML} from '../utils/html-utils';
+import {SharedComponentsLoggerService} from './shared-components-logger.service';
 
 /**
  * Service responsible for translation operations in the component.
@@ -14,6 +15,7 @@ class TranslationServiceClassDefinition {
   private readonly languageContextService: LanguageContextService = ServiceProvider.get(LanguageContextService);
   private languageChangeSubscription: () => void;
   private translationChangedObservers: Record<string, TranslationObserver[]> = {};
+  private readonly logger = SharedComponentsLoggerService.logger;
 
   constructor() {
     // log with background color
@@ -79,7 +81,7 @@ class TranslationServiceClassDefinition {
       return sanitizeHTML(translation);
     }
 
-    console.warn(`Missing translation for key: [${key}]`);
+    this.logger.warn(`Missing translation for key: [${key}]`);
     return key;
   }
 

--- a/packages/workbench/src/app/new-view/new-view.component.ts
+++ b/packages/workbench/src/app/new-view/new-view.component.ts
@@ -1,6 +1,7 @@
 import {Component, CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {AuthenticationService, RepositoryContextService, ServiceProvider, RepositoryList} from '@ontotext/workbench-api';
 import {TranslocoPipe} from '@jsverse/transloco';
+import {LoggingService} from '../services/logging.service';
 
 @Component({
   selector: 'app-new-view',
@@ -11,10 +12,11 @@ import {TranslocoPipe} from '@jsverse/transloco';
   schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
 export class NewViewComponent {
+  private readonly logger = LoggingService.logger;
   constructor() {
-    console.info('NewViewComponent login', ServiceProvider.get(AuthenticationService).login());
+    this.logger.info('NewViewComponent login', ServiceProvider.get(AuthenticationService).login());
     ServiceProvider.get(RepositoryContextService).onRepositoryListChanged((repositoryList: RepositoryList | undefined) => {
-      console.info('NewViewComponent repositories', repositoryList?.getItems());
+      this.logger.info('NewViewComponent repositories', repositoryList?.getItems());
     });
   }
 }

--- a/packages/workbench/src/app/services/logging.service.ts
+++ b/packages/workbench/src/app/services/logging.service.ts
@@ -1,0 +1,18 @@
+import { Loggers } from '@ontotext/workbench-api';
+
+const MODULE_NAME = 'Workbench';
+
+/**
+ * Logger for the Workbench module.
+ */
+export class LoggingService {
+
+  /**
+   * Gets the logger instance for the Workbench module.
+   *
+   * @returns LoggerService instance for the Workbench module
+   */
+  static get logger() {
+    return Loggers.getLoggerInstance(MODULE_NAME);
+  }
+}


### PR DESCRIPTION
## What
Implement a centralized logging service for the application

## Why
To provide consistent and configurable logging across all microfrontend modules, facilitating easier debugging and monitoring of the application.

## How
- Added `logger` interface to hold the contract for each concrete logger
- Added `console-logger.service` as a concrete implementation, which logs to the console
- Added `logger-service` which traverses all enabled concrete loggers and `log`s a formatted message on all of them
- Added `loggers` factory, which holds instances of module specific loggers. This way each microfrontend uses its own logger to have module specific info
- Added documentation

## Testing
jest

## Screenshots
<img width="816" height="105" alt="Screenshot from 2025-09-11 13-28-37" src="https://github.com/user-attachments/assets/53cdb25b-7605-49c2-bf73-20e48126c9f7" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [ ] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
