### PR TITLE
GDB-14496: Add fullscreen button configuration for YASR

### DIFF
--- a/packages/legacy-workbench/src/js/angular/explore/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/explore/controllers.js
@@ -344,6 +344,7 @@ function ExploreCtrl(
             showEditorTabs: false,
             showToolbar: false,
             showResultTabs: false,
+            showFullscreenButton: false,
             showResultInfo: true,
             downloadAsOn: false,
             showQueryButton: false,

--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-config.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-config.controller.js
@@ -506,6 +506,7 @@ function GraphConfigCtrl(
         showEditorTabs: false,
         showToolbar: false,
         showResultTabs: false,
+        showFullscreenButton: false,
         showYasqeActionButtons: false,
         yasqeActionButtons: INFERRED_AND_SAME_AS_BUTTONS_CONFIGURATION,
         showQueryButton: false,

--- a/packages/legacy-workbench/src/js/angular/jdbc/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/jdbc/controllers.js
@@ -373,6 +373,7 @@ function JdbcCreateCtrl(
             showEditorTabs: false,
             showToolbar: false,
             showResultTabs: false,
+            showFullscreenButton: false,
             showQueryButton: false,
             showResultInfo: false,
             downloadAsOn: false,

--- a/packages/legacy-workbench/src/js/angular/models/ontotext-yasgui/ontotext-yasgui-config.js
+++ b/packages/legacy-workbench/src/js/angular/models/ontotext-yasgui/ontotext-yasgui-config.js
@@ -39,6 +39,11 @@ export class OntotextYasguiConfig {
         this.showResultTabs = true;
 
         /**
+         * Flag that controls whether the button for toggling fullscreen mode in YASR should be displayed. By default, it is set to true.
+         */
+        this.showFullscreenButton = true;
+
+        /**
          * If the result information header of YASR should be rendered or not.
          *
          * @type {boolean}

--- a/packages/legacy-workbench/src/js/angular/similarity/controllers/create-index.controller.js
+++ b/packages/legacy-workbench/src/js/angular/similarity/controllers/create-index.controller.js
@@ -556,6 +556,7 @@ function CreateSimilarityIdxCtrl(
             showEditorTabs: false,
             showToolbar: false,
             showResultTabs: false,
+            showFullscreenButton: false,
             showYasqeActionButtons: false,
             showQueryButton: false,
             downloadAsOn: false,

--- a/packages/legacy-workbench/src/js/angular/similarity/controllers/similarity-list.controller.js
+++ b/packages/legacy-workbench/src/js/angular/similarity/controllers/similarity-list.controller.js
@@ -449,6 +449,7 @@ function SimilarityCtrl(
             showEditorTabs: false,
             showToolbar: false,
             showResultTabs: false,
+            showFullscreenButton: false,
             showQueryButton: false,
             downloadAsOn: false,
             showResultInfo: false,

--- a/packages/legacy-workbench/src/js/angular/sparql-template/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/sparql-template/controllers.js
@@ -219,6 +219,7 @@ function SparqlTemplateCreateCtrl(
             showEditorTabs: false,
             showToolbar: false,
             showResultTabs: false,
+            showFullscreenButton: false,
             showYasqeActionButtons: false,
             showYasqeResizer: false,
             yasqeActionButtons: DISABLE_YASQE_BUTTONS_CONFIGURATION,

--- a/packages/workbench/src/app/components/yasgui-component-facade/models/yasgui/ontotext-yasgui-config.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/models/yasgui/ontotext-yasgui-config.ts
@@ -35,6 +35,11 @@ export class OntotextYasguiConfig {
    * If the yasr tabs should be rendered or not.
    */
   public showResultTabs: boolean;
+
+  /**
+   * Flag that controls whether the button for toggling fullscreen mode in YASR should be displayed. By default, it is set to true.
+   */
+  public showFullscreenButton: boolean;
   /**
    * If the result information header of YASR should be rendered or not.
    */
@@ -258,6 +263,7 @@ export class OntotextYasguiConfig {
     this.orientation = YasguiOrientation.VERTICAL;
     this.showEditorTabs = true;
     this.showResultTabs = true;
+    this.showFullscreenButton = true;
     this.showResultInfo = true;
     this.showToolbar = true;
     this.showControlBar = false;


### PR DESCRIPTION
## What
Added a configuration option to control the visibility of the fullscreen button in YASR.

## Why
This enhancement allows users to toggle fullscreen mode, improving the user experience by providing more control over the interface.

## How
- Introduced `showFullscreenButton` property in `ontotext-yasgui-config.js` and `ontotext-yasgui-config.ts`.
- Updated default values for `showFullscreenButton` in relevant controllers to ensure consistent behavior.
- Added documentation comments for clarity on the new configuration option.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified
