### PR TITLE
GDB-14476 override the focus style coming from bootstrap targeting webkit engines

### DIFF
--- a/packages/root-config/src/styles/partials/anchor/_anchor.scss
+++ b/packages/root-config/src/styles/partials/anchor/_anchor.scss
@@ -9,4 +9,12 @@ a {
     text-decoration-thickness: var(--link-decoration-thickness) !important;
     text-underline-offset: var(--link-underline-offset) !important;
   }
+  // override the focus style coming from bootstrap targeting webkit engines
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+  &:focus-visible {
+    outline: 2px solid var(--gw-focus-ring-color);
+    outline-offset: 2px;
+  }
 }


### PR DESCRIPTION
## What
Override the focus style coming from bootstrap targeting webkit engines.

## Why
The focus wasn't working in webkit until latest revision and a style applying some outline coming from bootstrap got applied unexpectedly.

## How
Overridden the focus style for anchors to remove the unexpected outline.

## Testing


## Screenshots
<img width="431" height="178" alt="image" src="https://github.com/user-attachments/assets/e16411ba-ac5e-4541-8467-0f9531bf0e8b" />
<img width="410" height="171" alt="image" src="https://github.com/user-attachments/assets/9063ff8e-6c08-494e-8a3f-84f86b3aa441" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
