### PR TITLE
Gdb 13800 add visual graph split button to resource view

### DIFF
--- a/e2e-tests/e2e-legacy/explore/visual-graph/visual-graph-links-limit.spec.js
+++ b/e2e-tests/e2e-legacy/explore/visual-graph/visual-graph-links-limit.spec.js
@@ -5,6 +5,7 @@ import {ApplicationSteps} from '../../../steps/application-steps';
 import HomeSteps from '../../../steps/home-steps.js';
 import {BaseSteps} from "../../../steps/base-steps.js";
 import SparqlSteps from "../../../steps/sparql-steps.js";
+import {VisualGraphSplitButtonSteps} from '../../../steps/visual-graph-split-button-steps.js';
 
 const FILE_TO_IMPORT = 'wine.rdf';
 const VALID_RESOURCE = 'USRegion';
@@ -121,7 +122,7 @@ describe('Visual graph linksLimit URL parameter', () => {
             SparqlSteps.visit();
             SparqlSteps.typeQuery(`CONSTRUCT WHERE {?s ?p ?o} LIMIT 10`);
             SparqlSteps.executeQuery();
-            SparqlSteps.visualizeConstructQuery();
+            VisualGraphSplitButtonSteps.clickOnVisualizeMainButton();
 
             // Then, I expect to see 10 nodes before changing the limit
             VisualGraphSteps.getNodes().should('have.length', 10); // 10 nodes total, since we don't have a root node

--- a/e2e-tests/e2e-legacy/guides/table-graph-explore/table-graph-explore-guide.spec.js
+++ b/e2e-tests/e2e-legacy/guides/table-graph-explore/table-graph-explore-guide.spec.js
@@ -3,6 +3,7 @@ import {GuideSteps} from "../../../steps/guides/guide-steps.js";
 import {GuideDialogSteps} from "../../../steps/guides/guide-dialog-steps.js";
 import {YasrSteps} from "../../../steps/yasgui/yasr-steps.js";
 import {ResourceSteps} from "../../../steps/resource/resource-steps.js";
+import {VisualGraphSplitButtonSteps} from '../../../steps/visual-graph-split-button-steps.js';
 
 describe('Table Graph explore', () => {
     const FILE_TO_IMPORT = 'wine.rdf';
@@ -107,7 +108,7 @@ describe('Table Graph explore', () => {
 
             GuideDialogSteps.assertDialogWithTitleIsVisible('Explore RDF as a table — 6/8');
             GuideDialogSteps.assertDialogWithContentIsVisible('You can always explore the same data using the Visual graph view. Click on the Visual graph button to try it now.');
-            ResourceSteps.clickOnVisualGraphButton();
+            VisualGraphSplitButtonSteps.clickOnVisualizeMainButton();
 
             GuideDialogSteps.assertDialogWithTitleIsVisible('Explore RDF as a table — 7/8');
             GuideDialogSteps.assertDialogWithContentIsVisible('The graph shows connections between the start node, vin:WineGrape, and other nodes. Each arrow represents one or more connections (RDF statements).');

--- a/e2e-tests/e2e-legacy/resource/resource.spec.js
+++ b/e2e-tests/e2e-legacy/resource/resource.spec.js
@@ -7,10 +7,12 @@ import {YasqeSteps} from "../../steps/yasgui/yasqe-steps";
 import {YasrSteps} from "../../steps/yasgui/yasr-steps";
 import {YasguiSteps} from "../../steps/yasgui/yasgui-steps";
 import {JsonLdModalSteps} from "../../steps/json-ld-modal-steps";
+import {GraphConfigStubs} from '../../stubs/graph-config-stubs.js';
+import {VisualGraphSplitButtonSteps} from '../../steps/visual-graph-split-button-steps.js';
 
 const FILE_TO_IMPORT = 'resource-test-data.ttl';
-const SUBJECT_RESOURCE = 'http:%2F%2Fexample.com%2Fontology%23CustomerLoyalty';
-const SUBJECT_RESOURCE_SHORT_URI = 'http://example.com/ontology#CustomerLoyalty';
+const SUBJECT_RESOURCE_ENCODED = 'http:%2F%2Fexample.com%2Fontology%23CustomerLoyalty';
+const SUBJECT_RESOURCE = 'http://example.com/ontology#CustomerLoyalty';
 const PREDICATE_SOURCE = 'http:%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23subClassOf';
 const CONTEXT_EXPLICIT = 'http://www.ontotext.com/explicit';
 const OBJECT_RESOURCE = 'http:%2F%2Fexample.com%2Fontology%23Metric';
@@ -33,13 +35,13 @@ describe('Resource view', () => {
 
     it('should open resource view with active role tab depend on url role parameter', () => {
         ResourceSteps.getAllRoles().forEach((role) => {
-            ResourceSteps.visit(`uri=${SUBJECT_RESOURCE}&role=${role}`);
+            ResourceSteps.visit(`uri=${SUBJECT_RESOURCE_ENCODED}&role=${role}`);
             ResourceSteps.verifyActiveRoleTab(role);
         });
     });
 
     it('should open subject tab if role parameter is miss', () => {
-        ResourceSteps.visit(`uri=${SUBJECT_RESOURCE}&role=subject`);
+        ResourceSteps.visit(`uri=${SUBJECT_RESOURCE_ENCODED}&role=subject`);
         ResourceSteps.verifyActiveRoleTab('subject');
     });
 
@@ -62,15 +64,33 @@ describe('Resource view', () => {
         YasrSteps.getResults().should('have.length', 5);
     });
 
-    it('should navigate to visual graph view', () => {
+    it('should open graphs-visualizations view when click on main button', () => {
         // When I am on resource view and page loaded a resource.
-        ResourceSteps.visit(`uri=${SUBJECT_RESOURCE}&role=subject`);
+        ResourceSteps.visit(`uri=${SUBJECT_RESOURCE_ENCODED}&role=subject`);
 
         // When I click on "Visual graph" button.
-        ResourceSteps.clickOnVisualGraphButton();
+        VisualGraphSplitButtonSteps.clickOnVisualizeMainButton();
 
         // Then I expect to be redirected to explore graph view.
         VisualGraphSteps.verifyUrl();
+    });
+
+    it('should open graphs-visualizations view when select a graph configuration', () => {
+        // When I am on resource view and page loaded a resource.
+        ResourceSteps.visit(`uri=${SUBJECT_RESOURCE_ENCODED}&role=subject`);
+        GraphConfigStubs.stubGetGraphConfigs();
+
+        // WHEN: I open the dropdown.
+        VisualGraphSplitButtonSteps.toggleGraphConfigDropdown();
+        // THEN: I expect to see all graph configurations.
+        VisualGraphSplitButtonSteps.getGraphConfigs().should('have.length', 3);
+
+        // WHEN: I select a graph configuration
+        VisualGraphSplitButtonSteps.selectGraphConfig();
+        // THEN: I expect to be navigated to graphs-visualizations view.
+        cy.url().should('include', 'graphs-visualizations');
+        cy.getQueryParam('uri').should('include', SUBJECT_RESOURCE);
+        cy.getQueryParam('config').should('eq', 'de99fd5de7f94ef98f1875dff55fc1c9');
     });
 
     it('should displays results depends on explicit/implicit dropdown', () => {
@@ -175,11 +195,11 @@ describe('Resource view', () => {
         it('should list the triples of a resource used as subject', () => {
             // When I am on resource view,
             // and page loaded a resource that is used as subject,
-            ResourceSteps.visit(`uri=${SUBJECT_RESOURCE}&role=subject`);
+            ResourceSteps.visit(`uri=${SUBJECT_RESOURCE_ENCODED}&role=subject`);
 
             // Then I expect to see only one result because the resource has only one triplet as subject.
             YasrSteps.getResults().should('have.length', 1);
-            YasrSteps.getResultLink(0, 1).should('contain', SUBJECT_RESOURCE_SHORT_URI);
+            YasrSteps.getResultLink(0, 1).should('contain', SUBJECT_RESOURCE);
             YasrSteps.getResultLink(0, 2).should('contain', 'rdfs:subClassOf');
             YasrSteps.getResultLink(0, 3).should('contain', 'http://example.com/ontology#Metric');
             YasrSteps.getResultLink(0, 4).should('contain', CONTEXT_EXPLICIT);
@@ -196,7 +216,7 @@ describe('Resource view', () => {
             YasrSteps.getResults().should('have.length', 1);
             YasrSteps.getResultLink(0, 1).should('contain', 'http://example.com/resource/person/W6J1827/customerLoyalty');
             YasrSteps.getResultLink(0, 2).should('contain', 'rdf:type');
-            YasrSteps.getResultLink(0, 3).should('contain', SUBJECT_RESOURCE_SHORT_URI);
+            YasrSteps.getResultLink(0, 3).should('contain', SUBJECT_RESOURCE);
             YasrSteps.getResultLink(0, 4).should('contain', CONTEXT_EXPLICIT);
 
             // When I click on "context" tab.
@@ -211,14 +231,14 @@ describe('Resource view', () => {
             // Then I expect to see all triples of subject without mater of its role.
             YasrSteps.getResults().should('have.length', 2);
 
-            YasrSteps.getResultLink(0, 1).should('contain', SUBJECT_RESOURCE_SHORT_URI);
+            YasrSteps.getResultLink(0, 1).should('contain', SUBJECT_RESOURCE);
             YasrSteps.getResultLink(0, 2).should('contain', 'rdfs:subClassOf');
             YasrSteps.getResultLink(0, 3).should('contain', 'http://example.com/ontology#Metric');
             YasrSteps.getResultLink(0, 4).should('contain', CONTEXT_EXPLICIT);
 
             YasrSteps.getResultLink(1, 1).should('contain', 'http://example.com/resource/person/W6J1827/customerLoyalty');
             YasrSteps.getResultLink(1, 2).should('contain', 'rdf:type');
-            YasrSteps.getResultLink(1, 3).should('contain', SUBJECT_RESOURCE_SHORT_URI);
+            YasrSteps.getResultLink(1, 3).should('contain', SUBJECT_RESOURCE);
             YasrSteps.getResultLink(1, 4).should('contain', CONTEXT_EXPLICIT);
         });
 
@@ -364,7 +384,7 @@ describe('Resource view', () => {
     context('Download as', () => {
         it('should download as JSON-LD and then restore defaults', () => {
             // Given I am in the Resource view
-            ResourceSteps.visit(`uri=${SUBJECT_RESOURCE}&role=subject`);
+            ResourceSteps.visit(`uri=${SUBJECT_RESOURCE_ENCODED}&role=subject`);
             cy.window().then((win) => {
                 expect(win.jsonld).to.exist;
                 cy.stub(win.jsonld, 'compact').resolves({

--- a/e2e-tests/e2e-legacy/sparql-editor/yasr/toolbar/visual-graph-button.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/yasr/toolbar/visual-graph-button.spec.js
@@ -1,9 +1,9 @@
 import {SparqlEditorSteps} from '../../../../steps/sparql-editor-steps';
 import {YasqeSteps} from '../../../../steps/yasgui/yasqe-steps';
-import {YasrSteps} from '../../../../steps/yasgui/yasr-steps';
 import {QueryStubs} from '../../../../stubs/yasgui/query-stubs';
 import {GraphConfigStubs} from '../../../../stubs/graph-config-stubs.js';
 import {BrowserStubs} from '../../../../stubs/browser-stubs.js';
+import {VisualGraphSplitButtonSteps} from '../../../../steps/visual-graph-split-button-steps.js';
 
 describe('"Visualize" split button', () => {
     let repositoryId;
@@ -25,17 +25,17 @@ describe('"Visualize" split button', () => {
         // WHEN: I visit a page with 'ontotext-yasgui-web-component' on it, and execute select query.
         executeSelectQuery();
         // THEN: I expect the 'Visualize' button to not be visible.
-        YasrSteps.getVisualizeMainButton().should('not.be.visible');
+        VisualGraphSplitButtonSteps.getVisualizeMainButton().should('not.be.visible');
 
         // WHEN: I execute a CONSTRUCT query.
         executeConstructQuery();
         // THEN: I expect the 'Visualize' button to be visible.
-        YasrSteps.getVisualizeMainButton().should('be.visible');
+        VisualGraphSplitButtonSteps.getVisualizeMainButton().should('be.visible');
 
         // WHEN: I execute SELECT query again.
         executeSelectQuery();
         // THEN: I expect the 'Visualize' button to not be visible.
-        YasrSteps.getVisualizeMainButton().should('not.be.visible');
+        VisualGraphSplitButtonSteps.getVisualizeMainButton().should('not.be.visible');
     });
 
     it('should inform user that there no created graph configurations', () => {
@@ -45,13 +45,13 @@ describe('"Visualize" split button', () => {
         executeConstructQuery();
 
         // WHEN: I open the dropdown.
-        YasrSteps.toggleGraphConfigDropdown();
+        VisualGraphSplitButtonSteps.toggleGraphConfigDropdown();
         // THEN: I expect to see message that informs that there are no graph configurations.
-        YasrSteps.getNoConfigurationsMessage().should('contain.text', 'No advanced graph configuration.');
+        VisualGraphSplitButtonSteps.getNoConfigurationsMessage().should('contain.text', 'No advanced graph configuration.');
 
         // WHEN: I click on create link.
         BrowserStubs.stubWindowOpen();
-        YasrSteps.clickCreateGraphConfigLink();
+        VisualGraphSplitButtonSteps.clickCreateGraphConfigLink();
         // THEN: I expect to be navigated to graph configurations page.
         cy.get(BrowserStubs.WINDOW_OPEN_ALIAS()).should('have.been.calledWithMatch', 'graphs-visualizations', '_blank', 'noopener,noreferrer');
     });
@@ -61,7 +61,7 @@ describe('"Visualize" split button', () => {
         executeConstructQuery();
 
         // WHEN: I click on main button
-        YasrSteps.clickOnVisualizeMainButton();
+        VisualGraphSplitButtonSteps.clickOnVisualizeMainButton();
         // THEN: I expect to be navigated to graphs-visualizations view.
         cy.url().should('include', 'graphs-visualizations');
         cy.getQueryParam('query').should('include', 'PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>PREFIX onto: <http://www.ontotext.com/>CONSTRUCT {?source rdf:type ?destination .} WHERE {?bag rdf:type ?source .?flight rdf:type ?destination}');
@@ -74,12 +74,12 @@ describe('"Visualize" split button', () => {
         GraphConfigStubs.stubGetGraphConfigs();
 
         // WHEN: I open the dropdown.
-        YasrSteps.toggleGraphConfigDropdown();
+        VisualGraphSplitButtonSteps.toggleGraphConfigDropdown();
         // THEN: I expect to see all graph configurations.
-        YasrSteps.getGraphConfigs().should('have.length', 3);
+        VisualGraphSplitButtonSteps.getGraphConfigs().should('have.length', 3);
 
         // WHEN: I select a graph configuration
-        YasrSteps.selectGraphConfig();
+        VisualGraphSplitButtonSteps.selectGraphConfig();
         // THEN: I expect to be navigated to graphs-visualizations view.
         cy.url().should('include', 'graphs-visualizations');
         cy.getQueryParam('query').should('include', 'PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>PREFIX onto: <http://www.ontotext.com/>CONSTRUCT {?source rdf:type ?destination .} WHERE {?bag rdf:type ?source .?flight rdf:type ?destination}');

--- a/e2e-tests/steps/guides/movies-guide-steps.js
+++ b/e2e-tests/steps/guides/movies-guide-steps.js
@@ -5,6 +5,7 @@ import {VisualGraphSteps} from "../visual-graph-steps";
 import {YasrSteps} from "../yasgui/yasr-steps";
 import {YasqeSteps} from "../yasgui/yasqe-steps";
 import {ResourceSteps} from "../resource/resource-steps";
+import {VisualGraphSplitButtonSteps} from '../visual-graph-split-button-steps.js';
 
 export class MoviesGuideSteps {
 
@@ -181,7 +182,7 @@ export class MoviesGuideSteps {
     static assertExploreRDFStep7() {
         GuideSteps.assertPageNotInteractive();
         GuideDialogSteps.assertDialogWithTitleIsVisible('Explore RDF as a table — 7/10');
-        ResourceSteps.getVisualGraphButton().should('be.visible');
+        VisualGraphSplitButtonSteps.getVisualizeMainButton().should('be.visible');
     }
 
     static assertExploreRDFStep8() {

--- a/e2e-tests/steps/resource/resource-steps.js
+++ b/e2e-tests/steps/resource/resource-steps.js
@@ -61,14 +61,6 @@ export class ResourceSteps {
         cy.get('.download-options li').eq(option).click();
     }
 
-    static getVisualGraphButton() {
-        return cy.get('.visual-graph-btn');
-    }
-
-    static clickOnVisualGraphButton() {
-        ResourceSteps.getVisualGraphButton().click();
-    }
-
     static getEditResourceLink() {
         return cy.get('.edit-resource-link');
     }

--- a/e2e-tests/steps/visual-graph-split-button-steps.js
+++ b/e2e-tests/steps/visual-graph-split-button-steps.js
@@ -1,0 +1,45 @@
+export class VisualGraphSplitButtonSteps {
+    static getGraphExploreSplitButton() {
+        return cy.get('onto-graph-explore-split-button');
+    }
+
+    static getVisualizeMainButton() {
+        return VisualGraphSplitButtonSteps.getGraphExploreSplitButton().find('.explore-visual-graph-button');
+    }
+
+    static clickOnVisualizeMainButton() {
+        VisualGraphSplitButtonSteps.getVisualizeMainButton().click();
+    }
+
+    static getDropdownToggleButton() {
+        return VisualGraphSplitButtonSteps.getGraphExploreSplitButton().find('.onto-dropdown-button');
+    }
+
+    static toggleGraphConfigDropdown() {
+        VisualGraphSplitButtonSteps.getDropdownToggleButton().click();
+    }
+
+    static getGraphConfigs() {
+        return VisualGraphSplitButtonSteps.getGraphExploreSplitButton().find('.onto-dropdown-menu-item');
+    }
+
+    static getGraphConfig(index = 0) {
+        return VisualGraphSplitButtonSteps.getGraphConfigs().eq(index);
+    }
+
+    static selectGraphConfig(index = 0) {
+        VisualGraphSplitButtonSteps.getGraphConfig(index).click();
+    }
+
+    static getCreateGraphConfigLink() {
+        return VisualGraphSplitButtonSteps.getGraphExploreSplitButton().find('.graph-create-link');
+    }
+
+    static clickCreateGraphConfigLink() {
+        VisualGraphSplitButtonSteps.getCreateGraphConfigLink().click();
+    }
+
+    static getNoConfigurationsMessage() {
+        return VisualGraphSplitButtonSteps.getGraphExploreSplitButton().find('.no-configurations-message');
+    }
+}

--- a/e2e-tests/steps/yasgui/yasr-steps.js
+++ b/e2e-tests/steps/yasgui/yasr-steps.js
@@ -113,50 +113,6 @@ export class YasrSteps extends BaseSteps {
         return YasrSteps.getYasr().find('.yasr-toolbar');
     }
 
-    static getGraphExploreSplitButton() {
-        return YasrSteps.getYasrToolbar().find('.explore-visual-graph');
-    }
-
-    static getVisualizeMainButton() {
-        return YasrSteps.getGraphExploreSplitButton().find('.explore-visual-graph-button');
-    }
-
-    static clickOnVisualizeMainButton() {
-        YasrSteps.getVisualizeMainButton().click();
-    }
-
-    static getDropdownToggleButton() {
-        return YasrSteps.getGraphExploreSplitButton().find('.onto-dropdown-button');
-    }
-
-    static toggleGraphConfigDropdown() {
-        YasrSteps.getDropdownToggleButton().click();
-    }
-
-    static getGraphConfigs() {
-        return YasrSteps.getGraphExploreSplitButton().find('.onto-dropdown-menu-item');
-    }
-
-    static getGraphConfig(index = 0) {
-        return YasrSteps.getGraphConfigs().eq(index);
-    }
-
-    static selectGraphConfig(index = 0) {
-        YasrSteps.getGraphConfig(index).click();
-    }
-
-    static getCreateGraphConfigLink() {
-        return YasrSteps.getGraphExploreSplitButton().find('.graph-create-link');
-    }
-
-    static clickCreateGraphConfigLink() {
-        YasrSteps.getCreateGraphConfigLink().click();
-    }
-
-    static getNoConfigurationsMessage() {
-        return YasrSteps.getGraphExploreSplitButton().find('.no-configurations-message');
-    }
-
     static getNoDataElement() {
         return cy.get('.dataTables_empty');
     }

--- a/packages/legacy-workbench/src/css/explore.css
+++ b/packages/legacy-workbench/src/css/explore.css
@@ -1,3 +1,22 @@
+.explore-resource .action-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+
+.explore-resource .action-header .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.2rem;
+    margin-top: 4px;
+}
+
+#inference-select,
+.explore-resource .action-header .actions .dropdown-toggle.download-as {
+    margin: 0;
+    height: 100%;
+}
+
 .opacity-hide {
     opacity: 0;
     display: none;

--- a/packages/legacy-workbench/src/js/angular/explore/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/explore/controllers.js
@@ -10,9 +10,12 @@ import {DISABLE_YASQE_BUTTONS_CONFIGURATION} from "../core/directives/yasgui-com
 import * as jsonld from 'jsonld';
 import {ExportSettingsCtrl} from "../core/components/export-settings-modal/controller";
 import {
+    GraphConfigService,
+    openInNewTab,
     SecurityContextService,
     service,
 } from '@ontotext/workbench-api';
+import {ObjectUtils} from '../utils/object-utils';
 
 const modules = [
     'ngCookies',
@@ -23,7 +26,7 @@ const modules = [
     'graphdb.framework.core.services.repositories',
     'graphdb.framework.explore.services',
     'graphdb.workbench.utils.filetypes',
-    'graphdb.framework.rest.explore.rest.service'
+    'graphdb.framework.rest.explore.rest.service',
 ];
 
 angular
@@ -65,6 +68,7 @@ function ExploreCtrl(
     $q,
     ExploreRestService) {
     const securityContextService = service(SecurityContextService);
+    const graphConfigService = service(GraphConfigService);
 
     $scope.ContextTypes = ContextTypes;
     $scope.contextTypes = ContextType.getAllType();
@@ -151,14 +155,26 @@ function ExploreCtrl(
         return $scope.resourceInfo.context !== null && $scope.resourceInfo.context === "http://rdf4j.org/schema/rdf4j#SHACLShapeGraph";
     };
 
-    $scope.goToGraphsViz = () => {
-        $location.path('graphs-visualizations').search('uri', $scope.resourceInfo.uri);
+    $scope.goToGraphsViz = ({detail: payload}) => {
+        if (payload.action === 'create') {
+            openInNewTab('graphs-visualizations');
+            return;
+        }
+
+        $location
+            .path('graphs-visualizations')
+            .search('uri', $scope.resourceInfo.uri)
+            .search('config', payload.graphConfig?.id);
+    };
+
+    $scope.fetchGraphConfigs = () => {
+        return () => graphConfigService.getGraphConfigs().then((graphConfigs) => graphConfigs.getItems());
     };
 
     // Get resource table
     $scope.exploreResource = () => {
         toggleOntoLoader(true);
-        if ($routeParams.context != null) {
+        if (ObjectUtils.isNullOrUndefined($routeParams.context)) {
             $scope.resourceInfo.context = $routeParams.context;
         }
         // Remember the role in the URL so the URL is stable and leads back to the same view
@@ -192,27 +208,27 @@ function ExploreCtrl(
             });
     };
 
-    $scope.openJSONLDExportSettings = function (format) {
+    $scope.openJSONLDExportSettings = function(format) {
         const modalInstance = $uibModal.open({
             templateUrl: 'js/angular/core/components/export-settings-modal/exportSettingsModal.html',
             controller: ExportSettingsCtrl,
             size: 'lg',
             scope: $scope,
             resolve: {
-                format: function () {
+                format: function() {
                     return format.name;
-                }
-            }
+                },
+            },
         });
 
-        modalInstance.result.then(function (data) {
+        modalInstance.result.then(function(data) {
             $scope.downloadJSONLDExport(format, data.link, data.currentMode);
         });
     };
 
-    $scope.downloadJSONLDExport = function (format, link, mode) {
+    $scope.downloadJSONLDExport = function(format, link, mode) {
         ExploreRestService.getGraph($scope.resourceInfo, format.type, link)
-            .then(async function (data) {
+            .then(async function(data) {
                 if (format.name === "JSON") {
                     data = JSON.stringify(data);
                 }
@@ -253,7 +269,7 @@ function ExploreCtrl(
                     const file = new Blob([data], {type: format.type});
                     saveAs(file, 'statements' + format.extension);
                 }
-            }).catch(function (data) {
+            }).catch(function(data) {
                 const msg = getError(data);
                 toastr.error(msg, $translate.instant('common.error'));
             });
@@ -322,7 +338,7 @@ function ExploreCtrl(
         $scope.resourceInfo = new ResourceInfo();
         initResourceReference($scope.resourceInfo);
 
-        if ($routeParams.context != null) {
+        if (ObjectUtils.isNullOrUndefined($routeParams.context)) {
             $scope.resourceInfo.context = $routeParams.context;
         }
 
@@ -353,7 +369,7 @@ function ExploreCtrl(
             maxPersistentResponseSize: 0,
             render: RenderingMode.YASR,
             showYasqeActionButtons: false,
-            yasqeActionButtons: DISABLE_YASQE_BUTTONS_CONFIGURATION
+            yasqeActionButtons: DISABLE_YASQE_BUTTONS_CONFIGURATION,
         };
     };
 
@@ -389,9 +405,9 @@ function ExploreCtrl(
 
     // Wait until the active repository object is set, otherwise "canWriteActiveRepo()" may return a wrong result and the "ontotext-yasgui"
     // readOnly configuration may be incorrect.
-    subscriptions.push($scope.$watch(function () {
+    subscriptions.push($scope.$watch(function() {
         return $scope.getActiveRepositoryObject();
-    }, function (activeRepo) {
+    }, function(activeRepo) {
         if (activeRepo) {
             initComponent();
         }
@@ -411,7 +427,7 @@ function FindResourceCtrl($scope, $http, $location, $repositories, $q, $timeout,
     $scope.autocompleteEnabled = false;
 
     if (angular.isDefined($routeParams.search)) {
-        $timeout(function () {
+        $timeout(function() {
             $('#resources_finder_value').val($routeParams.search);
             $('.search-button').click();
         }, 500);
@@ -419,7 +435,7 @@ function FindResourceCtrl($scope, $http, $location, $repositories, $q, $timeout,
 
     function checkAutocompleteStatus() {
         AutocompleteRestService.checkAutocompleteStatus()
-            .success(function (response) {
+            .success(function(response) {
                 if (!response) {
                     const warningMsg = decodeHTML($translate.instant('explore.autocomplete.warning.msg'));
                     toastr.warning('', `<div class="autocomplete-toast"><a href="autocomplete">${warningMsg}</a></div>`,
@@ -427,22 +443,22 @@ function FindResourceCtrl($scope, $http, $location, $repositories, $q, $timeout,
                 }
                 $scope.autocompleteEnabled = response;
             })
-            .error(function () {
+            .error(function() {
                 toastr.error($translate.instant('explore.error.autocomplete'));
             });
     }
 
     function getAllNamespacesForActiveRepository() {
         RDF4JRepositoriesRestService.getNamespaces($repositories.getActiveRepository())
-            .success(function (data) {
-                $scope.namespaces = data.results.bindings.map(function (e) {
+            .success(function(data) {
+                $scope.namespaces = data.results.bindings.map(function(e) {
                     return {
                         prefix: e.prefix.value,
-                        uri: e.namespace.value
+                        uri: e.namespace.value,
                     };
                 });
                 $scope.loader = false;
-            }).error(function (data) {
+            }).error(function(data) {
             const msg = getError(data);
             toastr.error(msg, $translate.instant('common.error'));
             $scope.loader = false;
@@ -475,7 +491,7 @@ function FindResourceCtrl($scope, $http, $location, $repositories, $q, $timeout,
     function submit(uri) {
         function setFormInvalid(isDirty) {
             // does not work yet
-            $timeout(function () {
+            $timeout(function() {
                 if ($scope.form) {
                     $scope.form.$dirty = isDirty;
                 }
@@ -530,7 +546,7 @@ function FindResourceCtrl($scope, $http, $location, $repositories, $q, $timeout,
         return promise;
     }
 
-    $scope.$on('repositoryIsSet', function () {
+    $scope.$on('repositoryIsSet', function() {
         checkAutocompleteStatus();
         getAllNamespacesForActiveRepository();
     });
@@ -554,13 +570,13 @@ function EditResourceCtrl($scope, $http, $location, toastr, $repositories, $uibM
         subject: $scope.uriParam,
         object: {
             type: 'uri',
-            datatype: ''
-        }
+            datatype: '',
+        },
     };
     $scope.newResource = false;
     $scope.datatypeOptions = StatementsService.getDatatypeOptions();
 
-    $scope.activeRepository = function () {
+    $scope.activeRepository = function() {
         return $repositories.getActiveRepository();
     };
 
@@ -575,45 +591,45 @@ function EditResourceCtrl($scope, $http, $location, toastr, $repositories, $uibM
 
     function getClassInstancesDetails() {
         RDF4JRepositoriesRestService.getNamespaces($scope.activeRepository())
-            .success(function (data) {
-                $scope.namespaces = data.results.bindings.map(function (e) {
+            .success(function(data) {
+                $scope.namespaces = data.results.bindings.map(function(e) {
                     return {
                         prefix: e.prefix.value,
-                        uri: e.namespace.value
+                        uri: e.namespace.value,
                     };
                 });
                 $scope.loader = false;
-            }).error(function (data) {
+            }).error(function(data) {
             const msg = getError(data);
             toastr.error(msg, $translate.instant('common.error'));
             $scope.loader = false;
         });
 
         ClassInstanceDetailsService.getDetails($scope.uriParam)
-            .success(function (data) {
+            .success(function(data) {
                 $scope.details = data;
                 $scope.details.encodeURI = encodeURIComponent($scope.details.uri);
-            }).error(function (data) {
+            }).error(function(data) {
             toastr.error($translate.instant('explore.error.resource.details', {data: getError(data)}));
         });
 
         ClassInstanceDetailsService.getGraph($scope.uriParam)
-            .then(function (res) {
+            .then(function(res) {
                 const statements = StatementsService.buildStatements(res, $scope.uriParam);
                 $scope.statements = statements;
                 $scope.newResource = !statements.length;
             });
     }
 
-    $scope.$watch(function () {
+    $scope.$watch(function() {
         return $repositories.getActiveRepository();
-    }, function () {
+    }, function() {
         if ($scope.activeRepository()) {
             $scope.getClassInstancesDetails();
         }
     });
 
-    $scope.validateUri = function (val) {
+    $scope.validateUri = function(val) {
         let check = true;
         const text = val ? val : '';
 
@@ -654,8 +670,8 @@ function EditResourceCtrl($scope, $http, $location, toastr, $repositories, $uibM
                 subject: $scope.uriParam,
                 object: {
                     type: 'uri',
-                    datatype: ''
-                }
+                    datatype: '',
+                },
             };
             $scope.newRowPredicate.$setPristine();
             $scope.newRowPredicate.$setUntouched();
@@ -691,10 +707,10 @@ function EditResourceCtrl($scope, $http, $location, toastr, $repositories, $uibM
             controller: 'ViewTrigCtrl',
             size: 'lg',
             resolve: {
-                data: function () {
+                data: function() {
                     return StatementsService.transformToTrig($scope.statements);
-                }
-            }
+                },
+            },
         });
     }
 
@@ -704,18 +720,18 @@ function EditResourceCtrl($scope, $http, $location, toastr, $repositories, $uibM
             method: method,
             url: 'rest/resource?uri=' + encodeURIComponent($scope.uriParam),
             headers: {
-                'Content-Type': 'application/x-trig'
+                'Content-Type': 'application/x-trig',
             },
-            data: StatementsService.transformToTrig($scope.statements)
-        }).success(function () {
+            data: StatementsService.transformToTrig($scope.statements),
+        }).success(function() {
             toastr.success($translate.instant('explore.resource.saved'));
-            const timer = $timeout(function () {
+            const timer = $timeout(function() {
                 $location.path('resource').search('uri', $scope.uriParam);
             }, 500);
-            $scope.$on("$destroy", function () {
+            $scope.$on("$destroy", function() {
                 $timeout.cancel(timer);
             });
-        }).error(function (data) {
+        }).error(function(data) {
             toastr.error(getError(data));
         });
     }
@@ -726,7 +742,7 @@ ViewTrigCtrl.$inject = ['$scope', '$uibModalInstance', 'data'];
 function ViewTrigCtrl($scope, $uibModalInstance, data) {
     $scope.trig = data;
 
-    $scope.cancel = function () {
+    $scope.cancel = function() {
         $uibModalInstance.dismiss('cancel');
     };
 }

--- a/packages/legacy-workbench/src/pages/explore.html
+++ b/packages/legacy-workbench/src/pages/explore.html
@@ -1,7 +1,7 @@
 <link href="css/explore.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 
 <div core-errors></div>
-<div class="page fit-content-on-mobile">
+<div class="explore-resource page fit-content-on-mobile">
     <div class="resource-info" ng-if="resourceInfo && !isTripleResource()">
         <div class="thumb" ng-if="resourceInfo.details.img">
             <a href="{{resourceInfo.details.img}}">
@@ -54,85 +54,82 @@
         </p>
     </div>
 
-    <div class="pull-right" ng-if="resourceInfo">
-
-        <label for="inference-select" class="mb-0">
-            <select id="inference-select"
-                    class="form-control form-control-sm"
-                    ng-model="currentContextTypeId"
-                    ng-change="changeInference(currentContextTypeId)"
-                    ng-disabled="loading || resourceInfo.role === 'context' || getActiveRepository() === 'SYSTEM'">
-                <option ng-repeat="contextType in contextTypes"
-                        value="{{contextType.id}}"
-                        ng-selected="resourceInfo.contextType.id === contextType.id">
-                    {{contextType.labelKey | translate}}
-                </option>
-            </select>
-        </label>
-
-        <button type="button" class="btn btn-link same-as-btn btn-sm"
-                ng-model="sameAs"
-                ng-class="loading ? 'disabled' : ''"
-                ng-if="resourceInfo.contextType !== ContextTypes.EXPLICIT"
-                ng-click="toggleSameAs()"
-                uib-popover="{{'sidepanel.expand.results.sameas' | translate}}: {{resourceInfo.sameAs ? 'common.on.btn' : 'common.off.btn' | translate}}"
-                popover-trigger="mouseenter"
-                popover-placement="bottom">
-            <span class="icon-2x" ng-class="{'icon-same-as-on':resourceInfo.sameAs, 'icon-same-as-off':!resourceInfo.sameAs}"></span>
-        </button>
-
-        <button type="button"
-                class="btn btn-sm show-blank-nodes-btn" ng-model="resourceInfo.blanks"
-                ng-class="loading ? 'disabled' : (resourceInfo.blanks ? 'btn-primary' : 'btn-secondary')"
-                uib-btn-checkbox
-                btn-checkbox-true="true"
-                btn-checkbox-false="false"
-                ng-change="exploreResource()">
-            {{'show.blank.nodes.label' | translate}}
-        </button>
-
-        <div class="btn-group" uib-dropdown is-open="isopen">
-            <button type="button"
-                    class="btn btn-sm btn-secondary dropdown-toggle download-as"
-                    ng-class="loading ? 'disabled' : ''"
-                    uib-dropdown-toggle>
-                {{'download.as.label' | translate}}
-            </button>
-            <ul class="dropdown-menu small download-options" role="menu">
-                <li ng-repeat="fileType in fileTypes">
-                    <a href="javascript:" ng-click="openJSONLDExportSettings(fileType)"
-                       ng-if="fileType.name === 'JSON-LD' || fileType.name === 'NDJSON-LD'"
-                       class="dropdown-item">{{fileType.translateKey | translate}}</a>
-                    <a href="javascript:" ng-click="downloadExport(fileType)"
-                       ng-if="fileType.name !== 'JSON-LD' && fileType.name !== 'NDJSON-LD'"
-                       class="dropdown-item">{{fileType.translateKey | translate}}</a>
+    <div class="action-header" ng-show="resourceInfo">
+        <div id="selection" class="selection">
+            <ul class="nav nav-tabs">
+                <li ng-repeat="role in roles" class="nav-item">
+                    <a class="nav-link" href
+                       ng-click="changeRole(role)"
+                       ng-class="resourceInfo.role === role ? 'active' : (loading ? 'disabled': '')"
+                       ng-disabled="loading"
+                       guide-selector="role-{{role}}">
+                        {{role | translate}}
+                    </a>
                 </li>
             </ul>
         </div>
+        <div class="actions">
+            <label for="inference-select" class="mb-0">
+                <select id="inference-select"
+                        class="form-control form-control-sm"
+                        ng-model="currentContextTypeId"
+                        ng-change="changeInference(currentContextTypeId)"
+                        ng-disabled="loading || resourceInfo.role === 'context' || getActiveRepository() === 'SYSTEM'">
+                    <option ng-repeat="contextType in contextTypes"
+                            value="{{contextType.id}}"
+                            ng-selected="resourceInfo.contextType.id === contextType.id">
+                        {{contextType.labelKey | translate}}
+                    </option>
+                </select>
+            </label>
 
-        <button type="button" role="button" class="btn btn-primary btn-sm visual-graph-btn"
-                uib-popover="{{'explore.graph.visually.popover' | translate}}"
-                popover-trigger="mouseenter"
-                popover-placement="bottom"
-                ng-click="goToGraphsViz()"
-                guide-selector="explore-visual">
-            {{'visual.graph.label' | translate}}
-        </button>
+            <button type="button" class="btn btn-link same-as-btn btn-sm"
+                    ng-model="sameAs"
+                    ng-class="loading ? 'disabled' : ''"
+                    ng-if="resourceInfo.contextType !== ContextTypes.EXPLICIT"
+                    ng-click="toggleSameAs()"
+                    uib-popover="{{'sidepanel.expand.results.sameas' | translate}}: {{resourceInfo.sameAs ? 'common.on.btn' : 'common.off.btn' | translate}}"
+                    popover-trigger="mouseenter"
+                    popover-placement="bottom">
+                <span class="icon-2x"
+                      ng-class="{'icon-same-as-on':resourceInfo.sameAs, 'icon-same-as-off':!resourceInfo.sameAs}"></span>
+            </button>
 
-    </div>
+            <button type="button"
+                    class="btn btn-sm show-blank-nodes-btn" ng-model="resourceInfo.blanks"
+                    ng-class="loading ? 'disabled' : (resourceInfo.blanks ? 'btn-primary' : 'btn-secondary')"
+                    uib-btn-checkbox
+                    btn-checkbox-true="true"
+                    btn-checkbox-false="false"
+                    ng-change="exploreResource()">
+                {{'show.blank.nodes.label' | translate}}
+            </button>
 
-    <div id="selection" class="selection mb-1" ng-if="resourceInfo">
-        <ul class="nav nav-tabs">
-            <li ng-repeat="role in roles" class="nav-item">
-                <a class="nav-link" href
-                   ng-click="changeRole(role)"
-                   ng-class="resourceInfo.role === role ? 'active' : (loading ? 'disabled': '')"
-                   ng-disabled="loading"
-                   guide-selector="role-{{role}}">
-                    {{role | translate}}
-                </a>
-            </li>
-        </ul>
+            <div class="btn-group" uib-dropdown is-open="isopen">
+                <button type="button"
+                        class="btn btn-sm btn-secondary dropdown-toggle download-as"
+                        ng-class="loading ? 'disabled' : ''"
+                        uib-dropdown-toggle>
+                    {{'download.as.label' | translate}}
+                </button>
+                <ul class="dropdown-menu small download-options" role="menu">
+                    <li ng-repeat="fileType in fileTypes">
+                        <a href="javascript:" ng-click="openJSONLDExportSettings(fileType)"
+                           ng-if="fileType.name === 'JSON-LD' || fileType.name === 'NDJSON-LD'"
+                           class="dropdown-item">{{fileType.translateKey | translate}}</a>
+                        <a href="javascript:" ng-click="downloadExport(fileType)"
+                           ng-if="fileType.name !== 'JSON-LD' && fileType.name !== 'NDJSON-LD'"
+                           class="dropdown-item">{{fileType.translateKey | translate}}</a>
+                    </li>
+                </ul>
+            </div>
+            <onto-graph-explore-split-button
+                ng-custom-element
+                label="{{'query.editor.visual.btn' | translate}}"
+                ngce-prop-fetch_graph_configs="fetchGraphConfigs"
+                ngce-on-graph_explore="goToGraphsViz($event)">
+            </onto-graph-explore-split-button>
+        </div>
     </div>
 
     <yasgui-component id="query-editor"

--- a/packages/shared-components/src/components/onto-graph-explore-split-button/onto-graph-explore-split-button.tsx
+++ b/packages/shared-components/src/components/onto-graph-explore-split-button/onto-graph-explore-split-button.tsx
@@ -120,6 +120,7 @@ export class OntoGraphExploreSplitButton {
       <div class='explore-visual-graph-button-group'>
         <button class='explore-visual-graph-button icon-data'
           onClick={this.handleDefaultClick}
+          guide-selector='explore-visual'
           tooltip-content={TranslationService.translate('graph_explore_split_button.buttons.explore_visual_graph.tooltip')}
           tooltip-placement={OntoTooltipPlacement.TOP}>
           {this.label}


### PR DESCRIPTION
GDB-13800: Allow specifying VizGraph configuration for SPARQL results

## What
Added a visual graph split button to the Resource view. It includes a main button and a dropdown listing all available visual configurations. Clicking the main button preserves the current behavior. If the user selects an item from the dropdown, the chosen configuration is sent to the visual graph view and used for resource visualization.

## Why
Users can open a loaded resource in the Resource view with a predefined VizGraph configuration.

## How
Replaced the simple visual button with a visual graph split button.


## Screenshots
<img width="991" height="554" alt="image" src="https://github.com/user-attachments/assets/143b709d-4428-40f3-a583-c5e449681967" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [ ] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
