### PR TITLE
GDB-14505 add 'OTHER' type to repository type enum

### DIFF
--- a/packages/api/src/models/repositories/repository-type.ts
+++ b/packages/api/src/models/repositories/repository-type.ts
@@ -2,5 +2,6 @@ export enum RepositoryType {
   GRAPH_DB = 'graphdb',
   ONTOP = 'ontop',
   FEDX = 'fedx',
-  SYSTEM = 'system'
+  SYSTEM = 'system',
+  OTHER = 'other'
 }


### PR DESCRIPTION
## What
Add `other` type to RepositoryType enum.

## Why
Graphdb seems to default to `other` for repository type when it can't resolve amongst the known types like graphdb, ontop and fedex and UI is expecting one of those exactly plus system.
The impact is currently mainly for some already migrated parts of the WB that are outside of the views. For example, the repository selector. The repository rlated pages might still fetch repositories from the old services that are not typed and the `other` type goes unnoticed.

## How
Add the `other` type to prevent errors if GDB defaults the type for some reason.

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
