### PR TITLE
GDB-14217 improve physics simulation parameters for visual graph nodes

### DIFF
--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -1368,10 +1368,11 @@ function GraphsVisualizationsCtrl(
         }
     };
 
-    const forceX = d3.forceX(width / 2).strength(0.005);
-    const forceY = d3.forceY(height / 2).strength(0.005);
+    const forceX = d3.forceX(width / 2).strength(0.03);
+    const forceY = d3.forceY(height / 2).strength(0.03);
 
     const force = d3.forceSimulation()
+        .velocityDecay(0.6)
         .force('x', forceX)
         .force('y', forceY);
 
@@ -1463,12 +1464,10 @@ function GraphsVisualizationsCtrl(
 
         const collisionForce = d3.forceCollide((d) => d.size + 5).strength(0.5);
         const chargeForce = d3.forceManyBody().strength(-300);
-        const centerForce = d3.forceCenter(width/2, height/2);
 
         force.nodes(graph.nodes)
             .force("charge", chargeForce)
             .force("collide", collisionForce)
-            .force("center", centerForce)
             .force("link", d3.forceLink(graph.links).distance(function(l) {
                 if (l.source.isTriple || l.target.isTriple) {
                     return 0;


### PR DESCRIPTION
## What
Improve phisics applied to nodes in visual graph.

## Why
When nodes are pinned in the canvas and other nodes are draged in some direction causes other free nodes runaway unproportionally from the pinned nodes.

## How
1. forceCenter causes the runaway (primary cause)
d3.forceCenter(cx, cy) works by computing the centroid of ALL nodes (including pinned ones) and pushing every free node to shift the centroid toward (cx, cy). When nodes are pinned away from the canvas center, the centroid drifts toward the pinned cluster. forceCenter then compensates by pushing all free nodes in the opposite direction.
Also we already have forceX/forceY for centering, so forceCenter is redundant on top of them, doubling the centering aggression.
2. forceX/forceY are too weak to hold nodes once forceCenter is removed
Current strength is 0.005 — barely noticeable. Without forceCenter, they need a modest bump. forceX/forceY pull each node independently toward the canvas center without knowing about other nodes' positions. Pinning node A at position X has zero effect on the force applied to free node B.
3. forceManyBody repulsion is strong relative to the centering
-300 is quite aggressive. With the centroid trick removed the repulsion freely pushes nodes toward the viewport edge.


## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
