### PR TITLE
GDB-13418 sync repository deletion/creation from another tab

### DIFF
--- a/packages/api/src/models/broadcast/broadcast-message.ts
+++ b/packages/api/src/models/broadcast/broadcast-message.ts
@@ -1,0 +1,16 @@
+import {MessageType} from './message-type';
+
+/**
+ * BroadcastMessage represents a message that can be broadcasted to all browser contexts.
+ * No methods should be added here, since the broadcast API uses structured cloning to transfer messages,
+ * which removes any methods from the message.
+ */
+export class BroadcastMessage {
+  readonly type: MessageType;
+  readonly params?: unknown;
+
+  constructor(type: MessageType, params?: unknown) {
+    this.type = type;
+    this.params = params;
+  }
+}

--- a/packages/api/src/models/broadcast/index.ts
+++ b/packages/api/src/models/broadcast/index.ts
@@ -1,0 +1,3 @@
+export {MessageType} from './message-type';
+export {BroadcastMessage} from './broadcast-message';
+export type {MessageHandler} from './message-handler';

--- a/packages/api/src/models/broadcast/message-handler.ts
+++ b/packages/api/src/models/broadcast/message-handler.ts
@@ -1,0 +1,6 @@
+import {BroadcastMessage} from './broadcast-message';
+
+/**
+ * A callback executed when a {@link BroadcastMessage} is received from another browser context.
+ */
+export type MessageHandler = (message: BroadcastMessage) => void;

--- a/packages/api/src/models/broadcast/message-type.ts
+++ b/packages/api/src/models/broadcast/message-type.ts
@@ -1,0 +1,3 @@
+export enum MessageType {
+  REPOSITORIES_UPDATED = 'repositoriesUpdated',
+}

--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -36,6 +36,7 @@ export * from './models/http';
 
 // Export enums for external usages.
 export * from './models/url';
+export * from './models/broadcast';
 
 // Export providers for external usages.
 export * from './providers';
@@ -82,6 +83,7 @@ export * from './services/domain/graph-config';
 
 // Export interceptors for external usages.
 export * from './interceptor';
+export * from './services/broadcast';
 
 // Export utils for external usages.
 export * from './services/utils';

--- a/packages/api/src/services/broadcast/broadcast.service.ts
+++ b/packages/api/src/services/broadcast/broadcast.service.ts
@@ -1,0 +1,40 @@
+import {BroadcastMessage, MessageHandler} from '../../models/broadcast';
+import {Subscription} from '../../models/common';
+
+/**
+ * A service that facilitates communication between different browser contexts
+ * (such as tabs, windows, or iframes) of the same origin.
+ * It uses the `BroadcastChannel` API to send and receive messages.
+ */
+export class BroadcastService {
+  private readonly CHANNEL_NAME = 'ontotext-workbench-broadcast';
+  private readonly MESSAGE_EVENT = 'message';
+
+  private channel?: BroadcastChannel;
+
+  /**
+   * Sends a message to all listening browser contexts on the same origin.
+   * @param {BroadcastMessage} message The message to be sent.
+   */
+  sendMessage(message: BroadcastMessage): void {
+    this.getChannel().postMessage(message);
+  }
+
+  /**
+   * Subscribes to incoming messages.
+   * @param {MessageHandler} callback The function to be executed when a message is received.
+   * @returns {Subscription} An unsubscribe function.
+   */
+  subscribeToMessages(callback: MessageHandler): Subscription {
+    const channel = this.getChannel();
+    const listener = (event: MessageEvent) => callback(event.data);
+
+    channel.addEventListener(this.MESSAGE_EVENT, listener);
+    return () => channel.removeEventListener(this.MESSAGE_EVENT, listener);
+  }
+
+  private getChannel(): BroadcastChannel {
+    this.channel ??= new BroadcastChannel(this.CHANNEL_NAME);
+    return this.channel;
+  }
+}

