### PR TITLE
GDB-14327 fix misaligned highlight in class relationships

### DIFF
--- a/packages/legacy-workbench/src/pages/dependencies.html
+++ b/packages/legacy-workbench/src/pages/dependencies.html
@@ -17,10 +17,10 @@
 </div>
 <div class="content" ng-show="!isActiveRepoFedXType() && !repositoryError && isLicenseValid() && !isSystemRepository()" guide-selector="relationships-page">
     <div class="pull-right relations-toolbar" ng-show="status != 'NO_REPO' && status != 'N/A' && !isLoading()">
-        <div id="selectGraphDropdown" class="btn-group" role="group" ng-show="graphsInRepo.length > 2" guide-selector="graph-select-dropdown"
+        <div id="selectGraphDropdown" class="btn-group" role="group" ng-show="graphsInRepo.length > 2"
              uib-dropdown
              on-toggle="graphsDropdownToggled(open)">
-            <button id="graphsBtnGroup" type="button" class="btn btn-lg btn-secondary"
+            <button id="graphsBtnGroup" type="button" class="btn btn-lg btn-secondary" guide-selector="graph-select-dropdown"
                     uib-dropdown-toggle>
 
         <span tooltip-placement="bottom" gdb-tooltip="{{'select.graph.label' | translate}}">


### PR DESCRIPTION
## What
Fix misaligned highlight in class relationships.

## Why
It was highlighting some whitespace after the button

## How
Moved the guide selector to target the button instead of the wrapper.

## Testing
n/a

## Screenshots
<img width="1195" height="664" alt="image" src="https://github.com/user-attachments/assets/08a8de61-9cfe-4662-bf58-d6e529081dfc" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
