### PR TITLE
GDB-14400 reorganize visual graph config form

### DIFF
--- a/packages/legacy-workbench/src/css/graphs-config.css
+++ b/packages/legacy-workbench/src/css/graphs-config.css
@@ -88,3 +88,39 @@ yasgui-component .CodeMirror {
 .small-caps {
     font-variant: all-small-caps;
 }
+
+.graph-config-meta-right {
+    margin-top: 1rem;
+
+    textarea {
+        min-height: 10rem;
+    }
+}
+
+@media (min-width: 992px) {
+    .graph-config-meta-row {
+        display: flex;
+    }
+
+    .graph-config-meta-left,
+    .graph-config-meta-right {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .graph-config-meta-right {
+        margin-top: 0;
+    }
+
+    .graph-config-meta-right .form-group {
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+    }
+
+    .graph-config-meta-right textarea {
+        flex: 1 1 auto;
+        min-height: 0;
+        height: 100%;
+    }
+}

--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-config.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-config.controller.js
@@ -5,7 +5,7 @@ import {YasqeMode} from "../../models/ontotext-yasgui/yasqe-mode";
 import {RenderingMode} from "../../models/ontotext-yasgui/rendering-mode";
 import {
     INFERRED_AND_SAME_AS_BUTTONS_CONFIGURATION,
-    YasguiComponentDirectiveUtil
+    YasguiComponentDirectiveUtil,
 } from "../../core/directives/yasgui-component/yasgui-component-directive.util";
 import {GraphsConfig, StartMode} from "../../models/graphs/graphs-config";
 import {mapGraphConfigSamplesToGraphConfigs} from "../../rest/mappers/graphs-config-mapper";
@@ -17,8 +17,7 @@ angular
         'graphdb.framework.utils.notifications',
         'graphdb.framework.utils.localstorageadapter',
         'graphdb.core.services.workbench-context',
-        'graphdb.framework.core.services.rdf4j.repositories'
-
+        'graphdb.framework.core.services.rdf4j.repositories',
     ])
     .controller('GraphConfigCtrl', GraphConfigCtrl);
 
