### PR TITLE
GDB-14613 add warning for shown link limit

### DIFF
--- a/e2e-tests/e2e-legacy/explore/visual-graph/visual-graph-links-limit.spec.js
+++ b/e2e-tests/e2e-legacy/explore/visual-graph/visual-graph-links-limit.spec.js
@@ -43,12 +43,14 @@ describe('Visual graph linksLimit URL parameter', () => {
 
         // Then, I expect to see the visual graph with the default linksLimit
         BaseSteps.getUrl().should('include', `linksLimit=${DEFAULT_LINKS_LIMIT}`);
-
+        // And the limit shown warning should not exist, since it is currently 100 (default) and we have less than that
+        VisualGraphSteps.getShownLimitMessage().should('not.exist');
 
         // When, I update the link limit from the input field
         VisualGraphSteps.updateLinksLimitField(5);
-
-        // Then I expect the URL to include the updated linksLimit in the URL
+        // Then I limit shown warning to exist,since we have more than 5 links
+        VisualGraphSteps.getShownLimitMessage().should('exist');
+        // And I expect the URL to include the updated linksLimit in the URL
         BaseSteps.getUrl().should('include', 'linksLimit=5');
         // And, I expect to see the visual graph with the updated linksLimit
         VisualGraphSteps.getNodes().should('have.length', 6); // 5 links plus the main node
@@ -98,11 +100,17 @@ describe('Visual graph linksLimit URL parameter', () => {
             VisualGraphSteps.openGraphConfig(configName);
 
             // Then, I expect to see 10 nodes before changing the limit
-            BaseSteps.getUrl().should('include', 'linksLimit=10');
+            BaseSteps.getUrl().should('include', 'linksLimit=100');
             VisualGraphSteps.getNodes().should('have.length', 10); // 10 nodes total, since we don't have a root node
+
+            // And the limit shown warning should not exist, since it is currently 100 (default) and we have a set ot 10 nodes
+            VisualGraphSteps.getShownLimitMessage().should('not.exist');
 
             // When, I update the link limit from the input field
             VisualGraphSteps.updateLinksLimitField(5);
+
+            // Then I limit shown warning to exist, since we have more than 5 links available
+            VisualGraphSteps.getShownLimitMessage().should('exist');
 
             // Then I expect the URL to include the updated linksLimit in the URL
             BaseSteps.getUrl().should('include', 'linksLimit=5');
@@ -125,8 +133,11 @@ describe('Visual graph linksLimit URL parameter', () => {
             VisualGraphSplitButtonSteps.clickOnVisualizeMainButton();
 
             // Then, I expect to see 10 nodes before changing the limit
-            BaseSteps.getUrl().should('include', 'linksLimit=10');
+            BaseSteps.getUrl().should('include', 'linksLimit=100');
             VisualGraphSteps.getNodes().should('have.length', 10); // 10 nodes total, since we don't have a root node
+
+            // And the limit shown warning should not exist, since it is currently 100 (default) and we have a set ot 10 nodes
+            VisualGraphSteps.getShownLimitMessage().should('not.exist');
 
             // When, I update the link limit from the input field
             VisualGraphSteps.updateLinksLimitField(5);
@@ -135,6 +146,20 @@ describe('Visual graph linksLimit URL parameter', () => {
             BaseSteps.getUrl().should('include', 'linksLimit=5');
             // And, I expect to see the visual graph with the updated linksLimit
             VisualGraphSteps.getNodes().should('have.length', 5); // 5 nodes total, since we don't have a root node
+
+            // And, the limit shown warning should appear as we are showing the limit
+            VisualGraphSteps.getShownLimitMessage().should('exist');
+
+            // When, I set the limit to the number of nodes from the query
+            VisualGraphSteps.updateLinksLimitField(10);
+
+            // Then I expect limit shown warning to exist
+            VisualGraphSteps.getShownLimitMessage().should('exist');
+
+            // When I set it to 1 more than the number of nodes from the query
+            VisualGraphSteps.updateLinksLimitField(11);
+            // Then I expect the limit shown warning to not exist
+            VisualGraphSteps.getShownLimitMessage().should('not.exist');
         });
     });
 });

--- a/e2e-tests/steps/visual-graph-steps.js
+++ b/e2e-tests/steps/visual-graph-steps.js
@@ -411,6 +411,10 @@ export class VisualGraphSteps extends BaseSteps {
         return this.getByTestId('invalid-links-limit');
     }
 
+    static getShownLimitMessage() {
+        return this.getByTestId('shown-links-limit');
+    }
+
     static openVisualGraphHome() {
         cy.get('.toolbar-holder').should('be.visible')
             .find('.return-home-btn').should('be.visible').click();

--- a/packages/legacy-workbench/src/css/graphs-vizualizations.css
+++ b/packages/legacy-workbench/src/css/graphs-vizualizations.css
@@ -191,15 +191,31 @@ so the following styles target Safari exclusively to correct label positioning w
     flex-direction: column;
 }
 
-.link-limit-error {
+.link-limit-message {
     position: absolute;
+    display: flex;
+    align-items: center;
     top: 2rem;
+}
+
+.link-limit-message.limit-shown {
+    left: 0;
+}
+
+.link-limit-message.limit-shown:before {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
 }
 
 .link-limit-wrapper .link-limit-input-wrapper {
     display: flex;
     flex-direction: row;
     gap: 0.5rem;
+}
+
+.link-limit-wrapper .link-limit-input-wrapper input {
+    max-width: 8rem;
 }
 
 .rdf-info-side-panel {

--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -3050,6 +3050,7 @@
     "visual.limit.links.tooltip": "Allowed range: {{min}}-{{max}}",
     "visual.links.limit.label.tooltip": "Limit the number of links when often they are too many",
     "visual.links.maximum": "Max links shown",
+    "visual.links.limit.shown": "Showing up to the limit. There may be more results – adjust the link limit above.",
     "visual.search.instance.placeholder": "Search instance properties",
     "visual.node.tooltip.no_types": "No types",
     "visual.links.invalid.limit.msg": "Enter a number up to {{MAX_LINKS_LIMIT}}",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -3047,6 +3047,7 @@
     "sidepanel.truncate.node.labels": "Tronquer les étiquettes de nœuds longues",
     "visual.limit.links.tooltip": "Plage autorisée : {{min}}-{{max}}",
     "visual.links.limit.label.tooltip": "Limiter le nombre de liens quand souvent ils sont trop nombreux",
+    "visual.links.limit.shown": "Affichage jusqu'à la limite. Il peut y avoir plus de résultats – ajustez la limite de liens ci-dessus.",
     "visual.links.maximum": "Max. de liens affichés",
     "visual.search.instance.placeholder": "Recherche des propriétés de l'instance",
     "visual.node.tooltip.no_types": "Aucun type",

--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -141,6 +141,7 @@ function GraphsVisualizationsCtrl(
         max: MAX_LINKS_LIMIT,
         decreaseDisabled: false,
         increaseDisabled: false,
+        showingLimit: false,
     };
     $scope.invalidLimit = false;
     let linksLimitDebounceTimer = null;
@@ -2164,6 +2165,7 @@ function GraphsVisualizationsCtrl(
         const newNodes = _.reject(nodesFromLinks, function(n) {
             return _.some(existingNodes, n);
         });
+        $scope.linksLimit.showingLimit = newNodes.length === $scope.linksLimit.value;
 
         if (newNodes.length === 0) {
             // All nodes from links minus 1 gives number of connections

--- a/packages/legacy-workbench/src/pages/graphs-visualizations.html
+++ b/packages/legacy-workbench/src/pages/graphs-visualizations.html
@@ -39,8 +39,13 @@
                 </button>
             </div>
             <span ng-if="invalidLimit"
-                  class="idError alert alert-danger mt-1 link-limit-error"
+                  class="idError alert alert-danger mt-1 link-limit-message"
                   data-test="invalid-links-limit">{{'visual.links.invalid.limit.msg' | translate: {MAX_LINKS_LIMIT: linksLimit.max} }}</span>
+            <span ng-if="linksLimit.showingLimit && !invalidLimit"
+                  class="alert alert-warning mt-1 link-limit-message limit-shown"
+                  data-test="shown-links-limit">{{'visual.links.limit.shown' | translate }}
+                <button type="button" class="close ml-1" ng-click="linksLimit.showingLimit = false"></button>
+            </span>
         </div>
         <button ng-show="!queryResultsMode && !noGoHome" class="btn btn-link p-0 return-home-btn"
                 gdb-tooltip="{{'visual.graph.home.label' | translate}}"


### PR DESCRIPTION
## What
Add a warning message for users when the displayed links reach the specified limit.

## Why
This message tells the users that there might be more links and suggests increasing the limit to view them

## How
- Introduced a new scope variable `showingLimit` to track when the limit is reached.
- Updated the HTML to conditionally display the warning message based on the new variable.

## Testing
cypress


## Screenshots
<img width="1117" height="583" alt="image" src="https://github.com/user-attachments/assets/67ae6b91-e161-4d2f-8fdc-117c8d739596" />
<img width="1117" height="583" alt="Screenshot from 2026-05-15 11-42-58" src="https://github.com/user-attachments/assets/87977506-2e46-4d8b-b1f7-45868072aa9c" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
