### PR TITLE
Change default Slack channel in release pipeline

### DIFF
--- a/release.Jenkinsfile
+++ b/release.Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
 
         string(
             name: 'SLACK_CHANNEL',
-            defaultValue: '#graphdb-team',
+            defaultValue: '#frontend-notifications',
             description: 'Slack channel for notification (only used if checkbox above is selected)'
         )
     }


### PR DESCRIPTION
## What
Updated the default Slack channel in the release pipeline configuration from '#graphdb-team' to '#frontend-notifications'.

## Why
This change ensures that notifications are sent to the appropriate team channel, improving communication and response times during releases.

## How
- Modified the `defaultValue` of the `SLACK_CHANNEL` parameter in the `release.Jenkinsfile`.

## Testing
n/a

## Screenshots
n/a

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
