### PR TITLE
GDB-14470 change the style of the outofsync links between nodes in cluster view

### DIFF
--- a/e2e-tests/e2e-legacy/cluster/cluster-states.spec.js
+++ b/e2e-tests/e2e-legacy/cluster/cluster-states.spec.js
@@ -104,14 +104,14 @@ describe('Cluster states', () => {
         ClusterViewSteps.getLink('pc-desktop-7300-pc-desktop-7302').should('have.css', 'stroke-dasharray', '10px, 10px')
             .and('have.css', 'marker-mid', 'url("#arrowhead_big")')
             .invoke('attr', 'stroke')
-            .should('eq', 'var(--gw-secondary-base)');
+            .should('eq', 'var(--gw-foreground-on-surface-primary)');
         // And I expect an out of sync link between the leader and the out of sync node (the one receiving the snapshot)
         ClusterViewSteps.getLink('pc-desktop-7301-pc-desktop-7300').should('have.css', 'stroke-dasharray', '10px, 10px')
             .invoke('attr', 'stroke')
-            .should('eq', 'var(--gw-neutral-base)');
+            .should('eq', 'var(--gw-neutral-light)');
         // And I expect to have an in sync link between the leader and the node sending the snapshot
         ClusterViewSteps.getLink('pc-desktop-7301-pc-desktop-7302').should('have.css', 'stroke-dasharray', 'none')
             .invoke('attr', 'stroke')
-            .should('eq', 'var(--gw-secondary-base)');
+            .should('eq', 'var(--gw-foreground-on-surface-primary)');
     });
 });

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-graphical-view.directive.js
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-graphical-view.directive.js
@@ -40,29 +40,28 @@ const translationsMap = {
         applying_snapshot: "Applying a snapshot",
         building_snapshot: "Building a snapshot for node",
         sending_snapshot: "Sending a snapshot to node",
-        recovery_operation_failure_warning: "Node unable to recover. Action required"
-    }
+        recovery_operation_failure_warning: "Node unable to recover. Action required",
+    },
 };
 
 const idTranslationKeyMap = {
     node_state: 'legend_node_state',
-    link_state: 'legend_link_state'
+    link_state: 'legend_link_state',
 };
 
 const clusterManagementDirectives = angular.module('graphdb.framework.clustermanagement.directives.cluster-graphical-view', [
     'graphdb.framework.utils.localstorageadapter',
-    'graphdb.framework.clustermanagement.directives.cluster-legend'
+    'graphdb.framework.clustermanagement.directives.cluster-legend',
 ]);
 
 clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'LocalStorageAdapter', 'LSKeys', 'UriUtils', '$translate', '$jwtAuth', '$rootScope', 'ClusterViewContextService',
