### PR TITLE
GDB-13785: Can't create GraphQL endpoint with remote repository

### DIFF
--- a/e2e-tests/e2e-legacy/graphql/graphql-in-remote-location.spec.js
+++ b/e2e-tests/e2e-legacy/graphql/graphql-in-remote-location.spec.js
@@ -1,0 +1,49 @@
+import {RepositoriesStubs} from '../../stubs/repositories/repositories-stubs.js';
+import {GraphqlEndpointManagementSteps} from '../../steps/graphql/graphql-endpoint-management-steps.js';
+import {NamespaceStubs} from '../../stubs/namespace-stubs.js';
+import {CreateGraphqlEndpointSteps} from '../../steps/graphql/create-graphql-endpoint-steps.js';
+import {GraphqlPlaygroundSteps} from '../../steps/graphql/graphql-playground-steps.js';
+
+describe('Graphql: Remote Location', () => {
+    const REMOTE_REPOSITORY_ID = 'configurations';
+    const REMOTE_REPOSITORY_LOCATION = 'http://localhost:7202';
+
+    beforeEach(() => {
+        RepositoriesStubs.stubRepositories();
+        NamespaceStubs.stubGeneratedOntotextNamespacesResponse(REMOTE_REPOSITORY_ID);
+        cy.presetRepository(REMOTE_REPOSITORY_ID, REMOTE_REPOSITORY_LOCATION);
+    });
+
+    it('should inform users that GraphQL endpoints are not accessible when the selected repository is in a remote location', () => {
+        // GIVEN: The workbench is set up with a repository located in a remote location.
+
+        // WHEN: I visit the GraphQL endpoint management page.
+        GraphqlEndpointManagementSteps.visit();
+        // THEN: I expect the page content not to be visible.
+        GraphqlEndpointManagementSteps.getPageContainer().should('not.exist');
+        // AND: An info message is displayed to inform users to switch to a repository from the current location.
+        GraphqlEndpointManagementSteps.getRepositoryInRemoteLocation().should('contain.text', 'The selected repository is in a remote location, and its endpoints aren’t accessible here. Select a repository from the current location.');
+    });
+
+    it('should inform users that they cannot create a GraphQL endpoint when the selected repository is in a remote location', () => {
+        // GIVEN: The workbench is set up with a repository located in a remote location.
+
+        // WHEN: I visit the create GraphQL endpoint page.
+        CreateGraphqlEndpointSteps.visit();
+        // THEN: I expect the page content not to be visible.
+        CreateGraphqlEndpointSteps.getPageContainer().should('not.exist');
+        // AND: An info message is displayed to inform users to switch to a local repository.
+        CreateGraphqlEndpointSteps.getRepositoryInRemoteLocation().should('contain.text', 'Endpoints can only be created for repositories in the current location. Select a local repository to continue.');
+    });
+
+    it('should inform users that the GraphQL Playground is available only for local repositories', () => {
+        // GIVEN: The workbench is set up with a repository located in a remote location.
+
+        // WHEN: I visit the GraphQL Playground page.
+        GraphqlPlaygroundSteps.visit();
+        // THEN: I expect the page content not to be visible.
+        GraphqlPlaygroundSteps.getPageContainer().should('not.exist');
+        // AND: An info message is displayed to inform users to switch to a local repository.
+        GraphqlPlaygroundSteps.getRepositoryInRemoteLocation().should('contain.text', 'The active repository is in a remote location. Playground is only available for repositories in the current location.');
+    });
+});

--- a/e2e-tests/steps/graphql/create-graphql-endpoint-steps.js
+++ b/e2e-tests/steps/graphql/create-graphql-endpoint-steps.js
@@ -7,6 +7,14 @@ export class CreateGraphqlEndpointSteps {
         return cy.get('.create-graphql-endpoint-view');
     }
 
+    static getPageContainer() {
+        return CreateGraphqlEndpointSteps.getView().find('.content');
+    }
+
+    static getRepositoryInRemoteLocation() {
+        return CreateGraphqlEndpointSteps.getView().find('.unexpected-remote-repository-warning');
+    }
+
     static getSourceRepositorySelector() {
         return this.getView().find('.source-repository-selector');
     }

--- a/e2e-tests/steps/graphql/graphql-endpoint-management-steps.js
+++ b/e2e-tests/steps/graphql/graphql-endpoint-management-steps.js
@@ -10,6 +10,14 @@ export class GraphqlEndpointManagementSteps {
         return cy.get('.graphql-endpoint-management-view');
     }
 
+    static getPageContainer() {
+        return GraphqlEndpointManagementSteps.getView().find('.endpoint-management-container');
+    }
+
+    static getRepositoryInRemoteLocation() {
+        return GraphqlEndpointManagementSteps.getView().find('.unexpected-remote-repository-warning');
+    }
+
     static getEndpointFilterField() {
         return this.getView().find('.endpoints-filter-field');
     }

--- a/e2e-tests/steps/graphql/graphql-playground-steps.js
+++ b/e2e-tests/steps/graphql/graphql-playground-steps.js
@@ -10,6 +10,14 @@ export class GraphqlPlaygroundSteps {
         return cy.get('.graphql-playground-view');
     }
 
+    static getPageContainer() {
+        return GraphqlPlaygroundSteps.getView().find('.content');
+    }
+
+    static getRepositoryInRemoteLocation() {
+        return GraphqlPlaygroundSteps.getView().find('.unexpected-remote-repository-warning');
+    }
+
     static getNoSchemasAlert() {
         return this.getView().find('.no-endpoints-view');
     }

--- a/e2e-tests/support/repository-commands.js
+++ b/e2e-tests/support/repository-commands.js
@@ -47,13 +47,13 @@ Cypress.Commands.add('deleteRepository', (id, secured = false) => {
     });
 });
 
-Cypress.Commands.add('presetRepository', (id) => {
-    cy.setLocalStorage(PRESET_REPO, JSON.stringify({id: id, location: ''}));
+Cypress.Commands.add('presetRepository', (id, location = '') => {
+    cy.setLocalStorage(PRESET_REPO, JSON.stringify({id: id, location}));
     cy.waitUntil(() =>
         cy.getLocalStorage(PRESET_REPO)
             .then((preset) => {
                 const presetRepo = JSON.parse(preset);
-                return presetRepo && presetRepo.id === id
+                return presetRepo && presetRepo.id === id && presetRepo.location === location;
             }));
     cy.log('Pre-set repository:', id);
 });

--- a/packages/api/src/services/domain/repository/repository-context.service.ts
+++ b/packages/api/src/services/domain/repository/repository-context.service.ts
@@ -6,6 +6,7 @@ import {service} from '../../../providers';
 import {RepositoryStorageService} from './repository-storage.service';
 import {BeforeChangeValidationPromise} from '../../../models/context/before-change-validation-promise';
 import {LifecycleHooks} from '../../../providers/service/lifecycle-hooks';
+import {LoggerProvider} from '../../logging/logger-provider';
 
 type RepositoryContextFields = {
   readonly REPOSITORY_LIST: string;
@@ -23,6 +24,7 @@ type RepositoryContextFieldParams = {
 export class RepositoryContextService extends ContextService<RepositoryContextFields> implements DeriveContextServiceContract<RepositoryContextFields, RepositoryContextFieldParams>, LifecycleHooks {
   readonly SELECTED_REPOSITORY = 'selectedRepository';
   readonly REPOSITORY_LIST = 'repositoryList';
+  private readonly logger = LoggerProvider.logger;
 
   /**
    * Updates the selected repository and notifies subscribers about the change.
@@ -100,8 +102,21 @@ export class RepositoryContextService extends ContextService<RepositoryContextFi
     };
   }
 
-  private readonly deserializeRepository = (repository: string): Repository => {
-    return new Repository(JSON.parse(repository));
+  /**
+   * Deserializes a repository from the given string value. The value is expected to be a JSON string representing a RepositoryReference.
+   *
+   * This method is used to deserialize objects stored in localStorage.
+   *
+   * @param repository - The value retrieved from localStorage.
+   * @returns The repository from the repository list if found, otherwise `undefined`.
+   */
+  private readonly deserializeRepository = (repository: string): Repository | undefined => {
+    try {
+      return this.findRepository(JSON.parse(repository));
+    } catch (error) {
+      this.logger.error(`Failed to deserialize repository from: "${repository}"`, error);
+      return undefined;
+    }
   };
 
   /**

--- a/packages/api/src/services/domain/repository/test/repository-context.service.spec.ts
+++ b/packages/api/src/services/domain/repository/test/repository-context.service.spec.ts
@@ -313,6 +313,84 @@ describe('RepositoryContextService', () => {
       expect(repositoryContextService.isActiveRepoOntopType()).toBe(false);
     });
   });
+
+  describe('deserializeRepository', () => {
+    // deserializeRepository is a private method and is tested indirectly through deserializeProperty(), which delegates to it.
+    beforeEach(() => {
+      const repositories = new RepositoryList([
+        new Repository({id: 'remote-repo', location: 'http://example.com:7300', sesameType: 'graphdb:OntopRepository', local: false}),
+        new Repository({id: 'local-repo', location: '', sesameType: 'graphdb:SailRepository', local: true})
+      ]);
+      repositoryContextService.updateRepositoryList(repositories);
+    });
+
+    test('should return undefined when trying to deserialize a repository from an empty string', () => {
+      // GIVEN: A repository context service containing available repositories
+
+      // WHEN: I try to deserialize an empty string
+      const deserializedRepository = repositoryContextService.deserializeProperty('selectedRepository', '');
+      // THEN: I expect the deserialized repository to be undefined.
+      expect(deserializedRepository).toBeUndefined();
+    });
+
+    test('should return undefined when trying to deserialize a repository from an invalid JSON string', () => {
+      // GIVEN: A repository context service containing available repositories
+
+      // WHEN: I try to deserialize an invalid JSON string
+      const deserializedRepository = repositoryContextService.deserializeProperty('selectedRepository', 'wrongJsonString');
+      // THEN: I expect the deserialized repository to be undefined.
+      expect(deserializedRepository).toBeUndefined();
+    });
+
+    test('should return undefined when trying to deserialize a repository with a non-existent repository id', () => {
+      // GIVEN: A repository context service containing available repositories
+
+      // WHEN: I try to deserialize a non-existent repository
+      const deserializedRepository = repositoryContextService.deserializeProperty('selectedRepository', '{"id": "non-existent-repo", "location": ""}');
+      // THEN: I expect the deserialized repository to be undefined.
+      expect(deserializedRepository).toBeUndefined();
+    });
+
+    test('should return undefined when trying to deserialize a remote repository without a location', () => {
+      // GIVEN: A repository context service containing available repositories
+
+      // WHEN: I try to deserialize a remote repository without a location
+      const deserializedRepository = repositoryContextService.deserializeProperty('selectedRepository', '{"id": "remote-repo", "location": ""}');
+      // THEN: I expect the deserialized repository to be undefined.
+      expect(deserializedRepository).toBeUndefined();
+    });
+
+    test('should return undefined when trying to deserialize a local repository with a location', () => {
+      // GIVEN: A repository context service containing available repositories
+
+      // WHEN: I try to deserialize a local repository with a location
+      const deserializedRepository = repositoryContextService.deserializeProperty('selectedRepository', '{"id": "local-repo", "location": "http://example.com:7300"}');
+      // THEN: I expect the deserialized repository to be undefined.
+      expect(deserializedRepository).toBeUndefined();
+    });
+
+    test('should return a repository when trying to deserialize a remote repository', () => {
+      // GIVEN: A repository context service containing available repositories
+
+      // WHEN: I try to deserialize a remote repository
+      const deserializedRepository = repositoryContextService.deserializeProperty('selectedRepository', '{"id": "remote-repo", "location": "http://example.com:7300"}') as Repository;
+      // THEN: I expect the deserialized repository to be a populated repository instance.
+      expect(deserializedRepository).toBeInstanceOf(Repository);
+      expect(deserializedRepository.local).toBe(false);
+      expect(deserializedRepository.sesameType).toBe('graphdb:OntopRepository');
+    });
+
+    test('should return a repository when trying to deserialize a local repository', () => {
+      // GIVEN: A repository context service containing available repositories
+
+      // WHEN: I try to deserialize a local repository
+      const deserializedRepository = repositoryContextService.deserializeProperty('selectedRepository', '{"id": "local-repo", "location": ""}') as Repository;
+      // THEN: I expect the deserialized repository to be a populated repository instance.
+      expect(deserializedRepository).toBeInstanceOf(Repository);
+      expect(deserializedRepository.local).toBe(true);
+      expect(deserializedRepository.sesameType).toBe('graphdb:SailRepository');
+    });
+  });
 });
 
 function createRepositoryInstance(id: string, location = 'http://example.com:7300') {

--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -827,6 +827,9 @@
             },
             "endpoint_selector": {
                 "tooltip": "Active endpoints"
+            },
+            "warnings": {
+                "unexpected_remote_repository": "The active repository is in a remote location. Playground is only available for repositories in the current location."
             }
         },
         "endpoints_management": {
@@ -1089,6 +1092,9 @@
                         "success": "The endpoint generation report was deleted successfully."
                     }
                 }
+            },
+            "warnings": {
+                "unexpected_remote_repository": "The selected repository is in a remote location, and its endpoints aren’t accessible here. Select a repository from the current location."
             }
         },
         "create_endpoint": {
@@ -1332,7 +1338,7 @@
                 }
             },
             "warnings": {
-                "unexpected_remote_repository": "The active repository is located at a different remote location. Please select a repository from the current location."
+                "unexpected_remote_repository": "Endpoints can only be created for repositories in the current location. Select a local repository to continue."
             }
         }
     },

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -826,6 +826,9 @@
             },
             "endpoint_selector": {
                 "tooltip": "Interfaces actives"
+            },
+            "warnings": {
+                "unexpected_remote_repository": "Le dépôt actif se trouve dans un emplacement distant. Le Playground est uniquement disponible pour les dépôts situés dans l’emplacement actuel."
             }
         },
         "endpoints_management": {
@@ -1088,6 +1091,9 @@
                         "success": "Le rapport de génération du point de terminaison a été supprimé avec succès."
                     }
                 }
+            },
+            "warnings": {
+                "unexpected_remote_repository": "Le dépôt sélectionné se trouve dans un emplacement distant et ses endpoints ne sont pas accessibles ici. Sélectionnez un dépôt de l’emplacement actuel."
             }
         },
         "create_endpoint": {
@@ -1331,7 +1337,7 @@
                 }
             },
             "warnings": {
-                "unexpected_remote_repository": "Le dépôt actif se trouve sur un autre emplacement distant. Veuillez sélectionner un dépôt à l'emplacement actuel."
+                "unexpected_remote_repository": "Les endpoints ne peuvent être créés que pour les dépôts situés dans l’emplacement actuel. Sélectionnez un dépôt local pour continuer."
             }
         }
     },

--- a/packages/legacy-workbench/src/js/angular/graphql/controllers/graphql-endpoint-management-view.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphql/controllers/graphql-endpoint-management-view.controller.js
@@ -8,6 +8,7 @@ import {resolvePlaygroundUrlWithEndpoint} from "../services/endpoint-utils";
 import {saveAs} from 'lib/FileSaver-patch';
 import {GraphqlEndpointInfo} from "../../models/graphql/graphql-endpoints-info";
 import {LoggerProvider} from "../../core/services/logger-provider";
+import {RepositoryContextService, service} from '@ontotext/workbench-api';
 
 const logger = LoggerProvider.logger;
 const modules = [
@@ -28,6 +29,21 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
     // Private variables
     // =========================
 
+    /**
+     * Reference to import schema dialog instance.
+     */
+    let importSchemaDialog;
+
+    /**
+     * Reference to endpoint configuration dialog instance.
+     */
+    let endpointConfigurationDialog;
+
+    /**
+     * Reference to endpoint report dialog instance.
+     */
+    let endpointReportDialog;
+
     const subscriptions = [];
 
     /**
@@ -35,6 +51,7 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
      * @type {number}
      */
     const ENDPOINTS_INFO_POLLING_INTERVAL = 5000;
+    const repositoryContextService = service(RepositoryContextService);
 
     // =========================
     // Public variables
@@ -99,6 +116,12 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
      * @type {boolean}
      */
     $scope.changingEndpointActiveState = false;
+
+    /**
+     * A flag indicating if the selected source repository is local. This allows showing a warning message in the UI.
+     * @type {boolean}
+     */
+    $scope.isSelectedRepositoryLocal = false;
 
     // =========================
     // Public methods
@@ -220,7 +243,7 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
      * @returns {*} The modal instance.
      */
     $scope.importSchema = () => {
-        return $uibModal.open({
+        importSchemaDialog = $uibModal.open({
             templateUrl: 'js/angular/graphql/templates/modal/import-endpoint-definition-modal.html',
             controller: 'ImportEndpointDefinitionModalController',
             windowClass: 'import-endpoint-definition-modal',
@@ -234,7 +257,9 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
                     };
                 },
             },
-        }).result;
+        });
+        importSchemaDialog.result.finally(() => importSchemaDialog = null);
+        return importSchemaDialog.result;
     };
 
     /**
@@ -258,7 +283,7 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
      * @returns {*} The modal instance.
      */
     $scope.onConfigureEndpoint = (endpointConfiguration) => {
-        return $uibModal.open({
+        endpointConfigurationDialog = $uibModal.open({
             templateUrl: 'js/angular/graphql/templates/modal/endpoint-configuration-modal.html',
             controller: 'GraphqlEndpointConfigurationModalController',
             windowClass: 'graphql-endpoint-configuration-modal',
@@ -273,7 +298,9 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
                     };
                 },
             },
-        }).result;
+        });
+        endpointConfigurationDialog.result.finally(() => endpointConfigurationDialog = null);
+        return endpointConfigurationDialog.result;
     };
 
     /**
@@ -311,12 +338,46 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
     // Private methods
     // =========================
 
+    const onInit = () => {
+        loadEndpointsInfo(true)
+            .then(() => {
+                pollEndpointsInfo();
+            });
+    };
+
+    /**
+     * Closes all currently opened dialogs related to GraphQL endpoint management.
+     *
+     * Dialogs are repository-specific and must be closed when the active
+     * repository changes to avoid displaying stale or misleading information.
+     */
+    const closeDialogs = () => {
+        if (importSchemaDialog) {
+            importSchemaDialog.dismiss();
+        }
+        if (endpointConfigurationDialog) {
+            endpointConfigurationDialog.dismiss();
+        }
+        if (endpointReportDialog) {
+            endpointReportDialog.dismiss();
+        }
+    };
+
     /**
      * Handles the change of the active repository.
      * @param {object} repositoryObject
      */
