### PR TITLE
GDB-13833: Support fullscreen mode for the yasgui sparql editor

### DIFF
--- a/e2e-tests/e2e-legacy/sparql-editor/actions/expand-results-over-sameas.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/expand-results-over-sameas.spec.js
@@ -58,7 +58,7 @@ describe('Expand results over owl:sameAs', () => {
         YasguiSteps.getYasgui().should('be.visible');
 
         // Then I expect that "sameAs" element to be enabled by default
-        YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-on');
+        YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-on');
         // and the tooltip of element describes that "sameAs" element is enabled.
         YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Expand results over owl:sameAs: ON');
 
@@ -66,7 +66,7 @@ describe('Expand results over owl:sameAs', () => {
         YasguiSteps.openANewTab();
 
         // Then I expect that "sameAs" element to be enabled in the new tab.
-        YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-on');
+        YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-on');
         // and the tooltip of element describes that "sameAs" element is enabled.
         YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Expand results over owl:sameAs: ON');
     });
@@ -79,7 +79,7 @@ describe('Expand results over owl:sameAs', () => {
         YasguiSteps.getYasgui().should('be.visible');
 
         // Then I expect that "sameAs" element to be disabled by default
-        YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+        YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
         // and the tooltip of element describes that "sameAs" element is disabled.
         YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Expand results over owl:sameAs: OFF');
 
@@ -87,7 +87,7 @@ describe('Expand results over owl:sameAs', () => {
         YasguiSteps.openANewTab();
 
         // Then I expect that "sameAs" element to be disabled in the new tab.
-        YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+        YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
         // and the tooltip of element describes that "sameAs" element is disabled.
         YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Expand results over owl:sameAs: OFF');
     });
@@ -102,13 +102,13 @@ describe('Expand results over owl:sameAs', () => {
         // Then I expect that "sameAs" element to be disabled by default
         YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Requires \'Include Inferred\'!');
         // and the tooltip of element describes that "infer" is required.
-        YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+        YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
 
         // When I open a new Tab.
         YasguiSteps.openANewTab();
 
         // Then I expect that "sameAs" element to be disabled in the new tab,
-        YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+        YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
         // and the tooltip of element describes that "infer" is required.
         YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Requires \'Include Inferred\'!');
     });
@@ -121,7 +121,7 @@ describe('Expand results over owl:sameAs', () => {
         YasguiSteps.getYasgui().should('be.visible');
 
         // Then I expect that "sameAs" element to be disabled by default,
-        YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+        YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
         // and the tooltip of element describes that "infer" is required.
         YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Requires \'Include Inferred\'!');
 
@@ -129,7 +129,7 @@ describe('Expand results over owl:sameAs', () => {
         YasguiSteps.openANewTab();
 
         // Then I expect that "sameAs" element to be disabled in the new tab,
-        YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+        YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
         // and the tooltip of element describes that "infer" is required.
         YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Requires \'Include Inferred\'!');
     });

--- a/e2e-tests/e2e-legacy/sparql-editor/actions/include-inferred-statements.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/include-inferred-statements.spec.js
@@ -64,7 +64,7 @@ describe('Include inferred statements', () => {
         YasguiSteps.getYasgui().should('be.visible');
 
         // Then I expect that "infer" element to be enabled by default,
-        YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+        YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
         // and the tooltip of element describes that "infer" functionality is enabled.
         YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
 
@@ -72,7 +72,7 @@ describe('Include inferred statements', () => {
         YasguiSteps.openANewTab();
 
         // Then I expect that inferred element to be enabled in the new tab,
-        YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+        YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
         // and the tooltip of element describes that "infer" element is enabled.
         YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
     });
@@ -85,7 +85,7 @@ describe('Include inferred statements', () => {
         YasguiSteps.getYasgui().should('be.visible');
 
         // Then I expect that "infer" element to be disabled by default,
-        YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-off');
+        YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-off');
         // and the tooltip of element describes that "infer" element is disabled.
         YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: OFF');
 
@@ -93,7 +93,7 @@ describe('Include inferred statements', () => {
         YasguiSteps.openANewTab();
 
         // Then I expect that inferred element to be disabled in the new tab,
-        YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-off');
+        YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-off');
         // and the tooltip of element describes that "infer" element is disabled.
         YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: OFF');
     });

--- a/e2e-tests/e2e-legacy/sparql-editor/actions/inferred-sameas.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/inferred-sameas.spec.js
@@ -37,13 +37,13 @@ describe('Expand results over owl:sameAs', () => {
 
         // Then I expect inferred button to be on.
         YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
-        YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+        YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
 
         // When I click on inferred button
-        YasqeSteps.getActionButton(3).click({force: true});
+        YasqeSteps.getActionButton(4).click({force: true});
 
         // Then I expect inferred button to not be toggled.
         YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
-        YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+        YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
     });
 });

--- a/packages/legacy-workbench/package-lock.json
+++ b/packages/legacy-workbench/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
                 "ontotext-graphql-playground-component": "^0.0.9",
-                "ontotext-yasgui-web-component": "^1.6.2",
+                "ontotext-yasgui-web-component": "^1.6.3",
                 "single-spa-angularjs": "^4.3.1"
             },
             "devDependencies": {
@@ -5644,9 +5644,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.2.tgz",
-            "integrity": "sha512-IeMN43m1cqZ3xUKWQfXY3fSkV1C77+zi6/A3vhcKj6XTnXKVveiUb2yUWVhy5EpaDhEYHjad2LwdrOjQAiKXZw==",
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.3.tgz",
+            "integrity": "sha512-QGoXd4L7DN3qwkuoBoyvDIyhZtcqtY8zc0IRLSNiimIxJjEQuinAHYzMsuZfICd/0l7Yr3DY7havXXTw8KjJsA==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.7.4",

--- a/packages/legacy-workbench/package.json
+++ b/packages/legacy-workbench/package.json
@@ -76,7 +76,7 @@
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
         "ontotext-graphql-playground-component": "^0.0.9",
-        "ontotext-yasgui-web-component": "^1.6.2",
+        "ontotext-yasgui-web-component": "^1.6.3",
         "single-spa-angularjs": "^4.3.1"
     },
     "resolutions": {

--- a/packages/legacy-workbench/src/css/bootstrap-graphdb-theme.css
+++ b/packages/legacy-workbench/src/css/bootstrap-graphdb-theme.css
@@ -1621,10 +1621,6 @@ yasgui-component .yasr_plugin_control label .label {
     background-color: var(--gw-primary-base) !important;
 }
 
-.yasqe .CodeMirror {
-    min-height: 330px;
-}
-
 .nav-item.sparql-tab a.nav-link {
     max-width: 250px;
     padding-right: 20px;

--- a/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
+++ b/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
@@ -119,7 +119,6 @@ yasgui-component .yasgui-toolbar .btn-orientation {
 
 yasgui-component .yasqe .CodeMirror {
     font-family: var(--mono-font) !important;
-    font-size: 16px;
 }
 
 yasgui-component .yasqe .yasqe_buttons {
@@ -138,8 +137,9 @@ yasgui-component .tabPanel .yasqe  .yasqe-footer-buttons .abort-button {
 }
 
 yasgui-component .custom-button {
-    font-size: 2.5em !important;
-    height: 48px;
+    /* There is a generic font-size rule that overrides the font size of the YASGUI component, */
+    /* so we set it explicitly to match the intended size of the YASQE buttons. */
+    font-size: 1.5em !important;
     color: var(--gw-primary-base) !important;
     background-color: var(--gw-editor-content-background) !important;
 }

--- a/packages/workbench/package-lock.json
+++ b/packages/workbench/package-lock.json
@@ -20,7 +20,7 @@
         "@jsverse/transloco-messageformat": "^8.3.0",
         "@primeuix/themes": "^2.0.3",
         "file-saver": "^2.0.5",
-        "ontotext-yasgui-web-component": "^1.6.2",
+        "ontotext-yasgui-web-component": "^1.6.3",
         "primeng": "^20.4.0",
         "rxjs": "~7.8.2",
         "single-spa": "^6.0.3",
@@ -16391,9 +16391,9 @@
       }
     },
     "node_modules/ontotext-yasgui-web-component": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.2.tgz",
-      "integrity": "sha512-IeMN43m1cqZ3xUKWQfXY3fSkV1C77+zi6/A3vhcKj6XTnXKVveiUb2yUWVhy5EpaDhEYHjad2LwdrOjQAiKXZw==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.3.tgz",
+      "integrity": "sha512-QGoXd4L7DN3qwkuoBoyvDIyhZtcqtY8zc0IRLSNiimIxJjEQuinAHYzMsuZfICd/0l7Yr3DY7havXXTw8KjJsA==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -28,7 +28,7 @@
     "@jsverse/transloco-messageformat": "^8.3.0",
     "@primeuix/themes": "^2.0.3",
     "file-saver": "^2.0.5",
-    "ontotext-yasgui-web-component": "^1.6.2",
+    "ontotext-yasgui-web-component": "^1.6.3",
     "primeng": "^20.4.0",
     "rxjs": "~7.8.2",
     "single-spa": "^6.0.3",

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
@@ -119,8 +119,6 @@ app-yasgui-component-facade .yasgui-toolbar .btn-orientation {
 
 app-yasgui-component-facade .yasqe .CodeMirror {
   font-family: var(--mono-font) !important;
-  font-size: 16px;
-  min-height: 330px;
 }
 
 app-yasgui-component-facade .yasqe .yasqe_buttons {
@@ -139,8 +137,9 @@ app-yasgui-component-facade .tabPanel .yasqe  .yasqe-footer-buttons .abort-butto
 }
 
 app-yasgui-component-facade .custom-button {
-  font-size: 2.5em !important;
-  height: 48px;
+  /* There is a generic font-size rule that overrides the font size of the YASGUI component, */
+  /* so we set it explicitly to match the intended size of the YASQE buttons. */
+  font-size: 1.5em !important;
   color: var(--gw-primary-base) !important;
   background-color: var(--gw-editor-content-background) !important;
 }


### PR DESCRIPTION
## What
Add a fullscreen action to YASQE.

## Why
Improve the user experience by allowing users to work with the editor in fullscreen mode.

## How
Bump the version of ontotext-yasgui-web-component.

## Screenshots
<img width="1644" height="720" alt="image" src="https://github.com/user-attachments/assets/ea54c272-744d-4832-9943-7e3528860c76" />

<img width="1907" height="961" alt="image" src="https://github.com/user-attachments/assets/70a50c99-dfaf-44a2-b27e-02a74fcdb2d6" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
