### PR TITLE
GDB-14600 make popovers visible while hovered

### DIFF
--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -537,7 +537,8 @@
                     },
                     "similarity_search": {
                         "label": "Similarity search",
-                        "tooltip": "Answers questions by using Similarity search. Performs well on open-ended questions but not so well on providing aggregations."
+                        "tooltip": "Answers questions by using Similarity search. Performs well on open-ended questions but not so well on providing aggregations.",
+                        "link_text": "Learn more about the different similarity methods in the GraphDB documentation."
                     },
                     "similarity_search_max_number_of_triples_per_call": {
                         "label": "Max number of results (triples) per call",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -536,7 +536,8 @@
                     },
                     "similarity_search": {
                         "label": "Recherche de similarité",
-                        "tooltip": "Répond aux questions en utilisant la recherche de similarité. Fonctionne bien sur les questions ouvertes, mais moins bien sur les agrégations."
+                        "tooltip": "Répond aux questions en utilisant la recherche de similarité. Fonctionne bien sur les questions ouvertes, mais moins bien sur les agrégations.",
+                        "link_text": "En savoir plus sur les différentes méthodes de similarité dans la documentation de GraphDB."
                     },
                     "similarity_search_max_number_of_triples_per_call": {
                         "label": "Nombre maximal de résultats (triples) par appel",

--- a/packages/legacy-workbench/src/js/angular/repositories/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/controllers.js
@@ -510,6 +510,7 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
     $scope.enable = true;
     $scope.entityIndexSizeMin = ENTITY_INDEX_SIZE_MIN;
     $scope.documentationUrlForStorageEncryption = DocumentationUrlResolver.getDocumentationUrl(productInfo.productShortVersion, 'creating-a-repository.html#using-workbench');
+    $scope.encryptInput = {hovered: false};
 
     $scope.loader = true;
     $scope.pageTitle = $translate.instant('view.create.repo.title');

--- a/packages/legacy-workbench/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -103,6 +103,12 @@ function AgentSettingsModalController(
     // Public variables
     // =========================
 
+    /**
+     * Flag to control the popover visibility of the similarity input
+     * @type {{hovered: boolean}}
+     */
+    $scope.similarityInput = {hovered: false};
+
     $scope.AGENT_OPERATION = AGENT_OPERATION;
 
     /**

--- a/packages/legacy-workbench/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/packages/legacy-workbench/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -152,9 +152,11 @@
                                   uib-popover="{{'ttyg.agent.create_agent_modal.form.' + extractionMethod.method + '.tooltip' | translate}}"
                                   popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.' + extractionMethod.method + '.label' | translate}}</span>
                             <span class="mr-1" ng-if="extractionMethod.method === extractionMethods.SIMILARITY"
+                                  ng-mouseenter="similarityInput.hovered = true"
+                                  ng-mouseleave="similarityInput.hovered = false"
                                   uib-popover-template="'js/angular/ttyg/templates/modal/similarity-extraction-method-tooltip.html'"
-                                  popover-popup-close-delay="800"
-                                  popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.' + extractionMethod.method + '.label' | translate}}</span>
+                                  popover-is-open="similarityInput.hovered"
+                                  popover-trigger="none">{{'ttyg.agent.create_agent_modal.form.' + extractionMethod.method + '.label' | translate}}</span>
                             <i class="ri-arrow-down-s-line toggle-icon"
                                ng-class="{'expanded': extractionMethod.expanded}">
                             </i>

--- a/packages/legacy-workbench/src/js/angular/ttyg/templates/modal/similarity-extraction-method-tooltip.html
+++ b/packages/legacy-workbench/src/js/angular/ttyg/templates/modal/similarity-extraction-method-tooltip.html
@@ -1,9 +1,11 @@
-<span>
-    {{ 'ttyg.agent.create_agent_modal.form.' + extractionMethod.method + '.tooltip' | translate }}
-  </span>
-<div>
-    <a href="{{documentationUrlForSimilarity}}" target="_blank">
-        {{ 'ttyg.agent.create_agent_modal.form.similarity_search.link_text' | translate }}
-    </a>
-    <i class="ri-external-link-line"></i>
+<div ng-mouseenter="similarityInput.hovered = true" ng-mouseleave="similarityInput.hovered = false">
+    <span>
+        {{ 'ttyg.agent.create_agent_modal.form.' + extractionMethod.method + '.tooltip' | translate }}
+    </span>
+    <div>
+        <a href="{{documentationUrlForSimilarity}}" target="_blank">
+            {{ 'ttyg.agent.create_agent_modal.form.similarity_search.link_text' | translate }}
+        </a>
+        <i class="ri-external-link-line"></i>
+    </div>
 </div>

--- a/packages/legacy-workbench/src/pages/repository.html
+++ b/packages/legacy-workbench/src/pages/repository.html
@@ -65,14 +65,15 @@
                                        ng-model="repositoryInfo.params.readOnly.value"/>
                                 {{repositoryInfo.params.readOnly.label}}
                             </label>
-                            <label class="padding-label" for="storageEncryption">
+                            <label ng-mouseenter="encryptInput.hovered = true" ng-mouseleave="encryptInput.hovered = false"  class="padding-label" for="storageEncryption">
                                 <input id="storageEncryption" type="checkbox" ng-true-value="'true'" ng-false-value="'false'"
                                        ng-disabled="editRepoPage"
                                        ng-model="repositoryInfo.params.storageEncryption.value"/>
                                 <span ng-if="!editRepoPage"
                                       uib-popover-template="'js/angular/repositories/templates/storage-encryption-tooltip.html'"
-                                      popover-popup-close-delay="800"
-                                      popover-trigger="mouseenter">
+                                      popover-append-to-body="false"
+                                      popover-is-open="encryptInput.hovered"
+                                      popover-trigger="none">
                                     {{'repo.storageEncryption.label' | translate}}
                                 </span>
                                 <span ng-if="editRepoPage" gdb-tooltip="{{'repoTooltips.storageEncryption.edit' | translate}}">


### PR DESCRIPTION
## What
Make popovers for storage encryption and similarity extraction methods visible while hovered.

## Why
They closed after a set timeout of 800ms before. Now they remain visible on hover, which makes it easier to click their links

## How
- Added `ng-mouseenter` and `ng-mouseleave` events to control the visibility of popovers for the storage encryption checkbox and similarity extraction method.
- Updated the `uib-popover` attributes to use `popover-is-open` for dynamic visibility based on hover state.

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
