### PR TITLE
GDB-14664 fix unset footer when creating repo

### DIFF
--- a/packages/api/src/services/app-lifecycle/application-lifecycle-context.service.ts
+++ b/packages/api/src/services/app-lifecycle/application-lifecycle-context.service.ts
@@ -6,15 +6,11 @@ import {ApplicationStateChange} from '../../models/app-lifecycle/application-sta
 
 type LifecycleDataContextFields = {
   readonly APPLICATION_DATA_STATE: string;
-  readonly APPLICATION_STATE_CHANGE: string;
-  readonly APPLICATION_STATE_BEFORE_CHANGE: string;
   readonly NAVIGATION_BEFORE_MOUNT_ROUTING: string;
 }
 
 type LifecycleDataContextFieldParams = {
   readonly APPLICATION_DATA_STATE: LifecycleState;
-  readonly APPLICATION_STATE_CHANGE: ApplicationStateChange;
-  readonly APPLICATION_STATE_BEFORE_CHANGE: ApplicationStateChange;
   readonly NAVIGATION_BEFORE_MOUNT_ROUTING: ApplicationStateChange;
 }
 
@@ -25,8 +21,6 @@ type LifecycleDataContextFieldParams = {
  */
 export class ApplicationLifecycleContextService extends ContextService<LifecycleDataContextFields> implements DeriveContextServiceContract<LifecycleDataContextFields, LifecycleDataContextFieldParams> {
   readonly APPLICATION_DATA_STATE = 'applicationDataLoaded';
-  readonly APPLICATION_STATE_CHANGE = 'applicationStateChange';
-  readonly APPLICATION_STATE_BEFORE_CHANGE = 'applicationStateBeforeChange';
   readonly NAVIGATION_BEFORE_MOUNT_ROUTING = 'navigationBeforeMountRouting';
 
   /**
@@ -57,34 +51,6 @@ export class ApplicationLifecycleContextService extends ContextService<Lifecycle
    */
   getApplicationDataState(): LifecycleState | undefined {
     return this.getContextPropertyValue(this.APPLICATION_DATA_STATE);
-  }
-
-  /**
-   * Set the application state change payload.
-   */
-  updateApplicationStateChange(stateChange: ApplicationStateChange): void {
-    this.updateContextProperty(this.APPLICATION_STATE_CHANGE, stateChange);
-  }
-
-  /**
-   * Subscribe to application state change events.
-   */
-  onApplicationStateChange(callbackFn: ValueChangeCallback<ApplicationStateChange | undefined>): () => void {
-    return this.subscribe(this.APPLICATION_STATE_CHANGE, callbackFn);
-  }
-
-  /**
-   * Set the application state before-change payload.
-   */
-  updateApplicationStateBeforeChange(stateChange: ApplicationStateChange): void {
-    this.updateContextProperty(this.APPLICATION_STATE_BEFORE_CHANGE, stateChange);
-  }
-
-  /**
-   * Subscribe to application state before-change events.
-   */
-  onApplicationStateBeforeChange(callbackFn: ValueChangeCallback<ApplicationStateChange | undefined>): () => void {
-    return this.subscribe(this.APPLICATION_STATE_BEFORE_CHANGE, callbackFn);
   }
 
   /**

--- a/packages/root-config/src/ontotext-root-config.ts
+++ b/packages/root-config/src/ontotext-root-config.ts
@@ -87,23 +87,13 @@ function registerSingleSpaRouterListeners(): void {
   });
 
   WindowService.getWindow().addEventListener('single-spa:before-mount-routing-event', (evt: Event) => {
-    const d = (evt as NavigationEvent).detail;
+    const d = (evt as AppChangeEvent).detail;
     service(ApplicationLifecycleContextService).updateNavigationBeforeMountRouting(d);
   });
 
   WindowService.getWindow().addEventListener('single-spa:routing-event', (evt: Event) => {
     const d = (evt as NavigationEvent).detail;
     service(EventService).emit(new NavigationEnd(d.oldUrl, d.newUrl));
-  });
-
-  WindowService.getWindow().addEventListener('single-spa:before-app-change', (evt: Event) => {
-    const d = (evt as AppChangeEvent).detail;
-    service(ApplicationLifecycleContextService).updateApplicationStateBeforeChange(d.newAppStatuses);
-  });
-
-  WindowService.getWindow().addEventListener('single-spa:app-change', (evt: Event) => {
-    const d = (evt as AppChangeEvent).detail;
-    service(ApplicationLifecycleContextService).updateApplicationStateChange(d.newAppStatuses);
   });
 }
 

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -316,6 +316,7 @@ export class OntoLayout {
     this.subscriptions.add(
       this.eventService.subscribe(EventName.NAVIGATION_END, (navigationEndPayload: NavigationEndPayload) => {
         this.navigationContextService.updatePreviousRoute(navigationEndPayload.oldUrl);
+        this.loading = false;
       }));
   }
 
@@ -326,13 +327,5 @@ export class OntoLayout {
           this.loading = true;
         }
       }));
-
-    this.subscriptions.add(
-      this.applicationLifecycleContextService.onApplicationStateChange((state) => {
-        if (state) {
-          this.loading = false;
-        }
-      })
-    );
   }
 }


### PR DESCRIPTION
## What
Fix unset footer when creating a repository.

## Why
It was wrongly positioned when navigating in the application and not changing a microfrontend

## How
Updated the `loader` to be removed after navigation has completed in `onto-layout`, since `app-state-change` is conditionally executed. Now the loader is shown in `navigation-before-mount-routing` and is removed after `navigation-end`

## Testing
n/a

## Screenshots
<img width="1593" height="917" alt="image" src="https://github.com/user-attachments/assets/70e49df2-0060-4f54-aeb2-4171cd226d73" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
