### PR TITLE
GDB-14512: Similarity View more options dropdown icon not having on-click behavior

### DIFF
--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -1528,6 +1528,7 @@
     "index.name": "Index name",
     "my.index.name.required": "My index name (required)",
     "more.options.label": "more options",
+    "fewer.options.label": "fewer options",
     "semantic.vectors.index.params": "Semantic Vectors create index parameters",
     "see.full.label": "See the full",
     "list.of.supported.params": "list of supported parameters",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -1527,6 +1527,7 @@
     "index.name": "Nom d'index",
     "my.index.name.required": "Mon nom d'index (obligatoire)",
     "more.options.label": "plus d'options",
+    "fewer.options.label": "moins d'options",
     "semantic.vectors.index.params": "Vecteurs sémantiques créer des paramètres d'index",
     "see.full.label": "Voir la liste complète",
     "list.of.supported.params": "liste complète des paramètres supportés",

--- a/packages/legacy-workbench/src/pages/create-index.html
+++ b/packages/legacy-workbench/src/pages/create-index.html
@@ -62,8 +62,10 @@
                 <button ng-if="!isEditViewMode()"
                         class="btn btn-link btn-sm mt-1 px-0 collapsed more-options-btn"
                         data-toggle="collapse"
-                        data-target="#more-options">
-                    {{'more.options.label' | translate}} <span class="ri-arrow-up-s-line"></span>
+                        data-target="#more-options"
+                        ng-click="collapse = !collapse">
+                    {{ (collapse ? 'fewer.options.label' : 'more.options.label') | translate }}
+                    <span ng-class="{'ri-arrow-up-s-line': collapse, 'ri-arrow-down-s-line': !collapse}"></span>
                 </button>
 
                 <div id="more-options" class="collapse mt-1">


### PR DESCRIPTION
## What
In the Create Similarity Index view, clicking more options expands the additional settings, but:
 - The label does not update (it still shows “more options” instead of switching to “fewer options”)
 - The chevron icon does not rotate to reflect the expanded/collapsed state

## Why
This behavior was not implemented, resulting in inconsistent UI feedback for the expanded state.

## How
- Added support for toggling the label between more options and fewer options.
- Fixed the chevron icon to update/rotate based on the collapse state

## Screenshots
<img width="603" height="421" alt="image" src="https://github.com/user-attachments/assets/446b51bd-da35-44ce-a401-73a9fed16e62" />
<img width="603" height="421" alt="image" src="https://github.com/user-attachments/assets/fc302427-48f9-43f1-bd24-97687aa85f40" />



## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
