### PR TITLE
GDB-14579: Migrate JSON-LD download settings dialog

### DIFF
--- a/packages/api/src/models/application-settings/application-settings.ts
+++ b/packages/api/src/models/application-settings/application-settings.ts
@@ -1,3 +1,5 @@
+import {JsonldExportSettings} from './jsonld-export-settings';
+
 export enum ThemeMode {
   'light' = 'light',
   'dark' = 'dark',
@@ -26,10 +28,13 @@ export class ApplicationSettings {
    */
   themeMode: ThemeMode = ThemeMode.light;
 
+  jsonLdExportSettings?: JsonldExportSettings;
+
   constructor(data?: Partial<ApplicationSettings>) {
     if (data) {
       this.theme = data.theme ?? this.theme;
       this.themeMode = data.themeMode ?? this.themeMode;
+      this.jsonLdExportSettings = data.jsonLdExportSettings ?? this.jsonLdExportSettings;
     }
   }
 

--- a/packages/api/src/models/application-settings/index.ts
+++ b/packages/api/src/models/application-settings/index.ts
@@ -1,1 +1,2 @@
 export * from './application-settings';
+export * from './jsonld-export-settings';

--- a/packages/api/src/models/application-settings/jsonld-export-settings.ts
+++ b/packages/api/src/models/application-settings/jsonld-export-settings.ts
@@ -1,0 +1,5 @@
+export interface JsonldExportSettings {
+  formLink?: string;
+  formName?: string;
+  link?: string;
+}

--- a/packages/api/src/services/application-settings/application-settings-storage.service.ts
+++ b/packages/api/src/services/application-settings/application-settings-storage.service.ts
@@ -1,6 +1,7 @@
 import {LocalStorageService} from '../storage';
 import {ApplicationSettings, LegacySettings, ThemeMode} from '../../models/application-settings/application-settings';
 import {LoggerProvider} from '../logging/logger-provider';
+import {JsonldExportSettings} from '../../models/application-settings/jsonld-export-settings';
 
 /**
  * Service to manage the storage of application settings in the local storage.
@@ -101,5 +102,16 @@ export class ApplicationSettingsStorageService extends LocalStorageService {
       return settingsData.themeMode !== undefined;
     }
     return false;
+  }
+
+  getJsonLDExportSettings(): JsonldExportSettings | undefined {
+    const settings = this.getApplicationSettings();
+    return settings.jsonLdExportSettings;
+  }
+
+  setJsonLDExportSettings(jsonLdExportSettings: JsonldExportSettings): void {
+    const settings = this.getApplicationSettings();
+    settings.jsonLdExportSettings = jsonLdExportSettings;
+    this.setApplicationSettings(settings);
   }
 }

--- a/packages/api/src/services/application-settings/test/application-settings-storage.service.spec.ts
+++ b/packages/api/src/services/application-settings/test/application-settings-storage.service.spec.ts
@@ -1,5 +1,6 @@
 import { ApplicationSettingsStorageService } from '../application-settings-storage.service';
 import { ApplicationSettings, LegacySettings, ThemeMode } from '../../../models/application-settings';
+import { JsonldExportSettings } from '../../../models/application-settings/jsonld-export-settings';
 import {createMockStorage, MutableStorage} from '../../utils/test/local-storage-mock';
 
 const APPLICATION_SETTINGS_KEY = 'ontotext.gdb.application.settings';
@@ -117,5 +118,58 @@ describe('ApplicationSettingsStorageService', () => {
     const result = service.isThemeModePresent();
 
     expect(result).toBe(false);
+  });
+
+  it('should get raw theme mode without defaults when stored', () => {
+    const payload: Partial<ApplicationSettings> = { themeMode: ThemeMode.dark };
+    storage.setItem(APPLICATION_SETTINGS_KEY, JSON.stringify(payload));
+
+    const mode = service.getThemeModeRaw();
+
+    expect(mode).toBe(ThemeMode.dark);
+  });
+
+  it('should return undefined for raw theme mode when no settings are stored', () => {
+    const mode = service.getThemeModeRaw();
+
+    expect(mode).toBeUndefined();
+  });
+
+  it('should set JSON-LD export settings and persist them', () => {
+    const jsonLdExportSettings: JsonldExportSettings = { formLink: 'https://form', formName: 'MyForm', link: 'https://link' };
+
+    service.setJsonLDExportSettings(jsonLdExportSettings);
+
+    const stored = JSON.parse(storage.getItem(APPLICATION_SETTINGS_KEY)!) as ApplicationSettings;
+    expect(stored.jsonLdExportSettings).toEqual(jsonLdExportSettings);
+  });
+
+  it('should get JSON-LD export settings when stored', () => {
+    const jsonLdExportSettings: JsonldExportSettings = { formLink: 'https://form', formName: 'MyForm', link: 'https://link' };
+    const payload: Partial<ApplicationSettings> = { themeMode: ThemeMode.light, jsonLdExportSettings };
+    storage.setItem(APPLICATION_SETTINGS_KEY, JSON.stringify(payload));
+
+    const result = service.getJsonLDExportSettings();
+
+    expect(result).toEqual(jsonLdExportSettings);
+  });
+
+  it('should return undefined for JSON-LD export settings when not stored', () => {
+    const result = service.getJsonLDExportSettings();
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should preserve existing settings when updating JSON-LD export settings', () => {
+    const existing: Partial<ApplicationSettings> = { themeMode: ThemeMode.dark, theme: 'custom' };
+    storage.setItem(APPLICATION_SETTINGS_KEY, JSON.stringify(existing));
+    const jsonLdExportSettings: JsonldExportSettings = { link: 'https://link' };
+
+    service.setJsonLDExportSettings(jsonLdExportSettings);
+
+    const stored = JSON.parse(storage.getItem(APPLICATION_SETTINGS_KEY)!) as ApplicationSettings;
+    expect(stored.themeMode).toBe(ThemeMode.dark);
+    expect(stored.theme).toBe('custom');
+    expect(stored.jsonLdExportSettings).toEqual(jsonLdExportSettings);
   });
 });

--- a/packages/api/src/services/storage/local-storage-subscription-handler.service.ts
+++ b/packages/api/src/services/storage/local-storage-subscription-handler.service.ts
@@ -44,7 +44,7 @@ export class LocalStorageSubscriptionHandlerService implements Service {
    */
   private resolveHandler(namespace: string, propertyName: string): ContextService<Record<string, unknown>> | undefined {
     if (!namespace) {
-      this.logger.warn('Namespace is required to resolve a context property change handler.');
+      this.logger.debug('Namespace is required to resolve a context property change handler.');
       return;
     }
     const handler = ServiceProvider.getAllBySuperType(ContextService)
@@ -52,7 +52,7 @@ export class LocalStorageSubscriptionHandlerService implements Service {
         return service.canHandle(propertyName);
       });
     if (!handler) {
-      this.logger.warn(`No context property change handler found for namespace: ${namespace} and property: ${propertyName}`);
+      this.logger.debug(`No context property change handler found for namespace: ${namespace} and property: ${propertyName}`);
       return;
     }
     return handler;

--- a/packages/api/src/services/storage/test/local-storage-subscription-handler.service.spec.ts
+++ b/packages/api/src/services/storage/test/local-storage-subscription-handler.service.spec.ts
@@ -40,8 +40,8 @@ describe('LocalStorageSubscriptionHandlerService', () => {
     expect(mockContextService.updateContextProperty).toHaveBeenCalledWith('testProperty', 'newValue');
   });
 
-  test('should warn if namespace is missing in storage change event key', () => {
-    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  test('should show debug message if namespace is missing in storage change event key', () => {
+    const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
     const event = {
       key: `${StorageKey.GLOBAL_NAMESPACE}.propertyName`,
       newValue: 'newValue'
@@ -49,12 +49,12 @@ describe('LocalStorageSubscriptionHandlerService', () => {
 
     service.handleStorageChange(event);
 
-    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Namespace is required to resolve a context property change handler.'));
+    expect(consoleDebugSpy).toHaveBeenCalledWith(expect.stringContaining('Namespace is required to resolve a context property change handler.'));
   });
 
-  test('should warn if no context property change handler is found', () => {
+  test('should show debug message if no context property change handler is found', () => {
     jest.spyOn(ServiceProvider, 'getAllBySuperType').mockReturnValue([]);
-    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
     const event = {
       key: `${StorageKey.GLOBAL_NAMESPACE}.namespace.propertyName`,
       newValue: 'newValue'
@@ -62,11 +62,11 @@ describe('LocalStorageSubscriptionHandlerService', () => {
 
     service.handleStorageChange(event);
 
-    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('No context property change handler found for namespace: namespace and property: propertyName'));
+    expect(consoleDebugSpy).toHaveBeenCalledWith(expect.stringContaining('No context property change handler found for namespace: namespace and property: propertyName'));
   });
 
   test('should not trigger handler if event key is null', () => {
-    const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation(() => {
+    const consoleDebugMock = jest.spyOn(console, 'debug').mockImplementation(() => {
       // Do nothing
     });
     const event = {
@@ -78,7 +78,7 @@ describe('LocalStorageSubscriptionHandlerService', () => {
 
     expect(mockContextService.updateContextProperty).not.toHaveBeenCalled();
 
-    consoleWarnMock.mockRestore();
+    consoleDebugMock.mockRestore();
   });
 });
 

--- a/packages/workbench/src/app/components/download-settings-dialog/download-settings-dialog.component.html
+++ b/packages/workbench/src/app/components/download-settings-dialog/download-settings-dialog.component.html
@@ -1,0 +1,63 @@
+<div class="dialog-content">
+  <form class="export-settings-form">
+    <div class="form-row">
+      <label for="jsonldMode">
+        {{ 'components.dialog.download_settings.form.label' | transloco }}
+        <span class="info-icon"
+              [pTooltip]="'components.dialog.download_settings.form.info' | transloco"
+              tooltipEvent="both"
+              tooltipPosition="right">
+            <em class="icon ri-information-2-line"></em>
+          </span>
+      </label>
+      <div class="field-input">
+        <p-select
+          inputId="jsonldMode"
+          name="jsonldMode"
+          [(ngModel)]="currentMode"
+          [options]="JSONLDModeOptions"
+          styleClass="input"
+          appendTo="body"
+          (onChange)="clearLinkInput($event)"/>
+      </div>
+    </div>
+
+    @if (isFramedMode()) {
+      <div class="form-row">
+        <label for="jsonldFrame">
+          {{ 'components.dialog.download_settings.frame.link' | transloco }}
+          <span class="info-icon"
+                [pTooltip]="'components.dialog.download_settings.frame.info' | transloco"
+                tooltipEvent="both"
+                tooltipPosition="right">
+              <em class="icon ri-information-2-line"></em>
+            </span>
+        </label>
+        <div class="field-input">
+          <input pInputText id="jsonldFrame" name="jsonldFrame" type="text"
+                 [(ngModel)]="link"
+                 [placeholder]="'components.dialog.download_settings.frame.uri_placeholder' | transloco"/>
+        </div>
+      </div>
+    }
+
+    @if (isContextMode()) {
+      <div class="form-row">
+        <label for="jsonldContext">
+          {{ 'components.dialog.download_settings.context.link' | transloco }}
+          <span class="info-icon"
+                [pTooltip]="'components.dialog.download_settings.context.info' | transloco"
+                tooltipEvent="both"
+                tooltipPosition="right">
+              <em class="icon ri-information-2-line"></em>
+            </span>
+        </label>
+        <div class="field-input">
+          <input pInputText id="jsonldContext" name="jsonldContext" type="text"
+                 [(ngModel)]="link"
+                 [placeholder]="'components.dialog.download_settings.context.uri_placeholder' | transloco"/>
+        </div>
+      </div>
+    }
+  </form>
+</div>

--- a/packages/workbench/src/app/components/download-settings-dialog/download-settings-dialog.component.scss
+++ b/packages/workbench/src/app/components/download-settings-dialog/download-settings-dialog.component.scss
@@ -1,0 +1,49 @@
+.dialog-content {
+  display: grid;
+  grid-template-rows: auto;
+  gap: 1rem;
+
+  .export-settings-form {
+    display: grid;
+    grid-template-rows: auto;
+    gap: 1rem;
+
+    .form-row {
+      display: grid;
+      grid-template-columns: 250px 1fr;
+      gap: 1rem;
+      align-items: baseline;
+
+      .info-icon {
+        color: var(--gw-primary-base);
+        font-size: 1.4em;
+        cursor: pointer;
+
+        .icon {
+          transition: all 0.15s ease-out;
+        }
+
+        &:hover .icon {
+          transform: scale(1.2);
+        }
+      }
+
+      label {
+        width: 250px;
+      }
+
+      /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
+      ::ng-deep.field-input input {
+        width: 100%;
+      }
+
+      @media (width <= 990px) {
+        grid-template-columns: 1fr;
+
+        label {
+          width: 100%;
+        }
+      }
+    }
+  }
+}

--- a/packages/workbench/src/app/components/download-settings-dialog/download-settings-dialog.component.spec.ts
+++ b/packages/workbench/src/app/components/download-settings-dialog/download-settings-dialog.component.spec.ts
@@ -1,0 +1,103 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { DownloadSettingsDialogComponent } from './download-settings-dialog.component';
+import { provideTranslocoForTesting } from '../../../testing-utils/transloco-utils';
+import { ApplicationSettingsStorageService, ServiceProvider } from '@ontotext/workbench-api';
+import {DynamicDialogConfig, DynamicDialogRef} from 'primeng/dynamicdialog';
+
+describe('DownloadSettingsDialogComponent', () => {
+  let component: DownloadSettingsDialogComponent;
+  let fixture: ComponentFixture<DownloadSettingsDialogComponent>;
+  let dialogRef: jest.Mocked<DynamicDialogRef>;
+  let appSettingsService: jest.Mocked<ApplicationSettingsStorageService>;
+
+  beforeEach(async () => {
+    dialogRef = {
+      close: jest.fn(),
+    } as unknown as jest.Mocked<DynamicDialogRef>;
+
+    appSettingsService = {
+      getJsonLDExportSettings: jest.fn().mockReturnValue(undefined),
+      setJsonLDExportSettings: jest.fn(),
+    } as unknown as jest.Mocked<ApplicationSettingsStorageService>;
+
+    jest.spyOn(ServiceProvider, 'get').mockImplementation((serviceClass) => {
+      if (serviceClass === ApplicationSettingsStorageService) {
+        return appSettingsService;
+      }
+      throw new Error(`Unknown service: ${(serviceClass as { name: string }).name}`);
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [DownloadSettingsDialogComponent, provideTranslocoForTesting()],
+      providers: [
+        { provide: DynamicDialogRef, useValue: dialogRef },
+        { provide: DynamicDialogConfig, useValue: {} },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DownloadSettingsDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should default to expanded mode on init when no stored settings exist', () => {
+    expect(component['currentMode']).toBe('expanded');
+  });
+
+  it('should restore stored mode and link from settings on init', () => {
+    appSettingsService.getJsonLDExportSettings.mockReturnValue({
+      formName: 'framed',
+      formLink: 'http://www.w3.org/ns/json-ld#framed',
+      link: 'http://example.org/frame',
+    });
+
+    component.ngOnInit();
+
+    expect(component['currentMode']).toBe('framed');
+    expect(component['link']).toBe('http://example.org/frame');
+  });
+
+  it('should close the dialog with the export result when exportJsonLD is called', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    component['currentMode'] = 'compacted' as any;
+    component['link'] = 'http://example.org/context';
+
+    component.exportJsonLD();
+
+    expect(dialogRef.close).toHaveBeenCalledWith({
+      formName: 'compacted',
+      formLink: 'http://www.w3.org/ns/json-ld#compacted',
+      link: 'http://example.org/context',
+    });
+  });
+
+  it('should reset to default expanded mode and clear link when reset is called', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    component['currentMode'] = 'framed' as any;
+    component['link'] = 'http://example.org/frame';
+
+    component.reset();
+
+    expect(component['currentMode']).toBe('expanded');
+    expect(component['link']).toBeUndefined();
+  });
+
+  it('should clear the link and persist settings when clearLinkInput is called', () => {
+    component['link'] = 'http://example.org/context';
+
+    component.clearLinkInput({value: 'compacted'});
+
+    expect(component['link']).toBeUndefined();
+    expect(appSettingsService.setJsonLDExportSettings).toHaveBeenCalled();
+  });
+});

--- a/packages/workbench/src/app/components/download-settings-dialog/download-settings-dialog.component.ts
+++ b/packages/workbench/src/app/components/download-settings-dialog/download-settings-dialog.component.ts
@@ -1,0 +1,116 @@
+import {Component, inject, OnInit, signal} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {TranslocoPipe} from '@jsverse/transloco';
+import {DynamicDialogConfig, DynamicDialogRef} from 'primeng/dynamicdialog';
+import {Select, SelectChangeEvent} from 'primeng/select';
+import {InputText} from 'primeng/inputtext';
+import {Tooltip} from 'primeng/tooltip';
+import {ApplicationSettingsStorageService, JsonldExportSettings, service} from '@ontotext/workbench-api';
+import {Button} from 'primeng/button';
+import {DownloadSettingsDialogData} from './models/download-settings-dialog-data';
+
+interface JSONLDModeOption {
+  label: string;
+  value: string;
+}
+
+enum JSONLDMode {
+  FRAMED = 'framed',
+  EXPANDED = 'expanded',
+  FLATTENED = 'flattened',
+  COMPACTED = 'compacted'
+}
+
+@Component({
+  selector: 'app-download-settings-dialog',
+  imports: [
+    TranslocoPipe,
+    FormsModule,
+    Select,
+    InputText,
+    Tooltip,
+    Button
+  ],
+  templateUrl: './download-settings-dialog.component.html',
+  styleUrl: './download-settings-dialog.component.scss'
+})
+export class DownloadSettingsDialogComponent implements OnInit {
+  private readonly dialogRef = inject(DynamicDialogRef);
+  private readonly dialogConfig: DynamicDialogConfig<DownloadSettingsDialogData> = inject(DynamicDialogConfig);
+  private readonly applicationSettingsStorageService = service(ApplicationSettingsStorageService);
+  private readonly JSONLDModes: Record<string, string> = {
+    [JSONLDMode.FRAMED]: 'http://www.w3.org/ns/json-ld#framed',
+    [JSONLDMode.EXPANDED]: 'http://www.w3.org/ns/json-ld#expanded',
+    [JSONLDMode.FLATTENED]: 'http://www.w3.org/ns/json-ld#flattened',
+    [JSONLDMode.COMPACTED]: 'http://www.w3.org/ns/json-ld#compacted'
+  };
+  private readonly JSONLDFramedModes = [JSONLDMode.FRAMED];
+  private readonly JSONLDContextModes = [JSONLDMode.COMPACTED, JSONLDMode.FLATTENED];
+  private readonly defaultMode = JSONLDMode.EXPANDED;
+
+  readonly JSONLDModeOptions: JSONLDModeOption[] = Object.keys(this.JSONLDModes).map(key => ({label: this.JSONLDModes[key], value: key}));
+
+  currentMode = this.defaultMode;
+  link?: string;
+  isFramedMode = signal(false);
+  isContextMode = signal(false);
+
+  constructor() {
+    this.dialogConfig.data = {
+      exportAction: this.exportJsonLD.bind(this),
+      resetAction: this.reset.bind(this)
+    };
+  }
+
+  ngOnInit() {
+    const jsonldSettingsModel = this.applicationSettingsStorageService.getJsonLDExportSettings();
+    if (jsonldSettingsModel?.formName && this.isJSONLDMode(jsonldSettingsModel.formName)) {
+      this.setJSONLDMode(jsonldSettingsModel.formName);
+      this.link = jsonldSettingsModel.link;
+    }
+  }
+
+  exportJsonLD() {
+    this.setJSONLDSettingsToLocalStorage(this.currentMode, this.link);
+    const result: JsonldExportSettings = {
+      formName: this.currentMode,
+      formLink: this.JSONLDModes[this.currentMode],
+      link: this.link
+    };
+    this.dialogRef.close(result);
+  }
+
+  reset() {
+    this.setJSONLDMode(this.defaultMode);
+    this.link = undefined;
+    this.setJSONLDSettingsToLocalStorage(this.currentMode, this.link);
+  }
+
+  clearLinkInput(event: SelectChangeEvent) {
+    this.setJSONLDMode(event.value);
+    this.link = undefined;
+    this.setJSONLDSettingsToLocalStorage(this.currentMode, this.link);
+  }
+
+  private setJSONLDMode(mode: JSONLDMode) {
+    this.currentMode = mode;
+    this.isFramedMode.set(this.JSONLDFramedModes.includes(mode));
+    this.isContextMode.set(this.JSONLDContextModes.includes(mode));
+  }
+
+  private isJSONLDMode(value: string): value is JSONLDMode {
+    return Object.values(JSONLDMode).includes(value as JSONLDMode);
+  }
+
+  private setJSONLDSettingsToLocalStorage(mode?: string, link?: string) {
+    if (!mode) {
+      return;
+    }
+    const formLink = this.JSONLDModes[mode];
+    this.applicationSettingsStorageService.setJsonLDExportSettings({
+      formName: mode,
+      formLink: formLink,
+      link: link
+    });
+  }
+}

--- a/packages/workbench/src/app/components/download-settings-dialog/footer/download-settings-dialog-footer/download-settings-dialog-footer.component.html
+++ b/packages/workbench/src/app/components/download-settings-dialog/footer/download-settings-dialog-footer/download-settings-dialog-footer.component.html
@@ -1,0 +1,14 @@
+<p-button
+  class="restore-defaults"
+  [label]="'components.dialog.download_settings.actions.restore_defaults' | transloco"
+  [link]="true"
+  (onClick)="reset()"/>
+<div class="spacer"></div>
+<p-button
+  [label]="'components.dialog.download_settings.actions.cancel' | transloco"
+  severity="secondary"
+  (onClick)="cancel()"/>
+<p-button
+  id="exportJSONLD"
+  [label]="'components.dialog.download_settings.actions.export' | transloco"
+  (onClick)="exportJsonLD()"/>

--- a/packages/workbench/src/app/components/download-settings-dialog/footer/download-settings-dialog-footer/download-settings-dialog-footer.component.scss
+++ b/packages/workbench/src/app/components/download-settings-dialog/footer/download-settings-dialog-footer/download-settings-dialog-footer.component.scss
@@ -1,0 +1,9 @@
+:host {
+  width: 100%;
+  display: flex;
+  gap: 0.5rem;
+
+  .spacer {
+    flex-grow: 1;
+  }
+}

--- a/packages/workbench/src/app/components/download-settings-dialog/footer/download-settings-dialog-footer/download-settings-dialog-footer.component.spec.ts
+++ b/packages/workbench/src/app/components/download-settings-dialog/footer/download-settings-dialog-footer/download-settings-dialog-footer.component.spec.ts
@@ -1,0 +1,31 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {DownloadSettingsDialogFooterComponent} from './download-settings-dialog-footer.component';
+import {DynamicDialogConfig, DynamicDialogRef} from 'primeng/dynamicdialog';
+import {provideTranslocoForTesting} from '../../../../../testing-utils/transloco-utils';
+
+describe('DownloadSettingsDialogFooterComponent', () => {
+  let component: DownloadSettingsDialogFooterComponent;
+  let fixture: ComponentFixture<DownloadSettingsDialogFooterComponent>;
+
+  beforeEach(async () => {
+    const dialogRef = {
+    } as unknown as jest.Mocked<DynamicDialogRef>;
+
+    await TestBed.configureTestingModule({
+      imports: [DownloadSettingsDialogFooterComponent, provideTranslocoForTesting()],
+      providers: [
+        { provide: DynamicDialogRef, useValue: dialogRef },
+        { provide: DynamicDialogConfig, useValue: {} },
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DownloadSettingsDialogFooterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/workbench/src/app/components/download-settings-dialog/footer/download-settings-dialog-footer/download-settings-dialog-footer.component.ts
+++ b/packages/workbench/src/app/components/download-settings-dialog/footer/download-settings-dialog-footer/download-settings-dialog-footer.component.ts
@@ -1,0 +1,35 @@
+import {Component, inject} from '@angular/core';
+import {Button} from 'primeng/button';
+import {TranslocoPipe} from '@jsverse/transloco';
+import {DynamicDialogConfig, DynamicDialogRef} from 'primeng/dynamicdialog';
+import {DownloadSettingsDialogData} from '../../models/download-settings-dialog-data';
+
+@Component({
+  selector: 'app-download-settings-dialog-footer',
+  imports: [
+    Button,
+    TranslocoPipe
+  ],
+  templateUrl: './download-settings-dialog-footer.component.html',
+  styleUrl: './download-settings-dialog-footer.component.scss'
+})
+export class DownloadSettingsDialogFooterComponent {
+  private readonly dialogRef = inject(DynamicDialogRef);
+  private readonly dialogConfig: DynamicDialogConfig<DownloadSettingsDialogData> = inject(DynamicDialogConfig);
+
+  exportJsonLD() {
+    if (this.dialogConfig.data?.exportAction) {
+      this.dialogConfig.data?.exportAction();
+    }
+  }
+
+  reset() {
+    if (this.dialogConfig.data?.resetAction) {
+      this.dialogConfig.data?.resetAction();
+    }
+  }
+
+  cancel() {
+    this.dialogRef.close();
+  }
+}

--- a/packages/workbench/src/app/components/download-settings-dialog/models/download-settings-dialog-data.ts
+++ b/packages/workbench/src/app/components/download-settings-dialog/models/download-settings-dialog-data.ts
@@ -1,0 +1,4 @@
+export interface DownloadSettingsDialogData {
+  exportAction: () => void;
+  resetAction: () => void;
+}

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.spec.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.spec.ts
@@ -3,6 +3,7 @@ import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {YasguiComponentFacadeComponent} from './yasgui-component-facade.component';
 import {provideTranslocoForTesting} from '../../../testing-utils/transloco-utils';
 import {LanguageContextService, RuntimeConfigurationContextService, ServiceProvider} from '@ontotext/workbench-api';
+import {DialogService} from 'primeng/dynamicdialog';
 
 jest.mock('ontotext-yasgui-web-component/loader', () => ({
   defineCustomElements: jest.fn()
@@ -34,6 +35,9 @@ describe('YasguiComponentFacadeComponent', () => {
       imports: [
         YasguiComponentFacadeComponent,
         provideTranslocoForTesting()
+      ],
+      providers: [
+        DialogService
       ],
       schemas: [NO_ERRORS_SCHEMA]
     })

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.ts
@@ -20,7 +20,7 @@ import {SavedQueryConfig} from './models/query/saved-query-config';
 import {QueryMode} from './models/query-mode';
 import {QueryType} from './models/yasqe/query-type';
 import {Yasgui} from './models/yasgui/yasgui';
-import {TranslocoService} from '@jsverse/transloco';
+import {translate, TranslocoService} from '@jsverse/transloco';
 import {SaveQueryEvent} from './models/query/save-query-event';
 import {SavedQueryParams} from '../../pages/sparql-editor/sparql-editor-query-params';
 import {YasguiComponentUtil} from './yasgui-component-util';
@@ -54,6 +54,7 @@ import {
   MonitoringService,
   ThemeService,
   RuntimeConfigurationContextService, SubscriptionList,
+  JsonldExportSettings,
 } from '@ontotext/workbench-api';
 import {YasguiComponent} from './models/yasgui-component';
 import {FileUtils} from '../../utils/file-utils';
@@ -65,6 +66,9 @@ import {YasguiPersistenceMigrationService} from './service/yasgui-persistence-mi
 import {OntotextYasguiElement} from './models/ontotext-yasgui-element';
 import {QueryChangedPayload} from './models/yasqe/query-changed-payload';
 import {LoggerProvider} from '../../services/logger/logger-provider';
+import {DownloadSettingsDialogComponent} from '../download-settings-dialog/download-settings-dialog.component';
+import {DialogProviderService} from '../../services/dialog/dialog-provider.service';
+import {DownloadSettingsDialogFooterComponent} from '../download-settings-dialog/footer/download-settings-dialog-footer/download-settings-dialog-footer.component';
 
 defineCustomElements();
 
@@ -91,6 +95,7 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
   private readonly elementRef = inject(ElementRef);
   private readonly translocoService = inject(TranslocoService);
   private readonly yasguiPersistenceMigrationService = inject(YasguiPersistenceMigrationService);
+  private readonly dialogProviderService = inject(DialogProviderService);
 
   // ===================================
   // API module injections
@@ -749,24 +754,23 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
     const authToken = this.authenticationStorageService.getAuthToken().getValue()!;
 
     if (downloadAsEvent.contentType === 'application/ld+json' || downloadAsEvent.contentType === 'application/x-ld+ndjson') {
-      // TODO: Implement the modal. These types are used only in the resource view
-      // const modalInstance = $uibModal.open({
-      //   templateUrl: 'js/angular/core/components/export-settings-modal/exportSettingsModal.html',
-      //   controller: ExportSettingsCtrl,
-      //   size: 'lg',
-      //   scope: $scope,
-      //   resolve: {
-      //     format: function() {
-      //       return downloadAsEvent.contentType === "application/ld+json" ? 'JSON-LD' : 'NDJSON-LD';
-      //     },
-      //   },
-      // });
-      // modalInstance.result.then(function(data) {
-      //   const relValue = data.currentMode.name === 'framed' ? 'frame' : 'context';
-      //   const acceptHeader = accept + ';profile=' + data.currentMode.link;
-      //   const linkHeader = data.link ? `<${data.link}>; rel="http://www.w3.org/ns/json-ld#${relValue}"` : '';
-      //   downloadAs(query, infer, sameAs, authToken, acceptHeader, linkHeader);
-      // });
+      const format = downloadAsEvent.contentType === 'application/ld+json' ? 'json-ld' : 'ndjson-ld';
+
+      this.dialogProviderService.open<unknown, JsonldExportSettings>(DownloadSettingsDialogComponent, {
+        header: translate('components.dialog.download_settings.title.' + format),
+        closable: true,
+        footer: DownloadSettingsDialogFooterComponent,
+        modalClass: 'modal-content'
+      })
+        .then((data) => {
+          if (!data) {
+            return;
+          }
+          const relValue = data.formName === 'framed' ? 'frame' : 'context';
+          const acceptHeader = accept + ';profile=' + data.formLink;
+          const linkHeader = data.link ? `<${data.link}>; rel="http://www.w3.org/ns/json-ld#${relValue}"` : '';
+          this.downloadAs(query, infer, sameAs, authToken, acceptHeader, linkHeader);
+        });
     } else {
       this.downloadAs(query, infer, sameAs, authToken, accept, '');
     }

--- a/packages/workbench/src/app/models/dialog-open-options.ts
+++ b/packages/workbench/src/app/models/dialog-open-options.ts
@@ -1,3 +1,5 @@
+import {Type} from '@angular/core';
+
 /**
  * Options used by `DialogProviderService` when opening a dialog.
  *
@@ -11,4 +13,6 @@ export interface DialogOpenOptions<DataType> {
   height?: string;
   closable?: boolean;
   modal?: boolean;
+  footer?: Type<unknown>;
+  modalClass?: string;
 }

--- a/packages/workbench/src/app/services/dialog/dialog-provider-service.spec.ts
+++ b/packages/workbench/src/app/services/dialog/dialog-provider-service.spec.ts
@@ -120,7 +120,7 @@ describe('DialogProviderService', () => {
       void service.open(TestDialogComponent, {});
 
       const usedConfig: DynamicDialogConfig = mockDialogServiceOpen.mock.calls[0][1];
-      expect(usedConfig.styleClass).toBe('onto-dialog');
+      expect(usedConfig.styleClass).toContain('onto-dialog');
     });
 
     it('should always set draggable to false', () => {

--- a/packages/workbench/src/app/services/dialog/dialog-provider.service.ts
+++ b/packages/workbench/src/app/services/dialog/dialog-provider.service.ts
@@ -41,9 +41,14 @@ export class DialogProviderService {
       height: config.height,
       closable: config.closable ?? false,
       modal: config.modal ?? true,
-      styleClass: 'onto-dialog',
+      styleClass: `onto-dialog ${config.modalClass ?? ''}`,
       draggable: false
     };
+    if (config.footer) {
+      dialogConfig.templates = {
+        footer: config.footer
+      };
+    }
     const dialogRef = this.dialogService.open(componentType, dialogConfig);
     this.assertDialogIsDefined(dialogRef);
     return dialogRef;

--- a/packages/workbench/src/assets/i18n/en.json
+++ b/packages/workbench/src/assets/i18n/en.json
@@ -20,6 +20,31 @@
         "confirmation": {
           "message": "You have unsaved changes. Are you sure you want to continue?"
         }
+      },
+      "download_settings": {
+        "title": {
+          "json-ld": "Export settings: JSON-LD",
+          "ndjson-ld": "Export settings: NDJSON-LD"
+        },
+        "form": {
+          "label": "JSON-LD form",
+          "info": "Specifies the JSON-LD document form"
+        },
+        "context": {
+          "link": "JSON-LD Context",
+          "info": "Specifies external JSON-LD context as a URL. Only whitelisted URLs can be used.",
+          "uri_placeholder": "http://example.com/context.jsonld"
+        },
+        "frame": {
+          "link": "JSON-LD Frame",
+          "info": "Specifies JSON-LD frame document as a URL. Only whitelisted URLs can be used.",
+          "uri_placeholder": "http://example.com/frame.jsonld"
+        },
+        "actions": {
+          "export": "Export",
+          "cancel": "Cancel",
+          "restore_defaults": "Restore defaults"
+        }
       }
     },
     "page_info_tooltip": {
@@ -87,7 +112,7 @@
         "queries_non_updates": "{{sparql_editor.confirmation.running_queries_warning.queries_non_updates}}<div>Changing the language will reload the page. Are you sure you want to continue?</div>",
         "none_queries_updates": "{{sparql_editor.confirmation.running_queries_warning.none_queries_updates}}<div>Changing the language will reload the page. Are you sure you want to continue?</div>",
         "queries_updates": "{{sparql_editor.confirmation.running_queries_warning.queries_updates}}<div>Changing the language will reload the page. Are you sure you want to continue?</div>"
-        },
+      },
       "on_page_leave": {
         "title": "Confirm exit",
         "none_queries_non_updates": "Are you sure that you want to exit?",

--- a/packages/workbench/src/assets/i18n/fr.json
+++ b/packages/workbench/src/assets/i18n/fr.json
@@ -20,6 +20,31 @@
         "confirmation": {
           "message": "Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir continuer?"
         }
+      },
+      "download_settings": {
+        "title": {
+          "json-ld": "Paramètres d'exportation : JSON-LD",
+          "ndjson-ld": "Paramètres d'exportation : NDJSON-LD"
+        },
+        "form": {
+          "label": "Formulaire JSON-LD",
+          "info": "Spécifie la forme du document JSON-LD"
+        },
+        "context": {
+          "link": "Contexte JSON-LD",
+          "info": "Spécifie le contexte JSON-LD externe en tant qu'URL. Seules les URL figurant sur la liste blanche peuvent être utilisées.",
+          "uri_placeholder": "http://example.com/context.jsonld"
+        },
+        "frame": {
+          "link": "Cadre JSON-LD",
+          "info": "Spécifie le document cadre JSON-LD en tant qu'URL. Seules les URL figurant sur la liste blanche peuvent être utilisées.",
+          "uri_placeholder": "http://example.com/frame.jsonld"
+        },
+        "actions": {
+          "export": "Exportation",
+          "cancel": "Annuler",
+          "restore_defaults": "Restaurer les valeurs par défaut"
+        }
       }
     },
     "page_info_tooltip": {

--- a/packages/workbench/src/styles.scss
+++ b/packages/workbench/src/styles.scss
@@ -1,1 +1,2 @@
 /* You can add global styles to this file, and also import other style files */
+@use "styles/primeng-overrides";

--- a/packages/workbench/src/styles/primeng-overrides.scss
+++ b/packages/workbench/src/styles/primeng-overrides.scss
@@ -1,0 +1,1 @@
+@use "primeng/button";

--- a/packages/workbench/src/styles/primeng/_button.scss
+++ b/packages/workbench/src/styles/primeng/_button.scss
@@ -1,0 +1,6 @@
+.p-button.p-button-link {
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-decoration-thickness: var(--link-decoration-thickness);
+  text-underline-offset: var(--link-underline-offset);
+}


### PR DESCRIPTION
## What
Migrated JSON-LD download settings dialog for configuring JSON-LD export settings, including form selection and context links.

## Why
This feature enhances user experience by allowing users to customize their JSON-LD export settings directly from the application, improving usability and flexibility.

## How
- Created `DownloadSettingsDialogComponent`.
- Implemented form handling for JSON-LD modes and context links.
- Integrated local storage service to persist user settings.
- Added translations for dialog labels and tooltips in `en.json` and `fr.json`.
- Updated application settings model to include JSON-LD export settings.


## Testing


## Screenshots
<img width="765" height="329" alt="image" src="https://github.com/user-attachments/assets/14ac50b9-d0d3-431e-8116-19e7af855fdb" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
