### PR TITLE
GDB-14481 fix edit agent failing test

### DIFF
--- a/e2e-tests/e2e-legacy/guides/ttyg/configure-agent/configure-agent-guide.spec.js
+++ b/e2e-tests/e2e-legacy/guides/ttyg/configure-agent/configure-agent-guide.spec.js
@@ -137,6 +137,7 @@ describe('ttyg configure agent guide', () => {
 
         GuideDialogSteps.assertDialogWithTitleIsVisible('Talk to Your Graph — 27/30');
         GuideDialogSteps.assertDialogWithContentIsVisible('Set Context Size to 4096 so the model can use the ontology and conversation history to answer correctly');
+        TtygAgentSettingsModalSteps.getContextSizeField().focus();
         TtygAgentSettingsModalSteps.clearContextSize();
         TtygAgentSettingsModalSteps.enterContextSize(4096);
         GuideDialogSteps.clickOnNextButton();

--- a/e2e-tests/steps/ttyg/ttyg-agent-settings-modal.steps.js
+++ b/e2e-tests/steps/ttyg/ttyg-agent-settings-modal.steps.js
@@ -425,7 +425,7 @@ export class TtygAgentSettingsModalSteps extends ModalDialogSteps {
     }
 
     static clearContextSize() {
-        return this.getContextSizeField().focus().clear();
+        return this.getContextSizeField().clear();
     }
 
     static enterContextSize(input) {


### PR DESCRIPTION
## What
Fix the edit agent spec

## Why
It was broken due to a previous change in a reused step

## How
Reverted the change in `clearContextSize` and added manual focus only for the configuration guide spec, since the clear isn't working there

## Testing
cypress

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified
