### PR TITLE
GDB-14335 add connector progress dialog

### DIFF
--- a/packages/api/src/models/connector/before-update-query-result.ts
+++ b/packages/api/src/models/connector/before-update-query-result.ts
@@ -6,6 +6,7 @@ export class BeforeUpdateQueryResult {
     public parameters?: unknown,
     public message?: string,
     public iri?: string,
+    public name?: string,
   ) {
   }
 }

--- a/packages/api/src/models/connector/connector-build-status-response.ts
+++ b/packages/api/src/models/connector/connector-build-status-response.ts
@@ -1,0 +1,13 @@
+/**
+ * Raw JSON shape returned by the connector status SPARQL query.
+ * The `status` binding value is a JSON-encoded string of this interface.
+ */
+export interface ConnectorBuildStatusResponse {
+  status: string;
+  processedEntities: number;
+  estimatedEntities: number;
+  indexedEntities: number;
+  entitiesPerSecond: number;
+  etaSeconds: number;
+  repair: boolean;
+}

--- a/packages/api/src/models/connector/connector-build-status.ts
+++ b/packages/api/src/models/connector/connector-build-status.ts
@@ -1,0 +1,29 @@
+import {Model} from '../common';
+
+/**
+ * Domain model representing the current build progress of a connector instance.
+ */
+export class ConnectorBuildStatus extends Model<ConnectorBuildStatus> {
+  constructor(
+    public status = '',
+    public processedEntities = 0,
+    public estimatedEntities = 0,
+    public indexedEntities = 0,
+    public entitiesPerSecond = 0,
+    public etaSeconds = 0,
+    public repair = false,
+  ) {
+    super();
+  }
+
+  get isBuilt(): boolean {
+    return this.status === 'BUILT';
+  }
+
+  get percentDone(): number {
+    if (!this.estimatedEntities) {
+      return 0;
+    }
+    return Number.parseFloat((100 * this.processedEntities / this.estimatedEntities).toFixed(0));
+  }
+}

--- a/packages/api/src/models/connector/index.ts
+++ b/packages/api/src/models/connector/index.ts
@@ -1,2 +1,4 @@
 export * from './before-update-query-result';
+export * from './connector-build-status-response';
+export * from './connector-build-status';
 export * from './connector-command';

--- a/packages/api/src/models/connector/test/connector-build-status.spec.ts
+++ b/packages/api/src/models/connector/test/connector-build-status.spec.ts
@@ -1,0 +1,64 @@
+import {ConnectorBuildStatus} from '../connector-build-status';
+
+const buildStatus = (overrides: Partial<ConnectorBuildStatus> = {}) =>
+  new ConnectorBuildStatus(
+    overrides.status ?? 'BUILDING',
+    overrides.processedEntities ?? 0,
+    overrides.estimatedEntities ?? 0,
+    overrides.indexedEntities ?? 0,
+    overrides.entitiesPerSecond ?? 0,
+    overrides.etaSeconds ?? 0,
+    overrides.repair ?? false,
+  );
+
+describe('ConnectorBuildStatus', () => {
+  describe('percentDone', () => {
+    test('should return 0 when estimatedEntities is 0', () => {
+      const status = buildStatus({processedEntities: 0, estimatedEntities: 0});
+      expect(status.percentDone).toBe(0);
+    });
+
+    test('should compute percentage from processedEntities and estimatedEntities', () => {
+      const status = buildStatus({processedEntities: 50, estimatedEntities: 100});
+      expect(status.percentDone).toBe(50);
+    });
+
+    test('should return 100 when all entities are processed', () => {
+      const status = buildStatus({processedEntities: 200, estimatedEntities: 200});
+      expect(status.percentDone).toBe(100);
+    });
+
+    test('should recompute when processedEntities is mutated', () => {
+      const status = buildStatus({processedEntities: 25, estimatedEntities: 100});
+      expect(status.percentDone).toBe(25);
+      status.processedEntities = 75;
+      expect(status.percentDone).toBe(75);
+    });
+
+    test('should recompute when estimatedEntities is mutated', () => {
+      const status = buildStatus({processedEntities: 100, estimatedEntities: 200});
+      expect(status.percentDone).toBe(50);
+      status.estimatedEntities = 100;
+      expect(status.percentDone).toBe(100);
+    });
+  });
+
+  describe('isBuilt', () => {
+    test('should return true when status is BUILT', () => {
+      const status = buildStatus({status: 'BUILT'});
+      expect(status.isBuilt).toBe(true);
+    });
+
+    test('should return false when status is BUILDING', () => {
+      const status = buildStatus({status: 'BUILDING'});
+      expect(status.isBuilt).toBe(false);
+    });
+
+    test('should return false for any other status value', () => {
+      for (const s of ['', 'INIT', 'ERROR', 'built']) {
+        const status = buildStatus({status: s});
+        expect(status.isBuilt).toBe(false);
+      }
+    });
+  });
+});

--- a/packages/api/src/models/sparql/index.ts
+++ b/packages/api/src/models/sparql/index.ts
@@ -1,2 +1,3 @@
 export * from './saved-query-list';
 export * from './saved-query';
+export * from './sparql-results-response';

--- a/packages/api/src/models/sparql/sparql-results-response.ts
+++ b/packages/api/src/models/sparql/sparql-results-response.ts
@@ -1,0 +1,22 @@
+/**
+ * A single typed value within a SPARQL result binding (SPARQL 1.1 JSON format).
+ */
+export interface SparqlValue {
+  value: string;
+  type: string;
+  datatype: string;
+}
+
+/**
+ * One row of a SPARQL result, keyed by variable name.
+ */
+export type SparqlBinding = Record<string, SparqlValue>;
+
+/**
+ * Top-level shape of a SPARQL query JSON response.
+ */
+export interface SparqlResultsResponse {
+  results: {
+    bindings: SparqlBinding[];
+  };
+}

--- a/packages/api/src/services/domain/connector/connectors.service.ts
+++ b/packages/api/src/services/domain/connector/connectors.service.ts
@@ -2,13 +2,16 @@ import {Service} from '../../../providers/service/service';
 import {service} from '../../../providers';
 import {ConnectorsRestService} from './connectors-rest.service';
 import {mapConnectorResponseToModel} from './mapper/connector-response-to-model.mapper';
-import {BeforeUpdateQueryResult} from '../../../models/connector';
+import {mapConnectorBuildStatusResponseToModel} from './mapper/connector-build-status-response-to-model.mapper';
+import {BeforeUpdateQueryResult, ConnectorBuildStatus} from '../../../models/connector';
+import {Rdf4jRepositoryService} from '../rdf4j/rdf4j-repository.service';
 
 /**
  * Service for managing connectors.
  */
 export class ConnectorsService implements Service {
   private readonly connectorsRestService = service(ConnectorsRestService);
+  private readonly rdf4jRepositoryService = service(Rdf4jRepositoryService);
 
   /**
    * Checks connector status.
@@ -19,5 +22,28 @@ export class ConnectorsService implements Service {
   async checkConnector(query?: string): Promise<BeforeUpdateQueryResult> {
     const response = await this.connectorsRestService.checkConnector(query);
     return mapConnectorResponseToModel(response);
+  }
+
+  /**
+   * Retrieves the current build status of a connector.
+   * @param iri - The IRI of the connector instance.
+   * @param repositoryId - The ID of the repository to query.
+   * @returns A promise resolving to the build status, or null if not available.
+   */
+  async getConnectorBuildStatus(iri: string, repositoryId: string): Promise<ConnectorBuildStatus | null> {
+    const query = this.createConnectorStatusQuery(iri);
+    const response = await this.rdf4jRepositoryService.executeSparqlQuery(repositoryId, query);
+    return mapConnectorBuildStatusResponseToModel(response);
+  }
+
+  /**
+   * Builds a SPARQL SELECT query that retrieves the build status of a connector instance.
+   *
+   * The connector status predicate IRI is derived by replacing the `/instance#<id>` suffix
+   * of the instance IRI with `#connectorStatus`.
+   */
+  private createConnectorStatusQuery(iri: string): string {
+    const statusIri = iri.replace(/\/instance#.+$/, '#connectorStatus');
+    return `SELECT ?status {\n\t<${iri}> <${statusIri}> ?status\n}`;
   }
 }

--- a/packages/api/src/services/domain/connector/mapper/connector-build-status-response-to-model.mapper.ts
+++ b/packages/api/src/services/domain/connector/mapper/connector-build-status-response-to-model.mapper.ts
@@ -1,0 +1,23 @@
+import {MapperFn} from '../../../../providers';
+import {ConnectorBuildStatus} from '../../../../models/connector/connector-build-status';
+import {SparqlResultsResponse} from '../../../../models/sparql';
+import {ConnectorBuildStatusResponse} from '../../../../models/connector/connector-build-status-response';
+
+/**
+ * Maps the SPARQL response from the connector status query to a {@link ConnectorBuildStatus} model.
+ *
+ * The `?status` binding value is a JSON-encoded {@link ConnectorBuildStatusResponse}.
+ * Returns null if the binding is absent or the JSON cannot be parsed.
+ */
+export const mapConnectorBuildStatusResponseToModel: MapperFn<SparqlResultsResponse, ConnectorBuildStatus | null> = (response) => {
+  const statusValue = response?.results?.bindings?.[0]?.['status']?.value;
+  if (!statusValue) {
+    return null;
+  }
+  try {
+    const r = JSON.parse(statusValue) as ConnectorBuildStatusResponse;
+    return new ConnectorBuildStatus(r.status, r.processedEntities, r.estimatedEntities, r.indexedEntities, r.entitiesPerSecond, r.etaSeconds, r.repair);
+  } catch {
+    return null;
+  }
+};

--- a/packages/api/src/services/domain/connector/mapper/connector-response-to-model.mapper.ts
+++ b/packages/api/src/services/domain/connector/mapper/connector-response-to-model.mapper.ts
@@ -24,6 +24,7 @@ export const mapConnectorResponseToModel: MapperFn<ConnectorResponse, BeforeUpda
     throw new UnknownConnectorCommandError(data.command);
   }
   result.iri = data.iri;
+  result.name = data.name;
   return result;
 };
 

--- a/packages/api/src/services/domain/connector/mapper/test/connector-build-status-response-to-model.mapper.spec.ts
+++ b/packages/api/src/services/domain/connector/mapper/test/connector-build-status-response-to-model.mapper.spec.ts
@@ -1,0 +1,69 @@
+import {mapConnectorBuildStatusResponseToModel} from '../connector-build-status-response-to-model.mapper';
+import {SparqlResultsResponse} from '../../../../../models/sparql';
+import {ConnectorBuildStatus} from '../../../../../models/connector';
+
+const BUILDING_STATUS_JSON = {
+  status: 'BUILDING',
+  processedEntities: 50,
+  estimatedEntities: 100,
+  indexedEntities: 40,
+  entitiesPerSecond: 100,
+  etaSeconds: 60,
+  repair: false,
+};
+
+function makeResponse(statusValue: string): SparqlResultsResponse {
+  return {results: {bindings: [{status: {value: statusValue, type: 'literal', datatype: 'application/json'}}]}};
+}
+
+describe('mapConnectorBuildStatusResponseToModel', () => {
+  test('should map a valid SPARQL response to a ConnectorBuildStatus', () => {
+    const result = mapConnectorBuildStatusResponseToModel(makeResponse(JSON.stringify(BUILDING_STATUS_JSON)));
+
+    expect(result).toBeInstanceOf(ConnectorBuildStatus);
+    expect(result!.status).toBe('BUILDING');
+    expect(result!.processedEntities).toBe(50);
+    expect(result!.estimatedEntities).toBe(100);
+    expect(result!.indexedEntities).toBe(40);
+    expect(result!.entitiesPerSecond).toBe(100);
+    expect(result!.etaSeconds).toBe(60);
+    expect(result!.repair).toBe(false);
+    expect(result!.percentDone).toBe(50);
+  });
+
+  test('should return null when bindings are empty', () => {
+    const response: SparqlResultsResponse = {results: {bindings: []}};
+    expect(mapConnectorBuildStatusResponseToModel(response)).toBeNull();
+  });
+
+  test('should return null when the status binding is absent', () => {
+    const response: SparqlResultsResponse = {
+      results: {bindings: [{other: {value: 'x', type: 'literal', datatype: 'application/json'}}]},
+    };
+    expect(mapConnectorBuildStatusResponseToModel(response)).toBeNull();
+  });
+
+  test('should return null when the status value is not valid JSON', () => {
+    expect(mapConnectorBuildStatusResponseToModel(makeResponse('not-valid-json'))).toBeNull();
+  });
+
+  test('should return null when response is null', () => {
+    expect(mapConnectorBuildStatusResponseToModel(null as unknown as SparqlResultsResponse)).toBeNull();
+  });
+
+  test('should correctly map a BUILT status', () => {
+    const builtJson = {...BUILDING_STATUS_JSON, status: 'BUILT', processedEntities: 100};
+    const result = mapConnectorBuildStatusResponseToModel(makeResponse(JSON.stringify(builtJson)));
+
+    expect(result).toBeInstanceOf(ConnectorBuildStatus);
+    expect(result!.isBuilt).toBe(true);
+    expect(result!.percentDone).toBe(100);
+  });
+
+  test('should correctly map repair flag', () => {
+    const repairJson = {...BUILDING_STATUS_JSON, repair: true};
+    const result = mapConnectorBuildStatusResponseToModel(makeResponse(JSON.stringify(repairJson)));
+
+    expect(result!.repair).toBe(true);
+  });
+});

--- a/packages/api/src/services/domain/connector/test/connectors.service.spec.ts
+++ b/packages/api/src/services/domain/connector/test/connectors.service.spec.ts
@@ -1,11 +1,14 @@
 import {ConnectorsService} from '../connectors.service';
-import {BeforeUpdateQueryResult, BeforeUpdateQueryResultStatus, ConnectorCommand} from '../../../../models/connector';
+import {BeforeUpdateQueryResult, BeforeUpdateQueryResultStatus, ConnectorBuildStatus, ConnectorCommand} from '../../../../models/connector';
 import {TestUtil} from '../../../utils/test/test-util';
 import {ResponseMock} from '../../../http/test/response-mock';
 import {UnknownConnectorCommandError} from '../error/unknown-connector-command-error';
 import {ConnectorResponse} from '../response/connector-response';
+import {Rdf4jRepositoryService} from '../../rdf4j/rdf4j-repository.service';
+import {SparqlResultsResponse} from '../../../../models/sparql';
 
 const CONNECTORS_CHECK_ENDPOINT = 'rest/connectors/check';
+const REPOSITORY_ID = 'test-repo';
 
 describe('ConnectorsService', () => {
   let connectorsService: ConnectorsService;
@@ -27,7 +30,7 @@ describe('ConnectorsService', () => {
         connectorName: 'lucene',
         pluginName: 'lucene-plugin',
         name: 'my-connector',
-        iri: 'http://example.org/connector',
+        iri: 'https://example.org/connector',
         order: 1,
       };
       TestUtil.mockResponse(new ResponseMock(CONNECTORS_CHECK_ENDPOINT).setResponse(response));
@@ -40,7 +43,7 @@ describe('ConnectorsService', () => {
       expect(result.status).toBe(BeforeUpdateQueryResultStatus.SUCCESS);
       expect(result.command).toBe('');
       expect(result.messageLabelKey).toBeUndefined();
-      expect(result.iri).toBe('http://example.org/connector');
+      expect(result.iri).toBe('https://example.org/connector');
     });
 
     test('should return ERROR result with inactive plugin message when connector has no support', async () => {
@@ -51,7 +54,7 @@ describe('ConnectorsService', () => {
         connectorName: 'lucene',
         pluginName: 'lucene-plugin',
         name: 'my-connector',
-        iri: 'http://example.org/connector',
+        iri: 'https://example.org/connector',
         order: 1,
       };
       TestUtil.mockResponse(new ResponseMock(CONNECTORS_CHECK_ENDPOINT).setResponse(response));
@@ -65,7 +68,7 @@ describe('ConnectorsService', () => {
       expect(result.command).toBe(ConnectorCommand.CREATE);
       expect(result.messageLabelKey).toBe('query.editor.inactive.plugin.warning.msg');
       expect(result.parameters).toEqual([{connectorName: 'lucene'}, {pluginName: 'lucene-plugin'}]);
-      expect(result.iri).toBe('http://example.org/connector');
+      expect(result.iri).toBe('https://example.org/connector');
     });
 
     test('should return SUCCESS result with created.connector message for CREATE command', async () => {
@@ -76,7 +79,7 @@ describe('ConnectorsService', () => {
         connectorName: 'lucene',
         pluginName: 'lucene-plugin',
         name: 'my-connector',
-        iri: 'http://example.org/connector',
+        iri: 'https://example.org/connector',
         order: 1,
       };
       TestUtil.mockResponse(new ResponseMock(CONNECTORS_CHECK_ENDPOINT).setResponse(response));
@@ -90,7 +93,7 @@ describe('ConnectorsService', () => {
       expect(result.command).toBe(ConnectorCommand.CREATE);
       expect(result.messageLabelKey).toBe('created.connector');
       expect(result.parameters).toEqual([{name: 'my-connector'}]);
-      expect(result.iri).toBe('http://example.org/connector');
+      expect(result.iri).toBe('https://example.org/connector');
     });
 
     test('should return SUCCESS result with repaired connector message for REPAIR command', async () => {
@@ -101,7 +104,7 @@ describe('ConnectorsService', () => {
         connectorName: 'lucene',
         pluginName: 'lucene-plugin',
         name: 'my-connector',
-        iri: 'http://example.org/connector',
+        iri: 'https://example.org/connector',
         order: 1,
       };
       TestUtil.mockResponse(new ResponseMock(CONNECTORS_CHECK_ENDPOINT).setResponse(response));
@@ -115,7 +118,7 @@ describe('ConnectorsService', () => {
       expect(result.command).toBe(ConnectorCommand.REPAIR);
       expect(result.messageLabelKey).toBe('query.editor.repaired.connector');
       expect(result.parameters).toEqual([{name: 'my-connector'}]);
-      expect(result.iri).toBe('http://example.org/connector');
+      expect(result.iri).toBe('https://example.org/connector');
     });
 
     test('should return SUCCESS result with delete success message for DROP command', async () => {
@@ -126,7 +129,7 @@ describe('ConnectorsService', () => {
         connectorName: 'lucene',
         pluginName: 'lucene-plugin',
         name: 'my-connector',
-        iri: 'http://example.org/connector',
+        iri: 'https://example.org/connector',
         order: 1,
       };
       TestUtil.mockResponse(new ResponseMock(CONNECTORS_CHECK_ENDPOINT).setResponse(response));
@@ -140,7 +143,7 @@ describe('ConnectorsService', () => {
       expect(result.command).toBe(ConnectorCommand.DROP);
       expect(result.messageLabelKey).toBe('externalsync.delete.success.msg');
       expect(result.parameters).toEqual([{name: 'my-connector'}]);
-      expect(result.iri).toBe('http://example.org/connector');
+      expect(result.iri).toBe('https://example.org/connector');
     });
 
     test('should throw UnknownConnectorCommandError for an unrecognised command', async () => {
@@ -151,7 +154,7 @@ describe('ConnectorsService', () => {
         connectorName: 'lucene',
         pluginName: 'lucene-plugin',
         name: 'my-connector',
-        iri: 'http://example.org/connector',
+        iri: 'https://example.org/connector',
         order: 1,
       };
       TestUtil.mockResponse(new ResponseMock(CONNECTORS_CHECK_ENDPOINT).setResponse(response));
@@ -169,7 +172,7 @@ describe('ConnectorsService', () => {
         connectorName: 'lucene',
         pluginName: 'lucene-plugin',
         name: 'my-connector',
-        iri: 'http://example.org/connector',
+        iri: 'https://example.org/connector',
         order: 1,
       };
       TestUtil.mockResponse(new ResponseMock(CONNECTORS_CHECK_ENDPOINT).setResponse(response));
@@ -182,6 +185,22 @@ describe('ConnectorsService', () => {
       const capturedRequest = TestUtil.getRequest(CONNECTORS_CHECK_ENDPOINT);
       expect(capturedRequest).toBeDefined();
       expect(capturedRequest?.body).toBe(sparqlQuery);
+    });
+
+    test('should always set the name on the result regardless of command', async () => {
+      // Given responses with different commands but the same name
+      const name = 'my-special-connector';
+      const responses: ConnectorResponse[] = [
+        {command: '', hasSupport: true, connectorName: 'c', pluginName: 'p', name, iri: 'x', order: 1},
+        {command: ConnectorCommand.CREATE, hasSupport: true, connectorName: 'c', pluginName: 'p', name, iri: 'x', order: 1},
+        {command: ConnectorCommand.REPAIR, hasSupport: true, connectorName: 'c', pluginName: 'p', name, iri: 'x', order: 1},
+      ];
+
+      for (const response of responses) {
+        TestUtil.mockResponse(new ResponseMock(CONNECTORS_CHECK_ENDPOINT).setResponse(response));
+        const result = await connectorsService.checkConnector();
+        expect(result.name).toBe(name);
+      }
     });
 
     test('should always set the iri on the result regardless of command', async () => {
@@ -203,6 +222,65 @@ describe('ConnectorsService', () => {
         // Then the iri should always be set on the result
         expect(result.iri).toBe(iri);
       }
+    });
+  });
+
+  describe('getConnectorBuildStatus', () => {
+    const IRI = 'https://www.ontotext.com/connectors/lucene/instance#my_index';
+    const buildingStatus = {
+      status: 'BUILDING',
+      processedEntities: 50,
+      estimatedEntities: 100,
+      indexedEntities: 40,
+      entitiesPerSecond: 100,
+      etaSeconds: 30,
+      repair: false,
+    };
+    let executeSparqlQuerySpy: jest.SpyInstance<Promise<SparqlResultsResponse>>;
+
+    beforeEach(() => {
+      executeSparqlQuerySpy = jest.spyOn(Rdf4jRepositoryService.prototype, 'executeSparqlQuery');
+    });
+
+    test('should return a ConnectorBuildStatus when the SPARQL query returns a status binding', async () => {
+      // Given a SPARQL response with a JSON-encoded status binding
+      const sparqlResponse: SparqlResultsResponse = {
+        results: {bindings: [{status: {value: JSON.stringify(buildingStatus), type: 'literal', datatype: 'application/json'}}]},
+      };
+      executeSparqlQuerySpy.mockResolvedValue(sparqlResponse);
+
+      // When the service fetches the build status
+      const result = await connectorsService.getConnectorBuildStatus(IRI, REPOSITORY_ID);
+
+      // Then it should return a populated ConnectorBuildStatus
+      expect(result).toBeInstanceOf(ConnectorBuildStatus);
+      expect(result!.status).toBe('BUILDING');
+      expect(result!.processedEntities).toBe(50);
+      expect(result!.estimatedEntities).toBe(100);
+      expect(result!.percentDone).toBe(50);
+    });
+
+    test('should return null when the SPARQL response has no bindings', async () => {
+      // Given a SPARQL response with empty bindings
+      executeSparqlQuerySpy.mockResolvedValue({results: {bindings: []}});
+
+      // When the service fetches the build status
+      const result = await connectorsService.getConnectorBuildStatus(IRI, REPOSITORY_ID);
+
+      // Then it should return null
+      expect(result).toBeNull();
+    });
+
+    test('should call executeSparqlQuery with the repository ID and the connector status query', async () => {
+      // Given a mock for the SPARQL call
+      executeSparqlQuerySpy.mockResolvedValue({results: {bindings: []}});
+
+      // When the service fetches the build status
+      await connectorsService.getConnectorBuildStatus(IRI, REPOSITORY_ID);
+
+      const EXPECTED_QUERY = `SELECT ?status {\n\t<${IRI}> <https://www.ontotext.com/connectors/lucene#connectorStatus> ?status\n}`;
+      // Then executeSparqlQuery should be called with the repository ID and the expected query
+      expect(executeSparqlQuerySpy).toHaveBeenCalledWith(REPOSITORY_ID, EXPECTED_QUERY);
     });
   });
 });

--- a/packages/api/src/services/domain/rdf4j/rdf4j-repository.service.ts
+++ b/packages/api/src/services/domain/rdf4j/rdf4j-repository.service.ts
@@ -3,6 +3,7 @@ import {service} from '../../../providers';
 import {Rdf4jRestService} from './rdf4j-rest.service';
 import {HttpResponse} from '../../../models/http';
 import {UnexpectedRepositorySizeError} from './error/unexpected-repository-size-error';
+import {SparqlResultsResponse} from '../../../models/sparql';
 
 /**
  * Service for interacting with RDF4J repositories.
@@ -60,6 +61,16 @@ export class Rdf4jRepositoryService implements Service {
   async downloadResultsAsFile(repositoryId: string, data: object, acceptHeader: string, linkHeader: string) {
     const response = await this.rdf4jRestService.downloadResultsAsFile(repositoryId, data, acceptHeader, linkHeader);
     return await this.extractFileFromResponse(response);
+  }
+
+  /**
+   * Executes a SPARQL query against the specified repository.
+   * @param repositoryId - The ID of the repository to query.
+   * @param query - The SPARQL query string.
+   * @returns A promise resolving to the raw SPARQL results.
+   */
+  executeSparqlQuery(repositoryId: string, query: string): Promise<SparqlResultsResponse> {
+    return this.rdf4jRestService.executeSparqlQuery(repositoryId, query);
   }
 
   /**

--- a/packages/api/src/services/domain/rdf4j/rdf4j-rest.service.ts
+++ b/packages/api/src/services/domain/rdf4j/rdf4j-rest.service.ts
@@ -1,5 +1,6 @@
 import {HttpService} from '../../http/http.service';
 import {NamespacesResponse} from './response/namespaces-response';
+import {SparqlResultsResponse} from '../../../models/sparql';
 
 /**
  * Service for interacting with the external RDF4J REST API.
@@ -75,5 +76,22 @@ export class Rdf4jRestService extends HttpService {
    */
   getRepositorySize(repositoryId: string): Promise<number> {
     return this.get(`${this.REPOSITORIES_ENDPOINT}/${repositoryId}/size`);
+  }
+
+  /**
+   * Executes a SPARQL SELECT query against the specified repository.
+   * @param repositoryId - The ID of the repository to query.
+   * @param query - The SPARQL SELECT query string.
+   * @returns A promise resolving to the raw SPARQL SELECT results.
+   */
+  executeSparqlQuery(repositoryId: string, query: string): Promise<SparqlResultsResponse> {
+    return this.post<SparqlResultsResponse>(`${this.REPOSITORIES_ENDPOINT}/${repositoryId}`, {
+      body: new URLSearchParams({query}),
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Accept': 'application/sparql-results+json',
+        'X-GraphDB-Local-Consistency': 'updating',
+      }
+    });
   }
 }

--- a/packages/api/src/services/utils/date-util.ts
+++ b/packages/api/src/services/utils/date-util.ts
@@ -10,4 +10,30 @@ export class DateUtil {
   static now(): number {
     return Date.now();
   }
+
+  /**
+   * Converts a duration in seconds to a human-readable string (e.g. `"1d 2h 3m 4s"`).
+   * Leading zero components are omitted. Returns `"-"` for falsy or non-positive input.
+   */
+  static formatDuration(s: number): string {
+    if (!s || s <= 0) {
+      return '-';
+    }
+    const days = Math.floor(s / 86400);
+    const hours = Math.floor((s % 86400) / 3600);
+    const minutes = Math.floor((s % 3600) / 60);
+    const seconds = Math.round(s % 60);
+    let message = '';
+    if (days) {
+      message += days + 'd ';
+    }
+    if (days || hours) {
+      message += hours + 'h ';
+    }
+    if (days || hours || minutes) {
+      message += minutes + 'm ';
+    }
+    message += seconds + 's';
+    return message.replace(/( 0[a-z])+$/, '');
+  }
 }

--- a/packages/api/src/services/utils/test/date-util.spec.ts
+++ b/packages/api/src/services/utils/test/date-util.spec.ts
@@ -1,0 +1,35 @@
+import {DateUtil} from '../date-util';
+
+describe('DateUtil', () => {
+  describe('formatDuration', () => {
+    test('should return "-" for zero', () => {
+      expect(DateUtil.formatDuration(0)).toBe('-');
+    });
+
+    test('should return "-" for negative values', () => {
+      expect(DateUtil.formatDuration(-10)).toBe('-');
+    });
+
+    test('should format seconds only', () => {
+      expect(DateUtil.formatDuration(45)).toBe('45s');
+    });
+
+    test('should format minutes and seconds', () => {
+      expect(DateUtil.formatDuration(125)).toBe('2m 5s');
+    });
+
+    test('should format hours, minutes and seconds', () => {
+      expect(DateUtil.formatDuration(3661)).toBe('1h 1m 1s');
+    });
+
+    test('should format days, hours, minutes and seconds', () => {
+      expect(DateUtil.formatDuration(90061)).toBe('1d 1h 1m 1s');
+    });
+
+    test('should omit trailing zero components', () => {
+      expect(DateUtil.formatDuration(3600)).toBe('1h');
+      expect(DateUtil.formatDuration(60)).toBe('1m');
+      expect(DateUtil.formatDuration(86400)).toBe('1d');
+    });
+  });
+});

--- a/packages/workbench/src/app/components/connector-progress/connector-progress-data.ts
+++ b/packages/workbench/src/app/components/connector-progress/connector-progress-data.ts
@@ -1,0 +1,14 @@
+/**
+ * Data payload passed to {@link ConnectorProgressComponent}.
+ */
+export class ConnectorProgressData {
+  actionName: string;
+  iri: string;
+  connectorName: string;
+
+  constructor(actionName: string, iri: string, connectorName: string) {
+    this.actionName = actionName;
+    this.iri = iri;
+    this.connectorName = connectorName;
+  }
+}

--- a/packages/workbench/src/app/components/connector-progress/connector-progress-dialog.component.ts
+++ b/packages/workbench/src/app/components/connector-progress/connector-progress-dialog.component.ts
@@ -1,0 +1,21 @@
+import {Component, inject} from '@angular/core';
+import {DynamicDialogConfig, DynamicDialogRef} from 'primeng/dynamicdialog';
+import {ConnectorProgressComponent} from './connector-progress.component';
+import {ConnectorProgressData} from './connector-progress-data';
+
+/**
+ * Thin dialog wrapper around {@link ConnectorProgressComponent}.
+ * Opened via {@link DialogProviderService} and delegates close to the dialog ref.
+ */
+@Component({
+  selector: 'app-connector-progress-dialog',
+  standalone: true,
+  imports: [ConnectorProgressComponent],
+  template: '<app-connector-progress [connectorProgressData]="data" (closed)="dialogRef.close()" />'
+})
+export class ConnectorProgressDialogComponent {
+  protected readonly dialogRef = inject(DynamicDialogRef);
+  private readonly dialogConfig = inject(DynamicDialogConfig<ConnectorProgressData>);
+
+  readonly data = this.dialogConfig.data!;
+}

--- a/packages/workbench/src/app/components/connector-progress/connector-progress.component.html
+++ b/packages/workbench/src/app/components/connector-progress/connector-progress.component.html
@@ -1,0 +1,37 @@
+<div>
+  @if (inline) {
+    <h4>
+      {{ (buildStatus().repair ? 'sparql_editor.connector_progress.action.repairing' : 'sparql_editor.connector_progress.action.creating') | transloco }} {{ 'sparql_editor.connector_progress.connector_label' | transloco }}
+      <strong>{{ connectorProgressData.connectorName }}</strong>...
+    </h4>
+  }
+
+  <p-progressbar
+    [value]="buildStatus().percentDone"
+  />
+
+  <dl class="connector-progress-stats">
+    <div class="connector-progress-row">
+      <dt>{{ 'sparql_editor.connector_progress.eta' | transloco }}</dt>
+      <dd>{{ eta() }}</dd>
+    </div>
+    <div class="connector-progress-row">
+      <dt>{{ 'sparql_editor.connector_progress.processed_entities' | transloco }}</dt>
+      <dd>{{
+          'sparql_editor.connector_progress.processed_entities_value' | transloco: {
+            processed: buildStatus().processedEntities,
+            estimated: buildStatus().estimatedEntities
+          }
+        }}
+      </dd>
+    </div>
+    <div class="connector-progress-row">
+      <dt>{{ 'sparql_editor.connector_progress.indexed_entities' | transloco }}</dt>
+      <dd>{{ buildStatus().indexedEntities}}</dd>
+    </div>
+    <div class="connector-progress-row">
+      <dt>{{ 'sparql_editor.connector_progress.speed' | transloco }}</dt>
+      <dd>{{ 'sparql_editor.connector_progress.speed_value' | transloco: {speed: buildStatus().entitiesPerSecond} }}</dd>
+    </div>
+  </dl>
+</div>

--- a/packages/workbench/src/app/components/connector-progress/connector-progress.component.spec.ts
+++ b/packages/workbench/src/app/components/connector-progress/connector-progress.component.spec.ts
@@ -1,0 +1,31 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ConnectorProgressComponent} from './connector-progress.component';
+import {ConnectorsService, RepositoryStorageService} from '@ontotext/workbench-api';
+import {provideTranslocoForTesting} from '../../../testing-utils/transloco-utils';
+
+describe('ConnectorProgressComponent', () => {
+  let component: ConnectorProgressComponent;
+  let fixture: ComponentFixture<ConnectorProgressComponent>;
+
+  beforeEach(async () => {
+    jest.spyOn(RepositoryStorageService.prototype, 'getActiveRepositoryId').mockReturnValue('test-repo');
+    jest.spyOn(ConnectorsService.prototype, 'getConnectorBuildStatus').mockResolvedValue(null);
+
+    await TestBed.configureTestingModule({
+      imports: [ConnectorProgressComponent, provideTranslocoForTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConnectorProgressComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    component.ngOnDestroy();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/workbench/src/app/components/connector-progress/connector-progress.component.ts
+++ b/packages/workbench/src/app/components/connector-progress/connector-progress.component.ts
@@ -1,0 +1,70 @@
+import {Component, EventEmitter, Input, OnDestroy, OnInit, Output, signal} from '@angular/core';
+import {TranslocoPipe} from '@jsverse/transloco';
+import {ProgressBar} from 'primeng/progressbar';
+import {ConnectorBuildStatus, ConnectorsService, DateUtil, RepositoryStorageService, service} from '@ontotext/workbench-api';
+import {ConnectorProgressData} from './connector-progress-data';
+import {LoggerProvider} from '../../services/logger-provider';
+
+/**
+ * Component that shows live build progress for a connector CREATE or REPAIR operation.
+ *
+ * Polls the connector status every second via {@link ConnectorsService.getConnectorBuildStatus}
+ * and emits {@link ConnectorProgressComponent.closed} when the status reaches `BUILT` or on error.
+ * Can be used standalone (set {@link ConnectorProgressComponent.inline} to true) or hosted inside
+ * {@link ConnectorProgressDialogComponent}.
+ */
+@Component({
+  selector: 'app-connector-progress',
+  standalone: true,
+  imports: [TranslocoPipe, ProgressBar],
+  templateUrl: './connector-progress.component.html'
+})
+export class ConnectorProgressComponent implements OnInit, OnDestroy {
+  private readonly logger = LoggerProvider.logger;
+
+  private readonly connectorsService = service(ConnectorsService);
+  private readonly repositoryStorageService = service(RepositoryStorageService);
+
+  private readonly pollDelay = 1000;
+
+  private pollInterval?: ReturnType<typeof setInterval>;
+
+  @Input({ required: true }) connectorProgressData!: ConnectorProgressData;
+  @Input() inline = false;
+
+  @Output() readonly closed = new EventEmitter<void>();
+
+  readonly buildStatus = signal<ConnectorBuildStatus>(new ConnectorBuildStatus());
+  readonly eta = signal('-');
+
+  ngOnInit(): void {
+    this.pollInterval = setInterval(() => this.pollStatus(), this.pollDelay);
+  }
+
+  ngOnDestroy(): void {
+    clearInterval(this.pollInterval);
+  }
+
+  private pollStatus(): void {
+    const repositoryId = this.repositoryStorageService.getActiveRepositoryId();
+    if (!repositoryId) {
+      return;
+    }
+    this.connectorsService.getConnectorBuildStatus(this.connectorProgressData.iri, repositoryId)
+      .then((status) => {
+        if (!status) {
+          return;
+        }
+        this.buildStatus.set(status);
+        this.eta.set(DateUtil.formatDuration(status.etaSeconds));
+        if (status.isBuilt) {
+          clearInterval(this.pollInterval);
+          this.closed.emit();
+        }
+      }).catch((error) => {
+        this.logger.error('Error fetching connector build status:', error);
+        clearInterval(this.pollInterval);
+        this.closed.emit();
+      });
+  }
+}

--- a/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.spec.ts
+++ b/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.spec.ts
@@ -3,6 +3,7 @@ import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {SparqlEditorPageComponent} from './sparql-editor-page.component';
 import {provideTranslocoForTesting} from '../../../testing-utils/transloco-utils';
 import {provideRouter} from '@angular/router';
+import {DialogService} from 'primeng/dynamicdialog';
 
 describe('SparqlEditorPageComponent', () => {
   let component: SparqlEditorPageComponent;
@@ -16,7 +17,8 @@ describe('SparqlEditorPageComponent', () => {
       ],
       providers: [
         provideNoopAnimations(),
-        provideRouter([])
+        provideRouter([]),
+        DialogService
       ]
     })
       .compileComponents();

--- a/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.ts
+++ b/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.ts
@@ -60,6 +60,10 @@ import {mapSavedQueryToTabQueryModel} from './mappers/saved-query-to-tab-query-m
 import {OngoingRequestsInfo} from '../../components/yasgui-component-facade/models/ongoing-requests-info';
 import {CancelAbortingQuery} from './error/cancel-abort-query';
 import {ConfirmationService} from 'primeng/api';
+import {DialogProviderService} from '../../services/dialog-provider.service';
+import {DynamicDialogRef} from 'primeng/dynamicdialog';
+import {ConnectorProgressDialogComponent} from '../../components/connector-progress/connector-progress-dialog.component';
+import {ConnectorProgressData} from '../../components/connector-progress/connector-progress-data';
 import {YasguiOperation, YasguiOperationType} from './constants';
 import {
   GeoFeatureProperties
@@ -99,6 +103,7 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly translocoService = inject(TranslocoService);
   private readonly confirmationService = inject(ConfirmationService);
+  private readonly dialogProviderService = inject(DialogProviderService);
   private readonly graphConfigService = service(GraphConfigService);
 
   // ================================
@@ -157,7 +162,7 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
       element.remove();
     }
   };
-  private readonly tabIdToConnectorProgressModalMapping = new Map();
+  private readonly tabIdToConnectorProgressModalMapping = new Map<string, DynamicDialogRef>();
   private internallyReloaded = false;
   private queriesAreCanceled = false;
   // This is used to determine whether the view is embedded in another application. When embedded, we want to hide
@@ -530,9 +535,9 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
    * @param queryExecutedRequest - the event payload.
    */
   private queryExecutedHandler(queryExecutedRequest: QueryExecutedEvent){
-    const connectorProgressModal = this.tabIdToConnectorProgressModalMapping.get(queryExecutedRequest.tabId);
-    if (connectorProgressModal) {
-      connectorProgressModal.dismiss();
+    const connectorProgressDialogData = this.tabIdToConnectorProgressModalMapping.get(queryExecutedRequest.tabId);
+    if (connectorProgressDialogData) {
+      connectorProgressDialogData.close();
       this.tabIdToConnectorProgressModalMapping.delete(queryExecutedRequest.tabId);
     }
   }
@@ -550,15 +555,31 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
   }
 
   private showConnectorOperationProgressDialog(result: BeforeUpdateQueryResult, tabId?: string) {
-    console.info('tabId', tabId);
     if (result.command === ConnectorCommand.CREATE) {
-      // const connectorProgressModal = createConnectorProgressDialog($translate.instant('externalsync.creating'), result.iri, response.data.name);
-      // tabIdToConnectorProgressModalMapping.set(tabId, connectorProgressModal);
+      const dialogRef = this.createConnectorProgressDialog(
+        this.translocoService.translate('sparql_editor.connector_progress.action.creating'),
+        result.iri!,
+        result.name!
+      );
+      this.tabIdToConnectorProgressModalMapping.set(tabId!, dialogRef);
     } else if (result.command === ConnectorCommand.REPAIR) {
-      // const connectorProgressModal = createConnectorProgressDialog($translate.instant('externalsync.repairing'), response.data.iri, response.data.name);
-      // tabIdToConnectorProgressModalMapping.set(tabId, connectorProgressModal);
+      const dialogRef = this.createConnectorProgressDialog(
+        this.translocoService.translate('sparql_editor.connector_progress.action.repairing'),
+        result.iri!,
+        result.name!
+      );
+      this.tabIdToConnectorProgressModalMapping.set(tabId!, dialogRef);
     }
     return result;
+  }
+
+  private createConnectorProgressDialog(actionName: string, iri: string, connectorName: string): DynamicDialogRef {
+    const dialogData = new ConnectorProgressData(actionName, iri, connectorName);
+    return this.dialogProviderService.createDialogRef(ConnectorProgressDialogComponent, {
+      data: dialogData,
+      header: this.translocoService.translate('sparql_editor.connector_progress.title', {actionName, connectorName}),
+      closable: false,
+    });
   }
 
   private setInferAndSameAs(authenticatedUser: AuthenticatedUser | undefined) {

--- a/packages/workbench/src/app/pages/ux-test/ux-test-page.component.html
+++ b/packages/workbench/src/app/pages/ux-test/ux-test-page.component.html
@@ -21,6 +21,11 @@
   <input pInputText [(ngModel)]="value3" type="text" pSize="large" placeholder="Large" />
 
 <hr>
+<div>Progressbar</div>
+  <p-progressbar [value]="progressValue" [attr.aria-label]="'Loading progress'" />
+
+<hr>
+<div>Confirmation dialog</div>
 <div class="card flex justify-center gap-2">
   <p-toast />
   <p-confirmdialog />

--- a/packages/workbench/src/app/pages/ux-test/ux-test-page.component.ts
+++ b/packages/workbench/src/app/pages/ux-test/ux-test-page.component.ts
@@ -12,6 +12,7 @@ import {ToolbarModule} from 'primeng/toolbar';
 import {ConfirmDialogModule} from 'primeng/confirmdialog';
 import {ToastModule} from 'primeng/toast';
 import {ConfirmationService, MessageService} from 'primeng/api';
+import {ProgressBarModule} from 'primeng/progressbar';
 
 @Component({
   selector: 'app-ux-test',
@@ -29,6 +30,7 @@ import {ConfirmationService, MessageService} from 'primeng/api';
     ToolbarModule,
     ConfirmDialogModule,
     ToastModule,
+    ProgressBarModule,
   ],
   providers: [ConfirmationService, MessageService],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -45,6 +47,7 @@ export class UxTestPageComponent implements OnDestroy {
   value2: string | undefined;
   value3: string | undefined;
   checked = true;
+  progressValue = 40;
   loginForm: FormGroup;
   error = false;
 

--- a/packages/workbench/src/app/services/dialog-provider.service.ts
+++ b/packages/workbench/src/app/services/dialog-provider.service.ts
@@ -29,6 +29,10 @@ export class DialogProviderService {
    * Opens a dialog for the given component and returns its close stream.
    */
   private openDialogWithComponent<DataType, ReturnType>(componentType: Type<unknown>, config: DialogOpenOptions<DataType>): Observable<ReturnType | undefined> {
+    return this.createDialogRef<DataType>(componentType, config).onClose.pipe(map((value) => value as ReturnType | undefined));
+  }
+
+  public createDialogRef<DataType>(componentType: Type<unknown>, config: DialogOpenOptions<DataType>): DynamicDialogRef {
     const dialogConfig: DynamicDialogConfig<DataType> = {
       data: config.data,
       showHeader: !!config.header,
@@ -42,7 +46,7 @@ export class DialogProviderService {
     };
     const dialogRef = this.dialogService.open(componentType, dialogConfig);
     this.assertDialogIsDefined(dialogRef);
-    return dialogRef.onClose.pipe(map((value) => value as ReturnType | undefined));
+    return dialogRef;
   }
 
   private assertDialogIsDefined(dialogRef: DynamicDialogRef | null): asserts dialogRef is NonNullable<DynamicDialogRef> {

--- a/packages/workbench/src/assets/i18n/en.json
+++ b/packages/workbench/src/assets/i18n/en.json
@@ -81,6 +81,20 @@
         "queries_updates": "<div class=\"run_query_confirmation alert alert-warning\">You have running {{queriesCount}} queries and {{updatesCount}} updates. The queries will be aborted.</div><div>Are you sure that you want to exit?</div>"
       }
     },
+    "connector_progress": {
+      "action": {
+        "creating": "Creating",
+        "repairing": "Repairing"
+      },
+      "title": "{{actionName}} connector {{connectorName}}...",
+      "connector_label": "connector",
+      "eta": "ETA",
+      "processed_entities": "Processed entities",
+      "processed_entities_value": "{{processed}} of {{estimated}} (estimated)",
+      "indexed_entities": "Indexed entities",
+      "speed": "Speed",
+      "speed_value": "{{speed}} entities/second"
+    },
     "yasgui": {
       "tabs": {
         "unnamed_tab_title": "Unnamed"

--- a/packages/workbench/src/assets/i18n/fr.json
+++ b/packages/workbench/src/assets/i18n/fr.json
@@ -81,6 +81,20 @@
         "queries_updates": "<div class=\"run_query_confirmation alert alert-warning\">Vous avez {{queriesCount}} requêtes et {{updatesCount}} mises à jour en cours. Les requêtes seront annulées.</div><div>Êtes-vous sûr de vouloir quitter ?</div>"
       }
     },
+    "connector_progress": {
+      "action": {
+        "creating": "Création",
+        "repairing": "Réparation"
+      },
+      "title": "{{actionName}} du connecteur {{connectorName}}...",
+      "connector_label": "connecteur",
+      "eta": "ETA ",
+      "processed_entities": "Entités traitées",
+      "processed_entities_value": "{{processed}} sur {{estimated}} (estimé)",
+      "indexed_entities": "Entités indexées",
+      "speed": "Vitesse",
+      "speed_value": "{{speed}} entités/seconde"
+    },
     "yasgui": {
       "tabs": {
         "unnamed_tab_title": "Anonyme"


### PR DESCRIPTION
## What
Add a progress dialog for connector CREATE and REPAIR operations.

## Why
As part of the migration to angular

## How
- Introduced `ConnectorBuildStatus` and `ConnectorBuildStatusResponse` models to handle build status data.
- Created `ConnectorProgressDialogComponent` to display the progress dialog.
- Implemented polling for connector status updates in the dialog.
- Added a new method in the `DialogProviderService`, which returns the created dialog ref. This is needed to be able to close the dialog instance on query completion from the sparql editor component

## Testing
jest

## Screenshots
<img width="1185" height="600" alt="image" src="https://github.com/user-attachments/assets/9b31432f-6b5a-47b1-be74-f177cbe4f0a3" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
