### PR TITLE
GDB-13785 Warn about remote active repository on graphql endpoint management page

### DIFF
--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -1329,6 +1329,9 @@
                     "title": "Confirm source repository change",
                     "body": "Changing the source repository may affect your current setup and data. Are you sure you want to proceed?"
                 }
+            },
+            "warnings": {
+                "unexpected_remote_repository": "The active repository is located at a different remote location. Please select a repository from the current location."
             }
         }
     },

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -1328,6 +1328,9 @@
                     "title": "Confirmer le changement de référentiel source",
                     "body": "La modification du référentiel source peut affecter votre configuration et vos données actuelles. Êtes-vous sûr de vouloir continuer?"
                 }
+            },
+            "warnings": {
+                "unexpected_remote_repository": "Le dépôt actif se trouve sur un autre emplacement distant. Veuillez sélectionner un dépôt à l'emplacement actuel."
             }
         }
     },

--- a/packages/legacy-workbench/src/js/angular/graphql/controllers/create-graphql-endpoint-view.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphql/controllers/create-graphql-endpoint-view.controller.js
@@ -12,6 +12,7 @@ import 'angular/graphql/directives/configure-endpoint.directive';
 import 'angular/graphql/directives/generate-endpoint.directive';
 import {GraphqlEventName} from "../services/graphql-context.service";
 import {resolvePlaygroundUrlWithEndpoint} from "../services/endpoint-utils";
+import {RepositoryContextService, service} from '@ontotext/workbench-api';
 
 const modules = [
     'graphdb.framework.core.services.graphql-service',
@@ -31,6 +32,8 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
     // =========================
     // Private variables
     // =========================
+
+    const repositoryContextService = service(RepositoryContextService);
 
     const subscriptions = [];
 
@@ -75,6 +78,12 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
      * @type {boolean}
      */
     $scope.generatingEndpoint = false;
+
+    /**
+     * A flag indicating if the selected source repository is local. This allows to show a warning message in the UI.
+     * @type {boolean}
+     */
+    $scope.isSelectedRepositoryLocal = false;
 
     // =========================
     // Public methods
@@ -277,11 +286,15 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
         $scope.sourceRepositories = $repositories.getRepositoriesAsSelectMenuOptions(
             () => $repositories.getLocalReadableGraphdbRepositories(),
         );
-        const activeRepository = $repositories.getActiveRepository();
-        $scope.selectedSourceRepository = $scope.sourceRepositories
-            .find((repo) => repo.value === activeRepository);
-        GraphqlContextService.updateSourceRepository($scope.selectedSourceRepository.value);
-        $scope.previousSelectedSourceRepository = $scope.selectedSourceRepository;
+        const activeRepository = repositoryContextService.getSelectedRepository();
+        $scope.isSelectedRepositoryLocal = !!activeRepository?.local;
+        // Graphql endpoints can't be created on remote repositories.
+        if ($scope.isSelectedRepositoryLocal) {
+            $scope.selectedSourceRepository = $scope.sourceRepositories
+                .find((repo) => repo.value === activeRepository.id);
+            GraphqlContextService.updateSourceRepository($scope.selectedSourceRepository.value);
+            $scope.previousSelectedSourceRepository = $scope.selectedSourceRepository;
+        }
     };
 
     /**

--- a/packages/legacy-workbench/src/js/angular/graphql/templates/create-graphql-endpoint.html
+++ b/packages/legacy-workbench/src/js/angular/graphql/templates/create-graphql-endpoint.html
@@ -10,6 +10,9 @@
     <div class="core-errors-container" core-errors write></div>
 
     <div class="create-graphql-endpoint-container">
+        <div ng-if="!isSelectedRepositoryLocal" class="warnings unexpected-remote-repository-warning">
+            <div class="alert alert-warning">{{'graphql.create_endpoint.warnings.unexpected_remote_repository' | translate}}</div>
+        </div>
 
         <div class="content" ng-if="selectedSourceRepository">
             <div class="toolbar">


### PR DESCRIPTION
## What
Warn the user about remote active repository on graphql endpoint management page.

## Why
Graphql endpoints can't be created on remote locations and there is an error when the create endpoint page is opened.

## How
Add warning that the selected repository is on remote location and hide the page content.

## Testing


## Screenshots
<img width="1771" height="958" alt="image" src="https://github.com/user-attachments/assets/c30d1e5f-63d8-410e-b498-55317af63765" />

<img width="1954" height="620" alt="image" src="https://github.com/user-attachments/assets/d4bbb527-c607-401f-9b5d-01ce6e4dd640" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
