### PR TITLE
Cherry pick GDB-13147 fix empty 404 page handling

### DIFF
--- a/e2e-tests/e2e-legacy/not-found/not-found.spec.js
+++ b/e2e-tests/e2e-legacy/not-found/not-found.spec.js
@@ -1,0 +1,23 @@
+import {NotFoundSteps} from "../../steps/not-found/not-found-steps.js";
+
+describe('Not found page', () => {
+
+    it('Should display the 404 not found page for an unknown route', () => {
+        // Given, I navigate to an unknown route
+        NotFoundSteps.visit('/unknown-route');
+
+        // Then, I expect to see the 404 not found page
+        NotFoundSteps.getNotFoundBanner().should('be.visible');
+        NotFoundSteps.getNotFoundContent().should('contain', '404 That’s an error!');
+        NotFoundSteps.getNotFoundContent().should('contain', 'The requested URL was not found on this server. That’s all I know.');
+        NotFoundSteps.getGoHomeButton().should('be.visible');
+
+        // When, I click on the "Go Home" button
+        NotFoundSteps.clickGoHomeButton();
+
+        // Then, I expect to be redirected to the home page
+        NotFoundSteps.getUrl().should('eq', `${Cypress.config('baseUrl')}/`);
+        // And the banner should no longer be visible
+        NotFoundSteps.getNotFoundBanner().should('not.exist');
+    });
+});

--- a/e2e-tests/steps/base-steps.js
+++ b/e2e-tests/steps/base-steps.js
@@ -18,4 +18,8 @@ export class BaseSteps {
   static typeEscapeKey() {
     cy.get('body').type('{esc}');
   }
+
+  static getUrl() {
+    return cy.url();
+  }
 }

--- a/e2e-tests/steps/not-found/not-found-steps.js
+++ b/e2e-tests/steps/not-found/not-found-steps.js
@@ -1,0 +1,23 @@
+import {BaseSteps} from "../base-steps.js";
+
+export class NotFoundSteps extends BaseSteps {
+    static visit(url) {
+        BaseSteps.visit(url);
+    }
+
+    static getNotFoundBanner() {
+        return cy.getByTestId('not-found-banner');
+    }
+
+    static getNotFoundContent() {
+        return this.getNotFoundBanner().invoke('text');
+    }
+
+    static getGoHomeButton() {
+        return this.getNotFoundBanner().find('a.btn.btn-primary');
+    }
+
+    static clickGoHomeButton() {
+        this.getGoHomeButton().click();
+    }
+}

--- a/packages/legacy-workbench/src/app.js
+++ b/packages/legacy-workbench/src/app.js
@@ -167,9 +167,9 @@ const moduleDefinition = function (productInfo, translations) {
                 });
             });
 
-            // $routeProvider.otherwise({
-            //     templateUrl: 'pages/not_found.html'
-            // });
+            $routeProvider.otherwise({
+                templateUrl: 'pages/not_found.html',
+            });
 
             // use the HTML5 History API
             $locationProvider.html5Mode(true);

--- a/packages/legacy-workbench/src/pages/not_found.html
+++ b/packages/legacy-workbench/src/pages/not_found.html
@@ -1,5 +1,5 @@
 <!--Error Block-->
-<div class="alert alert-danger p-3 mt-2">
+<div data-test="not-found-banner" class="alert alert-danger p-3 mt-2">
 	<h1>{{'error.warning' | translate}}</h1>
 	<p class="lead">{{'requested.url.not.found.msg' | translate}}</p>
 	<a class="btn btn-primary" href="./">{{'back.home.btn' | translate}}</a>


### PR DESCRIPTION
## What

Fix missing 404 page on non-existent urls

## Why
Because it isn't shown

## How
Uncommented the `$routeProvider#otherwise` in `app.js`. Migrating this functionality is currently not possible, because it requires migration of the styles beforehand. Also, some changes to the security bootstrap and possibly more unknowns. The reason for this is, that when showing a 404 page, single spa will not be loading an application. Currently, we rely on the legacy workbench for security context and styling, which makes migrating the 404 component impossible currently

## Testing
cypress

(cherry picked from commit 590971f0a0b1ef56a7d45b90a8448a1c531b65b9)

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
