### PR TITLE
GDB-14600 fix popover click toggling for encryption at rest

### DIFF
--- a/packages/legacy-workbench/src/js/angular/repositories/templates/storage-encryption-tooltip.html
+++ b/packages/legacy-workbench/src/js/angular/repositories/templates/storage-encryption-tooltip.html
@@ -1,10 +1,14 @@
-<span>
+<section ng-mouseenter="encryptInput.hovered = true" ng-mouseleave="encryptInput.hovered = false"
+         ng-focus="encryptInput.hovered = true" ng-blur="encryptInput.hovered = false">
+    <span>
     {{ 'repoTooltips.storageEncryption.create.text' | translate }}
 </span>
-<section class="mt-1">
-    <a href="{{documentationUrlForStorageEncryption}}" target="_blank">
-        {{ 'repoTooltips.storageEncryption.create.link' | translate }}
-    </a>
-    <i class="ri-external-link-line"></i>
+    <section class="mt-1">
+        <a href="{{documentationUrlForStorageEncryption}}" target="_blank">
+            {{ 'repoTooltips.storageEncryption.create.link' | translate }}
+        </a>
+        <i class="ri-external-link-line"></i>
+    </section>
 </section>
+
 

--- a/packages/legacy-workbench/src/pages/repository.html
+++ b/packages/legacy-workbench/src/pages/repository.html
@@ -65,13 +65,14 @@
                                        ng-model="repositoryInfo.params.readOnly.value"/>
                                 {{repositoryInfo.params.readOnly.label}}
                             </label>
-                            <label ng-mouseenter="encryptInput.hovered = true" ng-mouseleave="encryptInput.hovered = false"  class="padding-label" for="storageEncryption">
+                            <label   class="padding-label" for="storageEncryption">
                                 <input id="storageEncryption" type="checkbox" ng-true-value="'true'" ng-false-value="'false'"
                                        ng-disabled="editRepoPage"
                                        ng-model="repositoryInfo.params.storageEncryption.value"/>
                                 <span ng-if="!editRepoPage"
+                                      ng-mouseenter="encryptInput.hovered = true" ng-mouseleave="encryptInput.hovered = false"
+                                      ng-focus="encryptInput.hovered = true" ng-blur="encryptInput.hovered = false"
                                       uib-popover-template="'js/angular/repositories/templates/storage-encryption-tooltip.html'"
-                                      popover-append-to-body="false"
                                       popover-is-open="encryptInput.hovered"
                                       popover-trigger="none">
                                     {{'repo.storageEncryption.label' | translate}}


### PR DESCRIPTION
## What
Fix popover click toggling for encryption at rest.

## Why
The checkbox was being toggled upon click on the popover

## How
Moved the popover to be displayed in the body instead of as a sibling. While inside the label it caused the input to be toggled

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
