### PR TITLE
GDB-14399 Fix language change handler in the new sparql editor view

### DIFF
--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.html
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.html
@@ -1,6 +1,7 @@
 <ontotext-yasgui
   class="{{cssClass()}}"
   [config]="config()"
+  [language]="language()"
   [savedQueryConfig]="savedQueryConfig"
   (loadSavedQueries)="loadSavedQueries()"
   (createSavedQuery)="createSavedQuery($event)"

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.spec.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.spec.ts
@@ -2,7 +2,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {YasguiComponentFacadeComponent} from './yasgui-component-facade.component';
 import {provideTranslocoForTesting} from '../../../testing-utils/transloco-utils';
-import {RuntimeConfigurationContextService, ServiceProvider} from '@ontotext/workbench-api';
+import {LanguageContextService, RuntimeConfigurationContextService, ServiceProvider} from '@ontotext/workbench-api';
 
 jest.mock('ontotext-yasgui-web-component/loader', () => ({
   defineCustomElements: jest.fn()
@@ -18,6 +18,14 @@ describe('YasguiComponentFacadeComponent', () => {
     // defineCustomElements is mocked as a no-op), so it lacks the setTheme() method that
     // the callback would try to invoke.
     jest.spyOn(ServiceProvider.get(RuntimeConfigurationContextService), 'onThemeModeChanged')
+      .mockImplementation(() => () => {
+        // No-op subscription that doesn't call the callback immediately.
+      });
+    jest.spyOn(ServiceProvider.get(LanguageContextService), 'getSelectedLanguage')
+      .mockReturnValue('en');
+    jest.spyOn(ServiceProvider.get(LanguageContextService), 'getDefaultLanguage')
+      .mockReturnValue('en');
+    jest.spyOn(ServiceProvider.get(LanguageContextService), 'onSelectedLanguageChanged')
       .mockImplementation(() => () => {
         // No-op subscription that doesn't call the callback immediately.
       });

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.ts
@@ -85,6 +85,28 @@ defineCustomElements();
   }
 })
 export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
+  // ===================================
+  // Angular injections
+  // ===================================
+  private readonly elementRef = inject(ElementRef);
+  private readonly translocoService = inject(TranslocoService);
+  private readonly yasguiPersistenceMigrationService = inject(YasguiPersistenceMigrationService);
+
+  // ===================================
+  // API module injections
+  // ===================================
+  private readonly sparqlService = service(SparqlService);
+  private readonly toastrService = service(OntoToastrService);
+  private readonly rdf4jRepositoryService = service(Rdf4jRepositoryService);
+  private readonly repositoryContextService = service(RepositoryContextService);
+  private readonly authenticationStorageService = service(AuthenticationStorageService);
+  private readonly languageContextService = service(LanguageContextService);
+  private readonly languageService = service(LanguageService);
+  private readonly autocompleteService = service(AutocompleteService);
+  private readonly monitoringService = service(MonitoringService);
+  private readonly themeService = service(ThemeService);
+  private readonly runtimeConfigurationContextService = service(RuntimeConfigurationContextService);
+
   private readonly logger = LoggerProvider.logger;
 
   @HostListener('click', ['$event'])
@@ -137,6 +159,12 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
    */
   config = signal<OntotextYasguiConfig | undefined>(undefined);
 
+  /**
+   * The currently selected language in the application. This is used to set the language of the ontotext-yasgui
+   * component and to update it when the selected language changes in the application.
+   */
+  language = signal<string | undefined>(this.languageContextService.getSelectedLanguage() || this.languageContextService.getDefaultLanguage());
+
   // ===================================
   // Outputs
   // ===================================
@@ -159,9 +187,10 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.subscriptionList.add(
-      this.runtimeConfigurationContextService.onThemeModeChanged(this.onThemeChanged.bind(this))
-    );
+    this.subscriptionList.addAll([
+      this.runtimeConfigurationContextService.onThemeModeChanged(this.onThemeChanged.bind(this)),
+      this.languageContextService.onSelectedLanguageChanged(this.onLanguageChange.bind(this), undefined, true),
+    ]);
   }
 
   ngOnDestroy(): void {
@@ -169,28 +198,6 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
     this.removeDirtyCheckHandlers();
     this.subscriptionList.unsubscribeAll();
   }
-
-  // ===================================
-  // Angular injections
-  // ===================================
-  private readonly elementRef = inject(ElementRef);
-  private readonly translocoService = inject(TranslocoService);
-  private readonly yasguiPersistenceMigrationService = inject(YasguiPersistenceMigrationService);
-
-  // ===================================
-  // API module injections
-  // ===================================
-  private readonly sparqlService = service(SparqlService);
-  private readonly toastrService = service(OntoToastrService);
-  private readonly rdf4jRepositoryService = service(Rdf4jRepositoryService);
-  private readonly repositoryContextService = service(RepositoryContextService);
-  private readonly authenticationStorageService = service(AuthenticationStorageService);
-  private readonly languageContextService = service(LanguageContextService);
-  private readonly languageService = service(LanguageService);
-  private readonly autocompleteService = service(AutocompleteService);
-  private readonly monitoringService = service(MonitoringService);
-  private readonly themeService = service(ThemeService);
-  private readonly runtimeConfigurationContextService = service(RuntimeConfigurationContextService);
 
   // ===================================
   // Public variables
@@ -483,6 +490,10 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
       });
   }
 