-    function ($window, LocalStorageAdapter, LSKeys, UriUtils, $translate, $jwtAuth, $rootScope, ClusterViewContextService) {
+    function($window, LocalStorageAdapter, LSKeys, UriUtils, $translate, $jwtAuth, $rootScope, ClusterViewContextService) {
         return {
             restrict: 'E',
             scope: {
-                clusterModel: '='
+                clusterModel: '=',
             },
-            link: function (scope, element) {
-
+            link: function(scope, element) {
                 // =========================
                 // Private variables
                 // =========================
@@ -91,11 +90,11 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
                 // Public functions
                 // =========================
 
-                scope.width = function () {
+                scope.width = function() {
                     return width;
                 };
 
-                scope.height = function () {
+                scope.height = function() {
                     return height;
                 };
 
@@ -262,12 +261,12 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
                     w.bind('resize', resize);
                     w.bind('mousedown', mousedownHandler);
 
-                    subscriptions.push($rootScope.$on('$translateChangeSuccess', function () {
+                    subscriptions.push($rootScope.$on('$translateChangeSuccess', function() {
                         updateTranslations(translationsMap);
                         updateLabels();
                     }));
 
-                    subscriptions.push(scope.$on(MODEL_UPDATED, function () {
+                    subscriptions.push(scope.$on(MODEL_UPDATED, function() {
                         plot();
                     }));
                 };
@@ -276,7 +275,7 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
                     subscriptions.forEach((subscription) => subscription());
                 };
 
-                scope.$on("$destroy", function () {
+                scope.$on("$destroy", function() {
                     w.unbind('resize', resize);
                     w.unbind('mousedown', mousedownHandler);
                     CDS.removeEventListeners();
@@ -296,7 +295,7 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
                     plot();
                 }
                 initialize();
-            }
+            },
         };
-    }
+    },
 ]);

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-graphical-view.directive.js
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-graphical-view.directive.js
@@ -196,6 +196,7 @@ clusterManagementDirectives.directive('clusterGraphicalView', ['$window', 'Local
                     const linksData = linksGroup.selectAll('.link').data(links, (link) => link.id);
                     CDS.createLinks(linksData);
                     CDS.updateLinks(linksData, nodes);
+                    CDS.updateLinkIcons(linksGroup, links, nodes);
                 }
 
                 function resizeClusterComponent() {

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-legend.directive.js
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-legend.directive.js
@@ -17,7 +17,6 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
         templateUrl: 'js/angular/clustermanagement/templates/cluster-legend.html',
         scope: {},
         link: ($scope) => {
-
             // =========================
             // Public variables
             // =========================
@@ -66,7 +65,7 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
                 CDS.updateNodes(legendNodesElements);
                 const LABEL_Y_POSITION = 3;
                 legendNodesElements
-                    .attr('transform', function (d, i) {
+                    .attr('transform', function(d, i) {
                         updateLegendDimensions();
                         return `translate(${CLUSTER_MANAGEMENT_CONSTANTS.LEGEND_ITEM_PADDING_LEFT}, ${legendHeight + CLUSTER_MANAGEMENT_CONSTANTS.LEGEND_ITEM_PADDING_TOP})`;
                     })
@@ -75,7 +74,8 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
                     .style('font-weight', CLUSTER_MANAGEMENT_CONSTANTS.LEGEND_ITEM_FONT_WEIGHT)
                     .attr('x', CLUSTER_MANAGEMENT_CONSTANTS.PADDING_LEFT + CLUSTER_MANAGEMENT_CONSTANTS.SVG_NODE_WIDTH)
                     .attr('y', LABEL_Y_POSITION)
-                    .text(function (d) {
+                    .text(function(d) {
+                        // eslint-disable-next-line no-invalid-this
                         return translateAndSubscribe(this, 'cluster_management.cluster_graphical_view.' + d.customText);
                     });
             };
@@ -94,12 +94,12 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
                     .append('text')
                     .attr('class', (d) => `sync-status ${d.classes}`)
                     .attr('x', CLUSTER_MANAGEMENT_CONSTANTS.LEGEND_ITEM_PADDING_LEFT - 10)
-                    .attr('y', function (d, index) {
+                    .attr('y', function(d, index) {
                         const rowTop = index * (20 + CLUSTER_MANAGEMENT_CONSTANTS.LEGEND_ITEM_PADDING_TOP) + legendHeight + CLUSTER_MANAGEMENT_CONSTANTS.LEGEND_ITEMS_PADDING_TOP;
                         rowY.set(index, rowTop);
                         return rowTop;
                     })
-                    .text(function (d) {
+                    .text(function(d) {
                         return d.icon;
                     });
 
@@ -107,11 +107,12 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
                 syncStatusesGroups
                     .append('text')
                     .style('font-weight', CLUSTER_MANAGEMENT_CONSTANTS.LEGEND_ITEM_FONT_WEIGHT)
-                    .text(function (d) {
+                    .text(function(d) {
+                        // eslint-disable-next-line no-invalid-this
                         return translateAndSubscribe(this, 'cluster_management.cluster_graphical_view.' + d.labelKey);
                     })
                     .attr('x', CLUSTER_MANAGEMENT_CONSTANTS.LEGEND_ITEM_PADDING_LEFT + CLUSTER_MANAGEMENT_CONSTANTS.LEGEND_ITEM_FONT_SIZE)
-                    .attr('y', function (d, index) {
+                    .attr('y', function(d, index) {
                         return rowY.get(index) - labelOffsetY;
                     })
                     .classed('links-statuses', true);
@@ -155,11 +156,12 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
                     .style('font-size', CLUSTER_MANAGEMENT_CONSTANTS.LEGEND_ITEM_FONT_SIZE)
                     .style('line-height', CLUSTER_MANAGEMENT_CONSTANTS.LEGEND_ITEM_LINE_HEIGHT)
                     .style('font-weight', CLUSTER_MANAGEMENT_CONSTANTS.LEGEND_ITEM_FONT_WEIGHT)
-                    .text(function (d) {
+                    .text(function(d) {
+                        // eslint-disable-next-line no-invalid-this
                         return translateAndSubscribe(this, 'cluster_management.cluster_graphical_view.' + d.linkTypeKey);
                     })
                     .attr('x', legendWidth/2 + CLUSTER_MANAGEMENT_CONSTANTS.LEGEND_ITEM_PADDING_LEFT)
-                    .attr('y', function (d, index) {
+                    .attr('y', function(d, index) {
                         return rowY.get(index) + 4;
                     })
                     .classed('links-statuses', true);
@@ -199,7 +201,8 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
             const getMaxWidthOfChildren = (parent) => {
                 let maxWidth = 0;
 
-                parent.selectAll(':not(.legend-background)').each(function () {
+                parent.selectAll(':not(.legend-background)').each(function() {
+                    // eslint-disable-next-line no-invalid-this
                     const bbox = this.getBBox();
                     maxWidth = Math.max(maxWidth, bbox.width);
                 });
@@ -222,7 +225,8 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
                     .style('font-size', CLUSTER_MANAGEMENT_CONSTANTS.TITLE_FONT_SIZE)
                     .style('font-weight', CLUSTER_MANAGEMENT_CONSTANTS.TITLE_FONT_WEIGHT)
                     .style('line-height', CLUSTER_MANAGEMENT_CONSTANTS.TITLE_LINE_HEIGHT)
-                    .text(function () {
+                    .text(function() {
+                        // eslint-disable-next-line no-invalid-this
                         return translateAndSubscribe(this, labelKey);
                     })
                     .attr('y', () => {
@@ -241,7 +245,7 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
             };
 
             const removeAllListeners = () => {
-                $document.off('keydown', closeDialog);
+                $document.off('keydown', onKeyDown);
                 subscriptions.forEach((subscription) => subscription());
             };
 
@@ -266,6 +270,6 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
             $scope.$on('$destroy', removeAllListeners);
 
             init();
-        }
+        },
     };
 }

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-legend.directive.js
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-legend.directive.js
@@ -165,6 +165,9 @@ function clusterLegend($rootScope, ClusterViewContextService, $translate, $docum
                         return rowY.get(index) + 4;
                     })
                     .classed('links-statuses', true);
+
+                // Add icon on OUT_OF_SYNC legend link
+                CDS.updateLegendLinkIcons(linkStatesGroup, legendWidth);
             };
 
             /**

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/services/cluster-drawing.service.js
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/services/cluster-drawing.service.js
@@ -4,21 +4,21 @@ import {select, line} from 'd3';
 
 const d3 = {
   line,
-  select
+  select,
 };
 
 const clusterColors = {
     ontoOrange: 'var(--gw-primary-base)',
     ontoBlue: 'var(--gw-secondary-base)',
     ontoGreen: 'var(--gw-tertiary-base)',
-    ontoGrey: 'var(--gw-neutral-base)'
+    ontoGrey: 'var(--gw-neutral-base)',
 };
 
 const linkStateColors = {
     [LinkState.IN_SYNC]: clusterColors.ontoBlue,
     [LinkState.SYNCING]: clusterColors.ontoBlue,
     [LinkState.OUT_OF_SYNC]: clusterColors.ontoGrey,
-    [LinkState.RECEIVING_SNAPSHOT]: clusterColors.ontoBlue
+    [LinkState.RECEIVING_SNAPSHOT]: clusterColors.ontoBlue,
 };
 
 const linkStateStyle = {
@@ -29,7 +29,7 @@ const linkStateStyle = {
     // dashed line
     [LinkState.OUT_OF_SYNC]: '10 10',
     // dashed line
-    [LinkState.RECEIVING_SNAPSHOT]: '10 10'
+    [LinkState.RECEIVING_SNAPSHOT]: '10 10',
 };
 
 const font = {
@@ -177,8 +177,9 @@ function updateNodesClasses(nodes) {
 
 function updateNodesIcon(nodes) {
     nodes.select('.node-icon')
-        .each(function (d) {
+        .each(function(d) {
             const iconType = hasRecoveryState(d) ? getNodeInfoIconType(d) : getNodeIconType(d);
+            // eslint-disable-next-line no-invalid-this
             d3.select(this)
                 .classed('icon-any', iconType.font === font.ICOMOON)
                 .classed('remixicon', iconType.font === font.REMIXICON)
@@ -205,7 +206,7 @@ const nodeStateIcons = {
     [NodeState.NO_CONNECTION]: {icon: '\ue931', font: font.ICOMOON},
     [NodeState.OUT_OF_SYNC]: {icon: '\ue920', font: font.ICOMOON},
     [NodeState.READ_ONLY]: {icon: '\ue95c', font: font.ICOMOON},
-    [NodeState.RESTRICTED]: {icon: '\ue933', font: font.ICOMOON}
+    [NodeState.RESTRICTED]: {icon: '\ue933', font: font.ICOMOON},
 };
 
 function getNodeInfoIconType(node) {
@@ -228,14 +229,16 @@ function updateNodesInfoText(nodes) {
     let objectWidth;
     // Set initial text element
     nodes.select('.node-info-text')
-        .each(function (d) {
+        .each(function(d) {
+            // eslint-disable-next-line no-invalid-this
             d.infoNode = this;
         })
-        .select(function () {
+        .select(function() {
+            // eslint-disable-next-line no-invalid-this
             return this.parentNode;
         })
         .append('foreignObject')
-        .attr('width', function (d) {
+        .attr('width', function(d) {
             let shortMessage = '';
             if (!isEmpty(d.recoveryStatus)) {
                 shortMessage = extractShortMessageFromNode(d);
@@ -245,16 +248,16 @@ function updateNodesInfoText(nodes) {
             objectWidth = rect.width;
             return objectWidth;
         })
-        .attr('height', function (d) {
+        .attr('height', function(d) {
             return objectHeight;
         })
-        .attr('x', function (d) {
+        .attr('x', function(d) {
             return -(objectWidth / 2);
         })
-        .attr('y', function (d) {
+        .attr('y', function(d) {
             return 78;
         })
-        .classed('hidden', function (d) {
+        .classed('hidden', function(d) {
             return isEmpty(d.recoveryStatus);
         })
         .style('font-size', '12px')
@@ -265,7 +268,7 @@ function updateNodesInfoText(nodes) {
         .style('border-radius', '6px')
         .attr('class', 'node-info-fo')
         .append('xhtml:div')
-        .html(function (d) {
+        .html(function(d) {
             return extractShortMessageFromNode(d);
         });
 
@@ -321,7 +324,8 @@ function addRecoveryLabelListeners(object, message, truncatedSize, displayMessag
 
 function resizeLabelDynamic(nodes) {
     nodes.select('.node-info-fo')
-        .each(function (d) {
+        .each(function(d) {
+            // eslint-disable-next-line no-invalid-this
             const object = d3.select(this);
             if (isEmpty(d.recoveryStatus)) {
                 object.attr('width', 0);
@@ -350,26 +354,27 @@ function resizeLabelDynamic(nodes) {
 function updateNodesHostnameText(nodes) {
     nodes
         .select('.id.id-host')
-        .each(function (d) {
+        .each(function(d) {
+            // eslint-disable-next-line no-invalid-this
             d.labelNode = this;
         })
-        .text(function (d) {
+        .text(function(d) {
             return d.hostname;
         });
 
     // Add padding styling to text background. left/right/top/bottom +5
     nodes
         .select('.id-host-background')
-        .attr('width', function (d) {
+        .attr('width', function(d) {
             return d3.select(d.labelNode).node().getBBox().width + 10;
         })
-        .attr('height', function (d) {
+        .attr('height', function(d) {
             return d3.select(d.labelNode).node().getBBox().height + 10;
         })
-        .attr('x', function (d) {
+        .attr('x', function(d) {
             return d3.select(d.labelNode).node().getBBox().x - 5;
         })
-        .attr('y', function (d) {
+        .attr('y', function(d) {
             return d3.select(d.labelNode).node().getBBox().y - 5;
         });
 }
@@ -397,7 +402,7 @@ export function updateLinks(linksDataBinding, nodes) {
 
 export const ARROW_CONFIG = {
     SMALL: {name: 'small', size: 3},
-    BIG: {name: 'big', size: 5}
+    BIG: {name: 'big', size: 5},
 };
 
 export function addArrowHead(svg, config) {

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/services/cluster-drawing.service.js
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/services/cluster-drawing.service.js
@@ -9,9 +9,9 @@ const d3 = {
 
 const clusterColors = {
     ontoOrange: 'var(--gw-primary-base)',
-    ontoBlue: 'var(--gw-secondary-base)',
+    ontoBlue: 'var(--gw-foreground-on-surface-primary)',
     ontoGreen: 'var(--gw-tertiary-base)',
-    ontoGrey: 'var(--gw-neutral-base)',
+    ontoGrey: 'var(--gw-neutral-light)',
 };
 
 const linkStateColors = {
@@ -38,6 +38,90 @@ const font = {
 };
 
 const shortMessageLimit = 40;
+
+function getLinkMidpoint(link, nodes) {
+    const source = nodes.find((node) => node.address === link.source);
+    const target = nodes.find((node) => node.address === link.target);
+    const deltaX = target.x - source.x;
+    const deltaY = target.y - source.y;
+    const dist = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+    const normX = deltaX / dist;
+    const normY = deltaY / dist;
+    const sourcePadding = 55;
+    const targetPadding = 55;
+    const sourceX = source.x + (sourcePadding * normX);
+    const sourceY = source.y + (sourcePadding * normY);
+    const targetX = target.x - (targetPadding * normX);
+    const targetY = target.y - (targetPadding * normY);
+    return {
+        x: (sourceX + targetX) / 2,
+        y: (sourceY + targetY) / 2,
+    };
+}
+
+function appendLinkIcon(parentGroup, iconType, iconCode, iconColor, iconSize) {
+    // Circle background so the icon is readable over the dashed line
+    parentGroup.append('circle')
+        .attr('r', 12)
+        .attr('fill', 'var(--gw-panel-background)');
+
+    parentGroup.append('text')
+        .attr('text-anchor', 'middle')
+        .attr('dominant-baseline', 'central')
+        .attr('class', iconType)
+        .attr('fill', iconColor)
+        .style('font-size', iconSize)
+        .text(iconCode);
+}
+
+function appendOutOfSyncLinkIcon(group, iconSize) {
+    appendLinkIcon(group, 'remixicon', '\uf064', 'var(--gw-foreground-on-surface-secondary)', iconSize);
+}
+
+export function updateLinkIcons(linksGroup, links, nodes) {
+    const outOfSyncLinks = links.filter((link) => link.status === LinkState.OUT_OF_SYNC);
+
+    const iconGroups = linksGroup.selectAll('.link-icon-group')
+        .data(outOfSyncLinks, (link) => link.id);
+
+    const entered = iconGroups.enter()
+        .append('g')
+        .classed('link-icon-group', true);
+
+    appendOutOfSyncLinkIcon(entered, '20px');
+
+    // Position both new and existing groups at the link midpoint
+    entered.merge(iconGroups)
+        .attr('transform', (link) => {
+            const {x, y} = getLinkMidpoint(link, nodes);
+            return `translate(${x}, ${y})`;
+        });
+
+    iconGroups.exit().remove();
+}
+
+export function updateLegendLinkIcons(linkStatesGroup, legendWidth) {
+    linkStatesGroup.selectAll('.link-icon-group').remove();
+
+    linkStatesGroup.each(function(d) {
+        if (d.status !== LinkState.OUT_OF_SYNC) {
+            return;
+        }
+        // eslint-disable-next-line no-invalid-this
+        const group = d3.select(this);
+        const path = group.select('path.link');
+        // Midpoint of the legend line: x is halfway along lineWidth, y is the line's y
+        const pathEl = path.node();
+        const totalLength = pathEl.getTotalLength();
+        const midPoint = pathEl.getPointAtLength(totalLength / 2);
+
+        const iconGroup = group.append('g')
+            .classed('link-icon-group', true)
+            .attr('transform', `translate(${midPoint.x}, ${midPoint.y})`);
+        // remixicon refresh-line
+        appendOutOfSyncLinkIcon(iconGroup, '18px');
+    });
+}
 
 export function createClusterSvgElement(element) {
     return d3.select(element)
@@ -416,7 +500,7 @@ export function addArrowHead(svg, config) {
         .attr("orient", "auto-start-reverse")
         .append("path")
         .attr("d", `M 0 0 L ${config.size * 2} ${config.size} L 0 ${config.size * 2} z`)
-        .style("fill", "var(--gw-secondary-base)");
+        .style("fill", clusterColors.ontoBlue);
 }
 
 export function setArrowLink(link, config) {
@@ -443,18 +527,13 @@ function getLinkCoordinates(link, nodes) {
     const dist = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
     const normX = deltaX / dist;
     const normY = deltaY / dist;
-    // Padding from node center point
     const sourcePadding = 55;
     const targetPadding = 55;
     const sourceX = source.x + (sourcePadding * normX);
     const sourceY = source.y + (sourcePadding * normY);
     const targetX = target.x - (targetPadding * normX);
     const targetY = target.y - (targetPadding * normY);
-    // Calculate midpoint
-    const midpointX = (sourceX + targetX) / 2;
-    const midpointY = (sourceY + targetY) / 2;
-    // In order to draw an arrowhead in the middle of a line, the line needs to be composed by
-    // two segments, otherwise the arrowhead won't show up.
+    const {x: midpointX, y: midpointY} = getLinkMidpoint(link, nodes);
     return 'M' + sourceX + ',' + sourceY + 'L' + midpointX + ',' + midpointY +
         'L' + targetX + ',' + targetY;
 }


### PR DESCRIPTION
## What
Change the style of the outofsync links between nodes in cluster view.

## Why
The link style was barely distinguishable from the one in syncing status and needed redesign.

## How
Added additional icon to the outofsync link.

## Testing


## Screenshots
<img width="497" height="437" alt="image" src="https://github.com/user-attachments/assets/045eeb93-0881-43e9-9606-7c4431a50383" />
<img width="264" height="149" alt="image" src="https://github.com/user-attachments/assets/c9f747bd-f720-4c82-a0e1-b58bedb76ae3" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
