### PR TITLE
GDB-14488 display markdown for markdown typed literals in the node info sidebar

### DIFF
--- a/e2e-tests/e2e-legacy/explore/visual-graph/node-info-panel.spec.js
+++ b/e2e-tests/e2e-legacy/explore/visual-graph/node-info-panel.spec.js
@@ -1,0 +1,58 @@
+import {VisualGraphSteps} from '../../../steps/visual-graph-steps.js';
+import {ApplicationSteps} from '../../../steps/application-steps.js';
+
+const DATA_SNIPPET =
+'PREFIX ex: <http://example.org/>\n' +
+'PREFIX sysont: <http://www.ontotext.com/proton/protonsys#>\n' +
+'PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n' +
+'ex:MyNode a ex:Thing ;\n' +
+'rdfs:label "My Node" ;\n' +
+'ex:description """# My Node\n\nThis is a **Markdown** literal.\n\n- item 1\n- item 2"""^^sysont:Markdown .';
+
+describe('Node info panel', () => {
+    let repositoryId;
+    let graphConfigName;
+
+    beforeEach(() => {
+        cy.clearLocalStorage('ls.graphs-viz');
+        repositoryId = 'node-info-panel-' + Date.now();
+        graphConfigName = 'graph-config-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        cy.importRDFTextSnippet(repositoryId, DATA_SNIPPET);
+    })
+
+    afterEach(() => {
+        cy.clearLocalStorage('ls.graphs-viz');
+        cy.deleteGraphConfig(graphConfigName);
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('should render markdown content for literals with markdown datatype', () => {
+        cy.enableAutocomplete(repositoryId);
+        // Given I have opened the graphs visualizations page
+        VisualGraphSteps.visit();
+        // And I have created a graph config with query results
+        VisualGraphSteps.getCreateCustomGraphLink().click();
+        cy.url().should('include', '/config/save');
+        VisualGraphSteps.typeGraphConfigName(graphConfigName);
+        VisualGraphSteps.selectStartMode('node');
+        VisualGraphSteps.selectStartNode('MyNode', 0);
+        VisualGraphSteps.saveConfig();
+        ApplicationSteps.getSuccessNotifications().should('be.visible');
+        VisualGraphSteps.getGraphConfig(graphConfigName).should('be.visible');
+        // When I open the graph config
+        VisualGraphSteps.openGraphConfig(graphConfigName);
+        // Then I expect the graph visualization of the saved config to be opened
+        cy.url().should('contain', Cypress.config('baseUrl') + '/graphs-visualizations?config=');
+        VisualGraphSteps.getGraphVisualizationPane().should('be.visible');
+        // When I click on the node with markdown content
+        VisualGraphSteps.getCircleOfNodeByNodeId('http://example.org/MyNode').click();
+        // Then node info panel should be opened
+        VisualGraphSteps.getSidePanelContent().should('be.visible');
+        // And the markdown typed literal should be rendered
+        VisualGraphSteps.getPropertyByIndex(1).should('contain', 'This is a Markdown literal')
+            .and('contain', 'item 1')
+            .and('contain', 'item 2');
+    });
+});

--- a/e2e-tests/steps/visual-graph-steps.js
+++ b/e2e-tests/steps/visual-graph-steps.js
@@ -196,6 +196,10 @@ export class VisualGraphSteps extends BaseSteps {
         return cy.get('.rdf-side-panel-content');
     }
 
+    static getPropertyByIndex(index) {
+        return this.getSidePanelContent().find('.rdf-list .datasource').eq(index);
+    }
+
     static closeSidePanel() {
         this.getSidePanelCloseButton().click();
     }

--- a/packages/legacy-workbench/src/js/angular/core/directives/markdown-content/markdown-content.js
+++ b/packages/legacy-workbench/src/js/angular/core/directives/markdown-content/markdown-content.js
@@ -1,7 +1,7 @@
 import 'angular/core/services/markdown/markdown.service';
 
 const modules = [
-    'graphdb.framework.core.services.markdown-service'
+    'graphdb.framework.core.services.markdown-service',
 ];
 
 /**
@@ -34,10 +34,10 @@ function markdownContentDirective($compile, MarkdownService) {
         restrict: 'E',
         scope: {
             content: '@',
-            options: '='
+            options: '=',
+            trusted: '@',
         },
-        link: function ($scope, element) {
-
+        link: function($scope, element) {
             // =========================
             // Public variables
             // =========================
@@ -45,7 +45,7 @@ function markdownContentDirective($compile, MarkdownService) {
             /**
              * The rendered HTML content generated from the provided Markdown.
              *
-             * @type {string} markdownContent
+             * @type {string|undefined} markdownContent
              */
             $scope.markdownContent = undefined;
 
@@ -54,8 +54,16 @@ function markdownContentDirective($compile, MarkdownService) {
             // =========================
 
             const init = () => {
-                $scope.markdownContent = MarkdownService.renderMarkdown($scope.content, $scope.options);
-                compileMarkdownAnswerContents();
+                if (!$scope.content) {
+                    $scope.markdownContent = undefined;
+                    return;
+                }
+                if ($scope.trusted === 'true') {
+                    $scope.markdownContent = MarkdownService.renderMarkdown($scope.content, $scope.options);
+                    compileMarkdownAnswerContents();
+                } else {
+                    $scope.markdownContent = MarkdownService.renderMarkdown($scope.content, $scope.options, false);
+                }
             };
 
             /**
@@ -71,7 +79,13 @@ function markdownContentDirective($compile, MarkdownService) {
                 });
             };
 
+            $scope.$watch('content', (newVal, oldVal) => {
+                if (newVal !== oldVal) {
+                    init();
+                }
+            });
+
             init();
-        }
+        },
     };
 }

--- a/packages/legacy-workbench/src/js/angular/core/services/markdown/markdown.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/markdown/markdown.service.js
@@ -15,12 +15,12 @@ const logger = LoggerProvider.logger;
  * @param {$sce} $sce - AngularJS service for Strict Contextual Escaping.
  */
 angular
-    .module('graphdb.framework.core.services.markdown-service', [])
+    .module('graphdb.framework.core.services.markdown-service', ['ngSanitize'])
     .service('MarkdownService', MarkdownService);
 
-MarkdownService.$inject = ['$sce'];
+MarkdownService.$inject = ['$sce', '$sanitize'];
 
-function MarkdownService($sce) {
+function MarkdownService($sce, $sanitize) {
     const markdownInstance = markdownIt()
         .use(markdownCodeCopyPlugin)
         .use(markdownOpenInSparqlEditorPlugin, OPEN_IN_SPARQL_PLUGIN_OPTIONS);
@@ -44,15 +44,22 @@ function MarkdownService($sce) {
      * Renders Markdown text into HTML.
      * @function renderMarkdown
      * @param {string} text - The Markdown text to render.
+     * @param {Object} [config] - Optional custom configuration for Markdown rendering.
+     * @param {boolean} [trusted=true] - Indicates whether the rendered HTML should be treated as trusted. If false, the
+     * HTML will be sanitized to prevent potential security risks.
      * @return {string} The rendered HTML, or the original text in case of an error.
      */
-    const renderMarkdown = (text, config) => {
+    const renderMarkdown = (text, config, trusted = true) => {
         try {
-            return $sce.trustAsHtml(getMarkdown(config).render(text));
+            const html = getMarkdown(config).render(text);
+            return trusted
+                // trusted: skip sanitize (plugins may add custom HTML)
+                ? $sce.trustAsHtml(html)
+                // untrusted: sanitize before content that may have angular bindings
+                : $sce.trustAsHtml($sanitize(html));
         } catch (e) {
             logger.error('Error rendering markdown:', e);
-            // Return the original text in case of an error
-            return $sce.trustAsHtml(text);
+            return $sce.trustAsHtml(trusted ? text : $sanitize(text));
         }
     };
 

--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -1,6 +1,7 @@
 import 'angular/core/services';
 import 'angular/core/services/workbench-context.service';
 import 'angular/core/services/rdf4j-repositories.service';
+import 'angular/core/directives/markdown-content/markdown-content';
 import D3 from 'lib/common/d3-utils.js';
 import d3tip from 'lib/d3-tip/d3-tip-patch';
 import * as d3 from 'd3';
@@ -32,6 +33,7 @@ const modules = [
     'graphdb.framework.utils.localstorageadapter',
     'graphdb.core.services.workbench-context',
     'graphdb.framework.core.services.rdf4j.repositories',
+    'graphdb.framework.core.directives.markdown-content',
 ];
 
 angular
@@ -103,6 +105,12 @@ function GraphsVisualizationsCtrl(
     // Based on this, we display different numbers of rows. Currently, this results in 3 rows of text
     const heightMultiplier = 4.2;
     let openedLink;
+    const MARKDOWN_DATATYPES = new Set([
+        'lt:http://www.ontotext.com/proton/protonsys#Markdown',
+        'lt:http://ns.ontowiki.net/SysOnt/Markdown',
+        'lt:https://www.w3.org/ns/iana/media-types/text/markdown#Resource',
+        'lt:http://www.w3.org/ns/iana/media-types/text/markdown#Resource',
+    ]);
 
     // =========================
     // Public fields
@@ -186,6 +194,16 @@ function GraphsVisualizationsCtrl(
     // =========================
     // Public functions
     // =========================
+
+    /**
+     * Checks if the given datatype is one of the supported markdown datatypes. This is used to determine whether the
+     * value should be rendered as markdown or not.
+     * @param type {string} The datatype to check, in the form of "lt:datatypeIRI"
+     * @returns {boolean} True if the datatype is a supported markdown datatype, false otherwise.
+     */
+    $scope.isMarkdownLiteral = function(type) {
+        return MARKDOWN_DATATYPES.has(type);
+    };
 
     // Handle pageslide directive callbacks which incidentally appeared to be present in the angular's
     // scope, so we need to define our's and pass them to pageslide, otherwise it throws an error.
@@ -490,15 +508,6 @@ function GraphsVisualizationsCtrl(
         current++;
     };
     subscriptions.push($rootScope.$watch(rootScopeGenericWatcher, rootScopeGenericChangeHandler));
-
-    const propertiesItemsChangeHandler = () => {
-        if (angular.isDefined($scope.propertiesObj.items) && $scope.propertiesObj.items.length > 0) {
-            $timeout(function() {
-                $scope.adapterContainer.adapter.reload();
-            }, 500);
-        }
-    };
-    subscriptions.push($scope.$watch('propertiesObj.items', propertiesItemsChangeHandler));
 
     // ========================= Save graph modal =========================
     let modalIsOpen = false;
@@ -2548,10 +2557,10 @@ function GraphsVisualizationsCtrl(
 
     function showNodeInfo(d) {
         force.stop();
+        const panelWasAlreadyOpen = $scope.showInfoPanel;
         openedLink = null;
         // Assign value of node, which info panel has been opened
         $scope.openedNodeInfoPanel = d;
-        $scope.showNodeInfo = true;
         $scope.showFilter = false;
         $scope.showPredicates = false;
         $scope.nodeLabels = d.labels;
@@ -2560,7 +2569,7 @@ function GraphsVisualizationsCtrl(
         $scope.nodeIri = d.iri;
         $scope.resourceType = d.isTriple ? 'triple' : 'uri';
         $scope.encodedIri = d.isTriple ? encodeURIComponent(createTriple(d.iri)) : encodeURIComponent(d.iri);
-        $scope.showInfoPanel = true;
+
         highlightNode(d);
 
         $scope.rdfsLabel = d.labels[0].label;
@@ -2581,25 +2590,33 @@ function GraphsVisualizationsCtrl(
             $scope.data = _.mapKeys(response.data, function(value, key) {
                 return $scope.replaceIRIWithPrefix(key);
             });
-            $scope.propertiesObj.items = [];
+
+            const items = [];
 
             _.forEach($scope.data, function(value, key) {
-                $scope.propertiesObj.items.push({key: key, value: value});
+                items.push({key: key, value: value});
             });
             $scope.nodeImage = undefined;
 
-            $scope.propertiesNotFiltered = $scope.propertiesObj.items;
+            $scope.propertiesNotFiltered = items;
 
-            const imageVal = _.find($scope.propertiesObj.items, function(o) {
+            const imageVal = _.find(items, function(o) {
                 return o.key === 'image';
             });
             if (imageVal) {
                 $scope.nodeImage = imageVal['value'][0].v;
             }
-            $scope.propertiesObj.items = _.reject($scope.propertiesObj.items, function(o) {
+            $scope.propertiesObj.items = _.reject(items, function(o) {
                 return o.key === 'image';
             });
             $scope.propertiesNotFiltered = $scope.propertiesObj.items;
+
+            $scope.showInfoPanel = true;
+            $scope.showNodeInfo = true;
+            if (panelWasAlreadyOpen) {
+                // ui-scroll doesn't re-init automatically when panel stays open
+                $timeout(() => $scope.adapterContainer.adapter.reload(), 500);
+            }
         }, function(response) {
             toastr.warning(getError(response.data), "Error");
         });

--- a/packages/legacy-workbench/src/js/angular/ttyg/templates/chat-item-detail.html
+++ b/packages/legacy-workbench/src/js/angular/ttyg/templates/chat-item-detail.html
@@ -5,7 +5,8 @@
         <div class="question alert-help"
              gdb-tooltip="{{ 'ttyg.chat_panel.labels.question_asked' | translate : { date: getHumanReadableQuestionTimestamp(chatItemDetail.question.timestamp), time: (chatItemDetail.question.timestamp | date:'HH:mm') } }}">
             <markdown-content class="question-text"
-                              content="{{chatItemDetail.question.message}}"></markdown-content>
+                              content="{{chatItemDetail.question.message}}"
+                              trusted="true"></markdown-content>
         </div>
     </div>
     <div class="answers" ng-repeat="answer in chatItemDetail.answers">
@@ -15,7 +16,10 @@
                 <i class="ri-lg ri-robot-2-line"></i>
             </div>
             <div class="assistant-message" ng-if="answer.status !== 'completed'">
-                <markdown-content class="answer" ng-class="{'italic': answer.isTerminalState}" content="{{answer.message}}" options="markdownContentOptions"></markdown-content>
+                <markdown-content class="answer"
+                                  ng-class="{'italic': answer.isTerminalState}"
+                                  content="{{answer.message}}"
+                                  options="markdownContentOptions" trusted="true"></markdown-content>
                 <div class="actions" ng-class="{'hidden-actions': !explainResponseModel[answer.id].expanded && (!showActions || !$last)}">
                     <button class="btn btn-link btn-sm regenerate-question-btn"
                             ng-click="regenerateQuestion()"

--- a/packages/legacy-workbench/src/pages/graphs-visualizations.html
+++ b/packages/legacy-workbench/src/pages/graphs-visualizations.html
@@ -541,7 +541,8 @@
                         <div class="item clearfix break-word-alt small">{{item.key}}</div>
                         <div class="data-value">
                             <a ng-if="item.value[0].t === 'i'" href="#" ng-click="openIRI(item.value[0].v, $event)" ng-bind="item.value[0].v"></a>
-                            <span ng-if="item.value[0].t !== 'i'" ng-bind="item.value[0].v"></span>
+                            <span ng-if="item.value[0].t !== 'i' && !isMarkdownLiteral(item.value[0].t)" ng-bind="item.value[0].v"></span>
+                            <markdown-content ng-if="::isMarkdownLiteral(item.value[0].t)" content="{{::item.value[0].v}}"></markdown-content>
                             <span class="language-tag" ng-if="item.value[0].t !== 'lt:http://www.w3.org/2001/XMLSchema#string'" ng-bind="replaceIRIWithPrefix(getLiteralFromPropValue(item.value[0].t))"></span>
                             <button class="btn btn-link btn-sm" type="button"
                                     ng-if="item.value.length > 1"
@@ -555,7 +556,8 @@
                                   ng-repeat="value in item.value track by $index"
                                   ng-hide="$index == 0">
                                 <a ng-if="value.t === 'i'" href="#" ng-click="openIRI(value.v, $event)" ng-bind="value.v"></a>
-                                <span ng-if="value.t !== 'i'" ng-bind="value.v"></span>
+                                <span ng-if="value.t !== 'i' && !isMarkdownLiteral(value.t)" ng-bind="value.v"></span>
+                                <markdown-content ng-if="::isMarkdownLiteral(value.t)" content="{{::value.v}}"></markdown-content>
                                 <span class="language-tag" ng-if="value.t !== 'lt:http://www.w3.org/2001/XMLSchema#string'" ng-bind="replaceIRIWithPrefix(getLiteralFromPropValue(value.t))"></span>
 							</li>
                         </ul>


### PR DESCRIPTION
## What
Support rendering markdown for markdown typed literals in the node info sidebar.

## Why
This is extending the support of different literal types.

## How
* Included the markdown-content directive in the graphs visualization view and using it for rendering literals with datatypes
```
http://www.ontotext.com/proton/protonsys#Markdown
http://ns.ontowiki.net/SysOnt/Markdown
https://www.w3.org/ns/iana/media-types/text/markdown#Resource
http://www.w3.org/ns/iana/media-types/text/markdown#Resource
```

* Optimized the markdown-content directive to prevent extra reinitialization when the content didn't change.
Also using one-time binding for the content and ng-if in the markdown-content directive declaration because the data used is static and doesn't change.
* Eliminate flickering of markdown-content directive in graph node info panel. The node info side panel was causing the markdown-content directive to rerender 4 times when a graph node was selected resulting in visible flickering.


## Testing
Insert data with query like this
```
PREFIX ex: <http://example.org/>
PREFIX sysont: <http://www.ontotext.com/proton/protonsys#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

INSERT DATA {
    ex:MyNode a ex:Thing ;
        rdfs:label "My Node" ;
        ex:description "# My Node\n\nThis is a **Markdown** literal.\n\n- item 1\n- item 2"^^sysont:Markdown .
}
```
and browse the visual graph for the `MyNode`

## Screenshots
<img width="1663" height="576" alt="image" src="https://github.com/user-attachments/assets/3a301233-0cd5-463d-925b-41738eb7741e" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