@@ -39,7 +38,7 @@ GraphConfigCtrl.$inject = [
     '$translate',
     'ModalService',
     'WorkbenchContextService',
-    'RDF4JRepositoriesService'
+    'RDF4JRepositoriesService',
 ];
 
 function GraphConfigCtrl(
@@ -59,9 +58,8 @@ function GraphConfigCtrl(
     $translate,
     ModalService,
     WorkbenchContextService,
-    RDF4JRepositoriesService
+    RDF4JRepositoriesService,
 ) {
-
     // =========================
     // Public fields
     // =========================
@@ -88,7 +86,7 @@ function GraphConfigCtrl(
     $scope.samples = [];
     $scope.tabConfig = {
         inference: $scope.newConfig.startQueryIncludeInferred,
-        sameAs: $scope.newConfig.startQuerySameAs
+        sameAs: $scope.newConfig.startQuerySameAs,
     };
     /**
      * @type {boolean|undefined}
@@ -108,20 +106,21 @@ function GraphConfigCtrl(
     let selectedFixedNodeChanged;
     const configName = $routeParams.configName;
     const activeRepository = $repositories.getActiveRepository();
+    // eslint-disable-next-line no-unused-vars
     const DISABLE_YASQE_BUTTONS_CONFIGURATION = [
         {
             name: 'createSavedQuery',
-            visible: false
+            visible: false,
         }, {
             name: 'showSavedQueries',
-            visible: false
+            visible: false,
         }, {
             name: 'shareQuery',
-            visible: false
+            visible: false,
         }, {
             name: 'includeInferredStatements',
-            visible: false
-        }
+            visible: false,
+        },
     ];
     // This flag is used to prevent multiple triggers of the location change listener.
     let locationChangeInProgress = false;
@@ -201,10 +200,10 @@ function GraphConfigCtrl(
      */
     $scope.createGraphConfig = (payload) => {
         GraphConfigRestService.createGraphConfig(payload)
-            .success(async function () {
+            .success(async function() {
                 await Notifications.showToastMessageWithDelay('graphexplore.saved.new.config');
                 $location.url('graphs-visualizations');
-            }).error(function (data) {
+            }).error(function(data) {
                 toastr.error(getError(data), $translate.instant('graphexplore.error.could.not.create'));
             });
     };
@@ -214,10 +213,10 @@ function GraphConfigCtrl(
      */
     $scope.updateGraphConfig = (payload) => {
         GraphConfigRestService.updateGraphConfig(payload)
-            .success(async function () {
+            .success(async function() {
                 await Notifications.showToastMessageWithDelay('graphexplore.saved.config');
                 $location.url('graphs-visualizations');
-            }).error(function (data) {
+            }).error(function(data) {
                 toastr.error(getError(data), $translate.instant('graphexplore.error.could.not.save'));
             });
     };
@@ -296,7 +295,7 @@ function GraphConfigCtrl(
      */
     $scope.setQuery = async (query) => {
         const newQuery = query ? query : ' ';
-        const yasguiInstance = await getYasguiInstance()
+        const yasguiInstance = await getYasguiInstance();
         yasguiInstance.setQuery(newQuery);
         $scope.markDirty();
     };
@@ -317,7 +316,7 @@ function GraphConfigCtrl(
 
     $scope.showPreview = () => {
         $scope.viewMode = 'editor';
-        runQuery()
+        runQuery();
     };
 
     $scope.revertEditor = () => {
@@ -335,10 +334,10 @@ function GraphConfigCtrl(
      */
     const getYasguiInstance = () => {
         return YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync('#query-editor');
-    }
+    };
 
     const runQuery = async (changePage, explain) => {
-        const yasguiInstance = await getYasguiInstance()
+        const yasguiInstance = await getYasguiInstance();
         const queryType = await yasguiInstance.getQueryType();
         if (explain && !(queryType === 'SELECT' || queryType === 'CONSTRUCT' || queryType === 'DESCRIBE')) {
             toastr.warning($translate.instant('query.editor.warning.msg'));
@@ -365,27 +364,28 @@ function GraphConfigCtrl(
     const executeYasqeQuery = async () => {
         const yasguiInstance = await getYasguiInstance();
         yasguiInstance.query(RenderingMode.YASR);
-    }
+    };
 
     const switchToYasqe = async () => {
-        const yasguiInstance = await getYasguiInstance()
+        const yasguiInstance = await getYasguiInstance();
         return yasguiInstance.changeRenderMode(RenderingMode.YASQE);
-    }
+    };
 
+    // eslint-disable-next-line no-unused-vars
     const switchToYasr = async () => {
-        const yasguiInstance = await getYasguiInstance()
+        const yasguiInstance = await getYasguiInstance();
         yasguiInstance.changeRenderMode(RenderingMode.YASR);
-    }
+    };
 
     const getYasqeQuery = async () => {
-        const yasguiInstance = await getYasguiInstance()
+        const yasguiInstance = await getYasguiInstance();
         return yasguiInstance.getQuery();
-    }
+    };
 
     const abortQuery = async () => {
-        const yasguiInstance = await getYasguiInstance()
+        const yasguiInstance = await getYasguiInstance();
         return yasguiInstance.abortQuery();
-    }
+    };
 
     const getNamespaces = () => {
         // Signals the namespaces are to be fetched => loader will be shown
@@ -393,16 +393,16 @@ function GraphConfigCtrl(
         $repositories.getPrefixes($repositories.getActiveRepository())
             .then((prefixes) => {
                 $scope.namespaces = prefixes;
-            }).catch(function (data) {
+            }).catch(function(data) {
             $scope.repositoryError = getError(data);
-        }).finally(function () {
+        }).finally(function() {
                 // Signals namespaces were fetched => loader will be hidden
                 setLoader(false);
             });
-    }
+    };
 
     const updateModel = async () => {
-        const yasguiInstance = await getYasguiInstance()
+        const yasguiInstance = await getYasguiInstance();
         /** @type string */
         let query = await yasguiInstance.getQuery();
         query = query.trim();
@@ -419,12 +419,12 @@ function GraphConfigCtrl(
             } else if (newConfig.isStartMode(StartMode.QUERY) && !newConfig.startGraphQuery) {
                 showInvalidMsg($translate.instant('graphexplore.provide.query'));
             } else if (newConfig.isStartMode(StartMode.QUERY)) {
-                validateQueryWithCallback(successCallback, newConfig.startGraphQuery, 'graph')
+                validateQueryWithCallback(successCallback, newConfig.startGraphQuery, 'graph');
             } else {
                 successCallback();
             }
         } else if ($scope.page === 2) {
-            validateQueryWithCallback(successCallback, newConfig.expandQuery, 'construct', ['node'])
+            validateQueryWithCallback(successCallback, newConfig.expandQuery, 'construct', ['node']);
         } else if ($scope.page === 3) {
             validateQueryWithCallback(successCallback, newConfig.resourceQuery, 'tuple', ['node'], [], ['type', 'label', 'comment', 'rank']);
         } else if ($scope.page === 4) {
@@ -436,7 +436,7 @@ function GraphConfigCtrl(
 
     const getGraphConfigSamples = () => {
         GraphConfigRestService.getGraphConfigSamples()
-            .success(function (data) {
+            .success(function(data) {
                 $scope.samples = mapGraphConfigSamplesToGraphConfigs(data)
                     .filter((graphConfig) => {
                         // Skip the currently edited config from samples and store it into a revert variable
@@ -447,7 +447,7 @@ function GraphConfigCtrl(
                             return false;
                         }
                     });
-            }).error(function (data) {
+            }).error(function(data) {
                 toastr.error(getError(data), $translate.instant('graphexplore.error.graph.configs'));
             });
     };
@@ -459,7 +459,7 @@ function GraphConfigCtrl(
     const updateEditor = () => {
         $scope.tabConfig.inference = $scope.newConfig.startQueryIncludeInferred;
         $scope.tabConfig.sameAs = $scope.newConfig.startQuerySameAs;
-        $scope.setQuery($scope.newConfig.getQueryType($scope.page))
+        $scope.setQuery($scope.newConfig.getQueryType($scope.page));
     };
 
     const showInvalidMsg = (message) => {
@@ -487,15 +487,15 @@ function GraphConfigCtrl(
         if (isBaseConfig()) {
             $scope.$broadcast('addStartFixedNodeAutomatically', {startIRI: $scope.newConfig.startIRI});
         }
-    }
+    };
 
     const isBaseConfig = () => {
         return $scope.page === 1 && $scope.newConfig.isStartMode(StartMode.NODE);
-    }
+    };
 
     const initForConfig = () => {
         getGraphConfigSamples();
-    }
+    };
 
     const getQueryEndpoint = () => {
         return `repositories/${$repositories.getActiveRepository()}`;
@@ -516,26 +516,26 @@ function GraphConfigCtrl(
         showYasqeResizer: false,
         yasqeMode: YasqeMode.READ,
         infer: $scope.newConfig.startQueryIncludeInferred,
-        sameAs: $scope.newConfig.startQuerySameAs
+        sameAs: $scope.newConfig.startQuerySameAs,
     };
 
     const initYasgui = (prefixes) => {
         // Wait until the active repository object is set, otherwise "canWriteActiveRepo()" may return a wrong result
         // and the "ontotext-yasgui" readOnly configuration may be incorrect.
-        const repoIsInitialized = $scope.$watch(function () {
+        const repoIsInitialized = $scope.$watch(function() {
             return $scope.getActiveRepositoryObject();
-        }, function (activeRepo) {
+        }, function(activeRepo) {
             if (activeRepo) {
                 $scope.canEditActiveRepo = $scope.canWriteActiveRepo();
                 const config = angular.extend({}, defaultYasguiConfig, {
                     prefixes: prefixes,
-                    yasqeMode: $scope.canWriteActiveRepo() ? YasqeMode.WRITE : YasqeMode.READ
+                    yasqeMode: $scope.canWriteActiveRepo() ? YasqeMode.WRITE : YasqeMode.READ,
                 });
                 $scope.yasguiConfig = config;
                 repoIsInitialized();
             }
         });
-    }
+    };
 
     const setLoader = (isRunning, progressMessage, extraMessage) => {
         $scope.queryIsRunning = isRunning;
@@ -545,12 +545,12 @@ function GraphConfigCtrl(
         ModalService.openSimpleModal({
             title,
             message,
-            warning: true
-        }).result.then(function () {
+            warning: true,
+        }).result.then(function() {
             if (angular.isFunction(onConfirm)) {
                 onConfirm();
             }
-        }, function () {
+        }, function() {
             if (angular.isFunction(onCancel)) {
                 onCancel();
             }
@@ -640,9 +640,9 @@ function GraphConfigCtrl(
             {page: 2, label: $translate.instant('graph.expansion'), type: 'expandQuery'},
             {page: 3, label: $translate.instant('node.basics'), type: 'resourceQuery'},
             {page: 4, label: $translate.instant('edge.basics'), type: 'predicateLabelQuery'},
-            {page: 5, label: $translate.instant('node.extra'), type: 'resourcePropertiesQuery'}
+            {page: 5, label: $translate.instant('node.extra'), type: 'resourcePropertiesQuery'},
         ];
-    }
+    };
 
     const initView = () => {
         translateTabsViewModel();
@@ -653,7 +653,7 @@ function GraphConfigCtrl(
         if (configName) {
             $scope.isUpdate = true;
             GraphConfigRestService.getConfig(configName)
-                .then(function (graphConfigModel) {
+                .then(function(graphConfigModel) {
                     $scope.newConfig = graphConfigModel;
                     initForConfig();
                 })

--- a/packages/legacy-workbench/src/pages/graph-config/saveGraphConfig.html
+++ b/packages/legacy-workbench/src/pages/graph-config/saveGraphConfig.html
@@ -9,30 +9,45 @@
           popover-append-to-body="true"><span class="ri-information-2-line text-tertiary"></span></span>
 </h1>
 
-<div class="card mb-2">
-    <div class="card-block" style="padding-top: 1rem">
-        <p class="lead">{{'config.name.label' | translate}}</p>
-        <div class="input-group input-group-lg">
-            <input required class="form-control graph-config-name" type="text"
-                   guide-selector="graph-config-name"
-                   placeholder="{{'graph.config.required' | translate}}" ng-model="newConfig.name">
+<div class="card mb-2 graph-config-meta-card">
+    <div class="card-block">
+        <div class="row graph-config-meta-row">
+            <div class="col-12 col-lg-6 graph-config-meta-left">
+                <div class="form-group">
+                    <label for="graphConfigName" class="d-block">{{'config.name.label' | translate}}*</label>
+                    <input id="graphConfigName" required class="form-control form-control-lg graph-config-name" type="text"
+                           guide-selector="graph-config-name"
+                           placeholder="{{'graph.config.required' | translate}}" ng-model="newConfig.name">
+                </div>
+                <div class="form-group">
+                    <label for="graphConfigHint" class="d-block">{{'hint.label' | translate}}</label>
+                    <input id="graphConfigHint" class="form-control form-control-lg graph-config-example" type="text"
+                           guide-selector="graph-config-hint"
+                           placeholder="{{'add.hint.prompt' | translate}}"
+                           ng-model="newConfig.hint">
+                </div>
+            </div>
+
+            <div class="col-12 col-lg-6 graph-config-meta-right">
+                <div class="form-group">
+                    <label for="graphConfigDesc" class="d-block">{{'description.text' | translate}}</label>
+                    <textarea id="graphConfigDesc"
+                              class="form-control form-control-lg graph-config-description"
+                              guide-selector="graph-config-description"
+                              placeholder="{{'enter.description' | translate}}"
+                              ng-model="newConfig.description"></textarea>
+                </div>
+            </div>
         </div>
-        <br/>
-        <p>{{'description.text' | translate}}</p>
-        <div class="input-group input-group-lg">
-            <input class="form-control graph-config-description" type="text"
-                   guide-selector="graph-config-description"
-                   placeholder="{{'enter.description' | translate}}"
-                   ng-model="newConfig.description">
-        </div>
-        <div ng-if="newConfig.startMode === 'search'">
-            <br/>
-            <p>{{'hint.label' | translate}}</p>
-            <div class="input-group input-group-lg">
-                <input class="form-control graph-config-example" type="text"
-                       guide-selector="graph-config-hint"
-                       placeholder="{{'add.hint.prompt' | translate}}"
-                       ng-model="newConfig.hint">
+        <div class="row">
+            <div class="col-12">
+                <div class="form-group ml-1 mb-0">
+                    <label for="share-graph-config" guide-selector="share-graph-config"
+                           gdb-tooltip="{{'visual.graph.other.users.see' | translate}}">
+                        <input id="share-graph-config" type="checkbox" ng-model="newConfig.shared" data-test="share-graph-config">
+                        {{'share.visual.graph' | translate}}
+                    </label>
+                </div>
             </div>
         </div>
     </div>
@@ -262,13 +277,6 @@
 </div>
 
 <div class="m-0 clearfix" style="padding-bottom: 2rem">
-    <div>
-        <label for="share-graph-config" guide-selector="share-graph-config"
-               gdb-tooltip="{{'visual.graph.other.users.see' | translate}}">
-            <input id="share-graph-config" type="checkbox" ng-model="newConfig.shared" data-test="share-graph-config">
-            {{'share.visual.graph' | translate}}
-        </label>
-    </div>
     <div class="pull-left">
         <button href ng-show="page > 1" ng-click="goToPreviousPage()" class="btn btn-lg btn-secondary btn-previous-page"
                 uib-popover="{{'previous.config.step' | translate}}"

--- a/packages/legacy-workbench/src/pages/graphs-visualizations.html
+++ b/packages/legacy-workbench/src/pages/graphs-visualizations.html
@@ -162,10 +162,9 @@
                                 </td>
                                 <td>
                                     <h5>
-                                        <a href ng-click="goToGraphConfig(config)" data-test="graph-config-{{config.name}}" uib-popover={{config.description}} popover-trigger="mouseenter">{{config.name}}</a>
+                                        <a href ng-click="goToGraphConfig(config)" data-test="graph-config-{{config.name}}">{{config.name}}</a>
                                     </h5>
-                                    <samp class="text-muted small text-overflow d-block" ng-if="config.startMode == 'query'">{{config.startGraphQuery}}</samp>
-                                    <samp class="text-muted small text-overflow d-block" ng-if="config.startMode == 'node'">{{config.startIRI}}</samp>
+                                    <samp class="text-muted small text-overflow d-block" ng-if="config.hint">{{config.hint}}</samp>
                                 </td>
                                 <td class="text-xs-right" ng-if="isUser() && config.owner === principal.username">
                                     <a ng-href="graphs-visualizations/config/save/{{config.id}}" class="btn btn-link btn-edit-config" gdb-tooltip="{{'visual.edit.config' | translate}}"><span class="ri-edit-line"></span></a>


### PR DESCRIPTION
## What
Visual graph config form needs to be reorganized.

## Why
Config description needs to allow markdown markup to be entered by the user.
The hint field needs to be always visible.
The Share config checkbox should be in the group with the other fields instead of next to the buttons below.

## How
Cleanup the graphs-config.controller
Reorganize graph config form: 
* Changed layout and made it flexible
* Description field becomes a textarea
* Hint field is now always visible in the form for all configuration types
* The share config checkbox is moved inside the form group
* Removed the tooltip that used to show the description on hover over each config in the list
* Display the hint value if present for each config in the list, replacing curently displayed query or uri
*

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
