### PR TITLE
GDB-12704: Implement authentication strategy resolver

### DIFF
--- a/e2e-tests/e2e-legacy/sparql-editor/saved-query/readonly-query.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/saved-query/readonly-query.spec.js
@@ -1,10 +1,9 @@
-import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
-import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
-import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
-import {UserAndAccessSteps} from "../../../steps/setup/user-and-access-steps";
-import {SavedQuery} from "../../../steps/yasgui/saved-query";
-import {SavedQueriesDialog} from "../../../steps/yasgui/saved-queries-dialog";
-import {LoginSteps} from "../../../steps/login-steps";
+import {SparqlEditorSteps} from '../../../steps/sparql-editor-steps';
+import {YasguiSteps} from '../../../steps/yasgui/yasgui-steps';
+import {QueryStubs} from '../../../stubs/yasgui/query-stubs';
+import {SavedQuery} from '../../../steps/yasgui/saved-query';
+import {SavedQueriesDialog} from '../../../steps/yasgui/saved-queries-dialog';
+import {LoginSteps} from '../../../steps/login-steps';
 
 const USER_NAME = 'saved_query_user';
 const USER_ADMINISTRATOR = 'admin';
@@ -21,8 +20,7 @@ describe('Readonly saved query', () => {
         cy.presetRepository(repositoryId);
         QueryStubs.stubDefaultQueryResponse(repositoryId);
         cy.createUser({username: USER_NAME, password: PASSWORD});
-        UserAndAccessSteps.visit();
-        UserAndAccessSteps.toggleSecurity();
+        cy.switchOnSecurity();
     });
 
     afterEach(() => {
@@ -34,11 +32,9 @@ describe('Readonly saved query', () => {
     });
 
     it('Should not allow modifying a saved query if it is readonly', () => {
+        SparqlEditorSteps.visitSparqlEditorPage()
         // Given: There is a public saved query created by a user.
         LoginSteps.loginWithUser(USER_NAME, PASSWORD);
-        // Wait for the users page to be loaded, before changing the URL to ensure the user is logged in successfully
-        UserAndAccessSteps.isUsersUrlLoaded();
-        SparqlEditorSteps.visitSparqlEditorPage();
         YasguiSteps.getYasgui().should('be.visible');
         const savedQueryName = SavedQuery.generateQueryName();
         SavedQuery.create(savedQueryName);

--- a/e2e-tests/e2e-security/setup/users-and-access/create-user-permissions.spec.js
+++ b/e2e-tests/e2e-security/setup/users-and-access/create-user-permissions.spec.js
@@ -73,7 +73,12 @@ describe('User Management – Creation, Validation, Permissions & Deletion', () 
             UserAndAccessSteps.clickWriteAccessRepo(repositoryId);
             UserAndAccessSteps.confirmUserCreate();
 
-            ToasterSteps.verifyError('An account with the given username already exists.');
+            // Using the toaster from the shared components which has different class names
+            ToasterSteps.getToast()
+                .should('be.visible')
+                .and('have.class', 'toast error')
+                .find('.toast-message')
+                .and('contain', 'An account with the given username already exists.');
             cy.deleteUser('user');
         });
 

--- a/e2e-tests/steps/sparql-editor-steps.js
+++ b/e2e-tests/steps/sparql-editor-steps.js
@@ -5,11 +5,16 @@ const VIEW_URL = '/sparql';
 export class SparqlEditorSteps {
     static visitSparqlEditorPage() {
         cy.visit(VIEW_URL);
+    }
+
+    static visitSparqlEditorPageAndWaitForEditor() {
+        SparqlEditorSteps.visitSparqlEditorPage();
         // Because we use angularjs less than 1.7.3 we use additional library ng-custom-element.umd.js to solve problem with property bindings
         // This library make additional call to ontotext-yasgui-web-component and the component that's way the component renders twice when page loaded.
         // This is bad because in tests cypress can find an element when it is rendered from first call and try to click it for example.
         // If time of clicking such element is when second call to the component is done then exception that element is detached will be thrown.
         // We will wait a little , to give a chance page is loaded correctly before test start.
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(1000);
         YasqeSteps.waitUntilQueryIsVisible();
     }

--- a/packages/api/src/models/events/auth/login.ts
+++ b/packages/api/src/models/events/auth/login.ts
@@ -1,0 +1,13 @@
+import {Event} from '../event';
+import {EventName} from '../event-name';
+
+/**
+ * Represents a "login" event.
+ *
+ * This event is triggered when users logs in.
+ */
+export class Login extends Event<undefined> {
+  constructor() {
+    super(EventName.LOGIN);
+  }
+}

--- a/packages/api/src/models/events/event-name.ts
+++ b/packages/api/src/models/events/event-name.ts
@@ -8,6 +8,7 @@
 export const EventName = {
   NAVIGATION_END: 'navigationEnd',
   NAVIGATION_START: 'navigationStart',
+  LOGIN: 'login',
   LOGOUT: 'logout',
   APP_DATA_LOADED: 'applicationDataLoaded',
 };

--- a/packages/api/src/models/security/authentication/auth-strategy.ts
+++ b/packages/api/src/models/security/authentication/auth-strategy.ts
@@ -1,5 +1,4 @@
 import {AuthStrategyType} from './auth-strategy-type';
-import {AuthenticatedUser} from '../authenticated-user';
 
 /**
  * Interface for authentication strategies.
@@ -22,9 +21,8 @@ export interface AuthStrategy {
   /**
    * Authenticates a user with the provided login data.
    * @param loginData - The data required for authentication (varies by strategy).
-   * @returns A promise resolving to the authenticated user.
    */
-  login(loginData: unknown): Promise<AuthenticatedUser>;
+  login(loginData: unknown): Promise<void>;
 
   /**
    * Logs out the currently authenticated user.

--- a/packages/api/src/models/security/authentication/no-security-provider.ts
+++ b/packages/api/src/models/security/authentication/no-security-provider.ts
@@ -1,0 +1,53 @@
+import {AuthStrategy} from './auth-strategy';
+import {AuthStrategyType} from './auth-strategy-type';
+import {service} from '../../../providers';
+import {AuthenticationStorageService, SecurityContextService, SecurityService} from '../../../services/security';
+import {LoggerProvider} from '../../../services/logging/logger-provider';
+
+export class NoSecurityProvider implements AuthStrategy {
+  private readonly logger = LoggerProvider.logger;
+  private readonly securityService = service(SecurityService);
+  private readonly authStorageService = service(AuthenticationStorageService);
+  private readonly securityContextService = service(SecurityContextService);
+
+  type = AuthStrategyType.NO_SECURITY;
+
+  /**
+   * Initializes the NoSecurityProvider and loads the admin user.
+   *
+   * @returns A promise that resolves when the initialization is complete.
+   */
+  initialize(): Promise<unknown> {
+    return this.securityService.getAdminUser()
+      .then((authenticatedUser) => {
+        this.securityContextService.updateAuthenticatedUser(authenticatedUser);
+      })
+      .catch((error) => {
+        this.logger.error('Could not load authenticated user', error);
+      });
+  }
+
+  /**
+   * Logs in a user. In the NoSecurityProvider, this method does nothing and resolves immediately.
+   */
+  login(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  /**
+   * Logs out the current user. In the NoSecurityProvider, this method does nothing and resolves immediately.
+   */
+  logout(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  /**
+   * Checks if a user is currently authenticated.
+   *
+   * @returns True if a user is authenticated, false otherwise.
+   */
+  isAuthenticated(): boolean {
+    const authenticatedUser = this.securityContextService.getAuthenticatedUser();
+    return !!authenticatedUser;
+  }
+}

--- a/packages/api/src/models/security/authentication/tests/gdb-token-auth-provider.spec.ts
+++ b/packages/api/src/models/security/authentication/tests/gdb-token-auth-provider.spec.ts
@@ -1,0 +1,184 @@
+import {TestUtil} from '../../../../services/utils/test/test-util';
+import {GdbTokenAuthProvider} from '../gdb-token-auth-provider';
+import {AuthenticationStorageService, SecurityContextService, SecurityService} from '../../../../services/security';
+import {ServiceProvider} from '../../../../providers';
+import {WindowService} from '../../../../services/window';
+import {ResponseMock} from '../../../../services/http/test/response-mock';
+import {LoggerProvider} from '../../../../services/logging/logger-provider';
+import {SecurityConfig} from '../../security-config';
+import {AuthenticatedUser} from '../../authenticated-user';
+import {ProviderResponseMocks} from './provider-response-mocks';
+
+describe('GdbTokenAuthProvider', () => {
+  let provider: GdbTokenAuthProvider;
+  let loggerErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    TestUtil.restoreAllMocks();
+    jest.clearAllMocks();
+    loggerErrorSpy = jest.spyOn(LoggerProvider.logger, 'error');
+
+    const securityContextService = ServiceProvider.get(SecurityContextService);
+    securityContextService.updateSecurityConfig(undefined as unknown as SecurityConfig);
+    securityContextService.updateAuthToken(undefined as unknown as string);
+    securityContextService.updateAuthenticatedUser(undefined as unknown as AuthenticatedUser);
+    const authenticationStorageService = ServiceProvider.get(AuthenticationStorageService);
+    authenticationStorageService.clearAuthToken();
+
+    provider = new GdbTokenAuthProvider();
+  });
+
+  describe('initialize', () => {
+    describe('when authenticated user returns', () => {
+      let getAuthenticatedUserSpy: jest.SpyInstance;
+      let updateAuthenticatedUserSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        TestUtil.mockResponse(new ResponseMock('rest/security/authenticated-user').setResponse(ProviderResponseMocks.authenticatedUserResponse));
+
+        getAuthenticatedUserSpy = jest.spyOn(ServiceProvider.get(SecurityService), 'getAuthenticatedUser');
+        updateAuthenticatedUserSpy = jest.spyOn(ServiceProvider.get(SecurityContextService), 'updateAuthenticatedUser');
+      });
+
+      it('should resolve immediately if current route is login', async () => {
+        jest.spyOn(WindowService, 'getWindow').mockReturnValue({
+          location: {
+            pathname: '/login'
+          },
+          PluginRegistry: {get: jest.fn(() => [])}
+        } as unknown as Window);
+
+        await expect(provider.initialize()).resolves.toBeUndefined();
+        expect(getAuthenticatedUserSpy).not.toHaveBeenCalled();
+      });
+
+      it('should update authenticated user if not on login route', async () => {
+        jest.spyOn(WindowService, 'getWindow').mockReturnValue({
+          location: {
+            pathname: '/home'
+          },
+          PluginRegistry: {get: jest.fn(() => [])}
+        } as unknown as Window);
+
+        await provider.initialize();
+        expect(getAuthenticatedUserSpy).toHaveBeenCalled();
+        expect(updateAuthenticatedUserSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('when authenticated user returns 401', () => {
+      let getAuthenticatedUserSpy: jest.SpyInstance;
+      let updateAuthenticatedUserSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        TestUtil.mockResponse(new ResponseMock('rest/security/authenticated-user').setStatus(401));
+        getAuthenticatedUserSpy = jest.spyOn(ServiceProvider.get(SecurityService), 'getAuthenticatedUser');
+        updateAuthenticatedUserSpy = jest.spyOn(ServiceProvider.get(SecurityContextService), 'updateAuthenticatedUser');
+      });
+
+      it('should handle errors from getAuthenticatedUser', async () => {
+        jest.spyOn(WindowService, 'getWindow').mockReturnValue({
+          location: {
+            pathname: '/home'
+          },
+          PluginRegistry: {get: jest.fn(() => [])}
+        } as unknown as Window);
+
+        await provider.initialize();
+        expect(loggerErrorSpy).toHaveBeenCalledWith('Could not load authenticated user', expect.anything());
+
+        expect(getAuthenticatedUserSpy).toHaveBeenCalled();
+        expect(updateAuthenticatedUserSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('login', () => {
+    let updateAuthenticatedUserSpy: jest.SpyInstance;
+    let setAuthTokenSpy: jest.SpyInstance;
+    let loginGdbTokenSpy: jest.SpyInstance;
+
+    const loginData = {username: 'testUser', password: '1234'};
+
+    beforeEach(() => {
+      updateAuthenticatedUserSpy = jest.spyOn(ServiceProvider.get(SecurityContextService), 'updateAuthenticatedUser');
+      setAuthTokenSpy = jest.spyOn(ServiceProvider.get(AuthenticationStorageService), 'setAuthToken');
+      loginGdbTokenSpy = jest.spyOn(ServiceProvider.get(SecurityService), 'loginGdbToken');
+    });
+
+    it('should login, set token, update user', async () => {
+      TestUtil.mockResponse(new ResponseMock('rest/login').setResponse(ProviderResponseMocks.loginResponse).setHeaders(new Headers({authorization: 'GDB someToken'})));
+
+      const result = await provider.login(loginData);
+      expect(result).toBeUndefined();
+
+      expect(loginGdbTokenSpy).toHaveBeenCalledWith(loginData.username, loginData.password);
+      expect(setAuthTokenSpy).toHaveBeenCalledWith('GDB someToken');
+      expect(updateAuthenticatedUserSpy).toHaveBeenCalled();
+    });
+
+    it('should throw if user mapping fails', async () => {
+      TestUtil.mockResponse(new ResponseMock('rest/login').setResponse('errorLogin').setSetThrowOnJson(true));
+
+      await expect(provider.login(loginData)).rejects.toThrow('Failed to map user from response');
+      expect(loggerErrorSpy).toHaveBeenCalledWith('Could not map user from response', expect.any(Error));
+    });
+
+    it('should not set token/user if auth header or user is missing', async () => {
+      TestUtil.mockResponse(new ResponseMock('rest/login').setResponse(ProviderResponseMocks.loginResponse));
+
+      await provider.login(loginData);
+      expect(setAuthTokenSpy).not.toHaveBeenCalled();
+      expect(updateAuthenticatedUserSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('logout', () => {
+    it('should clear the auth token', async () => {
+      const clearAuthTokenSpy = jest.spyOn(ServiceProvider.get(AuthenticationStorageService), 'clearAuthToken');
+      await provider.logout();
+      expect(clearAuthTokenSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('isAuthenticated', () => {
+    describe('security is enabled', () => {
+      beforeEach(() => {
+        const securityConfig = {
+          enabled: true
+        } as unknown as SecurityConfig;
+        ServiceProvider.get(SecurityContextService).updateSecurityConfig(securityConfig);
+      });
+
+      it('should return true if token exists', async () => {
+        TestUtil.mockResponse(new ResponseMock('rest/login').setResponse(ProviderResponseMocks.loginResponse).setHeaders(new Headers({authorization: 'GDB someToken'})));
+
+        await provider.login({username: 'testUser', password: '1234'});
+        expect(provider.isAuthenticated()).toBe(true);
+      });
+
+      it('should return false if token is null', () => {
+        expect(provider.isAuthenticated()).toBe(false);
+      });
+    });
+
+    describe('security is disabled', () => {
+      beforeEach(() => {
+        const securityConfig = {
+          enabled: false
+        } as unknown as SecurityConfig;
+        ServiceProvider.get(SecurityContextService).updateSecurityConfig(securityConfig);
+      });
+
+      it('should return true if token exists', async () => {
+        TestUtil.mockResponse(new ResponseMock('rest/login').setResponse(ProviderResponseMocks.loginResponse).setHeaders(new Headers({authorization: 'GDB someToken'})));
+        await provider.login({username: 'testUser', password: '1234'});
+        expect(provider.isAuthenticated()).toBe(true);
+      });
+
+      it('should return true if token is null', async () => {
+        expect(provider.isAuthenticated()).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/api/src/models/security/authentication/tests/no-security-provider.spec.ts
+++ b/packages/api/src/models/security/authentication/tests/no-security-provider.spec.ts
@@ -1,0 +1,58 @@
+import {NoSecurityProvider} from '../no-security-provider';
+import {TestUtil} from '../../../../services/utils/test/test-util';
+import {ResponseMock} from '../../../../services/http/test/response-mock';
+import {ServiceProvider} from '../../../../providers';
+import {SecurityContextService, SecurityService} from '../../../../services/security';
+import {AuthenticatedUser} from '../../authenticated-user';
+import {ProviderResponseMocks} from './provider-response-mocks';
+
+describe('NoSecurityProvider', () => {
+  let provider: NoSecurityProvider;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    TestUtil.restoreAllMocks();
+
+    ServiceProvider.get(SecurityContextService).updateAuthenticatedUser(undefined as unknown as AuthenticatedUser);
+
+    provider = new NoSecurityProvider();
+  });
+
+  describe('initialize', () => {
+    it('should fetch the admin user and update the context', async () => {
+      TestUtil.mockResponse(new ResponseMock('rest/security/users/admin').setResponse(ProviderResponseMocks.adminUserResponse));
+
+      const getAdminUserSpy = jest.spyOn(ServiceProvider.get(SecurityService), 'getAdminUser');
+      const updateAuthenticatedUserSpy = jest.spyOn(ServiceProvider.get(SecurityContextService), 'updateAuthenticatedUser');
+
+      await provider.initialize();
+      expect(getAdminUserSpy).toHaveBeenCalled();
+      expect(updateAuthenticatedUserSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('login', () => {
+    it('should resolve', async () => {
+      await expect(provider.login()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('logout', () => {
+    it('should resolve immediately', async () => {
+      await expect(provider.logout()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('isAuthenticated', () => {
+    it('should return true if there is an authenticated user', async () => {
+      TestUtil.mockResponse(new ResponseMock('rest/security/users/admin').setResponse(ProviderResponseMocks.adminUserResponse));
+
+      await provider.initialize();
+      expect(provider.isAuthenticated()).toBe(true);
+    });
+
+    it('should return false if there is no authenticated user', () => {
+      expect(provider.isAuthenticated()).toBe(false);
+    });
+  });
+});

--- a/packages/api/src/models/security/authentication/tests/provider-response-mocks.ts
+++ b/packages/api/src/models/security/authentication/tests/provider-response-mocks.ts
@@ -1,0 +1,58 @@
+export const ProviderResponseMocks = {
+  authenticatedUserResponse: {
+    username: 'testUser',
+    password: '{bcrypt}$2a$10$m/uKS8jQuz9.AVQscZUG5u9TFXhgWWUIzveT5JpocTVL4p6vO7K1K',
+    authorities: [
+      'ROLE_USER',
+      'READ_REPO_*',
+      'WRITE_REPO_*'
+    ],
+    appSettings: {
+      DEFAULT_SAMEAS: true,
+      DEFAULT_INFERENCE: true,
+      EXECUTE_COUNT: true,
+      IGNORE_SHARED_QUERIES: false,
+      DEFAULT_VIS_GRAPH_SCHEMA: true
+    },
+    external: false
+  },
+
+  adminUserResponse: {
+    username: 'admin',
+    password: '',
+    grantedAuthorities: [
+      'ROLE_ADMIN'
+    ],
+    appSettings: {
+      COOKIE_CONSENT: true,
+      DEFAULT_SAMEAS: true,
+      DEFAULT_INFERENCE: true,
+      EXECUTE_COUNT: true,
+      IGNORE_SHARED_QUERIES: false,
+      DEFAULT_VIS_GRAPH_SCHEMA: true
+    },
+    dateCreated: 1754309863184,
+    gptThreads: []
+  },
+
+  loginResponse: {
+    username: 'admin',
+    password: '[CREDENTIALS]',
+    authorities: [
+      'ROLE_USER',
+      'ROLE_ADMIN',
+      'ROLE_MONITORING',
+      'ROLE_REPO_MANAGER',
+      'ROLE_CLUSTER'
+    ],
+    appSettings: {
+      COOKIE_CONSENT: true,
+      DEFAULT_SAMEAS: true,
+      DEFAULT_INFERENCE: true,
+      EXECUTE_COUNT: true,
+      IGNORE_SHARED_QUERIES: false,
+      DEFAULT_VIS_GRAPH_SCHEMA: true
+    },
+    external: false
+  }
+};

--- a/packages/api/src/services/http/test/response-mock.ts
+++ b/packages/api/src/services/http/test/response-mock.ts
@@ -4,6 +4,7 @@ export class ResponseMock {
   private _status = 200;
   private _message = '';
   private _headers?: unknown = undefined;
+  private _shouldThrowOnJson = false;
 
   constructor(url: string) {
     this._url = url;
@@ -46,5 +47,14 @@ export class ResponseMock {
   setHeaders(headers: unknown) {
     this._headers = headers;
     return this;
+  }
+
+  setSetThrowOnJson(shouldThrowOnJson: boolean) {
+    this._shouldThrowOnJson = shouldThrowOnJson;
+    return this;
+  }
+
+  getShouldThrowOnJson(): boolean {
+    return this._shouldThrowOnJson;
   }
 }

--- a/packages/api/src/services/security/auth-strategy-resolver.ts
+++ b/packages/api/src/services/security/auth-strategy-resolver.ts
@@ -1,0 +1,18 @@
+import {AuthStrategy} from '../../models/security/authentication/auth-strategy';
+import {SecurityConfig} from '../../models/security';
+import {GdbTokenAuthProvider} from '../../models/security/authentication/gdb-token-auth-provider';
+import {NoSecurityProvider} from '../../models/security/authentication/no-security-provider';
+import {Service} from '../../providers/service/service';
+
+export class AuthStrategyResolver implements Service {
+  resolveStrategy(securityConfig: SecurityConfig): AuthStrategy {
+    if (!securityConfig.enabled) {
+      return new NoSecurityProvider();
+    }
+
+    if (!securityConfig.openIdEnabled) {
+      return new GdbTokenAuthProvider();
+    }
+    return new NoSecurityProvider();
+  }
+}

--- a/packages/api/src/services/security/authorization.service.ts
+++ b/packages/api/src/services/security/authorization.service.ts
@@ -23,6 +23,14 @@ export class AuthorizationService implements Service {
   }
 
   /**
+   * Checks if the current user has an admin role.
+   * @returns {boolean} True if the user has an admin role, false otherwise.
+   */
+  isAdmin(): boolean {
+    return this.hasRole(Authority.ROLE_ADMIN);
+  }
+
+  /**
    * Checks if the user has a specific role based on the provided authority, configuration, and user details.
    * @param {Authority} role - The authority role to check.
    * @returns {boolean} True if the user has the specified role, false otherwise.

--- a/packages/api/src/services/security/security-rest.service.ts
+++ b/packages/api/src/services/security/security-rest.service.ts
@@ -7,6 +7,7 @@ import {AuthenticatedUser, SecurityConfig} from '../../models/security';
 export class SecurityRestService extends HttpService {
   private readonly SECURITY_ENDPOINT = 'rest/security';
   private readonly LOGIN_ENDPOINT = 'rest/login';
+  private readonly SECURITY_USER_ENDPOINT = `${this.SECURITY_ENDPOINT}/users`;
 
   /**
    * Authenticates a user by sending credentials to the server.
@@ -58,5 +59,17 @@ export class SecurityRestService extends HttpService {
    */
   getAuthenticatedUser(): Promise<AuthenticatedUser> {
     return this.get(`${this.SECURITY_ENDPOINT}/authenticated-user`);
+  }
+
+  /**
+   * Retrieves information about the admin user.
+   *
+   * Sends a GET request to fetch details about the admin user in the system.
+   *
+   * @returns A Promise that resolves with the AuthenticatedUser object containing
+   *          the admin user's details such as username, roles, and application settings.
+   */
+  getAdminUser(): Promise<AuthenticatedUser> {
+    return this.get(`${this.SECURITY_USER_ENDPOINT}/admin`);
   }
 }

--- a/packages/api/src/services/security/security.service.ts
+++ b/packages/api/src/services/security/security.service.ts
@@ -5,7 +5,6 @@ import {AuthenticatedUser, SecurityConfig} from '../../models/security';
 import {SecurityContextService} from './security-context.service';
 import {SecurityConfigMapper} from './mappers/security-config.mapper';
 import {AuthenticatedUserMapper} from './mappers/authenticated-user.mapper';
-import {AuthenticationStorageService} from './authentication-storage.service';
 
 /**
  * Service class for handling security-related operations.
@@ -13,7 +12,6 @@ import {AuthenticationStorageService} from './authentication-storage.service';
 export class SecurityService implements Service {
   private readonly securityRestService: SecurityRestService = ServiceProvider.get(SecurityRestService);
   private readonly securityContextService: SecurityContextService = ServiceProvider.get(SecurityContextService);
-  private readonly authStorageService: AuthenticationStorageService = ServiceProvider.get(AuthenticationStorageService);
 
   /**
    * Updates the data of an authenticated user.
@@ -50,6 +48,19 @@ export class SecurityService implements Service {
    */
   getAuthenticatedUser(): Promise<AuthenticatedUser> {
     return this.securityRestService.getAuthenticatedUser()
+      .then((response) => MapperProvider.get(AuthenticatedUserMapper).mapToModel(response));
+  }
+
+  /**
+   * Retrieves the admin user from the backend.
+   *
+   * Fetches the admin user's information and maps it to an `AuthenticatedUser` model
+   * using the appropriate mapper.
+   *
+   * @returns A Promise that resolves with the mapped `AuthenticatedUser` instance representing the admin user.
+   */
+  getAdminUser(): Promise<AuthenticatedUser> {
+    return this.securityRestService.getAdminUser()
       .then((response) => MapperProvider.get(AuthenticatedUserMapper).mapToModel(response));
   }
 

--- a/packages/api/src/services/security/test/auth-strategy-resolver.spec.ts
+++ b/packages/api/src/services/security/test/auth-strategy-resolver.spec.ts
@@ -1,0 +1,37 @@
+import { AuthStrategyResolver } from '../auth-strategy-resolver';
+import { SecurityConfig } from '../../../models/security';
+import { GdbTokenAuthProvider } from '../../../models/security/authentication/gdb-token-auth-provider';
+import { NoSecurityProvider } from '../../../models/security/authentication/no-security-provider';
+
+// Mock SecurityConfig type for test clarity
+const getConfig = (enabled: boolean, openIdEnabled: boolean): SecurityConfig => ({
+  enabled,
+  openIdEnabled
+} as SecurityConfig);
+
+describe('AuthStrategyResolver', () => {
+  let resolver: AuthStrategyResolver;
+
+  beforeEach(() => {
+    resolver = new AuthStrategyResolver();
+  });
+
+  it('should return NoSecurityProvider when security is disabled', () => {
+    const config = getConfig(false, false);
+    const strategy = resolver.resolveStrategy(config);
+    expect(strategy).toBeInstanceOf(NoSecurityProvider);
+  });
+
+  it('should return GdbTokenAuthProvider when security is enabled and openId is disabled', () => {
+    const config = getConfig(true, false);
+    const strategy = resolver.resolveStrategy(config);
+    expect(strategy).toBeInstanceOf(GdbTokenAuthProvider);
+  });
+
+  it('should return NoSecurityProvider when both security and openId are enabled (current behavior)', () => {
+    const config = getConfig(true, true);
+    const strategy = resolver.resolveStrategy(config);
+    expect(strategy).toBeInstanceOf(NoSecurityProvider);
+  });
+});
+

--- a/packages/api/src/services/security/test/security.service.spec.ts
+++ b/packages/api/src/services/security/test/security.service.spec.ts
@@ -136,6 +136,20 @@ describe('SecurityService', () => {
     });
   });
 
+  describe('getAdminUser', () => {
+    it('should fetch and map admin user', async () => {
+      const rawAdminUser = {} as AuthenticatedUser;
+      const mappedAdminUser = {} as AuthenticatedUser;
+      restService.getAdminUser = jest.fn().mockResolvedValue(rawAdminUser);
+      userMapper.mapToModel.mockReturnValue(mappedAdminUser);
+
+      const result = await service.getAdminUser();
+      expect(restService.getAdminUser).toHaveBeenCalled();
+      expect(userMapper.mapToModel).toHaveBeenCalledWith(rawAdminUser);
+      expect(result).toBe(mappedAdminUser);
+    });
+  });
+
   describe('isPasswordLoginEnabled / isOpenIDEnabled', () => {
     it('should return flags from contextService.getSecurityConfig()', () => {
       contextService.getSecurityConfig.mockReturnValue({ passwordLoginEnabled: true, openIdEnabled: false } as never);

--- a/packages/api/src/services/utils/test/test-util.ts
+++ b/packages/api/src/services/utils/test/test-util.ts
@@ -15,7 +15,7 @@ export class TestUtil {
           ok: matchingMock.getStatus() >= 200 && matchingMock.getStatus() < 300,
           status: matchingMock.getStatus(),
           headers: matchingMock.getHeaders() || { get: (name: string) => name === 'Content-Type' ? 'application/json' : undefined },
-          json: async () => matchingMock.getResponse(),
+          json: async () => matchingMock.getShouldThrowOnJson() ? Promise.reject(new Error('JSON error')) : Promise.resolve(matchingMock.getResponse()),
           text: async () => matchingMock.getMessage(),
         } as Response);
       }

--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -39,7 +39,7 @@ import {
     RepositoryService,
     ServiceProvider,
     SecurityContextService,
-    OntoToastrService
+    OntoToastrService,
 } from "@ontotext/workbench-api";
 import {EventConstants} from "./utils/event-constants";
 import {CookieConsent} from "./models/cookie-policy/cookie-consent";
@@ -618,6 +618,9 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $location, $repositories,
             });
     }
 
+    const onLoginSubscription = ServiceProvider.get(EventService).subscribe(EventName.LOGIN, () => {
+        $jwtAuth.initSecurity();
+    });
     const onLogoutSubscription = ServiceProvider.get(EventService).subscribe(EventName.LOGOUT, () => logout());
 
     ServiceProvider.get(EventService).subscribe(EventConstants.RDF_SEARCH_ICON_CLICKED, () => {
@@ -1186,15 +1189,17 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $location, $repositories,
 
     $scope.$on('$destroy', () => {
         onSelectedRepositoryChangedSubscription?.();
-        cookieConsentChangedSubscription?.();onAppDataLoaded();
-        onLogoutSubscription?.()
-      document.removeEventListener('click', closeActiveRepoPopoverEventHandler);
-      window.removeEventListener('storage', localStoreChangeHandler);
-      $scope.cancelPopoverOpen();
-      deregisterMenuWatcher();
-      if ($scope.checkMenu) {
-        $timeout.cancel($scope.checkMenu);
-      }
+        cookieConsentChangedSubscription?.();
+        onAppDataLoaded?.();
+        onLogoutSubscription?.();
+        onLoginSubscription?.();
+        document.removeEventListener('click', closeActiveRepoPopoverEventHandler);
+        window.removeEventListener('storage', localStoreChangeHandler);
+        $scope.cancelPopoverOpen();
+        deregisterMenuWatcher();
+        if ($scope.checkMenu) {
+            $timeout.cancel($scope.checkMenu);
+        }
     });
 }
 

--- a/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
@@ -13,6 +13,7 @@ import {
   OpenidConfigMapper,
   AuthenticationStorageService,
   OntoToastrService,
+  AuthenticatedUser,
 } from "@ontotext/workbench-api";
 import {LoggerProvider} from "./logger-provider";
 
@@ -84,11 +85,14 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                 $location
                     .path('/login')
                     .search(params);
+
                 // Countering race condition. When the unauthorized interceptor catches error 401 or 409, then we must make
                 // sure that a request is made to access the login page before proceeding with the rejection of the
                 // original request. Otherwise the login page is not accessible in the context of spring security.
                 return new Promise((resolve) => {
                     setTimeout(() => {
+                        // Run digest cycle to update the location
+                        $rootScope.$apply();
                         resolve(true);
                     }, 100);
                 });
@@ -595,8 +599,13 @@ angular.module('graphdb.framework.core.services.jwtauth', [
                 securityContextService.updateOpenIdConfig(openIdConfigModel);
 
                 this.getPrincipal().then((data) => {
-                    const userMapper = MapperProvider.get(AuthenticatedUserMapper);
-                    const authenticatedUser = userMapper.mapToModel(data);
+                    let authenticatedUser;
+                    if (data instanceof AuthenticatedUser) {
+                        authenticatedUser = data;
+                    } else {
+                        const userMapper = MapperProvider.get(AuthenticatedUserMapper);
+                        authenticatedUser = userMapper.mapToModel(data);
+                    }
                     securityContextService.updateAuthenticatedUser(authenticatedUser);
                 });
 

--- a/packages/legacy-workbench/src/js/angular/jdbc/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/jdbc/controllers.js
@@ -127,6 +127,7 @@ function JdbcCreateCtrl(
 
     // This flag is used to prevent triggering the repository change event listener on initial subscription.
     let initialRepoChangeTrigger = true;
+    let currentRepository;
 
     // =========================
     // Public functions
@@ -620,7 +621,8 @@ function JdbcCreateCtrl(
         }
         if (initialRepoChangeTrigger) {
             initialRepoChangeTrigger = false;
-        } else {
+            currentRepository = repository.id;
+        } else if (repository.id !== currentRepository) {
             getOntotextYasgui().abortQuery().then(goToJdbcView);
         }
     };

--- a/packages/legacy-workbench/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/packages/legacy-workbench/src/js/angular/similarity/controllers/create-index.controller.js
@@ -95,7 +95,7 @@ function CreateSimilarityIdxCtrl(
 
     // This flag is used to prevent triggering the repository change event listener on initial subscription.
     let initialRepoChangeTrigger = true;
-
+    let currentRepository;
 
     // =========================
     // Public functions
@@ -901,7 +901,8 @@ function CreateSimilarityIdxCtrl(
         }
         if (initialRepoChangeTrigger) {
             initialRepoChangeTrigger = false;
-        } else {
+            currentRepository = repository.id;
+        } else if (repository.id !== currentRepository) {
             goToSimilarityIndexesView();
         }
     };

--- a/packages/legacy-workbench/src/js/angular/sparql-editor/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/sparql-editor/controllers.js
@@ -265,8 +265,8 @@ function SparqlEditorCtrl($rootScope,
     };
 
     const setInferAndSameAs = (principal) => {
-        $scope.inferUserSetting = principal.appSettings.DEFAULT_INFERENCE;
-        $scope.sameAsUserSetting = principal.appSettings.DEFAULT_SAMEAS;
+        $scope.inferUserSetting = principal?.appSettings.DEFAULT_INFERENCE;
+        $scope.sameAsUserSetting = principal?.appSettings.DEFAULT_SAMEAS;
     };
 
     const exploreVisualGraphYasrToolbarElementBuilder = {

--- a/packages/legacy-workbench/src/js/angular/sparql-template/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/sparql-template/controllers.js
@@ -4,17 +4,17 @@ import 'angular/rest/monitoring.rest.service';
 import 'angular/utils/notifications';
 import 'angular/utils/uri-utils';
 import 'angular/core/services/event-emitter-service';
-import {decodeHTML} from "../../../app";
-import {DEFAULT_SPARQL_QUERY, SparqlTemplateInfo} from "../models/sparql-template/sparql-template-info";
-import {SparqlTemplateError} from "../models/sparql-template/sparql-template-error";
-import {YasqeMode} from "../models/ontotext-yasgui/yasqe-mode";
-import {RenderingMode} from "../models/ontotext-yasgui/rendering-mode";
+import {decodeHTML} from '../../../app';
+import {DEFAULT_SPARQL_QUERY, SparqlTemplateInfo} from '../models/sparql-template/sparql-template-info';
+import {SparqlTemplateError} from '../models/sparql-template/sparql-template-error';
+import {YasqeMode} from '../models/ontotext-yasgui/yasqe-mode';
+import {RenderingMode} from '../models/ontotext-yasgui/rendering-mode';
 import {
     DISABLE_YASQE_BUTTONS_CONFIGURATION,
     YasguiComponentDirectiveUtil,
-} from "../core/directives/yasgui-component/yasgui-component-directive.util";
-import {RepositoryContextService, ServiceProvider} from "@ontotext/workbench-api";
-import {LoggerProvider} from "../core/services/logger-provider";
+} from '../core/directives/yasgui-component/yasgui-component-directive.util';
+import {RepositoryContextService, ServiceProvider} from '@ontotext/workbench-api';
+import {LoggerProvider} from '../core/services/logger-provider';
 
 const modules = [
     'ui.bootstrap',
@@ -144,6 +144,7 @@ function SparqlTemplateCreateCtrl(
 
     // This flag is used to prevent triggering the repository change event listener on initial subscription.
     let initialRepoChangeTrigger = true;
+    let currentRepository;
 
     // =========================
     // Public functions
@@ -479,7 +480,8 @@ function SparqlTemplateCreateCtrl(
         }
         if (initialRepoChangeTrigger) {
             initialRepoChangeTrigger = false;
-        } else {
+            currentRepository = repository.id;
+        } else if (repository.id !== currentRepository) {
             goToSparqlTemplatesView();
         }
     };
@@ -506,7 +508,6 @@ function SparqlTemplateCreateCtrl(
     // Subscriptions
     // =========================
     const subscriptions = [];
-
     const repositoryContextService = ServiceProvider.get(RepositoryContextService);
     const repositoryChangeSubscription = repositoryContextService.onSelectedRepositoryChanged(repositoryChangedHandler, repositoryWillChangeHandler);
 

--- a/packages/shared-components/cypress/e2e/header/header.cy.js
+++ b/packages/shared-components/cypress/e2e/header/header.cy.js
@@ -60,6 +60,7 @@ describe('Header', () => {
     it('Should be shown, when there are active operations', () => {
       // Given, I visit the header page
       HeaderSteps.visit();
+      HeaderSteps.disableSecurity();
 
       // Then, I expect to not see the operations notification component
       // since, I have not selected any repository

--- a/packages/shared-components/cypress/e2e/layout/layout.cy.js
+++ b/packages/shared-components/cypress/e2e/layout/layout.cy.js
@@ -15,6 +15,7 @@ describe('Layout', () => {
   it('Should filter menu items, based on role', () => {
     // Given I've visited the layout page and loaded menu items for the navbar
     LayoutSteps.visit();
+    LayoutSteps.disableSecurity();
 
     const monitoringMenuIndex = 3;
     const setupMenuIndex = 4;
@@ -124,6 +125,7 @@ describe('Layout', () => {
   it('should hide and display navbar and header based on security', () => {
     // Given I've visited the layout page and loaded menu items for the navbar
     LayoutSteps.visit();
+    LayoutSteps.disableSecurity();
 
     // Then I should see the header and navbar
     HeaderSteps.getHeader().should('exist');

--- a/packages/shared-components/cypress/e2e/operations-notification/operations-notification.cy.js
+++ b/packages/shared-components/cypress/e2e/operations-notification/operations-notification.cy.js
@@ -19,9 +19,13 @@ const assertRedirectLink = (index, textValue) => {
 }
 
 describe('onto-operations-notification', () => {
-  it('should display operations notification', () => {
+  beforeEach(() => {
     // Given, I am on the operations notification page and I have added mock operations
     OperationsNotificationSteps.visit();
+    OperationsNotificationSteps.disableSecurity();
+  })
+
+  it('should display operations notification', () => {
     // simulate repository selection to trigger request for operations
     OperationsNotificationSteps.loadRepositories();
     OperationsNotificationSteps.getRepositoryItems().should('have.length', 6);
@@ -53,8 +57,6 @@ describe('onto-operations-notification', () => {
   });
 
   it('should redirect to operation specific href, when clicked', () => {
-    // Given, I am on the operations notification page and I have added mock operations
-    OperationsNotificationSteps.visit();
     // simulate repository selection to trigger request for operations
     OperationsNotificationSteps.loadRepositories();
     OperationsNotificationSteps.getRepositoryItems().should('have.length', 6);

--- a/packages/shared-components/cypress/e2e/repository-selector/repository-selector.cy.js
+++ b/packages/shared-components/cypress/e2e/repository-selector/repository-selector.cy.js
@@ -5,6 +5,7 @@ describe("Repository Selector", () => {
   it('Should select repository', () => {
     // When I visit a page with repository selector in it.
     RepositorySelectorSteps.visit();
+    RepositorySelectorSteps.disableSecurity();
     RepositorySelectorSteps.triggerRepositoriesLoading();
     // Then I expect to see only toggle selector button with default label, because the repository is not selected,
     RepositorySelectorSteps.getRepositorySelectorToggleButton()

--- a/packages/shared-components/cypress/steps/header/repository-selector-steps.js
+++ b/packages/shared-components/cypress/steps/header/repository-selector-steps.js
@@ -33,4 +33,8 @@ export class RepositorySelectorSteps extends BaseSteps {
   static selectRepositorySelectorItem(index) {
     RepositorySelectorSteps.getRepositorySelectorItem(index).click();
   }
+
+  static disableSecurity() {
+    cy.get('#disable-security').click();
+  }
 }

--- a/packages/shared-components/cypress/steps/operations-notification/operations-notification.steps.js
+++ b/packages/shared-components/cypress/steps/operations-notification/operations-notification.steps.js
@@ -32,4 +32,8 @@ export class OperationsNotificationSteps extends BaseSteps {
   static getRepositoryItems() {
     return cy.get('.onto-repository-selector .repository-selector-dropdown-item');
   }
+
+  static disableSecurity() {
+    return cy.get('#disable-security').click();
+  }
 }

--- a/packages/shared-components/src/components/onto-header/onto-header.tsx
+++ b/packages/shared-components/src/components/onto-header/onto-header.tsx
@@ -90,6 +90,7 @@ export class OntoHeader {
   private readonly subscriptions: SubscriptionList = new SubscriptionList();
   private user: AuthenticatedUser;
   private skipUpdateActiveOperationsTimes = 0;
+  private isSecurityEnabled: boolean;
 
   // ========================
   // Lifecycle methods
@@ -136,8 +137,8 @@ export class OntoHeader {
             totalTripletsFormatter={this.totalTripletsFormatter}
             canWriteRepo={this.canWriteRepo}>
           </onto-repository-selector>
-          {this.securityConfig?.enabled && this.securityConfig?.userLoggedIn ? <onto-user-menu user={this.user} securityConfig={this.securityConfig}></onto-user-menu> : ''}
-          {this.securityConfig?.enabled && !this.securityConfig?.userLoggedIn && (this.currentRoute !== 'login') ? <onto-user-login></onto-user-login> : ''}
+          {this.isSecurityEnabled && this.authService.isAuthenticated() ? <onto-user-menu user={this.user} securityConfig={this.securityConfig}></onto-user-menu> : ''}
+          {this.isSecurityEnabled && !this.authService.isAuthenticated() && (this.currentRoute !== 'login') ? <onto-user-login></onto-user-login> : ''}
           <onto-language-selector dropdown-alignment="right"></onto-language-selector>
         </div>
       </Host>
@@ -194,6 +195,7 @@ export class OntoHeader {
     }));
     this.subscriptions.add(this.securityContextService.onSecurityConfigChanged((config) => {
       this.securityConfig = config;
+      this.isSecurityEnabled = config?.enabled;
     }));
   }
 

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -185,7 +185,11 @@ export class OntoLayout {
     this.subscriptions.add(
       securityContextService.onSecurityConfigChanged((securityConfig) => {
         this.securityConfig = securityConfig;
-        this.updateVisibility();
+        // FIXME: Remove  the timeout when the security event handling is refactored
+        // Wait for events to settle everywhere before updating the visibility
+        setTimeout(() => {
+          this.updateVisibility();
+        }, 0);
       })
     );
 
@@ -223,12 +227,12 @@ export class OntoLayout {
     if (!this.authenticationService.isSecurityEnabled()) {
       this.showHeader = true;
     } else {
-      this.showHeader = this.authenticationService.isLoggedIn() || this.authorizationService.hasFreeAccess();
+      this.showHeader = this.authenticationService.isAuthenticated() || this.authorizationService.hasFreeAccess();
     }
   }
 
   private isAuthenticatedFully() {
-    return !this.authenticationService.isSecurityEnabled() || this.authenticationService.isLoggedIn() || this.authorizationService.hasFreeAccess();
+    return !this.authenticationService.isSecurityEnabled() || this.authenticationService.isAuthenticated() || this.authorizationService.hasFreeAccess();
   }
 
   private shouldShowMenu(role: Authority): boolean {

--- a/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
+++ b/packages/shared-components/src/components/onto-test-context/onto-test-context.tsx
@@ -22,7 +22,7 @@ import {
   RepositoryLocationContextService,
   AutocompleteContextService,
   NamespacesContextService,
-  NamespaceMap, RepositoryReference
+  NamespaceMap, RepositoryReference, AuthenticationService, AuthenticationStorageService
 } from '@ontotext/workbench-api';
 import en from '../../assets/i18n/en.json';
 import fr from '../../assets/i18n/fr.json';
@@ -39,6 +39,7 @@ export class OntoTestContext {
 
   constructor() {
     this.onLanguageChanged();
+    this.setSecurityConfig({enabled: false, freeAccess: {enabled: false}} as unknown as SecurityConfig);
   }
 
   /**
@@ -93,6 +94,7 @@ export class OntoTestContext {
     ServiceProvider.get(SecurityContextService).updateAuthenticatedUser(
       MapperProvider.get(AuthenticatedUserMapper).mapToModel(user)
     );
+    ServiceProvider.get(AuthenticationStorageService).setAuthToken('token');
     return Promise.resolve();
   }
 
@@ -105,6 +107,7 @@ export class OntoTestContext {
   @Method()
   setSecurityConfig(securityConfig: SecurityConfig): Promise<void> {
     ServiceProvider.get(SecurityContextService).updateSecurityConfig(securityConfig);
+    this.setAuthStrategy(securityConfig);
     return Promise.resolve();
   }
 
@@ -228,5 +231,19 @@ export class OntoTestContext {
         this.changeLanguage(languageCode);
       }
     });
+  }
+
+  /**
+   * Configures the authentication strategy based on the provided security configuration.
+   *
+   * This private method retrieves the AuthenticationService and sets the authentication strategy
+   * according to the given SecurityConfig. It ensures that the application uses the correct
+   * authentication mechanism as specified in the security settings.
+   *
+   * @param securityConfig - The SecurityConfig object containing the security settings to be applied.
+   */
+  private setAuthStrategy(securityConfig: SecurityConfig): void {
+    const authService = ServiceProvider.get(AuthenticationService);
+    authService.setAuthenticationStrategy(securityConfig);
   }
 }

--- a/packages/shared-components/src/pages/operations-notification/index.html
+++ b/packages/shared-components/src/pages/operations-notification/index.html
@@ -22,6 +22,7 @@
   <link rel="stylesheet" href="../css/solid.min.css">
 </head>
 <body style="text-align: -webkit-right">
+<button id="disable-security" onclick="setSecurityConfig({enabled: false})">disable security</button>
 <button id="load-repositories" onclick="loadRepositories()">load repositories</button>
 <button id="set-marvel-repo" onclick="setMarvelRepo()">set Marvel repo</button>
   <onto-header></onto-header>

--- a/packages/shared-components/src/pages/repository-selector/index.html
+++ b/packages/shared-components/src/pages/repository-selector/index.html
@@ -29,6 +29,7 @@
 <body>
 
 <div class="page-content">
+  <button id="disable-security" onclick="setSecurityConfig({enabled: false})">disable security</button>
   <button id="loadRepositories" onclick="loadRepositories()">Load repositories</button>
   <hr/>
   <onto-header></onto-header>


### PR DESCRIPTION
## What
Added an `AuthStrategyResolver` to determine the appropriate authentication strategy based on the security configuration. Introduced `NoSecurityProvider` and refactored `GdbTokenAuthProvider` implementations. Set the strategy on security configuration change.

## Why
This change centralizes the logic for selecting the authentication strategy, improving maintainability and flexibility in handling different security configurations.

## How
- Created `AuthStrategyResolver` class to resolve authentication strategies.
- Implemented logic to return `NoSecurityProvider` when security is disabled.
- Returned `GdbTokenAuthProvider` when security is enabled and OpenID is disabled.
- Updated `SecurityRestService` to include a method for retrieving admin user details.
- Added unit tests for the new resolver and providers to ensure correct behavior.

## Testing
added

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
