### PR TITLE
GDB-13830: Migrate the page-info-tooltip directive

### DIFF
--- a/packages/api/src/models/product-info/product-info.ts
+++ b/packages/api/src/models/product-info/product-info.ts
@@ -6,7 +6,7 @@ export class ProductInfo {
   connectors: string;
   ontop: string;
   // Computed property
-  shortVersion?: string;
+  shortVersion: string;
 
   constructor(data: Omit<ProductInfo, 'shortVersion'>) {
     this.workbench = data.workbench;

--- a/packages/workbench/src/app/app.routes.ts
+++ b/packages/workbench/src/app/app.routes.ts
@@ -1,8 +1,15 @@
 import {Routes} from '@angular/router';
+import {documentationLinkResolve} from './services/route-data-resolver';
 
 export const routes: Routes = [
   {
     path: 'sparql-new',
+    data: {
+      title: 'sparql_editor.title',
+      helpInfo: 'sparql_editor.helpInfo',
+      documentationUrl: 'sparql-queries.html'
+    },
+    resolve: {documentationLink: documentationLinkResolve},
     loadComponent: () => import('./pages/sparql-editor/sparql-editor-page.component').then(m => m.SparqlEditorPageComponent)
   },
   {

--- a/packages/workbench/src/app/components/page-info-tooltip/page-info-tooltip.component.html
+++ b/packages/workbench/src/app/components/page-info-tooltip/page-info-tooltip.component.html
@@ -1,3 +1,29 @@
-<span class="btn btn-link page-info-icon">
-  <span class="ri-information-2-line text-tertiary"></span>
-</span>
+<p-button class="page-info-icon" icon="ri-icon ri-information-2-line"
+          [rounded]="true" [text]="true" styleClass="page-info-icon-button text-tertiary"
+          (focus)="show($event)"
+          (mouseover)="show($event)"
+          (mouseleave)="hide()"
+          (focusout)="hide()"/>
+
+<p-popover #popover styleClass="page-info-tooltip">
+  <ng-template #content>
+    <div class="help-info"
+         (mouseenter)="cancelHide()"
+         (mouseleave)="hide()"
+         (focusin)="cancelHide()"
+         (focusout)="hide()">
+      <h4>{{ title() }}</h4>
+      @if (helpInfo()) {
+        <div>
+          <p [innerHTML]="helpInfo()">
+          </p>
+        </div>
+      }
+      @if (documentationLink()) {
+        <div>
+          <a [href]="documentationLink()" target="_blank" rel="noopener">{{ 'components.page_info_tooltip.documentation_link' | transloco }}</a> <i class="ri-external-link-line"></i>
+        </div>
+      }
+    </div>
+  </ng-template>
+</p-popover>

--- a/packages/workbench/src/app/components/page-info-tooltip/page-info-tooltip.component.scss
+++ b/packages/workbench/src/app/components/page-info-tooltip/page-info-tooltip.component.scss
@@ -1,3 +1,33 @@
-.page-info-icon {
-  //  do nothing for now
+:host {
+  display: flex;
+
+  .page-info-icon {
+    display: inline-flex;
+  }
+}
+
+
+/* stylelint-disable-next-line selector-pseudo-element-no-unknown */
+::ng-deep {
+  .page-info-icon-button {
+    .ri-icon {
+      font-size: 1.4em;
+    }
+  }
+
+  .page-info-tooltip {
+    margin-top: 0 !important;
+    max-width: 400px;
+
+    &::before, &::after {
+      content: unset !important;
+    }
+
+    .p-popover-content {
+      .help-info {
+        font-size: .875rem;
+        font-weight: 400;
+      }
+    }
+  }
 }

--- a/packages/workbench/src/app/components/page-info-tooltip/page-info-tooltip.component.spec.ts
+++ b/packages/workbench/src/app/components/page-info-tooltip/page-info-tooltip.component.spec.ts
@@ -1,22 +1,153 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentRef} from '@angular/core';
 
-import { PageInfoTooltipComponent } from './page-info-tooltip.component';
+import {PageInfoTooltipComponent} from './page-info-tooltip.component';
+import {provideTranslocoForTesting} from '../../../testing-utils/transloco-utils';
 
 describe('PageInfoTooltipComponent', () => {
   let component: PageInfoTooltipComponent;
   let fixture: ComponentFixture<PageInfoTooltipComponent>;
+  let componentRef: ComponentRef<PageInfoTooltipComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PageInfoTooltipComponent]
+      imports: [PageInfoTooltipComponent, provideTranslocoForTesting()]
     }).compileComponents();
 
     fixture = TestBed.createComponent(PageInfoTooltipComponent);
     component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('DOM', () => {
+    it('should render the trigger button', () => {
+      const button = fixture.nativeElement.querySelector('p-button.page-info-icon');
+      expect(button).not.toBeNull();
+    });
+
+    it('should render the info icon inside the button', () => {
+      const icon = fixture.nativeElement.querySelector('.ri-information-2-line');
+      expect(icon).not.toBeNull();
+    });
+  });
+
+  describe('inputs', () => {
+    it('should accept a title input', () => {
+      componentRef.setInput('title', 'Test Title');
+      fixture.detectChanges();
+      expect(component.title()).toBe('Test Title');
+    });
+
+    it('should accept a helpInfo input', () => {
+      componentRef.setInput('helpInfo', '<p>Help information</p>');
+      fixture.detectChanges();
+      expect(component.helpInfo()).toBe('<p>Help information</p>');
+    });
+
+    it('should accept a documentationLink input', () => {
+      componentRef.setInput('documentationLink', 'https://docs.example.com');
+      fixture.detectChanges();
+      expect(component.documentationLink()).toBe('https://docs.example.com');
+    });
+  });
+
+  describe('show()', () => {
+    it('should cancel any pending hide and show the popover', () => {
+      const mockPopover = {show: jest.fn(), hide: jest.fn()};
+      Object.defineProperty(component, 'popover', {value: () => mockPopover, writable: true});
+      const cancelHideSpy = jest.spyOn(component, 'cancelHide');
+
+      const event = new MouseEvent('mouseover');
+      component.show(event);
+
+      expect(cancelHideSpy).toHaveBeenCalled();
+      expect(mockPopover.show).toHaveBeenCalledWith(event);
+    });
+
+    it('should be triggered by mouseover on the button', () => {
+      const showSpy = jest.spyOn(component, 'show');
+      const pButton: HTMLElement = fixture.nativeElement.querySelector('p-button');
+      pButton.dispatchEvent(new MouseEvent('mouseover'));
+      expect(showSpy).toHaveBeenCalled();
+    });
+
+    it('should be triggered by focus on the button', () => {
+      const showSpy = jest.spyOn(component, 'show');
+      const pButton: HTMLElement = fixture.nativeElement.querySelector('p-button');
+      pButton.dispatchEvent(new FocusEvent('focus'));
+      expect(showSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('hide()', () => {
+    it('should hide the popover after the delay', () => {
+      jest.useFakeTimers();
+      const mockPopover = {show: jest.fn(), hide: jest.fn()};
+      Object.defineProperty(component, 'popover', {value: () => mockPopover, writable: true});
+
+      component.hide();
+
+      expect(mockPopover.hide).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(180);
+      expect(mockPopover.hide).toHaveBeenCalled();
+      jest.useRealTimers();
+    });
+
+    it('should be triggered by mouseleave on the button', () => {
+      const hideSpy = jest.spyOn(component, 'hide');
+      const pButton: HTMLElement = fixture.nativeElement.querySelector('p-button');
+      pButton.dispatchEvent(new MouseEvent('mouseleave'));
+      expect(hideSpy).toHaveBeenCalled();
+    });
+
+    it('should be triggered by focusout on the button', () => {
+      const hideSpy = jest.spyOn(component, 'hide');
+      const pButton: HTMLElement = fixture.nativeElement.querySelector('p-button');
+      pButton.dispatchEvent(new FocusEvent('focusout'));
+      expect(hideSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('cancelHide()', () => {
+    it('should prevent the popover from hiding when called before the delay elapses', () => {
+      jest.useFakeTimers();
+      const mockPopover = {show: jest.fn(), hide: jest.fn()};
+      Object.defineProperty(component, 'popover', {value: () => mockPopover, writable: true});
+
+      component.hide();
+      component.cancelHide();
+      jest.advanceTimersByTime(180);
+
+      expect(mockPopover.hide).not.toHaveBeenCalled();
+      jest.useRealTimers();
+    });
+
+    it('should do nothing when no hide is pending', () => {
+      expect(() => component.cancelHide()).not.toThrow();
+    });
+  });
+
+  describe('ngOnDestroy()', () => {
+    it('should cancel any pending hide timeout', () => {
+      jest.useFakeTimers();
+      const mockPopover = {show: jest.fn(), hide: jest.fn()};
+      Object.defineProperty(component, 'popover', {value: () => mockPopover, writable: true});
+
+      component.hide();
+      component.ngOnDestroy();
+      jest.advanceTimersByTime(180);
+
+      expect(mockPopover.hide).not.toHaveBeenCalled();
+      jest.useRealTimers();
+    });
+
+    it('should not throw when called without a pending hide', () => {
+      expect(() => component.ngOnDestroy()).not.toThrow();
+    });
   });
 });

--- a/packages/workbench/src/app/components/page-info-tooltip/page-info-tooltip.component.ts
+++ b/packages/workbench/src/app/components/page-info-tooltip/page-info-tooltip.component.ts
@@ -1,12 +1,50 @@
-import { Component } from '@angular/core';
+import {Component, input, OnDestroy, viewChild} from '@angular/core';
+import {Popover} from 'primeng/popover';
+import {TranslocoPipe} from '@jsverse/transloco';
+import {Button} from 'primeng/button';
 
 @Component({
   selector: 'app-page-info-tooltip',
   standalone: true,
-  imports: [],
+  imports: [
+    Popover,
+    TranslocoPipe,
+    Button
+  ],
   templateUrl: './page-info-tooltip.component.html',
-  styleUrl: './page-info-tooltip.component.scss',
+  styleUrl: './page-info-tooltip.component.scss'
 })
-export class PageInfoTooltipComponent {
+export class PageInfoTooltipComponent implements OnDestroy {
+  readonly title = input<string>();
+  readonly helpInfo = input<string>();
+  readonly documentationLink = input<string>();
 
+  private readonly popover = viewChild<Popover>('popover');
+  private readonly hideDelayMs = 180;
+  private hideTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  show($event: MouseEvent | FocusEvent) {
+    this.cancelHide();
+    this.popover()?.show($event);
+  }
+
+  hide() {
+    this.cancelHide();
+    this.hideTimeout = setTimeout(() => {
+      this.popover()?.hide();
+    }, this.hideDelayMs);
+  }
+
+  cancelHide() {
+    if (!this.hideTimeout) {
+      return;
+    }
+
+    clearTimeout(this.hideTimeout);
+    this.hideTimeout = null;
+  }
+
+  ngOnDestroy() {
+    this.cancelHide();
+  }
 }

--- a/packages/workbench/src/app/components/page-layout/page-layout.component.html
+++ b/packages/workbench/src/app/components/page-layout/page-layout.component.html
@@ -1,8 +1,12 @@
 <div class="page-view">
   @if (!this.embedded()) {
     <h1 class="title-container">
-      <span class="page-title-label">{{ title() }}</span>
-      <ng-content select="[page-tooltip]"></ng-content>
+      <span class="page-title-label">{{ title() | transloco}}</span>
+      @if (helpInfo()) {
+        <app-page-info-tooltip [title]="title() | transloco"
+                               [helpInfo]="helpInfo() | transloco"
+                               [documentationLink]="documentationLink()"></app-page-info-tooltip>
+      }
     </h1>
 
     <div class="page-errors-container">

--- a/packages/workbench/src/app/components/page-layout/page-layout.component.scss
+++ b/packages/workbench/src/app/components/page-layout/page-layout.component.scss
@@ -11,4 +11,7 @@
 .page-view .title-container {
   position: var(--page-title-position);
   margin-bottom: var(--page-title-margin-bottom);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }

--- a/packages/workbench/src/app/components/page-layout/page-layout.component.spec.ts
+++ b/packages/workbench/src/app/components/page-layout/page-layout.component.spec.ts
@@ -2,22 +2,24 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {PageLayoutComponent} from './page-layout.component';
 import {CommonModule} from '@angular/common';
-import {ActivatedRoute, Router} from '@angular/router';
+import {ActivatedRoute} from '@angular/router';
+import {provideTranslocoForTesting} from '../../../testing-utils/transloco-utils';
+
+function buildActivatedRouteMock(queryParams: Record<string, string> = {}, data: Record<string, unknown> = {}) {
+  return {
+    snapshot: {queryParams, data}
+  };
+}
 
 describe('PageLayoutComponent', () => {
   let component: PageLayoutComponent;
   let fixture: ComponentFixture<PageLayoutComponent>;
 
   beforeEach(async () => {
-    const activatedRouteMock = {
-      snapshot: {queryParams: {}}
-    };
-
     await TestBed.configureTestingModule({
-      imports: [PageLayoutComponent, CommonModule],
+      imports: [PageLayoutComponent, CommonModule, provideTranslocoForTesting()],
       providers: [
-        {provide: Router, useValue: {}},
-        {provide: ActivatedRoute, useValue: activatedRouteMock}
+        {provide: ActivatedRoute, useValue: buildActivatedRouteMock()}
       ]
     })
       .compileComponents();
@@ -48,16 +50,11 @@ describe('PageLayoutComponent', () => {
   });
 
   it('should set embedded to true when the embedded query parameter is present', async () => {
-    const activatedRouteMock = {
-      snapshot: {queryParams: {embedded: ''}}
-    };
-
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
-      imports: [PageLayoutComponent, CommonModule],
+      imports: [PageLayoutComponent, CommonModule, provideTranslocoForTesting()],
       providers: [
-        {provide: Router, useValue: {}},
-        {provide: ActivatedRoute, useValue: activatedRouteMock}
+        {provide: ActivatedRoute, useValue: buildActivatedRouteMock({embedded: ''})}
       ]
     }).compileComponents();
 
@@ -66,5 +63,76 @@ describe('PageLayoutComponent', () => {
     embeddedFixture.detectChanges();
 
     expect(embeddedComponent.embedded()).toBe(true);
+  });
+
+  it('should set title from route data', async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [PageLayoutComponent, CommonModule, provideTranslocoForTesting()],
+      providers: [
+        {provide: ActivatedRoute, useValue: buildActivatedRouteMock({}, {title: 'my.title.key'})}
+      ]
+    }).compileComponents();
+
+    const f = TestBed.createComponent(PageLayoutComponent);
+    f.detectChanges();
+
+    expect(f.componentInstance.title()).toBe('my.title.key');
+  });
+
+  it('should set helpInfo from route data', async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [PageLayoutComponent, CommonModule, provideTranslocoForTesting()],
+      providers: [
+        {provide: ActivatedRoute, useValue: buildActivatedRouteMock({}, {helpInfo: 'my.help.key'})}
+      ]
+    }).compileComponents();
+
+    const f = TestBed.createComponent(PageLayoutComponent);
+    f.detectChanges();
+
+    expect(f.componentInstance.helpInfo()).toBe('my.help.key');
+  });
+
+  it('should set documentationLink from route data', async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [PageLayoutComponent, CommonModule, provideTranslocoForTesting()],
+      providers: [
+        {provide: ActivatedRoute, useValue: buildActivatedRouteMock({}, {documentationLink: 'https://docs.example.com'})}
+      ]
+    }).compileComponents();
+
+    const f = TestBed.createComponent(PageLayoutComponent);
+    f.detectChanges();
+
+    expect(f.componentInstance.documentationLink()).toBe('https://docs.example.com');
+  });
+
+  it('should leave title undefined when not in route data', () => {
+    expect(component.title()).toBeUndefined();
+  });
+
+  it('should leave helpInfo undefined when not in route data', () => {
+    expect(component.helpInfo()).toBeUndefined();
+  });
+
+  it('should leave documentationLink undefined when not in route data', () => {
+    expect(component.documentationLink()).toBeUndefined();
+  });
+
+  it('should render the page-errors slot when not embedded', () => {
+    const host = fixture.nativeElement as HTMLElement;
+    const errorsContainer = host.querySelector('.page-errors-container');
+    expect(errorsContainer).not.toBeNull();
+  });
+
+  it('should hide the page-errors slot when embedded', () => {
+    component.embedded.set(true);
+    fixture.detectChanges();
+    const host = fixture.nativeElement as HTMLElement;
+    const errorsContainer = host.querySelector('.page-errors-container');
+    expect(errorsContainer).toBeNull();
   });
 });

--- a/packages/workbench/src/app/components/page-layout/page-layout.component.ts
+++ b/packages/workbench/src/app/components/page-layout/page-layout.component.ts
@@ -1,24 +1,36 @@
-import {Component, inject, input, OnInit, signal} from '@angular/core';
+import {Component, inject, OnInit, signal} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {ActivatedRoute} from '@angular/router';
 import {ApplicationQueryParams} from '../../models/application-query-params';
+import {TranslocoPipe} from '@jsverse/transloco';
+import {PageInfoTooltipComponent} from '../page-info-tooltip/page-info-tooltip.component';
 
 @Component({
   selector: 'app-page-layout',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, TranslocoPipe, PageInfoTooltipComponent],
   templateUrl: './page-layout.component.html',
   styleUrl: './page-layout.component.scss'
 })
 export class PageLayoutComponent implements OnInit {
   private readonly activatedRoute = inject(ActivatedRoute);
-  title = input('');
   embedded = signal(false);
+  title = signal<string | undefined>(undefined);
+  helpInfo = signal<string | undefined>(undefined);
+  documentationLink = signal<string | undefined>(undefined);
 
   ngOnInit(): void {
+    this.getPageData();
     const queryParams = this.activatedRoute.snapshot.queryParams;
     if (queryParams.hasOwnProperty(ApplicationQueryParams.EMBEDDED)) {
       this.embedded.set(true);
     }
+  }
+
+  private getPageData(): void {
+    const routeData = this.activatedRoute.snapshot.data;
+    this.title.set(routeData['title']);
+    this.helpInfo.set(routeData['helpInfo']);
+    this.documentationLink.set(routeData['documentationLink']);
   }
 }

--- a/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.html
+++ b/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.html
@@ -1,12 +1,6 @@
-<app-page-layout [title]="'sparql_editor.title' | transloco"
-  class="sparql-editor-page">
-
-  <span page-tooltip>
-    <app-page-info-tooltip></app-page-info-tooltip>
-  </span>
-
+<app-page-layout class="sparql-editor-page">
   <div page-errors>
-<!--    <p-message severity="error">Error Message</p-message>-->
+    <!--    <p-message severity="error">Error Message</p-message>-->
   </div>
 
   <div>
@@ -17,5 +11,5 @@
         [yasguiConfig]="yasguiConfig()"></app-yasgui-component-facade>
     }
   </div>
-  <p-confirmdialog />
+  <p-confirmdialog/>
 </app-page-layout>

--- a/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.ts
+++ b/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.ts
@@ -2,9 +2,8 @@ import {Component, inject, OnDestroy, OnInit, signal} from '@angular/core';
 import {ActivatedRoute, Params, Router} from '@angular/router';
 import {ConfirmDialogModule} from 'primeng/confirmdialog';
 import {MessageModule} from 'primeng/message';
-import {TranslocoPipe, TranslocoService} from '@jsverse/transloco';
+import {TranslocoService} from '@jsverse/transloco';
 import {PageLayoutComponent} from '../../components/page-layout/page-layout.component';
-import {PageInfoTooltipComponent} from '../../components/page-info-tooltip/page-info-tooltip.component';
 import {
   YasguiComponentFacadeComponent
 } from '../../components/yasgui-component-facade/yasgui-component-facade.component';
@@ -81,10 +80,8 @@ interface UrlParametersAfterClear { repositoryId?: string, embedded?: boolean }
   selector: 'app-sparql-editor-page',
   standalone: true,
   imports: [
-    TranslocoPipe,
     MessageModule,
     PageLayoutComponent,
-    PageInfoTooltipComponent,
     YasguiComponentFacadeComponent,
     ConfirmDialogModule
   ],

--- a/packages/workbench/src/app/pages/ux-test/ux-test-page.component.html
+++ b/packages/workbench/src/app/pages/ux-test/ux-test-page.component.html
@@ -8,6 +8,7 @@
 <p-button label="Help" severity="help" />
 <p-button label="Danger" severity="danger" />
 <p-button label="Contrast" severity="contrast" />
+<p-button severity="contrast" icon="ri-information-2-line" />
 
 <hr>
 <div>Checkbox</div>

--- a/packages/workbench/src/app/services/documentation-url-resolver.ts
+++ b/packages/workbench/src/app/services/documentation-url-resolver.ts
@@ -1,0 +1,21 @@
+import {Injectable} from '@angular/core';
+import {BuildUtil} from '@ontotext/workbench-api';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DocumentationUrlResolver {
+  private static readonly BASE_DOCUMENTATION_URL = 'https://graphdb.ontotext.com/documentation/';
+  private static readonly LATEST_UNOFFICIAL_VERSION = 'master';
+
+  static getDocumentationUrl(productVersion: string, endpointPath: string) {
+    if (!endpointPath) {
+      return;
+    }
+
+    const isUnofficialVersion = productVersion.includes('-');
+    const isDevMode = BuildUtil.isDevMode();
+    const version = (isDevMode || isUnofficialVersion) ? DocumentationUrlResolver.LATEST_UNOFFICIAL_VERSION : productVersion;
+    return `${DocumentationUrlResolver.BASE_DOCUMENTATION_URL}${version}/${endpointPath}`;
+  }
+}

--- a/packages/workbench/src/app/services/route-data-resolver.ts
+++ b/packages/workbench/src/app/services/route-data-resolver.ts
@@ -1,0 +1,14 @@
+import {ProductInfoContextService, service} from '@ontotext/workbench-api';
+import {DocumentationUrlResolver} from './documentation-url-resolver';
+import {ActivatedRouteSnapshot, ResolveFn} from '@angular/router';
+
+export const documentationLinkResolve: ResolveFn<string> = (route: ActivatedRouteSnapshot) => {
+  const productInfoService = service(ProductInfoContextService);
+  const productInfo = productInfoService.getProductInfo();
+  if (!productInfo) {
+    return '';
+  }
+
+  const documentationLink = DocumentationUrlResolver.getDocumentationUrl(productInfo.shortVersion, route.data['documentationUrl']);
+  return documentationLink ?? '';
+};

--- a/packages/workbench/src/assets/i18n/en.json
+++ b/packages/workbench/src/assets/i18n/en.json
@@ -6,9 +6,12 @@
         "confirm_btn": "Yes",
         "cancel_btn": "Cancel"
       }
+    },
+    "page_info_tooltip": {
+      "documentation_link": "Learn more in the GraphDB documentation"
     }
   },
-  "login":{
+  "login": {
     "title": "Login",
     "logo_alt": "GraphDB Logo",
     "sign_in": "Login",
@@ -32,6 +35,7 @@
   },
   "sparql_editor": {
     "title": "SPARQL Query & Update",
+    "helpInfo": "The SPARQL Query & Update view is a unified editor for queries and updates. Enter any SPARQL query or update and click Run to execute it. The view also allows you to save queries for future retrieval and execution in the SPARQL editor.",
     "errors": {
       "saved_query_load_failed": "Could not get data for saved query: {{savedQueryName}}; {{error}}",
       "shared_query_load_failed": "Could not get data for shared query: {{sharedQueryName}}; {{error}}"

--- a/packages/workbench/src/assets/i18n/fr.json
+++ b/packages/workbench/src/assets/i18n/fr.json
@@ -6,6 +6,9 @@
         "confirm_btn": "Oui",
         "cancel_btn": "Annuler"
       }
+    },
+    "page_info_tooltip": {
+      "documentation_link": "Pour en savoir plus, consultez la documentation GraphDB"
     }
   },
   "login": {
@@ -32,6 +35,7 @@
   },
   "sparql_editor": {
     "title": "Requête et mise à jour SPARQL",
+    "helpInfo": "La vue Requête et mise à jour SPARQL est un éditeur unifié pour les requêtes et les mises à jour. Entrez n'importe quelle requête ou mise à jour SPARQL et cliquez sur Exécuter pour l'exécuter. La vue vous permet également d'enregistrer des requêtes pour une récupération et une exécution futures dans l'éditeur SPARQL.",
     "errors": {
       "saved_query_load_failed": "Impossible de récupérer des données pour la requête sauvegardée : {{savedQueryName}}; {{error}}",
       "shared_query_load_failed": "Impossible de récupérer des données pour la requête partagée : {{sharedQueryName}}; {{error}}"


### PR DESCRIPTION
## What
Migrates the page-info-tooltip implementation to the new Angular workbench. The component now uses modern APIs for inputs/view queries and safer tooltip hide behavior.

## Why
This aligns the tooltip code with the current Angular migration direction and improves maintainability. It also reduces UI edge cases by preventing stale hide timers and ensuring proper cleanup on destroy.

## How
- Migrated `page-info-tooltip` to a standalone component setup.
- Replaced legacy bindings with signal-based `input()` declarations.
- Switched view query usage to `viewChild()` for `Popover` access.
- Added delayed hide handling with timeout cancellation to avoid flicker/race conditions and to allow the user to hover over the popover.
- Implemented cleanup in `OnDestroy` to clear pending hide timers.

## Testing


## Screenshots
<img width="980" height="332" alt="image" src="https://github.com/user-attachments/assets/cdc786e8-c8fd-4652-acd1-bc9b119477d2" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified
