### PR TITLE
GDB-12880 introduce skeleton for the repository banners component

### DIFF
--- a/packages/workbench/src/app/components/page-layout/page-layout.component.html
+++ b/packages/workbench/src/app/components/page-layout/page-layout.component.html
@@ -9,8 +9,10 @@
       }
     </h1>
 
-    <div class="page-errors-container">
-      <ng-content select="[page-errors]"></ng-content>
+    <div class="page-banners">
+      @if (!selectedRepository()) {
+        <app-repository-required-banner></app-repository-required-banner>
+      }
     </div>
   }
 

--- a/packages/workbench/src/app/components/page-layout/page-layout.component.scss
+++ b/packages/workbench/src/app/components/page-layout/page-layout.component.scss
@@ -3,15 +3,22 @@
   flex-direction: column;
   height: 100%;
   width: 100%;
-}
 
-/**
- * Expose CSS variables for page title position and margin, so that they can be overridden by page components if needed.
- */
-.page-view .title-container {
-  position: var(--page-title-position);
-  margin-bottom: var(--page-title-margin-bottom);
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  /**
+   * Expose CSS variables for page title position and margin, so that they can be overridden by page components if needed.
+   */
+  .title-container {
+    position: var(--page-title-position);
+    margin-bottom: var(--page-title-margin-bottom);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .page-banners {
+    display: block;
+
+    /* Compensate for the potential negative margin as the one coming from the sparql-editor page */
+    margin-top: calc(-1 * var(--page-title-margin-bottom, 0px));
+  }
 }

--- a/packages/workbench/src/app/components/page-layout/page-layout.component.spec.ts
+++ b/packages/workbench/src/app/components/page-layout/page-layout.component.spec.ts
@@ -4,6 +4,8 @@ import {PageLayoutComponent} from './page-layout.component';
 import {CommonModule} from '@angular/common';
 import {ActivatedRoute} from '@angular/router';
 import {provideTranslocoForTesting} from '../../../testing-utils/transloco-utils';
+import {provideNoopAnimations} from '@angular/platform-browser/animations';
+import {Repository, RepositoryContextService, RepositoryList, ServiceProvider} from '@ontotext/workbench-api';
 
 function buildActivatedRouteMock(queryParams: Record<string, string> = {}, data: Record<string, unknown> = {}) {
   return {
@@ -14,19 +16,28 @@ function buildActivatedRouteMock(queryParams: Record<string, string> = {}, data:
 describe('PageLayoutComponent', () => {
   let component: PageLayoutComponent;
   let fixture: ComponentFixture<PageLayoutComponent>;
+  let repositoryContextService: RepositoryContextService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [PageLayoutComponent, CommonModule, provideTranslocoForTesting()],
       providers: [
-        {provide: ActivatedRoute, useValue: buildActivatedRouteMock()}
+        {provide: ActivatedRoute, useValue: buildActivatedRouteMock()},
+        provideNoopAnimations()
       ]
     })
       .compileComponents();
 
+    repositoryContextService = ServiceProvider.get(RepositoryContextService);
+
     fixture = TestBed.createComponent(PageLayoutComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    repositoryContextService.updateSelectedRepository(undefined);
+    repositoryContextService.updateRepositoryList(undefined as unknown as RepositoryList);
   });
 
   it('should create', () => {
@@ -54,7 +65,8 @@ describe('PageLayoutComponent', () => {
     await TestBed.configureTestingModule({
       imports: [PageLayoutComponent, CommonModule, provideTranslocoForTesting()],
       providers: [
-        {provide: ActivatedRoute, useValue: buildActivatedRouteMock({embedded: ''})}
+        {provide: ActivatedRoute, useValue: buildActivatedRouteMock({embedded: ''})},
+        provideNoopAnimations()
       ]
     }).compileComponents();
 
@@ -70,7 +82,8 @@ describe('PageLayoutComponent', () => {
     await TestBed.configureTestingModule({
       imports: [PageLayoutComponent, CommonModule, provideTranslocoForTesting()],
       providers: [
-        {provide: ActivatedRoute, useValue: buildActivatedRouteMock({}, {title: 'my.title.key'})}
+        {provide: ActivatedRoute, useValue: buildActivatedRouteMock({}, {title: 'my.title.key'})},
+        provideNoopAnimations()
       ]
     }).compileComponents();
 
@@ -85,7 +98,8 @@ describe('PageLayoutComponent', () => {
     await TestBed.configureTestingModule({
       imports: [PageLayoutComponent, CommonModule, provideTranslocoForTesting()],
       providers: [
-        {provide: ActivatedRoute, useValue: buildActivatedRouteMock({}, {helpInfo: 'my.help.key'})}
+        {provide: ActivatedRoute, useValue: buildActivatedRouteMock({}, {helpInfo: 'my.help.key'})},
+        provideNoopAnimations()
       ]
     }).compileComponents();
 
@@ -100,7 +114,8 @@ describe('PageLayoutComponent', () => {
     await TestBed.configureTestingModule({
       imports: [PageLayoutComponent, CommonModule, provideTranslocoForTesting()],
       providers: [
-        {provide: ActivatedRoute, useValue: buildActivatedRouteMock({}, {documentationLink: 'https://docs.example.com'})}
+        {provide: ActivatedRoute, useValue: buildActivatedRouteMock({}, {documentationLink: 'https://docs.example.com'})},
+        provideNoopAnimations()
       ]
     }).compileComponents();
 
@@ -122,17 +137,66 @@ describe('PageLayoutComponent', () => {
     expect(component.documentationLink()).toBeUndefined();
   });
 
-  it('should render the page-errors slot when not embedded', () => {
-    const host = fixture.nativeElement as HTMLElement;
-    const errorsContainer = host.querySelector('.page-errors-container');
-    expect(errorsContainer).not.toBeNull();
-  });
+  describe('repository-required-banner visibility', () => {
+    it('should show the banner when no repository is selected', () => {
+      const banner = fixture.nativeElement.querySelector('app-repository-required-banner');
+      expect(banner).not.toBeNull();
+    });
 
-  it('should hide the page-errors slot when embedded', () => {
-    component.embedded.set(true);
-    fixture.detectChanges();
-    const host = fixture.nativeElement as HTMLElement;
-    const errorsContainer = host.querySelector('.page-errors-container');
-    expect(errorsContainer).toBeNull();
+    it('should hide the banner when a repository is already selected on init', async () => {
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [PageLayoutComponent, CommonModule, provideTranslocoForTesting()],
+        providers: [
+          {provide: ActivatedRoute, useValue: buildActivatedRouteMock()},
+          provideNoopAnimations()
+        ]
+      }).compileComponents();
+
+      const repoContextService = ServiceProvider.get(RepositoryContextService);
+      const repository = new Repository({id: 'test', location: '', uri: 'http://test'});
+      repoContextService.updateRepositoryList(new RepositoryList([repository]));
+      await repoContextService.updateSelectedRepository(repository);
+
+      const f = TestBed.createComponent(PageLayoutComponent);
+      f.detectChanges();
+
+      const banner = f.nativeElement.querySelector('app-repository-required-banner');
+      expect(banner).toBeNull();
+    });
+
+    it('should hide the banner reactively when a repository is selected after init', async () => {
+      const repository = new Repository({id: 'test', location: '', uri: 'http://test'});
+      repositoryContextService.updateRepositoryList(new RepositoryList([repository]));
+
+      let banner = fixture.nativeElement.querySelector('app-repository-required-banner');
+      expect(banner).not.toBeNull();
+
+      await repositoryContextService.updateSelectedRepository(repository);
+      fixture.detectChanges();
+
+      banner = fixture.nativeElement.querySelector('app-repository-required-banner');
+      expect(banner).toBeNull();
+    });
+
+    it('should show the banner again when the selected repository is cleared', async () => {
+      const repository = new Repository({id: 'test', location: '', uri: 'http://test'});
+      repositoryContextService.updateRepositoryList(new RepositoryList([repository]));
+      await repositoryContextService.updateSelectedRepository(repository);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('app-repository-required-banner')).toBeNull();
+
+      await repositoryContextService.updateSelectedRepository(undefined);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('app-repository-required-banner')).not.toBeNull();
+    });
+
+    it('should unsubscribe from repository changes on destroy', () => {
+      const unsubscribeSpy = jest.spyOn(component['subscriptions'], 'unsubscribeAll');
+      component.ngOnDestroy();
+      expect(unsubscribeSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/workbench/src/app/components/page-layout/page-layout.component.ts
+++ b/packages/workbench/src/app/components/page-layout/page-layout.component.ts
@@ -1,30 +1,59 @@
-import {Component, inject, OnInit, signal} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, signal} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {ActivatedRoute} from '@angular/router';
 import {ApplicationQueryParams} from '../../models/application-query-params';
 import {TranslocoPipe} from '@jsverse/transloco';
 import {PageInfoTooltipComponent} from '../page-info-tooltip/page-info-tooltip.component';
+import {RepositoryRequiredBannerComponent} from '../repository-required-banner/repository-required-banner.component';
+import {
+  service,
+  RepositoryContextService,
+  Repository,
+  SubscriptionList,
+} from '@ontotext/workbench-api';
 
 @Component({
   selector: 'app-page-layout',
   standalone: true,
-  imports: [CommonModule, TranslocoPipe, PageInfoTooltipComponent],
+  imports: [
+    CommonModule,
+    TranslocoPipe,
+    PageInfoTooltipComponent,
+    RepositoryRequiredBannerComponent
+  ],
   templateUrl: './page-layout.component.html',
   styleUrl: './page-layout.component.scss'
 })
-export class PageLayoutComponent implements OnInit {
+export class PageLayoutComponent implements OnInit, OnDestroy {
+  private readonly repositoryContextService = service(RepositoryContextService);
+
   private readonly activatedRoute = inject(ActivatedRoute);
+
   embedded = signal(false);
   title = signal<string | undefined>(undefined);
   helpInfo = signal<string | undefined>(undefined);
   documentationLink = signal<string | undefined>(undefined);
+  selectedRepository = signal<Repository | undefined>(undefined);
+
+  private readonly subscriptions = new SubscriptionList();
 
   ngOnInit(): void {
+    this.selectedRepository.set(this.repositoryContextService.getSelectedRepository());
+    this.subscriptions.add(
+      this.repositoryContextService.onSelectedRepositoryChanged((repo) => {
+        this.selectedRepository.set(repo);
+      })
+    );
+
     this.getPageData();
     const queryParams = this.activatedRoute.snapshot.queryParams;
     if (queryParams.hasOwnProperty(ApplicationQueryParams.EMBEDDED)) {
       this.embedded.set(true);
     }
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribeAll();
   }
 
   private getPageData(): void {

--- a/packages/workbench/src/app/components/repository-picker-list/repository-picker-list.component.html
+++ b/packages/workbench/src/app/components/repository-picker-list/repository-picker-list.component.html
@@ -1,0 +1,1 @@
+<p>repository-picker-list works!</p>

--- a/packages/workbench/src/app/components/repository-picker-list/repository-picker-list.component.spec.ts
+++ b/packages/workbench/src/app/components/repository-picker-list/repository-picker-list.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RepositoryPickerListComponent } from './repository-picker-list.component';
+
+describe('RepositoryPickerListComponent', () => {
+  let component: RepositoryPickerListComponent;
+  let fixture: ComponentFixture<RepositoryPickerListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RepositoryPickerListComponent]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(RepositoryPickerListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/workbench/src/app/components/repository-picker-list/repository-picker-list.component.ts
+++ b/packages/workbench/src/app/components/repository-picker-list/repository-picker-list.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-repository-picker-list',
+  imports: [],
+  templateUrl: './repository-picker-list.component.html',
+})
+export class RepositoryPickerListComponent {
+
+}

--- a/packages/workbench/src/app/components/repository-required-banner/repository-required-banner.component.html
+++ b/packages/workbench/src/app/components/repository-required-banner/repository-required-banner.component.html
@@ -1,0 +1,7 @@
+<div class="repository-required-banner repository-errors-container">
+  <div class="repository-errors card">
+    <p-message severity="info" icon="ri-information-2-line" size="large" class="no-active-repo-message">
+      {{ 'components.repository_banners.no_active_repository' | transloco }}
+    </p-message>
+  </div>
+</div>

--- a/packages/workbench/src/app/components/repository-required-banner/repository-required-banner.component.scss
+++ b/packages/workbench/src/app/components/repository-required-banner/repository-required-banner.component.scss
@@ -1,0 +1,7 @@
+:host {
+  display: block;
+}
+
+.repository-required-banner {
+  margin-top: 1em;
+}

--- a/packages/workbench/src/app/components/repository-required-banner/repository-required-banner.component.spec.ts
+++ b/packages/workbench/src/app/components/repository-required-banner/repository-required-banner.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RepositoryRequiredBannerComponent } from './repository-required-banner.component';
+import {provideTranslocoForTesting} from '../../../testing-utils/transloco-utils';
+import {provideNoopAnimations} from '@angular/platform-browser/animations';
+
+describe('RepositoryRequiredBannerComponent', () => {
+  let component: RepositoryRequiredBannerComponent;
+  let fixture: ComponentFixture<RepositoryRequiredBannerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RepositoryRequiredBannerComponent, provideTranslocoForTesting()],
+      providers: [provideNoopAnimations()]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(RepositoryRequiredBannerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/workbench/src/app/components/repository-required-banner/repository-required-banner.component.ts
+++ b/packages/workbench/src/app/components/repository-required-banner/repository-required-banner.component.ts
@@ -1,0 +1,16 @@
+import {Component} from '@angular/core';
+import {TranslocoPipe} from '@jsverse/transloco';
+import {MessageModule} from 'primeng/message';
+
+@Component({
+  selector: 'app-repository-required-banner',
+  imports: [
+    TranslocoPipe,
+    MessageModule
+  ],
+  templateUrl: './repository-required-banner.component.html',
+  styleUrl: './repository-required-banner.component.scss',
+})
+export class RepositoryRequiredBannerComponent {
+
+}

--- a/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.html
+++ b/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.html
@@ -1,8 +1,4 @@
 <app-page-layout class="sparql-editor-page">
-  <div page-errors>
-    <!--    <p-message severity="error">Error Message</p-message>-->
-  </div>
-
   <div>
     @if (yasguiConfig() && activeRepositoryReference) {
       <app-yasgui-component-facade

--- a/packages/workbench/src/assets/i18n/en.json
+++ b/packages/workbench/src/assets/i18n/en.json
@@ -20,6 +20,9 @@
     },
     "page_info_tooltip": {
       "documentation_link": "Learn more in the GraphDB documentation"
+    },
+    "repository_banners": {
+      "no_active_repository": "Some functionalities are not available because you are not connected to any repository."
     }
   },
   "login": {

--- a/packages/workbench/src/assets/i18n/fr.json
+++ b/packages/workbench/src/assets/i18n/fr.json
@@ -20,6 +20,9 @@
     },
     "page_info_tooltip": {
       "documentation_link": "Pour en savoir plus, consultez la documentation GraphDB"
+    },
+    "repository_banners": {
+      "no_active_repository": "Certaines fonctionnalités ne sont pas disponibles car vous n'êtes connecté à aucun dépôt."
     }
   },
   "login": {


### PR DESCRIPTION
## What
Introduce an initial implementation of an alternative to core-errors directive component.

## Why
This initial implementation is to be able to bootstrap pages for the UI tests.
The full implementaion will be extended later.

## How
Introduced two components and wired them within the page-layout component.

## Testing


## Screenshots
<img width="2548" height="409" alt="image" src="https://github.com/user-attachments/assets/29e82135-57c2-4472-bf0c-55dd744e5d30" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
