### PR TITLE
GDB-14454 improve google chart table rendering

### DIFF
--- a/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
+++ b/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
@@ -626,6 +626,10 @@ yasgui-component .yasr .extended-boolean-plugin .response-success {
 }
 
 yasgui-component .yasr .google-visualization-table-table {
+    /* Override google chart's fixed inline height and apply with max-height constraint to prevent stretching the table
+    when there are few results but still maintain the scrollable table behavior for more results. */
+    height: auto !important;
+    max-height: 600px !important;
     color: var(--gw-datatable-row-color) !important;
     background: var(--gw-datatable-row-background) !important;
     border-color: var(--gw-datatable-border-color) !important;


### PR DESCRIPTION
## What
Improve google chart table rendering.

## Why
When the query returns one or fewer results, then the chart table is stretched to 600px in height because the plugin  applies it inline.

## How
Override the height to allow the table to layout itself properly and apply max-height to preserve the existing scrollable behavior. 

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