--- a/packages/api/src/services/broadcast/index.ts
+++ b/packages/api/src/services/broadcast/index.ts
@@ -1,0 +1,1 @@
+export {BroadcastService} from './broadcast.service';

--- a/packages/api/src/services/broadcast/test/broadcast.service.spec.ts
+++ b/packages/api/src/services/broadcast/test/broadcast.service.spec.ts
@@ -1,0 +1,140 @@
+import {BroadcastService} from '../broadcast.service';
+import {BroadcastMessage, MessageType} from '../../../models/broadcast';
+
+type ChannelListener = (event: MessageEvent) => void;
+
+describe('BroadcastService', () => {
+  const CHANNEL_NAME = 'ontotext-workbench-broadcast';
+
+  let channel: {
+    postMessage: jest.Mock;
+    addEventListener: jest.Mock;
+    removeEventListener: jest.Mock;
+  };
+  let channelConstructor: jest.Mock;
+  let broadcastService: BroadcastService;
+
+  /**
+   * Returns the listener the service registered on the channel with the given subscription.
+   * @param {number} subscriptionIndex The order in which the subscription was made.
+   * @returns {ChannelListener} The registered listener.
+   */
+  const registeredListener = (subscriptionIndex = 0): ChannelListener => {
+    return channel.addEventListener.mock.calls[subscriptionIndex][1];
+  };
+
+  beforeEach(() => {
+    channel = {
+      postMessage: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    // jsdom does not implement BroadcastChannel, so the global has to be provided, not spied on.
+    channelConstructor = jest.fn(() => channel);
+    (globalThis as unknown as Record<string, unknown>).BroadcastChannel = channelConstructor;
+
+    broadcastService = new BroadcastService();
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as Record<string, unknown>).BroadcastChannel;
+  });
+
+  describe('channel management', () => {
+    test('should not open a channel until the service is used', () => {
+      expect(channelConstructor).not.toHaveBeenCalled();
+    });
+
+    test('should open a single named channel shared by senders and subscribers', () => {
+      broadcastService.sendMessage(new BroadcastMessage(MessageType.REPOSITORIES_UPDATED));
+      broadcastService.sendMessage(new BroadcastMessage(MessageType.REPOSITORIES_UPDATED));
+      broadcastService.subscribeToMessages(jest.fn());
+      broadcastService.subscribeToMessages(jest.fn());
+
+      expect(channelConstructor).toHaveBeenCalledTimes(1);
+      expect(channelConstructor).toHaveBeenCalledWith(CHANNEL_NAME);
+    });
+  });
+
+  describe('sendMessage', () => {
+    test('should post the message to the channel', () => {
+      const message = new BroadcastMessage(MessageType.REPOSITORIES_UPDATED);
+
+      broadcastService.sendMessage(message);
+
+      expect(channel.postMessage).toHaveBeenCalledTimes(1);
+      expect(channel.postMessage).toHaveBeenCalledWith(message);
+    });
+
+    test('should post the message with its params untouched', () => {
+      const params = {repositoryId: 'repo-one', location: 'http://example.com:7300'};
+
+      broadcastService.sendMessage(new BroadcastMessage(MessageType.REPOSITORIES_UPDATED, params));
+
+      expect(channel.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({type: MessageType.REPOSITORIES_UPDATED, params})
+      );
+    });
+  });
+
+  describe('subscribeToMessages', () => {
+    test('should subscribe for message events on the channel', () => {
+      broadcastService.subscribeToMessages(jest.fn());
+
+      expect(channel.addEventListener).toHaveBeenCalledTimes(1);
+      expect(channel.addEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+    });
+
+    test('should hand the callback the message itself, not the event wrapping it', () => {
+      const callback = jest.fn();
+      const message = new BroadcastMessage(MessageType.REPOSITORIES_UPDATED, {repositoryId: 'repo-one'});
+      broadcastService.subscribeToMessages(callback);
+
+      registeredListener()({data: message} as MessageEvent);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(message);
+    });
+
+    test('should notify every subscriber', () => {
+      const firstCallback = jest.fn();
+      const secondCallback = jest.fn();
+      const message = new BroadcastMessage(MessageType.REPOSITORIES_UPDATED);
+      broadcastService.subscribeToMessages(firstCallback);
+      broadcastService.subscribeToMessages(secondCallback);
+
+      registeredListener(0)({data: message} as MessageEvent);
+      registeredListener(1)({data: message} as MessageEvent);
+
+      expect(firstCallback).toHaveBeenCalledWith(message);
+      expect(secondCallback).toHaveBeenCalledWith(message);
+    });
+  });
+
+  describe('unsubscribing', () => {
+    test('should remove the same listener it registered', () => {
+      const unsubscribe = broadcastService.subscribeToMessages(jest.fn());
+
+      unsubscribe();
+
+      expect(channel.removeEventListener).toHaveBeenCalledTimes(1);
+      expect(channel.removeEventListener).toHaveBeenCalledWith('message', registeredListener());
+    });
+
+    test('should leave the remaining subscribers registered', () => {
+      const survivingCallback = jest.fn();
+      const unsubscribe = broadcastService.subscribeToMessages(jest.fn());
+      broadcastService.subscribeToMessages(survivingCallback);
+
+      unsubscribe();
+
+      expect(channel.removeEventListener).toHaveBeenCalledTimes(1);
+      expect(channel.removeEventListener).not.toHaveBeenCalledWith('message', registeredListener(1));
+
+      // The surviving subscriber still receives messages.
+      const message = new BroadcastMessage(MessageType.REPOSITORIES_UPDATED);
+      registeredListener(1)({data: message} as MessageEvent);
+      expect(survivingCallback).toHaveBeenCalledWith(message);
+    });
+  });
+});

--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -43,6 +43,8 @@ import {
     service,
     ShepherdService,
     WindowService,
+    BroadcastService,
+    MessageType,
 } from '@ontotext/workbench-api';
 import {EventConstants} from './utils/event-constants';
 import {CookieConsent} from './models/cookie-policy/cookie-consent';
@@ -1137,6 +1139,12 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $location, $repositories,
     const licenseUpdatedSubscription = service(LicenseContextService).onLicenseChanged(onLicenseUpdated);
     const cookieConsentChangedSubscription = subscribeToCookieConsentChanged();
 
+    const broadcastUnsubscribe = service(BroadcastService).subscribeToMessages((message) => {
+        if (message.type === MessageType.REPOSITORIES_UPDATED) {
+            $repositories.init();
+        }
+    });
+
     // TODO: The $destroy hook is not called in the workbench unmounting process, so these subscriptions are not cleaned up.
     $scope.$on('$destroy', () => {
         onSelectedRepositoryChangedSubscription?.();
@@ -1146,6 +1154,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $location, $repositories,
         onAppDataLoaded?.();
         onLogoutSubscription?.();
         onLoginSubscription?.();
+        broadcastUnsubscribe?.();
         securityConfigChangedSubscription?.();
         document.removeEventListener('click', closeActiveRepoPopoverEventHandler);
         window.removeEventListener('storage', localStoreChangeHandler);

--- a/packages/legacy-workbench/src/js/angular/core/services/repositories.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/repositories.service.js
@@ -19,6 +19,9 @@ import {
     AuthenticationService,
     SecurityContextService,
     service,
+    BroadcastService,
+    BroadcastMessage,
+    MessageType,
 } from "@ontotext/workbench-api";
 
 const modules = [
@@ -47,6 +50,7 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
         const authorizationService = service(AuthorizationService);
         const securityContextService = service(SecurityContextService);
         const authenticationService = service(AuthenticationService);
+        const broadcastService = service(BroadcastService);
 
         const that = this;
 
@@ -427,6 +431,8 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
                         that.setRepository('');
                     }
                     that.init();
+                    // Deleting a location removes its repositories from the list
+                    broadcastService.sendMessage(new BroadcastMessage(MessageType.REPOSITORIES_UPDATED));
                 }).error(function(data) {
                 const msg = getError(data);
                 toastr.error(msg, $translate.instant('common.error'));
@@ -437,6 +443,7 @@ repositories.service('$repositories', ['toastr', '$rootScope', '$timeout', '$loc
             return RepositoriesRestService.deleteRepository(repo)
                 .success(function() {
                     that.init();
+                    broadcastService.sendMessage(new BroadcastMessage(MessageType.REPOSITORIES_UPDATED));
                 }).error(function(data) {
                     const msg = getError(data);
                     toastr.error(msg, $translate.instant('common.error'));

--- a/packages/legacy-workbench/src/js/angular/repositories/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/controllers.js
@@ -12,6 +12,9 @@ import {
     AuthenticationStorageService,
     AuthorizationService,
     GuidesService,
+    BroadcastService,
+    MessageType,
+    BroadcastMessage,
 } from '@ontotext/workbench-api';
 import {DocumentationUrlResolver} from "../utils/documentation-url-resolver";
 
@@ -537,6 +540,8 @@ AddRepositoryCtrl.$inject = ['$rootScope', '$scope', 'toastr', '$repositories', 
     'RepositoriesRestService', '$translate', 'productInfo'];
 
 function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location, $timeout, Upload, $routeParams, RepositoriesRestService, $translate, productInfo) {
+    const broadcastService = service(BroadcastService);
+
     $scope.rulesets = STATIC_RULESETS.slice();
     $scope.repositoryTypes = REPOSITORY_TYPES;
     $scope.params = $routeParams;
@@ -708,7 +713,10 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
                 toastr.success($translate.instant('created.repo.success.msg', {repoId: $scope.repositoryInfo.id}));
                 return $repositories.init();
             })
-            .then(() => $scope.goBackToPreviousLocation())
+            .then(() => {
+                $scope.goBackToPreviousLocation();
+                broadcastService.sendMessage(new BroadcastMessage(MessageType.REPOSITORIES_UPDATED));
+            })
             .catch(function(error) {
                 const msg = getError(error.data);
                 toastr.error(msg, $translate.instant('common.error'));
@@ -810,6 +818,7 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
     // =========================
 
     const authorizationService = service(AuthorizationService);
+    const broadcastService = service(BroadcastService);
 
     // =========================
     // Public variables
@@ -934,7 +943,10 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
         RepositoriesRestService.editRepository($scope.repositoryInfo.saveId, $scope.repositoryInfo)
             .success(function() {
                 toastr.success($translate.instant('edit.repo.success.msg', {saveId: $scope.repositoryInfo.saveId}));
-                $repositories.init().finally(() => $scope.goBackToPreviousLocation());
+                $repositories.init().finally(() => {
+                    $scope.goBackToPreviousLocation();
+                    broadcastService.sendMessage(new BroadcastMessage(MessageType.REPOSITORIES_UPDATED));
+                });
                 if ($scope.repositoryInfo.saveId === $scope.repositoryInfo.id && $scope.repositoryInfo.restartRequested) {
                     $repositories.restartRepository($scope.repositoryInfo);
                 }


### PR DESCRIPTION
## What
Implement synchronization of repository deletion/creation across different tabs

## Why
Because currently there is no such synchronization. When creating/deleting repositories, the changes are not reflected in other tabs from the same origin.

## How
- Added a `BroadcastService` to send `BroadcastChannel` messages to other browser contexts
- Added `broadcast-message` as a unified model of the message to be sent
- Added a subscription in the main `controller.js`, which listens for `MessageType.REPOSITORIES_UPDATED` and triggers `$repositories.init()`
- Added event dispatch on create/delete repository actions

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
