### PR TITLE
GDB-12154 add unsaved changes mechanism

### DIFF
--- a/packages/api/src/models/common/index.ts
+++ b/packages/api/src/models/common/index.ts
@@ -2,4 +2,5 @@ export * from './awaitable';
 export * from './copyable';
 export * from './model';
 export * from './model-list';
+export * from './subscription';
 export * from './subscription-list';

--- a/packages/api/src/models/common/subscription-list.ts
+++ b/packages/api/src/models/common/subscription-list.ts
@@ -13,7 +13,7 @@ export class SubscriptionList extends ModelList<Subscription> {
   constructor(subscriptions?: Subscription[]) {
     super(subscriptions);
   }
-  
+
   /**
    * Adds a new subscription to the list.
    * @param subscription - The Subscription function to be added to the list.
@@ -21,7 +21,15 @@ export class SubscriptionList extends ModelList<Subscription> {
   add(subscription: Subscription): void {
     this.items.push(subscription);
   }
-  
+
+  /**
+   * Removes a subscription from the list.
+   * @param subscription - The Subscription function to be removed from the list.
+   */
+  remove(subscription: Subscription): void {
+    this.items = this.items.filter(sub => sub !== subscription);
+  }
+
   /**
    * Adds multiple subscriptions to the list.
    * @param subscriptions - An array of Subscription functions to be added.
@@ -29,7 +37,7 @@ export class SubscriptionList extends ModelList<Subscription> {
   addAll(subscriptions: Subscription[]): void {
     this.items.push(...subscriptions);
   }
-  
+
   /**
    * Calls all subscription functions in the list and then clears the list. Calling a subscription
    * function unsubscribes the subscription. This effectively unsubscribes all subscriptions

--- a/packages/api/src/models/common/test/subscription-list.spec.ts
+++ b/packages/api/src/models/common/test/subscription-list.spec.ts
@@ -21,6 +21,31 @@ describe('SubscriptionList', () => {
     expect(subscriptionList.getItems()).toContain(newSubscription);
   });
 
+  describe('remove', () => {
+    test('should remove the given subscription from the list', () => {
+      subscriptionList.remove(mockSubscription1);
+      expect(subscriptionList.getItems()).not.toContain(mockSubscription1);
+      expect(subscriptionList.getItems()).toContain(mockSubscription2);
+    });
+
+    test('should not affect other subscriptions when removing one', () => {
+      subscriptionList.remove(mockSubscription1);
+      expect(subscriptionList.getItems()).toHaveLength(1);
+    });
+
+    test('should do nothing when the subscription is not in the list', () => {
+      const unknownSubscription = jest.fn();
+      subscriptionList.remove(unknownSubscription);
+      expect(subscriptionList.getItems()).toEqual([mockSubscription1, mockSubscription2]);
+    });
+
+    test('should remove all occurrences when the same subscription was added multiple times', () => {
+      subscriptionList.add(mockSubscription1);
+      subscriptionList.remove(mockSubscription1);
+      expect(subscriptionList.getItems()).not.toContain(mockSubscription1);
+    });
+  });
+
   test('unsubscribeAll should call all subscription functions and clear the list', () => {
     subscriptionList.unsubscribeAll();
     expect(mockSubscription1).toHaveBeenCalled();

--- a/packages/api/src/services/app-lifecycle/application-lifecycle-context.service.ts
+++ b/packages/api/src/services/app-lifecycle/application-lifecycle-context.service.ts
@@ -8,12 +8,14 @@ type LifecycleDataContextFields = {
   readonly APPLICATION_DATA_STATE: string;
   readonly APPLICATION_STATE_CHANGE: string;
   readonly APPLICATION_STATE_BEFORE_CHANGE: string;
+  readonly NAVIGATION_BEFORE_MOUNT_ROUTING: string;
 }
 
 type LifecycleDataContextFieldParams = {
   readonly APPLICATION_DATA_STATE: LifecycleState;
   readonly APPLICATION_STATE_CHANGE: ApplicationStateChange;
   readonly APPLICATION_STATE_BEFORE_CHANGE: ApplicationStateChange;
+  readonly NAVIGATION_BEFORE_MOUNT_ROUTING: ApplicationStateChange;
 }
 
 /**
@@ -25,6 +27,7 @@ export class ApplicationLifecycleContextService extends ContextService<Lifecycle
   readonly APPLICATION_DATA_STATE = 'applicationDataLoaded';
   readonly APPLICATION_STATE_CHANGE = 'applicationStateChange';
   readonly APPLICATION_STATE_BEFORE_CHANGE = 'applicationStateBeforeChange';
+  readonly NAVIGATION_BEFORE_MOUNT_ROUTING = 'navigationBeforeMountRouting';
 
   /**
    * Updates the application data state in the context.
@@ -82,5 +85,19 @@ export class ApplicationLifecycleContextService extends ContextService<Lifecycle
    */
   onApplicationStateBeforeChange(callbackFn: ValueChangeCallback<ApplicationStateChange | undefined>): () => void {
     return this.subscribe(this.APPLICATION_STATE_BEFORE_CHANGE, callbackFn);
+  }
+
+  /**
+   * Set the application state before-mount-routing payload.
+   */
+  updateNavigationBeforeMountRouting(payload: ApplicationStateChange): void {
+    this.updateContextProperty(this.NAVIGATION_BEFORE_MOUNT_ROUTING, payload);
+  }
+
+  /**
+   * Subscribe to application state before-mount-routing events.
+   */
+  onNavigationBeforeMountRouting(callbackFn: ValueChangeCallback<ApplicationStateChange | undefined>): () => void {
+    return this.subscribe(this.NAVIGATION_BEFORE_MOUNT_ROUTING, callbackFn);
   }
 }

