### PR TITLE
GDB-12700: Define authentication strategy interface

### DIFF
--- a/packages/api/src/models/security/authentication/auth-strategy-type.ts
+++ b/packages/api/src/models/security/authentication/auth-strategy-type.ts
@@ -1,0 +1,27 @@
+/**
+ * Enum representing the supported authentication strategy types.
+ *
+ * The security module provides a common interface for pluggable self-contained authentication strategies.
+ * This prevents bloating the security module with entangled logic and promotes flexibility and extensibility.
+ */
+export enum AuthStrategyType {
+  /**
+   * Authentication using a GraphDB-specific token.
+   */
+  GDB_TOKEN = 'GDB_TOKEN',
+
+  /**
+   * Authentication using OpenID Connect protocol.
+   */
+  OPENID = 'OPENID',
+
+  /**
+   * Authentication using Kerberos protocol.
+   */
+  KERBEROS = 'KERBEROS',
+
+  /**
+   * No authentication; open access.
+   */
+  NO_SECURITY = 'NO_SECURITY'
+}

--- a/packages/api/src/models/security/authentication/auth-strategy.ts
+++ b/packages/api/src/models/security/authentication/auth-strategy.ts
@@ -1,0 +1,40 @@
+import {AuthStrategyType} from './auth-strategy-type';
+import {AuthenticatedUser} from '../authenticated-user';
+
+/**
+ * Interface for authentication strategies.
+ *
+ * Each authentication strategy implements this interface to provide a self-contained mechanism for authentication.
+ * This design allows the security module to remain flexible and extensible, avoiding entangled logic.
+ */
+export interface AuthStrategy {
+  /**
+   * The type of authentication strategy.
+   */
+  type: AuthStrategyType;
+
+  /**
+   * Initializes the authentication strategy.
+   * Can be used to perform setup tasks such as loading configuration or establishing connections.
+   */
+  initialize(): Promise<unknown>;
+
+  /**
+   * Authenticates a user with the provided login data.
+   * @param loginData - The data required for authentication (varies by strategy).
+   * @returns A promise resolving to the authenticated user.
+   */
+  login(loginData: unknown): Promise<AuthenticatedUser>;
+
+  /**
+   * Logs out the currently authenticated user.
+   * @returns A promise that resolves when logout is complete.
+   */
+  logout(): Promise<void>;
+
+  /**
+   * Checks if a user is currently authenticated.
+   * @returns True if a user is authenticated, false otherwise.
+   */
+  isAuthenticated(): boolean;
+}


### PR DESCRIPTION
## What
Created an interface for authentication strategies and an enum for supported authentication types.

## Why
This implementation promotes flexibility and extensibility in the security module by allowing pluggable authentication strategies without entangled logic.

## How
- Added `AuthStrategyType` enum with various authentication strategy types.
- Defined `AuthStrategy` interface with methods for initialization, login, logout, and authentication checks.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
