### PR TITLE
GDB-14662: Fix YASGUI buttons background overrides

### DIFF
--- a/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
+++ b/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
@@ -66,12 +66,8 @@ yasgui-component .yasgui-toolbar .btn-orientation {
         background-color: #dbdeed;
     }
 
-    .yasqe_buttons {
+    .yasqe_buttons .custom-button {
         background-color: #1C1C1C !important;
-
-        .custom-button {
-            background-color: #1C1C1C !important;
-        }
     }
 
     .notification {

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
@@ -66,12 +66,8 @@ app-yasgui-component-facade .yasgui-toolbar .btn-orientation {
     background-color: #dbdeed;
   }
 
-  .yasqe_buttons {
+  .yasqe_buttons .custom-button {
     background-color: #1C1C1C !important;
-
-    .custom-button {
-      background-color: #1C1C1C !important;
-    }
   }
 
   .notification {


### PR DESCRIPTION
## What
Changed yasqe button override styles

## Why
This change allows the default style for `.yasqe_buttons` container to be used and not overriden.

## How
- Removed styling of `.yasqe_buttons`
- Merged the `.custom-button` styles into the `.yasqe_buttons` class.

## Testing


## Screenshots
<img width="416" height="403" alt="image" src="https://github.com/user-attachments/assets/d6faee82-ac93-4c48-81c3-2bd14439af3d" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
