### PR TITLE
GDB-14655: Fix uncaught exception in extended table rendering

### DIFF
--- a/packages/legacy-workbench/package-lock.json
+++ b/packages/legacy-workbench/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
                 "ontotext-graphql-playground-component": "^0.0.9",
-                "ontotext-yasgui-web-component": "^1.6.3",
+                "ontotext-yasgui-web-component": "^1.6.4",
                 "single-spa-angularjs": "^4.3.1"
             },
             "devDependencies": {
@@ -5644,9 +5644,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.3.tgz",
-            "integrity": "sha512-QGoXd4L7DN3qwkuoBoyvDIyhZtcqtY8zc0IRLSNiimIxJjEQuinAHYzMsuZfICd/0l7Yr3DY7havXXTw8KjJsA==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.4.tgz",
+            "integrity": "sha512-9HLFkBSFyOFk3mO7eHawEP/Gi200iQTt5zDjaMrVtFjkIriq1mB5O64y70kusMgU5H8AIXClsd5eXoO9EIBVfw==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.7.4",

--- a/packages/legacy-workbench/package.json
+++ b/packages/legacy-workbench/package.json
@@ -76,7 +76,7 @@
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
         "ontotext-graphql-playground-component": "^0.0.9",
-        "ontotext-yasgui-web-component": "^1.6.3",
+        "ontotext-yasgui-web-component": "^1.6.4",
         "single-spa-angularjs": "^4.3.1"
     },
     "resolutions": {

--- a/packages/workbench/package-lock.json
+++ b/packages/workbench/package-lock.json
@@ -20,7 +20,7 @@
         "@jsverse/transloco-messageformat": "^8.3.0",
         "@primeuix/themes": "^2.0.3",
         "file-saver": "^2.0.5",
-        "ontotext-yasgui-web-component": "^1.6.3",
+        "ontotext-yasgui-web-component": "^1.6.4",
         "primeng": "^20.4.0",
         "rxjs": "~7.8.2",
         "single-spa": "^6.0.3",
@@ -16391,9 +16391,9 @@
       }
     },
     "node_modules/ontotext-yasgui-web-component": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.3.tgz",
-      "integrity": "sha512-QGoXd4L7DN3qwkuoBoyvDIyhZtcqtY8zc0IRLSNiimIxJjEQuinAHYzMsuZfICd/0l7Yr3DY7havXXTw8KjJsA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.4.tgz",
+      "integrity": "sha512-9HLFkBSFyOFk3mO7eHawEP/Gi200iQTt5zDjaMrVtFjkIriq1mB5O64y70kusMgU5H8AIXClsd5eXoO9EIBVfw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -28,7 +28,7 @@
     "@jsverse/transloco-messageformat": "^8.3.0",
     "@primeuix/themes": "^2.0.3",
     "file-saver": "^2.0.5",
-    "ontotext-yasgui-web-component": "^1.6.3",
+    "ontotext-yasgui-web-component": "^1.6.4",
     "primeng": "^20.4.0",
     "rxjs": "~7.8.2",
     "single-spa": "^6.0.3",


### PR DESCRIPTION
## What
An exception occurs when the extended table plugin is created and then quickly destroyed.

## Why
A column resizer is initialized inside a `setTimeout` to ensure that the table is fully rendered and ready before the resizer is attached. The issue occurred when YASR was destroyed before the `setTimeout` callback executed, causing the column resizer to be initialized on a detached table element.

## How
Bump the ontotext-yasgui-web-component version.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
