### PR TITLE
GDB-14342 add warning for fedex repository on ACL page

### DIFF
--- a/e2e-tests/e2e-legacy/setup/aclmanagement/acl-management-with-selected repository.spec.js
+++ b/e2e-tests/e2e-legacy/setup/aclmanagement/acl-management-with-selected repository.spec.js
@@ -1,6 +1,8 @@
 import HomeSteps from "../../../steps/home-steps";
 import {MainMenuSteps} from "../../../steps/main-menu-steps";
 import {AclManagementSteps} from "../../../steps/setup/acl-management-steps";
+import {RepositorySteps} from '../../../steps/repository-steps.js';
+import {RepositorySelectorSteps} from '../../../steps/repository-selector-steps.js';
 
 function verifyStateWithSelectedRepository() {
     AclManagementSteps.getPageHeading().should('be.visible');
@@ -12,15 +14,18 @@ function verifyStateWithSelectedRepository() {
 
 describe('ACL Management initial state with repositories', () => {
     let repositoryId;
+    let fedexRepositoryId;
 
     beforeEach(() => {
         repositoryId = 'acl-management-' + Date.now();
+        fedexRepositoryId = 'fedex-repo-' + Date.now();
         cy.createRepository({id: repositoryId});
         cy.presetRepository(repositoryId);
     });
 
     afterEach(() => {
         cy.deleteRepository(repositoryId);
+        cy.deleteRepository(fedexRepositoryId);
     });
 
     it('Should display the correct initial state when navigating via URL', () => {
@@ -37,4 +42,43 @@ describe('ACL Management initial state with repositories', () => {
         // Then,
         verifyStateWithSelectedRepository();
     });
+
+    it('should prevent ACL management with FedEx repository', () => {
+        // Given I have created a Fedex repository
+        createFedexRepository(repositoryId, fedexRepositoryId);
+        // When I select the fedex repository
+        RepositorySelectorSteps.selectRepository(fedexRepositoryId);
+        RepositorySelectorSteps.getSelectedRepository().should('contain', fedexRepositoryId);
+        RepositorySteps.getActiveRepositoryRow().should('contain', fedexRepositoryId);
+        // And I navigate to ACL management page
+        MainMenuSteps.clickOnACLManagement();
+        // Then I should see the warning message about Fedex repository
+        AclManagementSteps.getFedexWarningMessage().should('be.visible');
+        AclManagementSteps.getAclManagementContent().should('not.exist');
+        // When I switch to graphdb repository
+        RepositorySelectorSteps.selectRepository(repositoryId);
+        // Then the warning message should be hidden
+        AclManagementSteps.getFedexWarningMessage().should('not.exist');
+        AclManagementSteps.getAclManagementContent().should('be.visible');
+        // When I select a fedex repository
+        RepositorySelectorSteps.selectRepository(fedexRepositoryId);
+        // Then the fedex warning should become visible
+        AclManagementSteps.getFedexWarningMessage().should('be.visible');
+        AclManagementSteps.getAclManagementContent().should('not.exist');
+        // Go to home page before end to prevent error when delete the repository happens
+        HomeSteps.visit();
+    });
 })
+
+function createFedexRepository(repositoryId, fedexRepositoryId) {
+    RepositorySteps.visit();
+    RepositorySteps.getCreateRepositoryButton().click();
+    RepositorySteps.createFedexRepositoryType();
+    cy.url().should('include', '/repository/create/fedx');
+    RepositorySteps.typeRepositoryId(fedexRepositoryId);
+    RepositorySteps.selectFedexMember(repositoryId);
+    RepositorySteps.saveRepository();
+    RepositorySteps.getRepositoriesPage().should('be.visible');
+    RepositorySteps.getRepositoryFromList(fedexRepositoryId)
+        .should('be.visible');
+}

--- a/e2e-tests/steps/repository-steps.js
+++ b/e2e-tests/steps/repository-steps.js
@@ -16,6 +16,14 @@ export class RepositorySteps extends BaseSteps {
         cy.visit(`repository/edit/${repositoryId}?location=`);
     }
 
+    static getRepositoryPage() {
+        return cy.get('#wb-repository');
+    }
+
+    static getRepositoriesPage() {
+        return cy.get('#wb-repositories');
+    }
+
     static getCreateRepositoryButton() {
         return cy.get('#wb-repositories-addRepositoryLink');
     }
@@ -133,6 +141,10 @@ export class RepositorySteps extends BaseSteps {
 
     static chooseRepositoryType(type) {
         RepositorySteps.getRepositoryTypeButton(type).click();
+    }
+
+    static createFedexRepositoryType() {
+        RepositorySteps.chooseRepositoryType('fedx');
     }
 
     static getGDBRepositoryTypeButton() {
@@ -353,5 +365,17 @@ export class RepositorySteps extends BaseSteps {
 
     static getEntityIndexSize() {
         return RepositorySteps.getRepositoryCreateForm().find('#entityIndexSize');
+    }
+
+    static getFedexMembersPanel() {
+        return this.getRepositoryPage().find('#fedx-members');
+    }
+
+    static selectFedexMember(repositoryId) {
+        this.getFedexMembersPanel()
+            .find('.form-local-repos')
+            .find('.location-item')
+            .contains(repositoryId)
+            .click();
     }
 }

--- a/e2e-tests/steps/setup/acl-management-steps.js
+++ b/e2e-tests/steps/setup/acl-management-steps.js
@@ -11,6 +11,18 @@ export class AclManagementSteps {
         return this.getPage().find('#acl-management-view-title');
     }
 
+    static getFedexWarningMessage() {
+        return this.getPage().find('.unexpected-fedex-repository-warning');
+    }
+
+    static getAclManagementContainer() {
+        return this.getPage().find('.acl-management-container');
+    }
+
+    static getAclManagementContent() {
+        return this.getPage().find('.acl-management-content');
+    }
+
     static getAclTable() {
         return this.getPage().find('.acl-rules');
     }

--- a/packages/legacy-workbench/src/css/aclmanagement.css
+++ b/packages/legacy-workbench/src/css/aclmanagement.css
@@ -10,7 +10,7 @@ html, body {
 
 .acl-management-view,
 .acl-management-view .acl-management-container,
-.acl-management-view .acl-management-container .acl-scope-tabs {
+.acl-management-view .acl-management-content .acl-scope-tabs {
     height: 100%;
 }
 

--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -277,6 +277,9 @@
             "duplicated_rules": "Every ACL rule should be unique.",
             "role_length_too_short": "Too short or not \"*\""
         },
+        "warnings": {
+            "unexpected_fedex_repository": "ACL rules cannot be loaded. Change the repository to a non-FedX repository and try again."
+        },
         "defaults": {
             "asterisk": "* - Any RDF value",
             "default": "default - The default graph",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -276,6 +276,9 @@
             "duplicated_rules": "Chaque règle ACL doit être unique.",
             "role_length_too_short": "Trop court ou pas \"*\""
         },
+        "warnings": {
+            "unexpected_fedex_repository": "Impossible de charger les règles ACL. Veuillez changer de référentiel et réessayer."
+        },
         "defaults": {
             "asterisk": "* - Toute valeur RDF",
             "default": "default - Le graphique par défaut",

--- a/packages/legacy-workbench/src/js/angular/aclmanagement/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/aclmanagement/controllers.js
@@ -143,6 +143,14 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
     // When the user clicks outside the input, this flag is used to signal that the CUSTOM_ prefix warning icon should appear and the warning text should disappear
     $scope.hasCustomPrefix = false;
 
+    /**
+     * Flag indicating that the currently selected repository is a Fedex repository, which is not expected in this view,
+     * because ACL is not supported for Fedex repositories. This flag is used to show a warning message and hide the ACL
+     * management UI.
+     * @type {boolean}
+     */
+    $scope.unexpectedFedexRepository = false;
+
     //
     // Public functions
     //
@@ -400,6 +408,7 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
         $scope.editedRuleScope = undefined;
         $scope.modelIsDirty = false;
         $scope.editedRuleCopy = undefined;
+        $scope.unexpectedFedexRepository = false;
         $scope.dirtyScope.clear();
     };
 
@@ -489,6 +498,12 @@ function AclManagementCtrl($scope, $location, toastr, AclManagementRestService, 
 
     const repositoryChangedHandler = () => {
         resetPageState();
+        const selectedRepository = repositoryContextService.getSelectedRepository();
+        // ACL expects non-Fedex repository
+        if (selectedRepository?.isFedx()) {
+            $scope.unexpectedFedexRepository = true;
+            return;
+        }
         loadRules();
     };
 

--- a/packages/legacy-workbench/src/pages/aclmanagement.html
+++ b/packages/legacy-workbench/src/pages/aclmanagement.html
@@ -9,7 +9,11 @@
     <div core-errors></div>
 
     <div class="acl-management-container" ng-if="getActiveRepository()">
-        <div class="acl-management-container">
+        <div ng-if="unexpectedFedexRepository" class="warnings unexpected-fedex-repository-warning">
+            <div class="alert alert-warning">{{'acl_management.warnings.unexpected_fedex_repository' | translate}}</div>
+        </div>
+
+        <div ng-if="!unexpectedFedexRepository" class="acl-management-content">
             <div class="pull-right">
                 <button ng-click="addRule(activeTabScope, 0)" ng-disabled="editedRuleIndex !== undefined"
                         class="btn btn-primary add-first-rule-btn"


### PR DESCRIPTION
## What
Add warning message for fedex repository restriction on the ACL management page.

## Why
ACL view can't function with Fedex repositories and the page looks odd when the active repository is of fedex type.

## How
Add warning message and hide the page content when the selected repository is fedex type.

## Testing
Implemented tests

## Screenshots
<img width="2556" height="824" alt="image" src="https://github.com/user-attachments/assets/86780908-3498-4573-b230-3b5271f9c30a" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
