### PR TITLE
GDB-14403 prevent empty question submit with enter key

### DIFF
--- a/packages/legacy-workbench/src/js/angular/ttyg/directives/chat-panel.directive.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/directives/chat-panel.directive.js
@@ -123,6 +123,20 @@ function ChatPanelComponent(toastr, $translate, TTYGContextService) {
             };
 
             /**
+             * Determines whether the Ask button should be disabled based on the current state of the chat item,
+             * selected agent, and ongoing operations.
+             * @returns {boolean} True if the Ask button should be disabled, false otherwise.
+             */
+            $scope.isAskDisabled = () => {
+                return !!(!$scope.chatItem.question.message
+                    || !$scope.selectedAgent
+                    || $scope.selectedAgent.isDeleted
+                    || $scope.waitingForLastMessage
+                    || $scope.loadingChat
+                    || $scope.askingChatItem);
+            };
+
+            /**
              * Handles pressing the Enter key in the question input.
              * Will not trigger if `Shift` or `Ctrl` keys are pressed, or if Ask button is disabled.
              *
@@ -130,7 +144,10 @@ function ChatPanelComponent(toastr, $translate, TTYGContextService) {
              */
             $scope.onKeypressOnInput = ($event) => {
                 if (!$scope.askingChatItem && $event.key === 'Enter' && !$event.shiftKey && !$event.ctrlKey) {
-                    $scope.ask();
+                    if (!$scope.isAskDisabled()) {
+                        $event.preventDefault();
+                        $scope.ask();
+                    }
                 }
             };
 

--- a/packages/legacy-workbench/src/js/angular/ttyg/templates/chat-panel.html
+++ b/packages/legacy-workbench/src/js/angular/ttyg/templates/chat-panel.html
@@ -51,7 +51,7 @@
                 <div class="left-side-actions"></div>
                 <div class="right-side-actions">
                     <button class="btn btn-primary ask-button" guide-selector="question-ask" ng-if="!showCancelButton"
-                            ng-disabled="!chatItem.question.message || !selectedAgent || selectedAgent.isDeleted || waitingForLastMessage || loadingChat || cancelling"
+                            ng-disabled="isAskDisabled()"
                             ng-click="ask()">
                         <i class="ri-arrow-up-line"></i>
                     </button>


### PR DESCRIPTION
## What
Prevent empty question submit in TTYG chat panel by hitting Enter.

## Why
In TTYG the question can be submitted by hitting [Enter] key. If the question field is empty the Ask button is disabled on the page, but the [Enter] key is still functional. Submitting empty question results in error in the backend due to missing logic that handles the case.

## How
Applied the same conditions for disabling in the onKeypress in the text field.

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
