### PR TITLE
GDB-14461 switching between predicates happens slowly.

### DIFF
--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -2840,6 +2840,7 @@ function GraphsVisualizationsCtrl(
                 source: d.source,
                 target: d.target,
             }, WindowService.getReferer());
+            return;
         }
 
         revertElementsStyleToDefault();
@@ -2858,6 +2859,11 @@ function GraphsVisualizationsCtrl(
         }
 
         openPredicates(d);
+
+        // We need to manually trigger a digest because linkActions runs outside angular's digest cycle (it's triggered
+        // by a D3 .on("click") handler, not by angular), so scope changes like $scope.showPredicates, $scope.predicates,
+        // etc. don't render until the next digest happens.
+        $scope.$applyAsync();
     }
 
     function openPredicates(d) {


### PR DESCRIPTION
## What
When user clicks on predicate links in the graph visualization, predicates are rendered somewhat slowly usually in a 2 seconds range.

## Why
The linkAction function called when user clicks on a predicate label in the graph visualization (the D3 canvas) is triggered by D3 and angular is unaware of that and a digest is not triggered. This causes a delay in the predicates rerendering in the sidebar, and it happens automatically just because we have the polling for the operations status on each 2 seconds.

## How
Fixed by manually triggering a digest after the entirely synchronous code in the linkActions completes.

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
