### PR TITLE
GDB-13199 fix autocomplete is off for anonymous users

### DIFF
--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -1131,7 +1131,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, toastr, $location, $repos
     };
 
     const updateAutocompleteStatus = () => {
-        if ($repositories.isActiveRepoFedXType() || !$licenseService.isLicenseValid() || !$jwtAuth.canReadRepo($repositories.getActiveRepository())) {
+        if ($repositories.isActiveRepoFedXType() || !$licenseService.isLicenseValid() || !$jwtAuth.canReadRepo($repositories.getActiveRepositoryObject())) {
             WorkbenchContextService.setAutocompleteEnabled(false);
             LocalStorageAdapter.set(LSKeys.AUTOCOMPLETE_ENABLED, false);
             return;

--- a/packages/legacy-workbench/src/js/angular/core/templates/core-errors.html
+++ b/packages/legacy-workbench/src/js/angular/core/templates/core-errors.html
@@ -21,7 +21,7 @@
                             <span ng-hide="getAccessibleRepositories().length">
                                 <span ng-if="isRestricted">{{'core.errors.no.accessible.writable.repositories.warning.msg' | translate}}</span>
                                 <span ng-if="!isRestricted">{{'core.errors.no.accessible.repositories.warning.msg' | translate}}</span>
-                                <span ng-if="canManageRepositories()">{{'core.errors.create.repository.warning.msg' | translate}}</span>.
+                                <span ng-if="canManageRepositories()">{{'core.errors.create.repository.warning.msg' | translate}}</span>
                             </span>
                         </small>
                 </div>


### PR DESCRIPTION
## What
Fix the autocomplete status resolution for anonymous.

## Why
It wasn't being calculated correctly. When an anonymous user tried to use the `view resource` search, the workbench incorrectly showed a `Autocomplete is off` message

## How
Modified the condition to check against `getActiveRepositoryObject()` instead of `getActiveRepository()` in `controllers.js`. The `jwtService#canReadRepo` expects a repository object. Currently, `getActiveRepository` is passed, which returns the repositoryId (string). This breaks the authorities calculation.

## Testing
n/a

## Screenshots
<img width="1692" height="882" alt="image" src="https://github.com/user-attachments/assets/0fb8f876-e246-46a4-b399-9b8833416d18" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
