### PR TITLE
Cherry pick GDB-13142 Disallow the guide from continuing if toggleable elements are not clicked

### DIFF
--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/sparql-search-method/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/ttyg/common/sparql-search-method/plugin.js
@@ -10,7 +10,7 @@ PluginRegistry.add('guide.step', [
             const toggleSelector = GuideUtils.getGuideElementSelector('query-method-sparql_search-input');
             return [
                 {
-                    guideBlockName: 'clickable-element',
+                    guideBlockName: 'toggle-element',
                     options: {
                         content: 'guide.step_plugin.sparql-search-method.enable-toggle',
                         // If mainAction is set the title will be set automatically
@@ -19,7 +19,7 @@ PluginRegistry.add('guide.step', [
                         ...options,
                         url: 'ttyg',
                         elementSelector: GuideUtils.getGuideElementSelector('query-method-sparql_search'),
-                        clickableElementSelector: toggleSelector,
+                        toggleableElementSelector: toggleSelector,
                         onNextValidate: () => Promise.resolve(GuideUtils.isChecked(toggleSelector)),
                     },
                 },
@@ -142,7 +142,7 @@ PluginRegistry.add('guide.step', [
 
           return [
               {
-                  guideBlockName: 'clickable-element',
+                  guideBlockName: 'toggle-element',
                   options: {
                       content: 'guide.step_plugin.sparql-search-method.add-missing-namespaces',
                       // If mainAction is set the title will be set automatically
@@ -151,7 +151,7 @@ PluginRegistry.add('guide.step', [
                       ...options,
                       url: 'ttyg',
                       elementSelector: GuideUtils.getGuideElementSelector('add-missing-namespaces-option'),
-                      clickableElementSelector: namespacesCheckbox,
+                      toggleableElementSelector: namespacesCheckbox,
                       onNextValidate: () => Promise.resolve(GuideUtils.isChecked(namespacesCheckbox)),
                   },
               },

--- a/packages/legacy-workbench/src/js/angular/guides/steps/core/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/core/plugin.js
@@ -136,6 +136,50 @@ PluginRegistry.add('guide.step', [
         }
     },
     {
+        // An element, which can be toggled via click
+        guideBlockName: 'toggle-element',
+        getStep: (options, services) => {
+            const notOverridable = {
+                type: 'toggleable',
+            };
+
+            let stepHTMLElement;
+            const selector = options.toggleableElementSelector || options.elementSelector;
+
+            const toggleListener = (event) => {
+                if (!event.target.checked) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                }
+            };
+            const stepDescription = {
+                ...BASIC_STEP,
+                advanceOn: {
+                    selector,
+                    event: 'click',
+                },
+
+                initPreviousStep: services.GuideUtils.defaultInitPreviousStep,
+                ...options,
+                show: () => () => {
+                    stepHTMLElement = document.querySelector(selector);
+                    stepHTMLElement.addEventListener('click', toggleListener, true);
+                },
+                hide: () => () => {
+                    if (stepHTMLElement) {
+                        stepHTMLElement.removeEventListener('click', toggleListener);
+                    }
+                },
+                ...notOverridable,
+            };
+
+            if (!stepDescription.beforeShowPromise) {
+                stepDescription.beforeShowPromise = beforeShowPromise(services, stepDescription.elementSelector, stepDescription.maxWaitTime);
+            }
+            return stepDescription;
+        },
+    },
+    {
         // An element which is expected to be focused. It allows user interaction.
         guideBlockName: 'focus-element',
         getStep: (options, services) => {


### PR DESCRIPTION
## What
Disallow the guide from continuing if toggleable elements are not clicked.

## Why
There are scenarios, where you have a previous button, and you can go back and uncheck a checkbox/toggle button. This click advances the guide, but the checkbox/toggle button need to be checked

## How
- Added new `toggle-element` step, which functions similarly to `clickable-element`. It also contains click event listener and doesn't allow the guide to proceed, if the input element is not checked. This effectively blocks deselecting of the element
- Replaced `ttyg-sparql-method-enable` and `ttyg-sparql-click-add-namespaces` steps to be toggleable elements

## Testing
n/a

(cherry picked from commit bcbee92fce1a4a22780aa286a6808c781a2962d8)

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
