### PR TITLE
GDB-12373 fix hierarchy view sidebar interactability

### DIFF
--- a/packages/legacy-workbench/src/js/angular/guides/steps/complex/class-hierarchy/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/guides/steps/complex/class-hierarchy/plugin.js
@@ -13,6 +13,7 @@ const disableAllRDFClasses = () => {
         .forEach((el) => {
             el.classList.add('disable-rdf-class');
         });
+    disableSidebarInteraction();
 };
 
 const enableAllRDFClasses = () => {
@@ -20,6 +21,19 @@ const enableAllRDFClasses = () => {
         .forEach((el) => {
             el.classList.remove('disable-rdf-class');
         });
+    enableSidebarInteraction();
+};
+
+const disableSidebarInteraction = () => {
+    document.querySelector('.rdf-info-side-panel')
+        .classList
+        .add('pointer-events-none');
+};
+
+const enableSidebarInteraction = () => {
+    document.querySelector('.rdf-info-side-panel')
+        .classList
+        .remove('pointer-events-none');
 };
 
 const CLASS_HIERARCHY_DEFAULT_TITLE = 'view.class.hierarchy.title';
@@ -149,12 +163,14 @@ PluginRegistry.add('guide.step', [
                             if (element) {
                                 element.addEventListener('dblclick', handleDoubleClick, true);
                             }
+                            disableSidebarInteraction();
                         },
                         hide: () => () => {
                             if (element) {
                                 element.removeEventListener('dblclick', handleDoubleClick);
                                 element = null;
                             }
+                            enableSidebarInteraction();
                         },
                         ...options,
                     },

--- a/packages/root-config/src/vendor/common.css
+++ b/packages/root-config/src/vendor/common.css
@@ -454,3 +454,7 @@ h3 [class^=icon-] {
 .bg-lightgray {
     background-color: #eee;
 }
+
+.pointer-events-none {
+    pointer-events: none;
+}


### PR DESCRIPTION
## What
Fix the interaction behavior of the sidebar in the hierarchy view during guide

## Why
To ensure a user can't click any sidebar links and break the guide, while on the class-hierarchy steps. Currently 

## How
- added `pointer-events-none` global class
- Added toggling of the class for the sidebar, during `class-hierarchy-open-rdf-instances-side-panel` and `class-hierarchy-explain-class`

## Testing
n/a

## Screenshots
<img width="476" height="563" alt="Screenshot from 2025-10-02 14-31-41" src="https://github.com/user-attachments/assets/3b204131-ed04-4f76-9078-3d0597793bc0" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
