### PR TITLE
GDB-13827: Implement generic dialog service in workbench

### DIFF
--- a/packages/workbench/src/app/app.config.ts
+++ b/packages/workbench/src/app/app.config.ts
@@ -7,7 +7,8 @@ import {routes} from './app.routes';
 import {bootstrapProviders} from './bootstrap/bootstrap';
 import {APP_BASE_HREF} from '@angular/common';
 import {getSingleSpaExtraProviders} from 'single-spa-angular';
-import { providePrimeNG } from 'primeng/config';
+import {providePrimeNG} from 'primeng/config';
+import {DialogService} from 'primeng/dynamicdialog';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -24,6 +25,7 @@ export const appConfig: ApplicationConfig = {
           prefix: 'gw',
         }
       }
-    })
+    }),
+    DialogService
   ]
 };

--- a/packages/workbench/src/app/models/dialog-open-options.ts
+++ b/packages/workbench/src/app/models/dialog-open-options.ts
@@ -1,0 +1,14 @@
+/**
+ * Options used by `DialogProviderService` when opening a dialog.
+ *
+ * @template DataType - Type of the payload passed to the dialog component via `data`.
+ */
+export interface DialogOpenOptions<DataType> {
+  data?: DataType;
+  showHeader?: boolean;
+  header?: string;
+  width?: string;
+  height?: string;
+  closable?: boolean;
+  modal?: boolean;
+}