--- a/packages/root-config/src/ontotext-root-config.ts
+++ b/packages/root-config/src/ontotext-root-config.ts
@@ -86,6 +86,11 @@ function registerSingleSpaRouterListeners(): void {
     service(EventService).emit(new NavigationStart(d.oldUrl, d.newUrl, d.cancelNavigation));
   });
 
+  WindowService.getWindow().addEventListener('single-spa:before-mount-routing-event', (evt: Event) => {
+    const d = (evt as NavigationEvent).detail;
+    service(ApplicationLifecycleContextService).updateNavigationBeforeMountRouting(d);
+  });
+
   WindowService.getWindow().addEventListener('single-spa:routing-event', (evt: Event) => {
     const d = (evt as NavigationEvent).detail;
     service(EventService).emit(new NavigationEnd(d.oldUrl, d.newUrl));

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -321,8 +321,8 @@ export class OntoLayout {
 
   private subscribeToApplicationChange() {
     this.subscriptions.add(
-      this.applicationLifecycleContextService.onApplicationStateBeforeChange((state) => {
-        if (state) {
+      this.applicationLifecycleContextService.onNavigationBeforeMountRouting((payload) => {
+        if (payload) {
           this.loading = true;
         }
       }));

--- a/packages/workbench/src/app/app.component.html
+++ b/packages/workbench/src/app/app.component.html
@@ -1,3 +1,4 @@
 <div class="main-container">
   <router-outlet></router-outlet>
 </div>
+<p-confirmdialog />

--- a/packages/workbench/src/app/app.component.spec.ts
+++ b/packages/workbench/src/app/app.component.spec.ts
@@ -1,12 +1,14 @@
 import {TestBed} from '@angular/core/testing';
 import {AppComponent} from './app.component';
 import {ActivatedRoute} from '@angular/router';
+import {ConfirmationService} from 'primeng/api';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
       providers: [
+        ConfirmationService,
         {
           provide: ActivatedRoute,
           useValue: {

--- a/packages/workbench/src/app/app.component.ts
+++ b/packages/workbench/src/app/app.component.ts
@@ -2,13 +2,15 @@ import {Component, inject, OnDestroy, OnInit} from '@angular/core';
 import {Router, RouterOutlet} from '@angular/router';
 import {EventName, EventService, getCurrentRoute, service, WindowService} from '@ontotext/workbench-api';
 import {Subscription} from 'rxjs';
+import {ConfirmDialogModule} from 'primeng/confirmdialog';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
   imports: [
-    RouterOutlet
+    RouterOutlet,
+    ConfirmDialogModule
   ]
 })
 export class AppComponent implements OnInit, OnDestroy {

--- a/packages/workbench/src/app/app.config.ts
+++ b/packages/workbench/src/app/app.config.ts
@@ -9,6 +9,7 @@ import {APP_BASE_HREF} from '@angular/common';
 import {getSingleSpaExtraProviders} from 'single-spa-angular';
 import {providePrimeNG} from 'primeng/config';
 import {DialogService} from 'primeng/dynamicdialog';
+import {ConfirmationService} from 'primeng/api';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -26,6 +27,7 @@ export const appConfig: ApplicationConfig = {
         }
       }
     }),
-    DialogService
+    DialogService,
+    ConfirmationService
   ]
 };

--- a/packages/workbench/src/app/services/unsaved-changes/unsaved-changes.service.spec.ts
+++ b/packages/workbench/src/app/services/unsaved-changes/unsaved-changes.service.spec.ts
@@ -1,0 +1,138 @@
+import {TestBed} from '@angular/core/testing';
+import {UnsavedChangesService} from './unsaved-changes.service';
+import {ConfirmationService} from 'primeng/api';
+import {provideTranslocoForTesting} from '../../../testing-utils/transloco-utils';
+import {EventName, NavigationStartPayload, service} from '@ontotext/workbench-api';
+
+jest.mock('@ontotext/workbench-api', () => ({
+  ...jest.requireActual('@ontotext/workbench-api'),
+  service: jest.fn()
+}));
+
+const mockService = service as jest.MockedFunction<typeof service>;
+
+describe('UnsavedChangesService', () => {
+  let unsavedChangesService: UnsavedChangesService;
+  let mockSubscribe: jest.Mock;
+  let confirmFn: jest.Mock;
+  let triggerNavigation: (payload: Partial<NavigationStartPayload>) => Promise<void>;
+
+  const makePayload = (cancelNavigation = jest.fn()): Partial<NavigationStartPayload> => ({
+    newUrl: 'http://localhost/new-route',
+    cancelNavigation
+  });
+
+  beforeEach(() => {
+    mockSubscribe = jest.fn();
+    confirmFn = jest.fn();
+    mockService.mockReturnValue({subscribe: mockSubscribe});
+
+    TestBed.configureTestingModule({
+      imports: [provideTranslocoForTesting()],
+      providers: [
+        UnsavedChangesService,
+        {provide: ConfirmationService, useValue: {confirm: confirmFn}}
+      ]
+    });
+
+    unsavedChangesService = TestBed.inject(UnsavedChangesService);
+
+    const handlerCall = mockSubscribe.mock.calls.find(([name]: [string]) => name === EventName.NAVIGATION_START);
+    const handler = handlerCall?.[1] as (payload: NavigationStartPayload) => Promise<void>;
+    triggerNavigation = (payload) => handler(payload as NavigationStartPayload);
+  });
+
+  it('should be created', () => {
+    expect(unsavedChangesService).toBeTruthy();
+  });
+
+  it('should subscribe to NAVIGATION_START on creation', () => {
+    expect(mockSubscribe).toHaveBeenCalledWith(EventName.NAVIGATION_START, expect.any(Function));
+  });
+
+  describe('#register', () => {
+    it('should cancel navigation after registering a callback that returns true', async () => {
+      unsavedChangesService.register(() => true);
+      const cancelNavigation = jest.fn();
+
+      await triggerNavigation(makePayload(cancelNavigation));
+
+      expect(cancelNavigation).toHaveBeenCalled();
+    });
+
+    it('should return a subscription that unregisters the callback', async () => {
+      const unsubscribe = unsavedChangesService.register(() => true);
+      unsubscribe();
+      const cancelNavigation = jest.fn();
+
+      await triggerNavigation(makePayload(cancelNavigation));
+
+      expect(cancelNavigation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('navigation interception', () => {
+    it('should not cancel navigation when no callbacks are registered', async () => {
+      const cancelNavigation = jest.fn();
+      await triggerNavigation(makePayload(cancelNavigation));
+      expect(cancelNavigation).not.toHaveBeenCalled();
+    });
+
+    it('should not cancel navigation when no registered callback returns true', async () => {
+      unsavedChangesService.register(() => false);
+      unsavedChangesService.register(() => false);
+      const cancelNavigation = jest.fn();
+
+      await triggerNavigation(makePayload(cancelNavigation));
+
+      expect(cancelNavigation).not.toHaveBeenCalled();
+    });
+
+    it('should cancel navigation when at least one callback returns true', async () => {
+      unsavedChangesService.register(() => false);
+      unsavedChangesService.register(() => true);
+      const cancelNavigation = jest.fn();
+
+      await triggerNavigation(makePayload(cancelNavigation));
+
+      expect(cancelNavigation).toHaveBeenCalledWith(expect.any(Promise));
+    });
+
+    it('should show the confirmation dialog with translated strings', async () => {
+      unsavedChangesService.register(() => true);
+
+      await triggerNavigation(makePayload());
+
+      expect(confirmFn).toHaveBeenCalledWith(expect.objectContaining({
+        header: 'Confirm',
+        message: 'You have unsaved changes. Are you sure you want to continue?',
+        acceptButtonProps: expect.objectContaining({label: 'Yes'}),
+        rejectButtonProps: expect.objectContaining({label: 'Cancel'})
+      }));
+    });
+  });
+
+  describe('confirmation dialog resolution', () => {
+    it('should resolve false (allow navigation) when the user confirms', async () => {
+      unsavedChangesService.register(() => true);
+      let capturedPromise: Promise<boolean> | undefined;
+      const cancelNavigation = jest.fn((p) => { capturedPromise = p; });
+      confirmFn.mockImplementation(({accept}: {accept: () => void}) => accept());
+
+      await triggerNavigation(makePayload(cancelNavigation));
+
+      await expect(capturedPromise).resolves.toBe(false);
+    });
+
+    it('should resolve true (cancel navigation) when the user rejects', async () => {
+      unsavedChangesService.register(() => true);
+      let capturedPromise: Promise<boolean> | undefined;
+      const cancelNavigation = jest.fn((p) => { capturedPromise = p; });
+      confirmFn.mockImplementation(({reject}: {reject: () => void}) => reject());
+
+      await triggerNavigation(makePayload(cancelNavigation));
+
+      await expect(capturedPromise).resolves.toBe(true);
+    });
+  });
+});

--- a/packages/workbench/src/app/services/unsaved-changes/unsaved-changes.service.ts
+++ b/packages/workbench/src/app/services/unsaved-changes/unsaved-changes.service.ts
@@ -1,0 +1,81 @@
+import {inject, Injectable} from '@angular/core';
+import {
+  service,
+  EventService,
+  EventName,
+  NavigationStartPayload,
+  Subscription,
+  SubscriptionList
+} from '@ontotext/workbench-api';
+import {ConfirmationService} from 'primeng/api';
+import {TranslocoService} from '@jsverse/transloco';
+
+/**
+ * Coordinates unsaved-changes detection across the application.
+ *
+ * Callers register a callback via {@link register}, which returns a {@link Subscription}
+ * that removes the callback when invoked. When a `NAVIGATION_START` event fires and at least
+ * one registered callback returns `true`, the service intercepts navigation and shows a
+ * confirmation dialog. The user can then allow or cancel the navigation.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class UnsavedChangesService {
+  private readonly callbacks = new SubscriptionList();
+  private readonly eventService = service(EventService);
+  private readonly translocoService = inject(TranslocoService);
+  private readonly confirmationService = inject(ConfirmationService);
+
+  constructor() {
+    this.subscribeToNavigationStart();
+  }
+
+  /**
+   * Registers `callback` to be consulted before each navigation. Returns a {@link Subscription}
+   * that, when called, removes the callback so it no longer blocks navigation.
+   */
+  public register(callback: () => boolean): Subscription {
+    this.callbacks.add(callback);
+    return () => this.callbacks.remove(callback);
+  }
+
+  private subscribeToNavigationStart() {
+    this.eventService.subscribe(EventName.NAVIGATION_START, (eventPayload: NavigationStartPayload) => this.onNavigationStart(eventPayload));
+  }
+
+  private async onNavigationStart(eventPayload: NavigationStartPayload) {
+    if (!this.callbacks.size || !this.hasAnyUnsavedChanges()) {
+      return;
+    }
+
+    eventPayload.cancelNavigation(this.confirmUnsavedChanges());
+  }
+
+  private hasAnyUnsavedChanges() {
+    return this.callbacks.getItems().some(callback => callback());
+  }
+
+  private readonly confirmUnsavedChanges = () => {
+    return new Promise<boolean>((resolve) => {
+      return this.confirmationService.confirm({
+        header: this.translocoService.translate('components.dialog.confirmation.title'),
+        message: this.translocoService.translate('components.dialog.confirmation.message'),
+        acceptButtonProps: {
+          label: this.translocoService.translate('components.dialog.confirmation.confirm_btn'),
+          severity: 'primary'
+        },
+        rejectButtonProps: {
+          label: this.translocoService.translate('components.dialog.confirmation.cancel_btn'),
+          severity: 'secondary'
+        },
+        accept: () => {
+          resolve(false);
+        },
+        reject: () => {
+          resolve(true);
+        }
+      });
+    });
+  };
+}

--- a/packages/workbench/src/assets/i18n/en.json
+++ b/packages/workbench/src/assets/i18n/en.json
@@ -9,6 +9,7 @@
     "dialog": {
       "confirmation": {
         "title": "Confirm",
+        "message": "You have unsaved changes. Are you sure you want to continue?",
         "confirm_btn": "Yes",
         "cancel_btn": "Cancel"
       }

--- a/packages/workbench/src/assets/i18n/fr.json
+++ b/packages/workbench/src/assets/i18n/fr.json
@@ -9,6 +9,7 @@
     "dialog": {
       "confirmation": {
         "title": "Confirmer",
+        "message": "Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir continuer ?",
         "confirm_btn": "Oui",
         "cancel_btn": "Annuler"
       }


### PR DESCRIPTION
## What
Add unsaved changes detection mechanism to prevent navigation when there are unsaved changes.

## Why
This feature addresses the issue of users accidentally losing unsaved changes when navigating away from a component. It enhances user experience by providing a confirmation dialog that alerts users about unsaved changes.

## How
- Introduced a new service `UnsavedChangesService` to manage unsaved changes across components.
- Created an abstract class `UnsavedChangesComponent` for components to implement unsaved changes logic.
- Updated `app.component.html` to include a confirmation dialog component.
- Modified the `application-lifecycle-context.service.ts` to handle navigation events related to unsaved changes.
- Added French and English translations for confirmation messages.

## Testing
jest

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
