### PR TITLE
GDB-14399 fix request method used when executing sparql query

### DIFF
--- a/e2e-tests/e2e-legacy/sparql-editor/actions/execute-query.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/execute-query.spec.js
@@ -26,6 +26,7 @@ describe('Execute query', () => {
         cy.intercept('POST', `/repositories/${repositoryId}`).as('query');
         YasqeSteps.executeQuery();
         cy.wait('@query').then((interception) => {
+            expect(interception.request.method).to.equal('POST');
             const headers = interception.request.headers;
             expect(headers).to.have.property('x-graphdb-local-consistency');
             expect(headers).to.have.property('x-graphdb-repository-location');
@@ -35,6 +36,7 @@ describe('Execute query', () => {
         YasguiSteps.getTabs().should('have.length', 2);
         YasqeSteps.executeQuery();
         cy.wait('@query').then((interception) => {
+            expect(interception.request.method).to.equal('POST');
             const headers = interception.request.headers;
             expect(headers).to.have.property('x-graphdb-local-consistency');
             expect(headers).to.have.property('x-graphdb-repository-location');

--- a/packages/workbench/src/app/components/yasgui-component-facade/models/yasgui/ontotext-yasgui-config.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/models/yasgui/ontotext-yasgui-config.ts
@@ -289,7 +289,7 @@ export class OntotextYasguiConfig {
     this.endpoint = '';
     this.language = 'en';
     this.i18n = undefined;
-    this.method = YasguiQueryHttpMethod.GET;
+    this.method = YasguiQueryHttpMethod.POST;
     this.headers = undefined;
     this.infer = undefined;
     this.immutableInfer = undefined;

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.ts
@@ -286,7 +286,7 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
     const payload = this.queryPayloadFromEvent(event as unknown as SaveQueryEvent);
     this.sparqlService.saveQuery(payload)
       .then(() => this.queryCreatedHandler(payload))
-      .catch((err: unknown) => this.querySaveErrorHandler(err));
+      .catch((err: HttpErrorResponse) => this.querySaveErrorHandler(err));
   }
 
   /**
@@ -299,7 +299,7 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
     const payload = this.queryPayloadFromEvent(saveQueryEvent);
     this.sparqlService.updateQuery(saveQueryEvent.detail.originalQueryName!, payload)
       .then(() => this.queryUpdatedHandler(payload))
-      .catch((err: unknown) => this.querySaveErrorHandler(err));
+      .catch((err: HttpErrorResponse) => this.querySaveErrorHandler(err));
   }
 
   /**
@@ -819,10 +819,10 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
     return this.querySavedHandler(this.translocoService.translate('sparql_editor.success.query_was_updated', {name: payload.name}));
   }
 
-  private querySaveErrorHandler(err: unknown) {
+  private querySaveErrorHandler(err: HttpErrorResponse) {
     const errorMessage = this.translocoService.translate('sparql_editor.errors.query_save_failed');
     this.toastrService.error(
-      err instanceof Error ? err.message : String(err),
+      err instanceof HttpErrorResponse ? String(err.data) : String(err),
       {title: errorMessage}
     );
     this.savedQueryConfig = {


### PR DESCRIPTION
## What
Fix request method used when executing sparql query.

## Why
The yasgui configuration had a wrong method=GET default which was unexpected.

## How
Fixed the default request method.
Also fixed the http error response type and resolving the error message from the response.

## Testing
Extended e2e test to cover the used request method type.

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
