### PR TITLE
GDB-14258 run and fix sparql view tests

### DIFF
--- a/e2e-tests/cypress-legacy.config.js
+++ b/e2e-tests/cypress-legacy.config.js
@@ -15,7 +15,7 @@ export default defineConfig({
     screenshotsFolder: 'report/screenshots',
     videosFolder: 'report/videos',
     video: true,
-    defaultCommandTimeout: 25000,
+    defaultCommandTimeout: 8000,
     numTestsKeptInMemory: 10,
     viewportWidth: 1600,
     viewportHeight: 1200,

--- a/e2e-tests/e2e-legacy/sparql-editor/actions/execute-query.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/execute-query.spec.js
@@ -4,7 +4,6 @@ import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
 import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
 
 describe('Execute query', () => {
-
     let repositoryId;
 
     beforeEach(() => {
@@ -23,9 +22,8 @@ describe('Execute query', () => {
     });
 
     it('Should be able to execute query from each editor tab', () => {
-        cy.intercept('POST', `/repositories/${repositoryId}`).as('query');
         YasqeSteps.executeQuery();
-        cy.wait('@query').then((interception) => {
+        cy.wait(`@${repositoryId}-stub-query`).then((interception) => {
             expect(interception.request.method).to.equal('POST');
             const headers = interception.request.headers;
             expect(headers).to.have.property('x-graphdb-local-consistency');
@@ -35,7 +33,7 @@ describe('Execute query', () => {
         YasguiSteps.openANewTab();
         YasguiSteps.getTabs().should('have.length', 2);
         YasqeSteps.executeQuery();
-        cy.wait('@query').then((interception) => {
+        cy.wait(`@${repositoryId}-stub-query`).then((interception) => {
             expect(interception.request.method).to.equal('POST');
             const headers = interception.request.headers;
             expect(headers).to.have.property('x-graphdb-local-consistency');

--- a/e2e-tests/e2e-legacy/sparql-editor/actions/save-query.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/save-query.spec.js
@@ -1,10 +1,10 @@
 import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
 import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
-import {ApplicationSteps} from "../../../steps/application-steps";
 import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
 import {SaveQueryDialog} from "../../../steps/yasgui/save-query-dialog";
 import {SavedQuery} from "../../../steps/yasgui/saved-query";
 import {SavedQueriesDialog} from "../../../steps/yasgui/saved-queries-dialog";
+import {OntoToastrSteps} from '../../../steps/onto-toastr-steps.js';
 
 describe('Save query', () => {
 
@@ -54,9 +54,7 @@ describe('Save query', () => {
         SaveQueryDialog.writeQueryName(savedQueryName);
         SaveQueryDialog.saveQuery();
         // Then I expect that dialog will remain open and an error will be visible
-        // TODO: find out why this check fails on Jenkins sometimes with
-        // AssertionError: Timed out retrying after 30000ms: Expected to find element: `.toast-error`, but never found it. Queried from element: <div#toast-container.toast-bottom-right>
-        // ApplicationSteps.getErrorNotifications().should('be.visible');
+        OntoToastrSteps.getErrorToast().should('be.visible');
         SaveQueryDialog.getSaveQueryDialog().should('be.visible');
         SaveQueryDialog.getErrorsPane().should('contain', 'Error! Cannot create saved query');
         // When I change the query name
@@ -65,6 +63,6 @@ describe('Save query', () => {
         SaveQueryDialog.saveQuery();
         // Then I should be able to save the query
         SaveQueryDialog.getSaveQueryDialog().should('not.exist');
-        ApplicationSteps.getSuccessNotifications().should('be.visible');
+        OntoToastrSteps.getSuccessToast().should('be.visible');
     });
 });

--- a/e2e-tests/e2e-legacy/sparql-editor/saved-query/delete-query.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/saved-query/delete-query.spec.js
@@ -1,10 +1,10 @@
 import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
 import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
-import {ApplicationSteps} from "../../../steps/application-steps";
 import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
 import {SavedQuery} from "../../../steps/yasgui/saved-query";
 import {SavedQueriesDialog} from "../../../steps/yasgui/saved-queries-dialog";
 import {SaveQueryDialog} from "../../../steps/yasgui/save-query-dialog";
+import {OntoToastrSteps} from '../../../steps/onto-toastr-steps.js';
 
 describe('Delete saved queries', () => {
 
@@ -49,7 +49,7 @@ describe('Delete saved queries', () => {
         YasguiSteps.confirmDeleteOperation();
         // Then selected query should be deleted
         YasguiSteps.getDeleteQueryConfirmation().should('not.exist');
-        ApplicationSteps.getSuccessNotifications().should('be.visible');
+        OntoToastrSteps.getSuccessToast().should('be.visible');
         YasguiSteps.showSavedQueries();
         SavedQueriesDialog.getSavedQueries().should('not.contain.text', savedQueryName);
     });

--- a/e2e-tests/e2e-legacy/sparql-editor/yasgui-tabs.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/yasgui-tabs.spec.js
@@ -91,15 +91,15 @@ describe('Yasgui tabs', () => {
 
     it('Should display information about ongoing requests if try to navigate to other page when there is a tab with ongoing request', () => {
         // When I execute a long-running query,
-        QueryStubs.stubLongRunningQuery(repositoryId);
         SparqlEditorSteps.visitSparqlEditorPage();
+        QueryStubs.stubLongRunningQuery(repositoryId);
         YasqeSteps.executeQueryWithoutWaiteResult();
         // and try to navigate to other page.
         MainMenuSteps.clickOnMenuImport();
 
         // Then I expect to see confirm dialog that explain me about ongoing query.
         ModalDialogSteps.getDialog().should('be.visible');
-        ModalDialogSteps.getDialogBody().contains('You have running 1 query, that will be aborted.');
+        ModalDialogSteps.getDialogBody().should('contain','You have running 1 query. The query will be aborted.');
     });
 });
 

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -12,7 +12,7 @@
     "cy:open-flaky": "cypress open --config-file cypress-flaky.config.js",
     "cy:guides": "cypress run --config-file cypress-legacy.config.js --spec \"e2e-legacy/guides/**/*.spec.js\" --browser chrome",
     "cy:run": "npm run cy:run-legacy && cypress run",
-    "cy:run:partial": "cypress run --config-file cypress-legacy.config.js --spec \"e2e-legacy/**/jdbc-create.spec.js\" --browser chrome",
+    "cy:run:partial": "cypress run --config-file cypress-legacy.config.js --spec \"e2e-legacy/**/sparql-editor/**/*.spec.js\" --browser chrome",
     "cy:run-legacy": "cypress run --config-file cypress-legacy.config.js --browser chrome",
     "cy:run-security": "cypress run --config-file cypress-security.config.js --browser chrome",
     "cy:run-legacy:coverage": "cypress run --config-file cypress-legacy.config.js --browser chrome",

--- a/e2e-tests/steps/error-steps.js
+++ b/e2e-tests/steps/error-steps.js
@@ -9,7 +9,7 @@ export class ErrorSteps {
     }
 
     static getNoConnectedRepoMessage() {
-        return this.getRepositoryErrors().find('.alert.lead.alert-info');
+        return this.getRepositoryErrors().find('.alert.lead.alert-info, .no-active-repo-message');
     }
 
     static verifyNoConnectedRepoMessage() {

--- a/e2e-tests/steps/modal-dialog-steps.js
+++ b/e2e-tests/steps/modal-dialog-steps.js
@@ -31,7 +31,8 @@ export class ModalDialogSteps extends BaseSteps {
     }
 
     static getDialogBody() {
-        return ModalDialogSteps.getDialog().find('.modal-body');
+        // the second selector is for the new dialog body
+        return ModalDialogSteps.getDialog().find('.modal-body, [data-pc-section="content"]');
     }
 
     static verifyDialogBody(message) {

--- a/e2e-tests/steps/onto-toastr-steps.js
+++ b/e2e-tests/steps/onto-toastr-steps.js
@@ -1,0 +1,21 @@
+export class OntoToastrSteps {
+    static getToastrContainer() {
+        return cy.get('.onto-toastr-container');
+    }
+
+    static getSuccessToast() {
+        return this.getToastrContainer().find('.toast.success');
+    }
+
+    static getErrorToast() {
+        return this.getToastrContainer().find('.toast.error');
+    }
+
+    static getInfoToast() {
+        return this.getToastrContainer().find('.toast.info');
+    }
+
+    static getWarningToast() {
+        return this.getToastrContainer().find('.toast.warning');
+    }
+}

--- a/e2e-tests/steps/yasgui/saved-query.js
+++ b/e2e-tests/steps/yasgui/saved-query.js
@@ -1,6 +1,6 @@
 import {YasguiSteps} from "./yasgui-steps";
 import {SaveQueryDialog} from "./save-query-dialog";
-import {ApplicationSteps} from "../application-steps";
+import {OntoToastrSteps} from '../onto-toastr-steps.js';
 
 export const DEFAULT_QUERY = 'select *';
 
@@ -16,7 +16,7 @@ export class SavedQuery {
         SaveQueryDialog.toggleIsPublic();
         SaveQueryDialog.saveQuery();
         SaveQueryDialog.getSaveQueryDialog().should('not.exist');
-        ApplicationSteps.getSuccessNotifications().should('be.visible');
+        OntoToastrSteps.getSuccessToast().should('be.visible');
     }
 
     static generateQueryName() {

--- a/e2e-tests/stubs/yasgui/query-stubs.js
+++ b/e2e-tests/stubs/yasgui/query-stubs.js
@@ -1,6 +1,9 @@
 import {SecurityStubs} from "../security-stubs";
 
 export class QueryStubs {
+    static spyQuery(repositoryId) {
+        cy.intercept('POST', `/repositories/${repositoryId}`).as('query');
+    }
 
     static stubInferAndSameAsDefaults(infer = true, sameAs = true) {
         SecurityStubs.stubInferAndSameAsDefaults();

--- a/packages/legacy-workbench/src/js/angular/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/plugin.js
@@ -47,12 +47,12 @@ PluginRegistry.add('main.menu', {
     },
 );
 PluginRegistry.add('main.menu', {
-        disabled: true,
+        disabled: false,
         items: [
             {
-                label: 'New YASGUI',
-                labelKey: 'New YASGUI',
-                href: 'sparql-new',
+                label: 'SPARQL',
+                labelKey: 'SPARQL',
+                href: 'sparql',
                 order: 1.9,
                 role: 'IS_AUTHENTICATED_FULLY',
                 icon: "icon-sparql",

--- a/packages/legacy-workbench/src/js/angular/sparql-editor/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/sparql-editor/plugin.js
@@ -1,5 +1,5 @@
 PluginRegistry.add('route', {
-    'url': '/sparql',
+    'url': '/sparql-old',
     'module': 'graphdb.framework.sparql-editor',
     'path': 'sparql-editor/app',
     'chunk': 'sparql',
@@ -9,20 +9,21 @@ PluginRegistry.add('route', {
     'helpInfo': 'view.sparql-editor.helpInfo',
     'reloadOnSearch': false,
     'documentationUrl': 'sparql-queries.html',
-    'allowAuthorities': ['READ_REPO_{repoId}']
+    'allowAuthorities': ['READ_REPO_{repoId}'],
 });
 
-PluginRegistry.add('main.menu', {
-    'items': [
-        {
-            label: 'SPARQL',
-            labelKey: 'menu.sparql.label',
-            href: 'sparql',
-            order: 2,
-            role: 'IS_AUTHENTICATED_FULLY',
-            icon: "icon-sparql",
-            guideSelector: 'menu-sparql',
-            children: []
-        }
-    ]
-});
+// PluginRegistry.add('main.menu', {
+//     'disabled': true,
+//     'items': [
+//         {
+//             label: 'SPARQL',
+//             labelKey: 'menu.sparql.label',
+//             href: 'sparqlaaa',
+//             order: 2,
+//             role: 'IS_AUTHENTICATED_FULLY',
+//             icon: "icon-sparql",
+//             guideSelector: 'menu-sparql',
+//             children: [],
+//         },
+//     ],
+// });

--- a/packages/root-config/src/services/workbench-routes-provider.ts
+++ b/packages/root-config/src/services/workbench-routes-provider.ts
@@ -7,11 +7,7 @@ export function getWorkbenchRoutes(): Route[] {
       default: false,
     },
     {
-      path: 'new-view',
-      default: false,
-    },
-    {
-      path: 'sparql-new',
+      path: 'sparql',
       default: false,
     },
     {

--- a/packages/workbench/src/app/app.routes.ts
+++ b/packages/workbench/src/app/app.routes.ts
@@ -3,7 +3,7 @@ import {documentationLinkResolve} from './services/route-data-resolver';
 
 export const routes: Routes = [
   {
-    path: 'sparql-new',
+    path: 'sparql',
     data: {
       title: 'sparql_editor.title',
       helpInfo: 'sparql_editor.helpInfo',


### PR DESCRIPTION
## What


## Why


## How
Make the new SPARQL view to be default

Extend selector for no active repo message to account the new sparql view structure

Fixing yasgui-tabs.spec

Change sparql view test related with tabs to use a real query to prevent failings

Changed the yasgui default http method to POST. The method is used when issuing a sparql query. The default in the yasgui component is also POST.

Revert the stub in editor tabs test. The issue was the wrong http method used when executing the query which cause the interceptor to not be triggered.

Removed the redundant spy on sparql endpoint because it is already intercepted in the beforeEach

Fix error response message extraction for the error toastr

Update save query tests to use a new page object for the onto-toastr component

## Testing


## Screenshots


## Checklist
- [ ] Branch name
- [ ] Target branch
- [ ] Commit messages
- [ ] Squash commits
- [ ] MR name
- [ ] MR Description
- [ ] Tests
- [ ] Browser support verified
