### PR TITLE
GDB-14548 fix missing link limit in URL with construct query

### DIFF
--- a/e2e-tests/e2e-legacy/explore/visual-graph/visual-graph-links-limit.spec.js
+++ b/e2e-tests/e2e-legacy/explore/visual-graph/visual-graph-links-limit.spec.js
@@ -125,6 +125,7 @@ describe('Visual graph linksLimit URL parameter', () => {
             VisualGraphSplitButtonSteps.clickOnVisualizeMainButton();
 
             // Then, I expect to see 10 nodes before changing the limit
+            BaseSteps.getUrl().should('include', 'linksLimit=10');
             VisualGraphSteps.getNodes().should('have.length', 10); // 10 nodes total, since we don't have a root node
 
             // When, I update the link limit from the input field

--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -614,6 +614,9 @@ function GraphsVisualizationsCtrl(
     function configureLinkLimit() {
         const linksLimitParam = $location.search().linksLimit;
         if (!linksLimitParam) {
+            $location.replace();
+            $location.search('linksLimit', $scope.linksLimit.value);
+            $location.state({skipOnPopState: true});
             return;
         }
         const parsedLinkLimit = Number.parseInt(linksLimitParam, 10);


### PR DESCRIPTION
## What
Fix missing link limit in URL when constructing query.

## Why
It was not being set, when we open a visual graphs with a query parameter

## How
Added logic to set the `linksLimit` parameter in the URL whenever a visual graph is opened and the parameter is missing

## Testing
cypress

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