-    const getActiveRepositoryObjectHandler = (repositoryObject) => {
-        if (repositoryObject) {
+    const getSelectedRepositoryChangeHandler = (repositoryObject) => {
+        if (!repositoryObject) {
+            return;
+        }
+        // Close any open dialogs before reloading repository-specific data. Dialogs are tied to the currently selected
+        // repository and should not remain open if the repository changes.
+        //
+        // This can occur when a dialog is open and the repository is changed from another browser tab.
+        closeDialogs();
+        $scope.isSelectedRepositoryLocal = repositoryObject.local;
+        if ($scope.isSelectedRepositoryLocal) {
             onInit();
         }
     };
@@ -327,7 +388,7 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
      * @returns {*}
      */
     const showReportModal = (endpointGenerationReport) => {
-        return $uibModal.open({
+        endpointReportDialog = $uibModal.open({
             templateUrl: 'js/angular/graphql/templates/modal/endpoint-generation-failure-result-modal.html',
             controller: 'EndpointGenerationResultFailureModalController',
             windowClass: 'endpoint-generation-failure-result-modal',
@@ -341,7 +402,9 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
                     };
                 },
             },
-        }).result;
+        });
+        endpointReportDialog.result.finally(() => endpointReportDialog = null);
+        return endpointReportDialog.result;
     };
 
     /**
@@ -463,6 +526,7 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
      * Unsubscribes all watchers.
      */
     const unsubscribeAll = () => {
+        closeDialogs();
         endpointsInfoPollingTimer && $interval.cancel(endpointsInfoPollingTimer);
         endpointsInfoPollingTimer = undefined;
         endpointsInfoLoader = undefined;
@@ -473,19 +537,10 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
     // Subscriptions
     // =========================
 
-    subscriptions.push(GraphqlContextService.subscribe(GraphqlEventName.START_CREATE_ENDPOINT_WIZARD, onStartCreateEndpointWizard));
-    subscriptions.push(GraphqlContextService.subscribe(GraphqlEventName.DELETE_ENDPOINT_REPORT, onDeleteEndpointReport));
-    subscriptions.push($scope.$watch($scope.getActiveRepositoryObject, getActiveRepositoryObjectHandler));
+    subscriptions.push(
+        GraphqlContextService.subscribe(GraphqlEventName.START_CREATE_ENDPOINT_WIZARD, onStartCreateEndpointWizard),
+        GraphqlContextService.subscribe(GraphqlEventName.DELETE_ENDPOINT_REPORT, onDeleteEndpointReport),
+        repositoryContextService.onSelectedRepositoryChanged(getSelectedRepositoryChangeHandler),
+    );
     $scope.$on('$destroy', unsubscribeAll);
-
-    // =========================
-    // Initialization
-    // =========================
-
-    const onInit = () => {
-        loadEndpointsInfo(true)
-            .then(() => {
-                pollEndpointsInfo();
-            });
-    };
 }

