### PR TITLE
Increase ontotext-yasgui module version to 1.6.0

### DIFF
--- a/packages/legacy-workbench/package-lock.json
+++ b/packages/legacy-workbench/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
                 "ontotext-graphql-playground-component": "^0.0.9",
-                "ontotext-yasgui-web-component": "^1.6.0-TR8",
+                "ontotext-yasgui-web-component": "^1.6.0",
                 "single-spa-angularjs": "^4.3.1"
             },
             "devDependencies": {
@@ -5644,10 +5644,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.6.0-TR8",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.0-TR8.tgz",
-            "integrity": "sha512-P3sQavxcOe/pBpK7EzBqEIQ8wti/hj6V2rGfblXQWTgw0WkfZM7bFHumPHfrV1iuojedASXdfDQhB14u//roZw==",
-            "license": "MIT",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.0.tgz",
+            "integrity": "sha512-BtFvEhwMT8q8rzvRxtDIBnSXyvX/coZu3dfOuH5N5Qp/xSwnZ7vQcAriP/9GJ5xTtR6PzUwwkhFTYKdj2U6N0g==",
             "dependencies": {
                 "@floating-ui/dom": "^1.7.4",
                 "@stencil/core": "2.20.0",

--- a/packages/legacy-workbench/package.json
+++ b/packages/legacy-workbench/package.json
@@ -76,7 +76,7 @@
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
         "ontotext-graphql-playground-component": "^0.0.9",
-        "ontotext-yasgui-web-component": "^1.6.0-TR8",
+        "ontotext-yasgui-web-component": "^1.6.0",
         "single-spa-angularjs": "^4.3.1"
     },
     "resolutions": {

--- a/packages/workbench/package-lock.json
+++ b/packages/workbench/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/router": "^20.3.15",
         "@jsverse/transloco": "^8.2.0",
         "@primeuix/themes": "^2.0.3",
-        "ontotext-yasgui-web-component": "^1.6.0-TR8",
+        "ontotext-yasgui-web-component": "^1.6.0",
         "primeng": "^20.4.0",
         "rxjs": "~7.8.2",
         "single-spa": "^6.0.3",
@@ -16266,10 +16266,9 @@
       }
     },
     "node_modules/ontotext-yasgui-web-component": {
-      "version": "1.6.0-TR8",
-      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.0-TR8.tgz",
-      "integrity": "sha512-P3sQavxcOe/pBpK7EzBqEIQ8wti/hj6V2rGfblXQWTgw0WkfZM7bFHumPHfrV1iuojedASXdfDQhB14u//roZw==",
-      "license": "MIT",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.0.tgz",
+      "integrity": "sha512-BtFvEhwMT8q8rzvRxtDIBnSXyvX/coZu3dfOuH5N5Qp/xSwnZ7vQcAriP/9GJ5xTtR6PzUwwkhFTYKdj2U6N0g==",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",
         "@stencil/core": "2.20.0",

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -26,7 +26,7 @@
     "@angular/router": "^20.3.15",
     "@jsverse/transloco": "^8.2.0",
     "@primeuix/themes": "^2.0.3",
-    "ontotext-yasgui-web-component": "^1.6.0-TR8",
+    "ontotext-yasgui-web-component": "^1.6.0",
     "primeng": "^20.4.0",
     "rxjs": "~7.8.2",
     "single-spa": "^6.0.3",


### PR DESCRIPTION
## What
Increase ontotext-yasgui module version to 1.6.0

## Why
Introduce latest changes from the yasgui component to the workbench.

## How
Changed version in legacy and new workbench applications.

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
