### PR TITLE
GDB-12871: update version of graphdb-workbench-plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@single-spa/import-map-injector": "^2.0.2",
-                "graphdb-workbench-plugins": "^0.0.1-TR14",
+                "graphdb-workbench-plugins": "0.0.1-TR16",
                 "import-map-overrides": "^6.0.1"
             },
             "devDependencies": {
@@ -5881,9 +5881,9 @@
             "license": "ISC"
         },
         "node_modules/graphdb-workbench-plugins": {
-            "version": "0.0.1-TR9",
-            "resolved": "https://registry.npmjs.org/graphdb-workbench-plugins/-/graphdb-workbench-plugins-0.0.1-TR9.tgz",
-            "integrity": "sha512-nf/Ov9MEeJQBZ8cA1x5hD7OTBBSCuNSkl0sd1y/Wzxcq9YFdPFv8qI3wBzjiLDZPSAO8En6WESxUy5xKG+o8CA==",
+            "version": "0.0.1-TR16",
+            "resolved": "https://registry.npmjs.org/graphdb-workbench-plugins/-/graphdb-workbench-plugins-0.0.1-TR16.tgz",
+            "integrity": "sha512-bOlgck0o68bbtGXuB5QFySr72ARC+qOPdEnH5CIBiqbtQxHxperpz2FaFpHLNBqJMoihPdnMwAHEH7tQnC1qEA==",
             "license": "Apache-2.0"
         },
         "node_modules/gzip-size": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "resolutions": {},
     "dependencies": {
         "@single-spa/import-map-injector": "^2.0.2",
-        "graphdb-workbench-plugins": "^0.0.1-TR14",
+        "graphdb-workbench-plugins": "0.0.1-TR16",
         "import-map-overrides": "^6.0.1"
     }
 }

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -141,7 +141,7 @@ module.exports = (webpackConfigEnv, argv) => {
                       to: 'assets'
                     },
                     {
-                      from: 'plugins',
+                      from: 'node_modules/graphdb-workbench-plugins/dist',
                       to: 'plugins',
                       noErrorOnMissing: true
                     },


### PR DESCRIPTION
## What
Update the graphdb-workbench-plugins version.

## Why
A new version is available with all guide plugins updated.

## How
Bump the graphdb-workbench-plugins dependency to the latest version.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
