### PR TITLE
GDB-14672 allow HTML formatting in guide content

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -39,6 +39,7 @@
         "webpack-merge": "^6.0.1"
       },
       "peerDependencies": {
+        "dompurify": "^3.4.7",
         "shepherd.js": "^11.2.0"
       }
     },
@@ -3862,6 +3863,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@types/webpack-env": {
       "version": "1.18.8",
       "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.8.tgz",
@@ -6210,6 +6219,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -47,6 +47,7 @@
     "single-spa": "^6.0.3"
   },
   "peerDependencies": {
-    "shepherd.js": "^11.2.0"
+    "shepherd.js": "^11.2.0",
+    "dompurify": "^3.4.7"
   }
 }

--- a/packages/api/src/services/domain/guides/guide-api.ts
+++ b/packages/api/src/services/domain/guides/guide-api.ts
@@ -6,6 +6,7 @@ import {LoggerProvider} from '../../logging/logger-provider';
 import {GuideStepBridge} from './guide-step-bridge';
 import {WindowService} from '../../window';
 import {ScrollLocation} from '../../../models/interactive-guide/scroll-location';
+import {HtmlUtil} from '../../utils';
 
 /**
  * The bridge API between the guide step plugins and the application services.
@@ -40,7 +41,7 @@ export class GuideApi implements Service, GuideStepBridge {
         this.logger.warn(`Missing translation for language [${lang}] in message object`);
         return '';
       }
-      return this.sanitize(this.applyParameters(translation, parameters));
+      return HtmlUtil.sanitize(this.applyParameters(translation, parameters));
     }
 
     bundle ??= this.languageContextService.getLanguageBundle();
@@ -56,18 +57,7 @@ export class GuideApi implements Service, GuideStepBridge {
       return key;
     }
 
-    return this.sanitize(this.applyParameters(translation as string, parameters));
-  }
-
-  /**
-   * Decodes HTML entities in the translated string safely using DOMParser,
-   * preventing XSS when the result is appended to the DOM.
-   *
-   * @param html - The string to sanitize.
-   * @returns The decoded plain-text string.
-   */
-  sanitize(html: string): string {
-    return new DOMParser().parseFromString(html, 'text/html').body.innerText;
+    return HtmlUtil.sanitize(this.applyParameters(translation as string, parameters));
   }
 
   /**

--- a/packages/api/src/services/domain/guides/guide-step-bridge.ts
+++ b/packages/api/src/services/domain/guides/guide-step-bridge.ts
@@ -20,15 +20,6 @@ export interface GuideStepBridge {
   translate(bundle: TranslationBundle | undefined, key: string | Record<string, string>, parameters?: Record<string, string>): string;
 
   /**
-   * Decodes HTML entities in the translated string safely using DOMParser,
-   * preventing XSS when the result is appended to the DOM.
-   *
-   * @param html - The string to sanitize.
-   * @returns The decoded plain-text string.
-   */
-  sanitize(html: string): string;
-
-  /**
    * Replaces placeholders in the translation string with the given parameters.
    * Example: 'Hello {{name}}' + { name: 'Alice' } → 'Hello Alice'
    *

--- a/packages/api/src/services/domain/guides/shepherd.service.ts
+++ b/packages/api/src/services/domain/guides/shepherd.service.ts
@@ -291,7 +291,7 @@ export class ShepherdService implements Service {
       };
     }
 
-    const title = this.guideApi.sanitize(this.guideApi.translate(undefined, guideStep.title || ''));
+    const title = this.guideApi.translate(undefined, guideStep.title || '');
 
     // Adds " — n/N" to titles if the step is part of a multistep process
     let extraTitle = '';

--- a/packages/api/src/services/domain/guides/test/guide-api.spec.ts
+++ b/packages/api/src/services/domain/guides/test/guide-api.spec.ts
@@ -5,14 +5,6 @@ import {LoggerProvider} from '../../../logging/logger-provider';
 import {WindowService} from '../../../window';
 import {ScrollLocation} from '../../../../models/interactive-guide/scroll-location';
 
-// jsdom does not support DOMParser#body.innerText — mock it globally
-const mockDOMParserParse = jest.fn((html: string) => ({
-  body: {innerText: html},
-}));
-globalThis.DOMParser = jest.fn().mockImplementation(() => ({
-  parseFromString: mockDOMParserParse,
-}));
-
 describe('GuideApi', () => {
   let guideApi: GuideApi;
   const languageContextService = service(LanguageContextService);
@@ -86,29 +78,6 @@ describe('GuideApi', () => {
 
       expect(result).toBe('');
       expect(warnSpy).toHaveBeenCalledWith('Missing translation for language [de] in message object');
-    });
-  });
-
-  describe('sanitize', () => {
-    test('should pass the html string through DOMParser and return innerText', () => {
-      mockDOMParserParse.mockReturnValueOnce({body: {innerText: 'Hello & World'}});
-      expect(guideApi.sanitize('Hello &amp; World')).toBe('Hello & World');
-    });
-
-    test('should return plain text unchanged when DOMParser returns it as-is', () => {
-      mockDOMParserParse.mockReturnValueOnce({body: {innerText: 'Hello World'}});
-      expect(guideApi.sanitize('Hello World')).toBe('Hello World');
-    });
-
-    test('should return empty string when DOMParser returns empty innerText', () => {
-      mockDOMParserParse.mockReturnValueOnce({body: {innerText: ''}});
-      expect(guideApi.sanitize('')).toBe('');
-    });
-
-    test('should call DOMParser.parseFromString with text/html mime type', () => {
-      mockDOMParserParse.mockReturnValueOnce({body: {innerText: 'test'}});
-      guideApi.sanitize('<b>test</b>');
-      expect(mockDOMParserParse).toHaveBeenCalledWith('<b>test</b>', 'text/html');
     });
   });
 

--- a/packages/api/src/services/utils/html-util.ts
+++ b/packages/api/src/services/utils/html-util.ts
@@ -1,0 +1,29 @@
+import DOMPurify from 'dompurify';
+
+// Scoped instance — hooks are isolated to this instance and won't affect other DOMPurify consumers.
+// If we need to sanitize, without the hooks, we can use DOMPurify.sanitize directly.
+const purify = DOMPurify(globalThis);
+
+// Default sanitization config — individual call sites can supply their own ALLOWED_TAGS / ALLOWED_ATTR etc.
+// target and rel are always allowed, so the afterSanitizeAttributes hook can enforce _blank / noopener.
+const DEFAULT_CONFIG: DOMPurify.Config = {
+  ADD_ATTR: ['target', 'rel'],
+};
+
+purify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.getAttribute('target') === '_blank') {
+    node.setAttribute('rel', 'noopener noreferrer');
+  } else if (!node.hasAttribute('target') && (node.hasAttribute('xlink:href') || node.hasAttribute('href'))) {
+    node.setAttribute('xlink:show', 'new');
+  }
+});
+
+export class HtmlUtil {
+  static sanitize(html: string, config: DOMPurify.Config = {}): string {
+    const mergedConfig: DOMPurify.Config = {
+      ...DEFAULT_CONFIG,
+      ...config
+    };
+    return purify.sanitize(html, mergedConfig);
+  }
+}

--- a/packages/api/src/services/utils/index.ts
+++ b/packages/api/src/services/utils/index.ts
@@ -6,3 +6,4 @@ export * from './routing-utils';
 export {BuildUtil} from './build-util';
 export * from './enum-util';
 export {DateUtil} from './date-util';
+export {HtmlUtil} from './html-util';

--- a/packages/api/src/services/utils/test/html-util.spec.ts
+++ b/packages/api/src/services/utils/test/html-util.spec.ts
@@ -1,0 +1,48 @@
+import {HtmlUtil} from '../html-util';
+
+describe('HtmlUtil', () => {
+  describe('sanitize', () => {
+    test('should return empty string for empty input', () => {
+      expect(HtmlUtil.sanitize('')).toBe('');
+    });
+
+    test('should pass plain text through unchanged', () => {
+      expect(HtmlUtil.sanitize('Hello World')).toBe('Hello World');
+    });
+
+    test('should strip script tags and their content', () => {
+      expect(HtmlUtil.sanitize('<script>alert(1)</script>')).toBe('');
+    });
+
+    test('should remove on* event handler attributes', () => {
+      expect(HtmlUtil.sanitize('<b onclick="evil()">text</b>')).toBe('<b>text</b>');
+    });
+
+    test('should remove javascript: hrefs', () => {
+      expect(HtmlUtil.sanitize('<a href="javascript:alert(1)">link</a>')).not.toContain('javascript:');
+    });
+
+    test('should not add target or rel to links without a target attribute', () => {
+      const result = HtmlUtil.sanitize('<a href="https://example.com">link</a>');
+      expect(result).not.toContain('target=');
+      expect(result).not.toContain('rel=');
+    });
+
+    test('should add rel="noopener noreferrer" to target="_blank" links', () => {
+      const result = HtmlUtil.sanitize('<a href="https://example.com" target="_blank">link</a>');
+      expect(result).toContain('target="_blank"');
+      expect(result).toContain('rel="noopener noreferrer"');
+    });
+
+    test('should preserve target value other than _blank without adding rel', () => {
+      const result = HtmlUtil.sanitize('<a href="https://example.com" target="_self">link</a>');
+      expect(result).toContain('target="_self"');
+      expect(result).not.toContain('rel=');
+    });
+
+    test('should accept a custom config', () => {
+      const result = HtmlUtil.sanitize('<div><b>text</b></div>', {ALLOWED_TAGS: ['div', 'b']});
+      expect(result).toBe('<div><b>text</b></div>');
+    });
+  });
+});

--- a/packages/root-config/package-lock.json
+++ b/packages/root-config/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "@ontotext/root-config",
       "dependencies": {
+        "dompurify": "^3.4.7",
         "graphwise-styleguide": "^1.2.1",
         "regenerator-runtime": "^0.14.1",
         "remixicon": "^4.7.0",
@@ -3890,6 +3891,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -6140,6 +6148,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/packages/root-config/package.json
+++ b/packages/root-config/package.json
@@ -31,6 +31,7 @@
     "webpack-dev-server": "^5.2.2"
   },
   "dependencies": {
+    "dompurify": "^3.4.7",
     "graphwise-styleguide": "^1.2.1",
     "regenerator-runtime": "^0.14.1",
     "remixicon": "^4.7.0",


### PR DESCRIPTION
## What
Allow HTML formatting in guide content.

## Why
Previously, HTML content was sanitized, preventing users from using formatting options

## How
- Removed the `sanitize` method from the `guideApi` and replaced it with `HtmlUtil.sanitize`
- Introduced a new `HtmlUtil` class that implements a whitelist-based HTML sanitizer, allowing specific tags and attributes while stripping out unsafe content.

## Testing
jest

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