--- a/packages/legacy-workbench/src/js/angular/graphql/controllers/graphql-playground-view.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphql/controllers/graphql-playground-view.controller.js
@@ -9,6 +9,7 @@ import {
     AuthenticationStorageService,
     RuntimeConfigurationContextService,
     ThemeService,
+    RepositoryContextService,
 } from '@ontotext/workbench-api';
 
 const modules = [
@@ -31,6 +32,7 @@ function GraphqlPlaygroundViewCtrl($scope, $location, $repositories, $languageSe
     const authStorageService = service(AuthenticationStorageService);
     const runtimeConfigurationContextService = service(RuntimeConfigurationContextService);
     const themeService = service(ThemeService);
+    const repositoryContextService = service(RepositoryContextService);
     // =========================
     // Public variables
     // =========================
@@ -61,6 +63,12 @@ function GraphqlPlaygroundViewCtrl($scope, $location, $repositories, $languageSe
      */
     $scope.configuration = undefined;
 
+    /**
+     * A flag indicating if the selected source repository is local. This allows showing a warning message in the UI.
+     * @type {boolean}
+     */
+    $scope.isSelectedRepositoryLocal = false;
+
     // =========================
     // Public methods
     // =========================
@@ -84,6 +92,11 @@ function GraphqlPlaygroundViewCtrl($scope, $location, $repositories, $languageSe
     // =========================
     // Private methods
     // =========================
+    const onInit = () => {
+        loadEndpoints().finally(() => {
+            $scope.initialized = true;
+        });
+    };
 
     /**
      * Builds the configuration object for the GraphQL Playground.
@@ -216,8 +229,12 @@ function GraphqlPlaygroundViewCtrl($scope, $location, $repositories, $languageSe
      * Handles the change of the active repository.
      * @param {object} repositoryObject
      */
-    const getActiveRepositoryObjectHandler = (repositoryObject) => {
-        if (repositoryObject) {
+    const getSelectedRepositoryChangeHandler = (repositoryObject) => {
+        if (!repositoryObject) {
+            return;
+        }
+        $scope.isSelectedRepositoryLocal = repositoryObject.local;
+        if ($scope.isSelectedRepositoryLocal) {
             onInit();
         }
     };
@@ -230,10 +247,15 @@ function GraphqlPlaygroundViewCtrl($scope, $location, $repositories, $languageSe
      * @param {string} args.locale - The new locale to be set for the GraphQL Playground.
      */
     const getLanguageChangeHandler = (event, args) => {
-        GraphqlPlaygroundDirectiveUtil.getGraphqlPlaygroundComponentAsync("#graphql-playground")
-            .then((graphqlPlayground) => {
-                graphqlPlayground.setLanguage(args.locale);
-            });
+        const hasGraphqlEndpoints = $scope.graphqlEndpoints?.length;
+        // The GraphQL Playground is rendered only when at least one GraphQL endpoint exists.
+        // Therefore, we attempt to locate it and change language only in that case.
+        if (hasGraphqlEndpoints) {
+            GraphqlPlaygroundDirectiveUtil.getGraphqlPlaygroundComponentAsync("#graphql-playground")
+                .then((graphqlPlayground) => {
+                    graphqlPlayground.setLanguage(args.locale);
+                });
+        }
     };
 
     /**
@@ -271,19 +293,9 @@ function GraphqlPlaygroundViewCtrl($scope, $location, $repositories, $languageSe
     // =========================
 
     subscriptions = [
-        $scope.$watch($scope.getActiveRepositoryObject, getActiveRepositoryObjectHandler),
+        repositoryContextService.onSelectedRepositoryChanged(getSelectedRepositoryChangeHandler),
         $scope.$on('language-changed', getLanguageChangeHandler),
         runtimeConfigurationContextService.onThemeModeChanged(onThemeChanged),
     ];
     $scope.$on('$destroy', unsubscribeAll);
-
-    // =========================
-    // Initialization
-    // =========================
-
-    const onInit = () => {
-        loadEndpoints().finally(() => {
-            $scope.initialized = true;
-        });
-    };
 }

--- a/packages/legacy-workbench/src/js/angular/graphql/templates/graphql-endpoint-management.html
+++ b/packages/legacy-workbench/src/js/angular/graphql/templates/graphql-endpoint-management.html
@@ -14,7 +14,11 @@
          size="100">
     </div>
 
-    <div ng-if="getActiveRepository() && !loadingEndpointsInfo" class="endpoint-management-container">
+    <div ng-if="!isSelectedRepositoryLocal && getActiveRepository()" class="warnings unexpected-remote-repository-warning">
+        <div class="alert alert-warning">{{'graphql.endpoints_management.warnings.unexpected_remote_repository' | translate}}</div>
+    </div>
+
+    <div ng-if="isSelectedRepositoryLocal && getActiveRepository() && !loadingEndpointsInfo" class="endpoint-management-container">
 
         <div class="toolbar">
             <div class="endpoints-filter">

--- a/packages/legacy-workbench/src/js/angular/graphql/templates/graphql-playground.html
+++ b/packages/legacy-workbench/src/js/angular/graphql/templates/graphql-playground.html
@@ -25,7 +25,11 @@
          size="100">
     </div>
 
-    <div class="content" ng-if="initialized">
+    <div ng-if="!isSelectedRepositoryLocal" class="warnings unexpected-remote-repository-warning">
+        <div class="alert alert-warning">{{'graphql.playground.warnings.unexpected_remote_repository' | translate}}</div>
+    </div>
+
+    <div class="content" ng-if="isSelectedRepositoryLocal && initialized">
         <div class="no-endpoints-view" ng-show="!loadingEndpoints && configuration === undefined && !graphqlEndpoints.length">
             <div class="alert alert-warning">
                 <div ng-bind-html="'graphql.playground.message.no_schemas_in_repository' | translate | trustAsHtml"></div>


### PR DESCRIPTION
## What
- Add a warning when the selected repository is located remotely and hide the page content.
- Close dialogs when the selected repository changes.

## Why
- Currently, GraphQL endpoints cannot be created for repositories located in remote locations.
- The selected repository can change while a dialog is open, typically when the repository is changed in another browser tab. In such cases, the dialog remains open and may display information related to a different repository. This can mislead users into thinking they are working with one repository while they are actually interacting with another.

## How
- Updated GraphQL-related pages to display a warning message and hide their content when the selected repository is in a remote location.
- Store references to opened dialogs in the controller and close them programmatically when the selected repository changes.

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [ ] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified
