### PR TITLE
GDB-13149: Copy URL is White on White Background

### DIFF
--- a/packages/legacy-workbench/package-lock.json
+++ b/packages/legacy-workbench/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
                 "ontotext-graphql-playground-component": "^0.0.8",
-                "ontotext-yasgui-web-component": "1.3.25",
+                "ontotext-yasgui-web-component": "1.3.27",
                 "shepherd.js": "^11.2.0",
                 "single-spa-angularjs": "^4.3.1"
             },
@@ -5635,10 +5635,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.3.25",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.25.tgz",
-            "integrity": "sha512-HR09J00bEOpqC0MQlmXIXOAyjYNUI75Yx+uRAo2+p29+RvZ3jEV/l09DrfXcljbt/bJzhlcSNb6yIQmTzrCujQ==",
-            "license": "MIT",
+            "version": "1.3.27",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.3.27.tgz",
+            "integrity": "sha512-aQ3ugzfTPgxhCY3qrL1J0BvsqdZg5A0GYEwaad4B8Oyi3L+JmxMDyYLAg2CkGH3bBH49V3NlwqaFBj7zDfAF4A==",
             "dependencies": {
                 "@stencil/core": "^2.21.0",
                 "tippy.js": "^6.3.7"

--- a/packages/legacy-workbench/package.json
+++ b/packages/legacy-workbench/package.json
@@ -75,7 +75,7 @@
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
         "ontotext-graphql-playground-component": "^0.0.8",
-        "ontotext-yasgui-web-component": "1.3.25",
+        "ontotext-yasgui-web-component": "1.3.27",
         "shepherd.js": "^11.2.0",
         "single-spa-angularjs": "^4.3.1"
     },


### PR DESCRIPTION
## What
In dark mode, the background color of text inputs and textareas appears white, causing readability issues.

## Why
The background colors for text inputs and textareas were not explicitly defined, leaving them to depend on the browser’s default styling, which may conflict with dark themes.

## How
Updated the ontotext-yasgui-web-component dependency to a version where the issue is fixed.

## Screenshots

| Before | After | 
|----------|----------|
| <img width="320" alt="image" src="https://github.com/user-attachments/assets/1aaa9284-85e7-43ea-8c31-6f227388a57c" />   | <img width="320" alt="image" src="https://github.com/user-attachments/assets/eedbc6fe-0016-41ac-998d-36566cfe7e6a" />  |
| <img width="320"  alt="image" src="https://github.com/user-attachments/assets/dd131f50-b88c-48db-a08b-feb81a08a4ac" />    | <img width="320" alt="image" src="https://github.com/user-attachments/assets/6fe0cb02-8f18-428a-9de9-6565b46357f3" />   |
| <img width="320" alt="image" src="https://github.com/user-attachments/assets/1d40f796-472b-4a3c-9d51-c9539bb918a4" />   | <img width="513" height="160" alt="image" src="https://github.com/user-attachments/assets/176920d7-2602-4a06-ae72-48db2701b8b7" />  |

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