+  private onLanguageChange(newLang: string | undefined) {
+    this.language.set(newLang ?? this.languageContextService.getDefaultLanguage());
+  }
+
   private removeDirtyCheckHandlers(): void {
     this.getOntotextYasguiElements().forEach((el) => {
       el.removeEventListener('paste', this.delegatedPasteHandler);
@@ -494,7 +505,7 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
     if (!yasguiConfig) {
       return;
     }
-    console.info('%cinit config', 'background: orange', yasguiConfig);
+
     const selectedRepository = this.repositoryContextService.getSelectedRepository();
     const isVirtualRepository = !!selectedRepository?.isOntop();
     // FIXME: This doesn't seem to do the same as in the legacy.
@@ -549,10 +560,8 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
       runtimeConfig.themeName = this.themeService.getCodeEditorThemeName();
     }
 
-    const actualConfig = ObjectUtil.mergeWithDefaults(
-      yasguiConfig,
-      { ...this.getDefaultConfig(), ...runtimeConfig }
-    );
+    const baseConfig = ObjectUtil.mergeWithDefaults(yasguiConfig, this.getDefaultConfig());
+    const actualConfig = ObjectUtil.mergeWithDefaults(runtimeConfig as OntotextYasguiConfig, baseConfig);
     this.config.set(actualConfig);
 
     this.addDirtyCheckHandlers();
@@ -560,8 +569,6 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
     this.setInitialQueryState().then(() => {
       this.afterInit()?.();
     });
-
-    console.info('%cconfig updated', 'background: tan', {runtimeConfig, actualConfig, config: this.config()});
   }
 
   private readonly setInitialQueryState = async () => {

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-util.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-util.ts
@@ -66,7 +66,6 @@ export class YasguiComponentUtil {
           iteration -= waitTime;
           if (iteration < 0) {
             clearInterval(interval);
-            console.info('YASGUI component is not found', directiveSelector);
             reject(new Error('Element is not found: ' + directiveSelector));
           }
         }


### PR DESCRIPTION
## What
Fix language change behavior in the new sparql editor view.

## Why
There was a misbehavior in the new sparql editor view where the new selected language was not applied properly in the yasgui after user confimed the change.

## How
Before applying the new language, we as the user for conformation, because in order for the new language to be applied in the yasgui plugins like google charts and the pivot table, the page need to be reloaded for the relevant translated resources to be loaded.

Fixed yasgui component config merging after changes with the runtime config to allow proper overriding of existing already set properties.

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
