### PR TITLE
GDB-13086 fix ttyg guide step covering chat panel on smaller screen

### DIFF
--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/ask-ttyg-agent/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/ask-ttyg-agent/plugin.js
@@ -234,7 +234,6 @@ const getWaitForAnswerStep = (GuideUtils, options) => {
             content: 'guide.step_plugin.ask-ttyg-agent.wait-for-answer',
             class: 'wait-for-answer',
             url: 'ttyg',
-            placement: 'left',
             elementSelector: GuideUtils.getGuideElementSelector(CHAT_DETAILS_SELECTOR),
             elementSelectorToWait: GuideUtils.getGuideElementSelector('question-loader'),
         }, options),


### PR DESCRIPTION
## What
Fix the placement of the guide step for the ttyg agent in the chat panel

## Why
On smaller screens, the dialog covers the chat panel

## How
Removed the `placement: 'left'` line from the configuration object in `plugin.js`. This now positions the dialog either above or below the chat panel. Since it resizes, this is much more flexible

## Testing
n/a

## Screenshots

[Screencast from 2025-09-24 09-04-30.webm](https://github.com/user-attachments/assets/8a0e30dd-854c-45fb-863e-0b33c389c1a2)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
