### PR TITLE
GDB-13506 Visual graph config should have the repositoryId as a context

### DIFF
--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-config.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-config.controller.js
@@ -281,9 +281,9 @@ function GraphConfigCtrl(
             }
             $scope.queryEditorIsDirty = false;
             if ($scope.isUpdate) {
-                $scope.updateGraphConfig($scope.newConfig.toSavePayload());
+                $scope.updateGraphConfig($scope.newConfig.toSavePayload($repositories.getActiveRepository()));
             } else {
-                $scope.createGraphConfig($scope.newConfig.toSavePayload());
+                $scope.createGraphConfig($scope.newConfig.toSavePayload($repositories.getActiveRepository()));
             }
         });
     };

--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -3186,6 +3186,7 @@ function GraphsVisualizationsCtrl(
             name: $scope.lastSavedGraphName,
             data: data,
             shared: $scope.shared,
+            repositoryId: repositoryContextService.getSelectedRepository().id,
         };
 
         if (graphToSave.id) {
@@ -3295,8 +3296,11 @@ function GraphsVisualizationsCtrl(
 
         // Preserve existing query params and only set/override `saved`
         const currentSearch = $location.search();
-        const newSearch = {...currentSearch, saved: graphToLoad.id};
-        $location.search('saved', graphToLoad.id);
+        const newSearch = {
+            ...currentSearch,
+            saved: graphToLoad.id,
+            [REPOSITORY_ID_PARAM]: repositoryContextService.getSelectedRepository().id,
+        };
         graph.restoreState(JSON.parse(graphToLoad.data));
         if (!noHistory) {
             pushHistory(newSearch, {savedGraph: graphToLoad});
@@ -3304,9 +3308,10 @@ function GraphsVisualizationsCtrl(
     };
 
     $scope.copyToClipboardSavedGraph = function(savedGraph) {
-        // TODO: Not sure we must add the repositoryId param here.
-        const url = [location.protocol, '//', location.host, location.pathname, '?saved=', savedGraph.id].join('');
-        $scope.copyToClipboard(url);
+        const url = new URL(window.location.href);
+        url.searchParams.set('saved', savedGraph.id);
+        url.searchParams.set(REPOSITORY_ID_PARAM, repositoryContextService.getSelectedRepository().id);
+        $scope.copyToClipboard(url.toString());
     };
 
     function deleteSavedGraphHttp(savedGraph) {

--- a/packages/legacy-workbench/src/js/angular/models/graphs/graphs-config.js
+++ b/packages/legacy-workbench/src/js/angular/models/graphs/graphs-config.js
@@ -140,9 +140,10 @@ export class GraphsConfig {
 
     /**
      * Converts this model to a payload JSON object needed for a save config operation.
+     * @param {string} repositoryId The repository identifier to which this config belongs.
      * @return {{owner: (string|undefined), shared: (boolean|undefined), startIRI: (string|undefined), resourceQuery: (string|undefined), startGraphQuery: (string|undefined), expandQuery: (string|undefined), description: (string|undefined), startIRILabel: (string|undefined), startQueryIncludeInferred: (boolean|undefined), resourcePropertiesQuery: (string|undefined), predicateLabelQuery: (string|undefined), startMode: (string|undefined), hint: (string|undefined), name: (string|undefined), id: (string|undefined), startQuerySameAs: (boolean|undefined)}}
      */
-    toSavePayload() {
+    toSavePayload(repositoryId) {
         return {
             id: this.id,
             name: this.name,
@@ -159,7 +160,8 @@ export class GraphsConfig {
             resourcePropertiesQuery: this.resourcePropertiesQuery,
             shared: this.shared,
             description: this.description,
-            hint: this.hint
+            hint: this.hint,
+            repositoryId: repositoryId,
         };
     }
 


### PR DESCRIPTION
## What
Saved visual graph configs should have repositoryId property.

## Why
This is needed in order to allow a user to open them in the repository in which they were created.

## How
Add repositoryId to graph configuration save payload and clipboard URL

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
