### PR TITLE
GDB-12310 reset predicates list scrollbar on selection

### DIFF
--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -2972,6 +2972,12 @@ function GraphsVisualizationsCtrl(
 
             $scope.allPredicates = $scope.predicates;
 
+            // Reset scroll before the new list renders
+            const predicatesContainer = document.querySelector('.predicates-panel .predicates');
+            if (predicatesContainer) {
+                predicatesContainer.scrollTop = 0;
+            }
+
             // Reverse predicates
             if (reverseLink) {
                 const reverseRawByLocalName = new Map();


### PR DESCRIPTION
## What
Reset the predicates list in the visual graph sidebar on selection.

## Why
When predicates list is rendered and the user had scrolled the list down, then selects another predicates list, the list in the sidebar is updated, but the scroll position is not reset to top.

## How
Fixed by resetting the scroll position on new selection.

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
