### PR TITLE
GDB-14513 fix popover position on save and cancel button in visual graph

### DIFF
--- a/packages/legacy-workbench/src/css/graphs-config.css
+++ b/packages/legacy-workbench/src/css/graphs-config.css
@@ -124,3 +124,8 @@ yasgui-component .CodeMirror {
         height: 100%;
     }
 }
+
+.config-action-popover {
+    /* These popovers are a bit off vertically and nothing else really helped position them properly */
+    margin-top: -30px !important;
+}

--- a/packages/legacy-workbench/src/pages/graph-config/saveGraphConfig.html
+++ b/packages/legacy-workbench/src/pages/graph-config/saveGraphConfig.html
@@ -276,8 +276,8 @@
     </div>
 </div>
 
-<div class="m-0 clearfix" style="padding-bottom: 2rem">
-    <div class="pull-left">
+<div class="m-0 d-flex justify-content-between align-items-start">
+    <div>
         <button href ng-show="page > 1" ng-click="goToPreviousPage()" class="btn btn-lg btn-secondary btn-previous-page"
                 uib-popover="{{'previous.config.step' | translate}}"
                 popover-placement="top"
@@ -310,9 +310,10 @@
             {{'revert.changes.btn' | translate}}
         </button>
     </div>
-    <div class="pull-right">
+    <div>
         <a ng-href="graphs-visualizations/" class="btn btn-lg btn-secondary btn-cancel-save-config"
            uib-popover="{{'closes.config.no.save' | translate}}"
+           popover-class="config-action-popover"
            popover-placement="top"
            popover-trigger="mouseenter">
             {{'common.cancel.btn' | translate}}
@@ -320,6 +321,7 @@
         <a href ng-click="saveGraphConfig()" class="btn btn-lg btn-primary btn-save-config"
            uib-popover="{{'closes.config.save' | translate}}"
            guide-selector="save-graph-config"
+           popover-class="config-action-popover"
            popover-placement="top"
            popover-trigger="mouseenter">
             {{'common.save.btn' | translate}}


### PR DESCRIPTION
## What
Fix popover position on save and cancel button in visual graph.

## Why
These buttons appear a bit off vertically for unknown reason.

## How
Added class and applied negative margin to position them properly.

## Testing


## Screenshots
<img width="602" height="300" alt="image" src="https://github.com/user-attachments/assets/0ce03ab8-8ec6-4a2c-9b95-4abe748ab2f2" />

<img width="589" height="305" alt="image" src="https://github.com/user-attachments/assets/818feda9-44d0-4743-9f04-4c7730964c9d" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
