### PR TITLE
GDB-14123 show Ontop version in footer

### DIFF
--- a/packages/api/src/models/product-info/product-info.ts
+++ b/packages/api/src/models/product-info/product-info.ts
@@ -4,6 +4,7 @@ export class ProductInfo {
   productVersion: string;
   sesame: string;
   connectors: string;
+  ontop: string;
   // Computed property
   shortVersion?: string;
 
@@ -14,6 +15,7 @@ export class ProductInfo {
     this.sesame = data.sesame;
     this.connectors = data.connectors;
     this.shortVersion = this.resolveShortVersion(data);
+    this.ontop = data.ontop;
   }
 
   private resolveShortVersion(data: Partial<ProductInfo>) {

--- a/packages/api/src/services/domain/product-info/mappers/product-info.mapper.ts
+++ b/packages/api/src/services/domain/product-info/mappers/product-info.mapper.ts
@@ -15,5 +15,6 @@ export const mapProductInfoResponseToModel: MapperFn<ProductInfoResponse, Produc
     productVersion: data.productVersion || '',
     sesame: data.sesame || '',
     connectors: data.connectors || '',
+    ontop: data.Ontop || '',
   });
 };

--- a/packages/api/src/services/domain/product-info/response/product-info-response.ts
+++ b/packages/api/src/services/domain/product-info/response/product-info-response.ts
@@ -5,4 +5,5 @@ export interface ProductInfoResponse {
   shortVersion?: string;
   sesame: string;
   connectors: string;
+  Ontop: string;
 }

--- a/packages/api/src/services/domain/product-info/test/product-info.service.spec.ts
+++ b/packages/api/src/services/domain/product-info/test/product-info.service.spec.ts
@@ -16,8 +16,9 @@ describe('ProductInfoService', () => {
     // Note: the Workbench property in the response has an uppercase 'W'
     const mockProductInfo: ProductInfoResponse = {
       Workbench: '2.8.0',
-      productVersion: '1.0.0'
-    } as ProductInfo & { Workbench: string };
+      productVersion: '1.0.0',
+      Ontop: '5.3.0',
+    } as ProductInfoResponse;
     TestUtil.mockResponse(new ResponseMock('rest/info/version?local=1').setResponse(mockProductInfo));
 
     // When I call the getVersionLocal method
@@ -30,6 +31,7 @@ describe('ProductInfoService', () => {
       shortVersion: '1.0',
       sesame: '',
       connectors: '',
+      ontop: '5.3.0',
     };
 
     // Then, I should get a ProductInfo object, with default property values
@@ -41,7 +43,7 @@ describe('ProductInfoService', () => {
       Workbench: '1.0.0',
       productType: 'GraphDB',
       productVersion: '9.10.1-M3-RC1'
-    } as ProductInfo & { Workbench: string };
+    } as ProductInfoResponse;
     TestUtil.mockResponse(new ResponseMock('rest/info/version?local=1').setResponse(data));
 
     // When I call the getVersionLocal method
@@ -55,7 +57,7 @@ describe('ProductInfoService', () => {
       Workbench: '1.0.0',
       productType: 'GraphDB',
       productVersion: '9.10.1'
-    } as ProductInfo & { Workbench: string };
+    } as ProductInfoResponse;
     TestUtil.mockResponse(new ResponseMock('rest/info/version?local=1').setResponse(data));
     const result = await productInfoService.getProductInfoLocal();
 
@@ -74,8 +76,9 @@ describe('ProductInfoService', () => {
       productType: 'GraphDB',
       productVersion: '9.10.1',
       sesame: '3.6.0',
-      connectors: '5.0.0'
-    } as ProductInfo & { Workbench: string };
+      connectors: '5.0.0',
+      Ontop: '5.3.0',
+    } as ProductInfoResponse;
 
     TestUtil.mockResponse(new ResponseMock('rest/info/version?local=1').setResponse(data));
     const result = await productInfoService.getProductInfoLocal();

--- a/packages/shared-components/cypress/e2e/footer/footer.cy.js
+++ b/packages/shared-components/cypress/e2e/footer/footer.cy.js
@@ -13,7 +13,7 @@ describe('Footer', () => {
 
     // Then, I expect the product information to be loaded and visible in the footer
     const currentYear = new Date().getFullYear();
-    const expectedFooterContent = `GraphDB 11.0-SNAPSHOT • RDF4J 4.3.15 • Connectors 16.2.13-RC2 • Workbench 2.8.0 • © 2002–${currentYear} Ontotext AD`;
+    const expectedFooterContent = `GraphDB 11.0-SNAPSHOT • RDF4J 4.3.15 • Connectors 16.2.13-RC2 • Ontop 5.3.0 • Workbench 2.8.0 • © 2002–${currentYear} Ontotext AD`;
     FooterSteps.getFooter()
       .invoke('text')
       .should('contain', expectedFooterContent);

--- a/packages/shared-components/src/components/onto-footer/onto-footer.tsx
+++ b/packages/shared-components/src/components/onto-footer/onto-footer.tsx
@@ -55,7 +55,7 @@ export class OntoFooter {
           <a href="http://graphdb.ontotext.com" target="_blank"
             rel="noopener noreferrer">GraphDB</a>&nbsp;{this.productInfo?.productVersion} &bull;&nbsp;<a
             href="http://rdf4j.org" target="_blank" rel="noopener noreferrer">RDF4J</a
-          >&nbsp;{this.productInfo?.sesame} &bull; Connectors {this.productInfo?.connectors} &bull; Workbench {this.productInfo?.workbench} &bull; &copy;
+          >&nbsp;{this.productInfo?.sesame} &bull; Connectors {this.productInfo?.connectors} &bull; Ontop {this.productInfo?.ontop} &bull; Workbench {this.productInfo?.workbench} &bull; &copy;
           2002&ndash;{this.currentYear}&nbsp;<a href="http://ontotext.com" target="_blank" rel="noopener noreferrer">Ontotext
           AD</a>.&nbsp;<translate-label labelKey={'footer.label.all_rights_reserved'}></translate-label>
         </div>

--- a/packages/shared-components/src/pages/js/main.js
+++ b/packages/shared-components/src/pages/js/main.js
@@ -27,7 +27,8 @@ const loadProductInfo = () => {
     workbench: '2.8.0',
     sesame: '4.3.15',
     connectors: '16.2.13-RC2',
-    productVersion: '11.0-SNAPSHOT'
+    productVersion: '11.0-SNAPSHOT',
+    ontop: '5.3.0'
   });
 };
 


### PR DESCRIPTION
## What
Show Ontop version in the footer.

## Why
This way it is easier for the users to know the Ontop version, instead of going to the documentation

## How
Updated the models with the new property and added it to the footer

## Testing
cypress

## Screenshots
<img width="1400" height="105" alt="Screenshot from 2026-04-23 15-24-18" src="https://github.com/user-attachments/assets/16f184fe-0928-4d4e-9f3c-7edeb6e15e34" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
