### PR TITLE
GDB-14468 fix chevron size in navbar

### DIFF
--- a/packages/shared-components/src/components/onto-navbar/onto-navbar.scss
+++ b/packages/shared-components/src/components/onto-navbar/onto-navbar.scss
@@ -71,8 +71,9 @@ main menu height*/
 }
 
 .navbar-component .menu-element-root {
-  padding: 0.8em 2.5em 0.8em 0.8em;
-  display: block;
+  padding: 0.8em;
+  display: flex;
+  align-items: center;
   line-height: 2.5rem;
   position: relative;
   z-index: 100;
@@ -102,6 +103,18 @@ main menu height*/
 
 .navbar-component .menu-element-root .menu-item {
   pointer-events: none;
+}
+
+.navbar-component .chevron {
+  margin-left: auto;
+  font-size: 1rem;
+  transition: all 0.2s ease-in;
+  pointer-events: none;
+  color: var(--gw-sidenav-menuitem-icon-second-color);
+}
+
+.navbar-component .chevron.open {
+  transform: rotate(90deg);
 }
 
 .navbar-component :not(.brand) .menu-element-root {
@@ -135,25 +148,6 @@ main menu height*/
 
 .navbar-component .menu-element.open ul li {
   display: block;
-}
-
-.navbar-component .menu-element ul:before {
-  font-family: 'icomoon', sans-serif !important;
-  content: "\e91b";
-  display: block;
-  font-size: 1.5em;
-  position: absolute;
-  top: -3.3rem;
-  right: 1rem;
-  -moz-transition: all 0.2s ease-in; /* FF4+ */
-  -o-transition: all 0.2s ease-in; /* Opera 10.5+ */
-  -webkit-transition: all 0.2s ease-in; /* Saf3.2+, Chrome */
-  transition: all 0.2s ease-in;
-  pointer-events: none;
-}
-
-.navbar-component .menu-element.open ul:before, .rdf-list ul.open.datasource:before {
-  transform: rotate(90deg);
 }
 
 .navbar-component.collapsed {
@@ -224,7 +218,7 @@ main menu height*/
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  font-size: 0.8em;
+  font-size: 1em;
   line-height: 1.5;
   padding: 0 0.3em;
   z-index: 101;

--- a/packages/shared-components/src/components/onto-navbar/onto-navbar.tsx
+++ b/packages/shared-components/src/components/onto-navbar/onto-navbar.tsx
@@ -364,7 +364,7 @@ export class OntoNavbar {
             <a class="toggle-menu no-underline" title={
               this.isCollapsed ? this.labels[labelKeys.EXPAND] : this.labels[labelKeys.COLLAPSE]
             } onClick={this.toggleNavbarHandler()}>
-              <em class={this.isCollapsed ? 'ri-arrow-right-s-line' : 'ri-arrow-left-s-line'}></em>
+              <i class={`chevron ${this.isCollapsed ? 'ri-arrow-right-s-line' : 'ri-arrow-left-s-line'}`}></i>
             </a>
           </li>
           {this.menuModel.items.map((item) => (
@@ -376,6 +376,7 @@ export class OntoNavbar {
                     onClick={this.handleSelectMenuItem(item)}>
                     <span class={`menu-item-icon ${item.icon}`}></span>&nbsp;
                     <translate-label class="menu-item" labelKey={item.labelKey}></translate-label>
+                    {!this.isCollapsed && <i class={`chevron ri-arrow-right-s-line ${item.open ? ' open' : ''}`}></i>}
                   </div>
                   <ul class="sub-menu">
                     <li key={item.labelKey} class="submenu-title">


### PR DESCRIPTION
## What
Fix chevron size in navbar.

## Why
The chevron size was inconsistent between the individual menus and the entire navbar toggle chevron

## How
- Replaced the content with a remix icon for the menus
- Created a .chevron class, which is attached to both icons
- Adjusted surrounding styles

## Testing
n/a

## Screenshots
Figma
<img width="753" height="944" alt="Screenshot from 2026-05-13 11-00-24" src="https://github.com/user-attachments/assets/28071107-6c2f-4753-9751-59ca741395c3" />

Result
<img width="310" height="842" alt="Screenshot from 2026-05-13 11-00-43" src="https://github.com/user-attachments/assets/673b2eff-1ad2-4f1a-8e3c-bffafbb97a60" />
<img width="310" height="842" alt="Screenshot from 2026-05-13 11-00-51" src="https://github.com/user-attachments/assets/578d1b8d-ef96-403e-8298-79431c68fc16" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