--- a/packages/workbench/src/app/services/dialog-provider-service.spec.ts
+++ b/packages/workbench/src/app/services/dialog-provider-service.spec.ts
@@ -1,0 +1,163 @@
+import {TestBed} from '@angular/core/testing';
+import {Component} from '@angular/core';
+import {DialogService, DynamicDialogConfig, DynamicDialogRef} from 'primeng/dynamicdialog';
+import {Subject} from 'rxjs';
+import {DialogProviderService} from './dialog-provider.service';
+import {DialogOpenOptions} from '../models/dialog-open-options';
+
+@Component({standalone: true, template: ''})
+class TestDialogComponent {}
+
+describe('DialogProviderService', () => {
+  let service: DialogProviderService;
+  let mockDialogServiceOpen: jest.Mock;
+  let onCloseSubject: Subject<unknown>;
+  let dialogRef: Partial<DynamicDialogRef>;
+
+  beforeEach(() => {
+    onCloseSubject = new Subject<unknown>();
+    dialogRef = {onClose: onCloseSubject.asObservable()};
+    mockDialogServiceOpen = jest.fn().mockReturnValue(dialogRef);
+
+    TestBed.configureTestingModule({
+      providers: [
+        DialogProviderService,
+        {provide: DialogService, useValue: {open: mockDialogServiceOpen}}
+      ]
+    });
+    service = TestBed.inject(DialogProviderService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('#open', () => {
+    it('should call DialogService.open with the correct component type', () => {
+      const config: DialogOpenOptions<unknown> = {};
+
+      void service.open(TestDialogComponent, config);
+
+      expect(mockDialogServiceOpen).toHaveBeenCalledWith(TestDialogComponent, expect.any(Object));
+    });
+
+    it('should pass data from config to the dialog', () => {
+      const data = {foo: 'bar'};
+      const config: DialogOpenOptions<typeof data> = {data};
+
+      void service.open(TestDialogComponent, config);
+
+      const usedConfig: DynamicDialogConfig = mockDialogServiceOpen.mock.calls[0][1];
+      expect(usedConfig.data).toEqual(data);
+    });
+
+    it('should set showHeader to true when header is provided', () => {
+      const config: DialogOpenOptions<unknown> = {header: 'My Dialog'};
+
+      void service.open(TestDialogComponent, config);
+
+      const usedConfig: DynamicDialogConfig = mockDialogServiceOpen.mock.calls[0][1];
+      expect(usedConfig.showHeader).toBe(true);
+      expect(usedConfig.header).toBe('My Dialog');
+    });
+
+    it('should set showHeader to false when header is not provided', () => {
+      const config: DialogOpenOptions<unknown> = {};
+
+      void service.open(TestDialogComponent, config);
+
+      const usedConfig: DynamicDialogConfig = mockDialogServiceOpen.mock.calls[0][1];
+      expect(usedConfig.showHeader).toBe(false);
+    });
+
+    it('should forward width and height from config', () => {
+      const config: DialogOpenOptions<unknown> = {width: '600px', height: '400px'};
+
+      void service.open(TestDialogComponent, config);
+
+      const usedConfig: DynamicDialogConfig = mockDialogServiceOpen.mock.calls[0][1];
+      expect(usedConfig.width).toBe('600px');
+      expect(usedConfig.height).toBe('400px');
+    });
+
+    it('should default closable to false when not provided', () => {
+      const config: DialogOpenOptions<unknown> = {};
+
+      void service.open(TestDialogComponent, config);
+
+      const usedConfig: DynamicDialogConfig = mockDialogServiceOpen.mock.calls[0][1];
+      expect(usedConfig.closable).toBe(false);
+    });
+
+    it('should use the provided closable value', () => {
+      const config: DialogOpenOptions<unknown> = {closable: true};
+
+      void service.open(TestDialogComponent, config);
+
+      const usedConfig: DynamicDialogConfig = mockDialogServiceOpen.mock.calls[0][1];
+      expect(usedConfig.closable).toBe(true);
+    });
+
+    it('should default modal to true when not provided', () => {
+      const config: DialogOpenOptions<unknown> = {};
+
+      void service.open(TestDialogComponent, config);
+
+      const usedConfig: DynamicDialogConfig = mockDialogServiceOpen.mock.calls[0][1];
+      expect(usedConfig.modal).toBe(true);
+    });
+
+    it('should use the provided modal value', () => {
+      const config: DialogOpenOptions<unknown> = {modal: false};
+
+      void service.open(TestDialogComponent, config);
+
+      const usedConfig: DynamicDialogConfig = mockDialogServiceOpen.mock.calls[0][1];
+      expect(usedConfig.modal).toBe(false);
+    });
+
+    it('should always apply the onto-dialog styleClass', () => {
+      void service.open(TestDialogComponent, {});
+
+      const usedConfig: DynamicDialogConfig = mockDialogServiceOpen.mock.calls[0][1];
+      expect(usedConfig.styleClass).toBe('onto-dialog');
+    });
+
+    it('should always set draggable to false', () => {
+      void service.open(TestDialogComponent, {});
+
+      const usedConfig: DynamicDialogConfig = mockDialogServiceOpen.mock.calls[0][1];
+      expect(usedConfig.draggable).toBe(false);
+    });
+
+    it('should return a Promise that resolves with the value passed when the dialog closes', async () => {
+      const returnValue = {result: 'success'};
+      const resultPromise = service.open<unknown, typeof returnValue>(TestDialogComponent, {});
+
+      onCloseSubject.next(returnValue);
+
+      await expect(resultPromise).resolves.toEqual(returnValue);
+    });
+
+    it('should return a Promise that resolves undefined when the dialog closes without a value', async () => {
+      const resultPromise = service.open(TestDialogComponent, {});
+
+      onCloseSubject.next(undefined);
+
+      await expect(resultPromise).resolves.toBeUndefined();
+    });
+
+    it('should throw an error when the dialog fails to open (null ref)', () => {
+      mockDialogServiceOpen.mockReturnValue(null);
+
+      expect(() => service.open(TestDialogComponent, {})).toThrow('Dialog failed to open');
+    });
+
+    it('should throw an error when the dialog fails to open (undefined ref)', () => {
+      mockDialogServiceOpen.mockReturnValue(undefined);
+
+      expect(() => service.open(TestDialogComponent, {})).toThrow('Dialog failed to open');
+    });
+  });
+
+});

--- a/packages/workbench/src/app/services/dialog-provider.service.ts
+++ b/packages/workbench/src/app/services/dialog-provider.service.ts
@@ -1,0 +1,53 @@
+import {inject, Injectable, Type} from '@angular/core';
+import {DialogService, DynamicDialogConfig, DynamicDialogRef} from 'primeng/dynamicdialog';
+import {firstValueFrom, map, Observable} from 'rxjs';
+import {DialogOpenOptions} from '../models/dialog-open-options';
+
+/**
+ * Service for opening application dialogs.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class DialogProviderService {
+  private readonly dialogService = inject(DialogService);
+
+  /**
+   * Opens a dialog for the given component and resolves with its close value.
+   *
+   * @template DataType Type of the payload passed to the dialog via `data`.
+   * @template ReturnType Type expected when the dialog closes.
+   * @param componentType Component rendered inside the dialog.
+   * @param config Options controlling how the dialog is opened.
+   * @returns Promise resolving to the value provided when the dialog closes.
+   */
+  public open<DataType, ReturnType>(componentType: Type<unknown>, config: DialogOpenOptions<DataType>): Promise<ReturnType | undefined> {
+    return firstValueFrom(this.openDialogWithComponent(componentType, config));
+  }
+
+  /**
+   * Opens a dialog for the given component and returns its close stream.
+   */
+  private openDialogWithComponent<DataType, ReturnType>(componentType: Type<unknown>, config: DialogOpenOptions<DataType>): Observable<ReturnType | undefined> {
+    const dialogConfig: DynamicDialogConfig<DataType> = {
+      data: config.data,
+      showHeader: !!config.header,
+      header: config.header,
+      width: config.width,
+      height: config.height,
+      closable: config.closable ?? false,
+      modal: config.modal ?? true,
+      styleClass: 'onto-dialog',
+      draggable: false
+    };
+    const dialogRef = this.dialogService.open(componentType, dialogConfig);
+    this.assertDialogIsDefined(dialogRef);
+    return dialogRef.onClose.pipe(map((value) => value as ReturnType | undefined));
+  }
+
+  private assertDialogIsDefined(dialogRef: DynamicDialogRef | null): asserts dialogRef is NonNullable<DynamicDialogRef> {
+    if (dialogRef === undefined || dialogRef === null) {
+      throw new Error('Dialog failed to open');
+    }
+  }
+}


### PR DESCRIPTION
## What
Added a new DialogProviderService for managing dialog components and their configurations. Introduced an DialogOpenOptions interface to standardize dialog options.

## Why
This change enhances the dialog management capabilities within the application, allowing for more flexible and reusable dialog components.

## How
- Created `DialogOpenOptions` interface to define dialog configuration options.
- Implemented `DialogProviderService` to handle dialog opening and configuration.
- Updated `app.config.ts` to provide the PrimeNG `DialogService`.
- Added unit tests for `DialogProviderService` to ensure functionality and reliability.

## Testing
added

## Screenshots
n/a

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified
