### PR TITLE
GDB-12310 show single predicates on click

### DIFF
--- a/packages/legacy-workbench/src/css/graphs-vizualizations.css
+++ b/packages/legacy-workbench/src/css/graphs-vizualizations.css
@@ -1,3 +1,11 @@
+.main-container {
+    padding-bottom: 5px;
+}
+
+.visual-graph-view {
+    position: relative;
+}
+
 .rdf-info-side-panel.visual-graph.embedded {
     top: 0 !important;
 }
@@ -53,12 +61,11 @@
 }
 
 .toolbar-holder {
-    position: relative;
-    top: -3em;
+    position: absolute;
+    top: 10px;
+    right: 0;
     z-index: 10;
     background-color: var(--gw-panel-background);
-    width: max-content;
-    margin-left: auto;
 }
 
 .rdf-list .node-info {
@@ -73,7 +80,8 @@
 }
 
 .graph-visualization {
-    height: calc(100vh - 190px);
+    /* 200px includes the application header, page heading/title, footer */
+    height: calc(100vh - 200px);
 }
 
 .graph-visualization svg {
@@ -87,6 +95,7 @@
 
 .predicate, .predicates {
     font-size: 90%;
+    cursor: pointer;
 }
 
 .predicates {

--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -865,7 +865,7 @@ function GraphsVisualizationsCtrl(
     // define zoom and drag behavior; keep this out of draw() to preserve state when nodes are added/removed
     const zoomLayout = d3.zoom().scaleExtent([0.1, 10]);
     let container;
-    const INITIAL_CONTAINER_TRANSFORM = d3.zoomIdentity.translate(0, -70).scale(1);
+    const INITIAL_CONTAINER_TRANSFORM = d3.zoomIdentity.translate(100, 50).scale(1);
 
     function zoomed(event) {
         if (!guidesService.isScrollingAllowed()) {
@@ -2870,8 +2870,8 @@ function GraphsVisualizationsCtrl(
         const reverseLink = graph.links.find(function(l) {
             return l.source.iri === d.target.iri && l.target.iri === d.source.iri;
         });
-        // Show panel if this direction has multiple predicates OR a reverse link exists
-        $scope.showPredicates = d.predicates.length > 1 || (!!reverseLink && reverseLink.predicates.length > 0);
+        // Show panel if this direction has predicates OR a reverse link exists
+        $scope.showPredicates = d.predicates.length >= 1 || (!!reverseLink && reverseLink.predicates.length > 0);
 
         if (openedLink === d) {
             $scope.showNodeInfo = false;

--- a/packages/legacy-workbench/src/pages/graphs-visualizations.html
+++ b/packages/legacy-workbench/src/pages/graphs-visualizations.html
@@ -3,7 +3,7 @@
 <link href="css/lib/ng-tags-input/ng-tags-input.min.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 <link href="js/lib/d3-tip/d3-tip.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 
-<div class="container-fluid visual-graph-view">
+<div class="visual-graph-view">
 
     <h1>
         {{title}}
@@ -255,7 +255,7 @@
                                   id="{{predicate.linkId + predicate.nodeIndex}}"
                                   gdb-tooltip="{{predicate.rawIri}}"
                                   tooltip-placement="top">{{splitPredicate(predicate.value)}}</span>
-                            <button class="btn btn-link btn-sm px-0 copy-btn"
+                            <button class="btn btn-link btn-sm px-0 mr-1 copy-btn"
                                     ng-click="copyPredicateIri($event, predicate.rawIri)"
                                     gdb-tooltip="{{'common.copy_to_clipboard.btn' | translate}}"
                                     tooltip-placement="top"
@@ -282,7 +282,7 @@
                                       id="{{predicate.linkId + predicate.nodeIndex}}"
                                       gdb-tooltip="{{predicate.rawIri}}"
                                       tooltip-placement="top">{{splitPredicate(predicate.value)}}</span>
-                                <button class="btn btn-link btn-sm px-0 copy-btn"
+                                <button class="btn btn-link btn-sm px-0 mr-1 copy-btn"
                                         ng-click="copyPredicateIri($event, predicate.rawIri)"
                                         gdb-tooltip="{{'common.copy_to_clipboard.btn' | translate}}"
                                         tooltip-placement="top"


### PR DESCRIPTION
## What
1. Allow single predicates label to also be clicked and rendered in the sidebar.
2. Improve the visual graph page layout a bit to increase the visible area for the canvas.
3. Improved graph nodes positioning after initial render.

## Why
1. Currently user can click only on links where there are more than one predicate which makes the behavior inconsistent.
2. The page layout had too much vertical space lost due to badly implemented toolbar and too big bottom padding of the main container.
3. After changing the physics to prevent free nodes runaway from pinned nodes while dragging nodes to the other direction it happened that now the graph is rendered initially a bit off-canvas which is somewhat inconvenient.

## How
1. Changed the condition that prevented triggering the sidebar for single predicates.
2. Optimized the layout by reducing bottom padding and reimplemented the toolbar styling.
3. Changed svg translation from -70 to 170 to make it closer to the canvas center.

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
