### PR TITLE
GDB-13099 fix guide continuing without namespace checkbox

### DIFF
--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/sparql-search-method/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/sparql-search-method/plugin.js
@@ -138,6 +138,7 @@ PluginRegistry.add('guide.step', [
       guideBlockName: 'ttyg-sparql-click-add-namespaces',
       getSteps: (options, services) => {
           const GuideUtils = services.GuideUtils;
+          const namespacesCheckbox = GuideUtils.getGuideElementSelector('add-missing-namespaces-input');
 
           return [
               {
@@ -150,7 +151,8 @@ PluginRegistry.add('guide.step', [
                       ...options,
                       url: 'ttyg',
                       elementSelector: GuideUtils.getGuideElementSelector('add-missing-namespaces-option'),
-                      onNextValidate: () => Promise.resolve(GuideUtils.isChecked(GuideUtils.getGuideElementSelector('add-missing-namespaces-input'))),
+                      clickableElementSelector: namespacesCheckbox,
+                      onNextValidate: () => Promise.resolve(GuideUtils.isChecked(namespacesCheckbox)),
                   },
               },
           ];


### PR DESCRIPTION
## What
Fix the guide step for continuing without selecting the `Auto-add missing namespaces` checkbox

## Why
To ensure that users will proceed in the guide only after checking the checkbox

## How
Added the element to the  `clickableElementSelector` property to ensure the checkbox is clicked. Previously the guide continued when the clicked element is the surrounding parent

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
