### PR TITLE
Update ontotext-yasgui-web-component version

### DIFF
--- a/packages/legacy-workbench/package-lock.json
+++ b/packages/legacy-workbench/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
                 "ontotext-graphql-playground-component": "^0.0.9",
-                "ontotext-yasgui-web-component": "^1.6.0",
+                "ontotext-yasgui-web-component": "^1.6.2",
                 "single-spa-angularjs": "^4.3.1"
             },
             "devDependencies": {
@@ -5644,9 +5644,10 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.0.tgz",
-            "integrity": "sha512-BtFvEhwMT8q8rzvRxtDIBnSXyvX/coZu3dfOuH5N5Qp/xSwnZ7vQcAriP/9GJ5xTtR6PzUwwkhFTYKdj2U6N0g==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.2.tgz",
+            "integrity": "sha512-IeMN43m1cqZ3xUKWQfXY3fSkV1C77+zi6/A3vhcKj6XTnXKVveiUb2yUWVhy5EpaDhEYHjad2LwdrOjQAiKXZw==",
+            "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.7.4",
                 "@stencil/core": "2.20.0",
@@ -5656,15 +5657,10 @@
                 "dompurify": "^3.4.1",
                 "h3-js": "^4.4.0",
                 "leaflet": "^1.9.4",
-                "open-location-code-typescript": "^1.5.0",
+                "markdown-it": "^14.1.1",
                 "proj4": "^2.20.3",
                 "remixicon": "^4.7.0"
             }
-        },
-        "node_modules/open-location-code-typescript": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/open-location-code-typescript/-/open-location-code-typescript-1.5.0.tgz",
-            "integrity": "sha512-nGlOwLrmexCqCxEx7Vy6hsHGA9NmrUf/1bZNj0XzP5WrXYj+Oz1MJwUWFv3N012P/Y15bwC+ViVuCV6inoI1KQ=="
         },
         "node_modules/optionator": {
             "version": "0.9.4",

--- a/packages/legacy-workbench/package.json
+++ b/packages/legacy-workbench/package.json
@@ -76,7 +76,7 @@
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
         "ontotext-graphql-playground-component": "^0.0.9",
-        "ontotext-yasgui-web-component": "^1.6.0",
+        "ontotext-yasgui-web-component": "^1.6.2",
         "single-spa-angularjs": "^4.3.1"
     },
     "resolutions": {

--- a/packages/workbench/package-lock.json
+++ b/packages/workbench/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/router": "^20.3.15",
         "@jsverse/transloco": "^8.2.0",
         "@primeuix/themes": "^2.0.3",
-        "ontotext-yasgui-web-component": "^1.6.0",
+        "ontotext-yasgui-web-component": "^1.6.2",
         "primeng": "^20.4.0",
         "rxjs": "~7.8.2",
         "single-spa": "^6.0.3",
@@ -11568,7 +11568,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -14898,6 +14897,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/listr2": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.1.tgz",
@@ -15337,6 +15345,29 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -15346,6 +15377,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -16266,9 +16303,10 @@
       }
     },
     "node_modules/ontotext-yasgui-web-component": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.0.tgz",
-      "integrity": "sha512-BtFvEhwMT8q8rzvRxtDIBnSXyvX/coZu3dfOuH5N5Qp/xSwnZ7vQcAriP/9GJ5xTtR6PzUwwkhFTYKdj2U6N0g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.2.tgz",
+      "integrity": "sha512-IeMN43m1cqZ3xUKWQfXY3fSkV1C77+zi6/A3vhcKj6XTnXKVveiUb2yUWVhy5EpaDhEYHjad2LwdrOjQAiKXZw==",
+      "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",
         "@stencil/core": "2.20.0",
@@ -16278,7 +16316,7 @@
         "dompurify": "^3.4.1",
         "h3-js": "^4.4.0",
         "leaflet": "^1.9.4",
-        "open-location-code-typescript": "^1.5.0",
+        "markdown-it": "^14.1.1",
         "proj4": "^2.20.3",
         "remixicon": "^4.7.0"
       }
@@ -16301,11 +16339,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/open-location-code-typescript": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/open-location-code-typescript/-/open-location-code-typescript-1.5.0.tgz",
-      "integrity": "sha512-nGlOwLrmexCqCxEx7Vy6hsHGA9NmrUf/1bZNj0XzP5WrXYj+Oz1MJwUWFv3N012P/Y15bwC+ViVuCV6inoI1KQ=="
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -17228,6 +17261,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -19354,6 +19396,12 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -26,7 +26,7 @@
     "@angular/router": "^20.3.15",
     "@jsverse/transloco": "^8.2.0",
     "@primeuix/themes": "^2.0.3",
-    "ontotext-yasgui-web-component": "^1.6.0",
+    "ontotext-yasgui-web-component": "^1.6.2",
     "primeng": "^20.4.0",
     "rxjs": "~7.8.2",
     "single-spa": "^6.0.3",


### PR DESCRIPTION
## What
Update the ontotext-yasgui-web-component version.

## Why
This version includes fixes for:
 - GDB-14608: Fix map not loading with unsupported features
 - Fix popover width and improve popup styling
 - GDB-14485: Display markdown in the geo popups
 - Remove open-location-code-typescript package from dependencies

## How
Bumped the ontotext-yasgui-web-component version.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
