### PR TITLE
21.05.2026 update tokens

### DIFF
--- a/packages/root-config/package-lock.json
+++ b/packages/root-config/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@ontotext/root-config",
       "dependencies": {
-        "graphwise-styleguide": "^1.2.0",
+        "graphwise-styleguide": "^1.2.1",
         "regenerator-runtime": "^0.14.1",
         "remixicon": "^4.7.0",
         "shepherd.js": "^11.2.0",
@@ -7231,9 +7231,9 @@
       "license": "ISC"
     },
     "node_modules/graphwise-styleguide": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/graphwise-styleguide/-/graphwise-styleguide-1.2.0.tgz",
-      "integrity": "sha512-RewOoIXwwJ1qLg/NodQaymnX5u8KYOHWxQlLdnd8lLndlwxmzKpUKJ20xKmDjaEriz0SlIP8kDTFf54vw6gaDQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/graphwise-styleguide/-/graphwise-styleguide-1.2.1.tgz",
+      "integrity": "sha512-R3/1g2ncyN1dwL5eKUW0zkv3bmNK79iSTmguwfOcF+ZlwUdPycEHi8jWvEyI2GlyEKdH8qMcaOJxrkzcJgcaAA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tokens-studio/sd-transforms": "^2.0.2",

--- a/packages/root-config/package.json
+++ b/packages/root-config/package.json
@@ -31,7 +31,7 @@
     "webpack-dev-server": "^5.2.2"
   },
   "dependencies": {
-    "graphwise-styleguide": "^1.2.0",
+    "graphwise-styleguide": "^1.2.1",
     "regenerator-runtime": "^0.14.1",
     "remixicon": "^4.7.0",
     "shepherd.js": "^11.2.0",


### PR DESCRIPTION
## What
There was an issue with some shadow styles that used shadow.md.

## Why
The shadow value is an array and was expected to contain two definitions, but it had been changed to contain only one.

## How
Bump the version of graphwise-styleguide.

## Screenshots
<img width="1381" height="612" alt="image" src="https://github.com/user-attachments/assets/44cd9f1a-4497-4682-af45-c4a037e701d6" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
