### PR TITLE
GDB-13822 migration of the repositoryId url param handler

### DIFF
--- a/e2e-tests/e2e-legacy/repository/url-with-repository-id-parameter.spec.js
+++ b/e2e-tests/e2e-legacy/repository/url-with-repository-id-parameter.spec.js
@@ -171,7 +171,7 @@ describe('URL with Repository ID parameter', () => {
             // Given I am on the 404 page which is in the new workbench
             ErrorPageSteps.visit404();
             ErrorPageSteps.get404Page().should('be.visible');
-            cy.url().should('not.include', 'repositoryId=');
+            cy.url().should('include', `repositoryId=${repositoryId}`);
             // When I navigate to some legacy page
             MainMenuSteps.clickOnSparqlMenu();
             // Then repositoryId parameter should be preserved in the URL

--- a/packages/root-config/scripts/validate-translations.js
+++ b/packages/root-config/scripts/validate-translations.js
@@ -86,7 +86,9 @@ const identicalTranslations = [
   "http://example.com/context.jsonld",
   "http://example.com/frame.jsonld",
   "http://my-hostname:7200",
-  "node-name:7300"
+  "node-name:7300",
+
+  "OK"
 ];
 
 // Unverified identical or TO DO translations - printed as warnings

--- a/packages/workbench/src/app/app.component.spec.ts
+++ b/packages/workbench/src/app/app.component.spec.ts
@@ -2,6 +2,7 @@ import {TestBed} from '@angular/core/testing';
 import {AppComponent} from './app.component';
 import {ActivatedRoute} from '@angular/router';
 import {ConfirmationService} from 'primeng/api';
+import {TranslocoService} from '@jsverse/transloco';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -9,6 +10,7 @@ describe('AppComponent', () => {
       imports: [AppComponent],
       providers: [
         ConfirmationService,
+        {provide: TranslocoService, useValue: {translate: (key: string) => key}},
         {
           provide: ActivatedRoute,
           useValue: {

--- a/packages/workbench/src/app/app.component.ts
+++ b/packages/workbench/src/app/app.component.ts
@@ -1,8 +1,17 @@
 import {Component, inject, OnDestroy, OnInit} from '@angular/core';
 import {Router, RouterOutlet} from '@angular/router';
-import {EventName, EventService, getCurrentRoute, service, WindowService} from '@ontotext/workbench-api';
 import {Subscription} from 'rxjs';
 import {ConfirmDialogModule} from 'primeng/confirmdialog';
+import {RepositoryUrlSyncService} from './services/repository-url-sync.service';
+import {
+  EventName,
+  EventService,
+  getCurrentRoute,
+  Repository,
+  RepositoryContextService,
+  service,
+  WindowService
+} from '@ontotext/workbench-api';
 
 @Component({
   selector: 'app-root',
@@ -15,15 +24,32 @@ import {ConfirmDialogModule} from 'primeng/confirmdialog';
 })
 export class AppComponent implements OnInit, OnDestroy {
   private readonly router = inject(Router);
+  private readonly repositoryUrlSyncService = inject(RepositoryUrlSyncService);
+  private readonly repositoryContextService = service(RepositoryContextService);
   private readonly eventService = service(EventService);
   private readonly subscriptions = new Subscription();
 
+  private isFirstRepoChangeEvent = true;
+
   ngOnInit(): void {
     this.subscribeToRoutingEvents();
+    this.subscriptions.add(
+      this.repositoryContextService.onSelectedRepositoryChanged((repo) => this.onSelectedRepositoryChangedHandler(repo))
+    );
   }
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
+  }
+
+  private onSelectedRepositoryChangedHandler(repo: Repository | undefined): void {
+    if (this.isFirstRepoChangeEvent) {
+      this.isFirstRepoChangeEvent = false;
+      return;
+    }
+    if (repo) {
+      this.repositoryUrlSyncService.onRepositoryChanged(repo.id);
+    }
   }
 
   /**
@@ -39,7 +65,10 @@ export class AppComponent implements OnInit, OnDestroy {
         const queryParams = Object.fromEntries(
           new URLSearchParams(WindowService.getLocationQueryParams())
         );
-        this.router.navigate([getCurrentRoute()], {queryParams});
+        this.router.navigate([getCurrentRoute()], {queryParams})
+          .then(() => {
+            this.repositoryUrlSyncService.syncRepositoryIdWithUrl();
+          });
       })
     );
   }

--- a/packages/workbench/src/app/services/dialog/confirmation-provider.service.spec.ts
+++ b/packages/workbench/src/app/services/dialog/confirmation-provider.service.spec.ts
@@ -11,6 +11,7 @@ describe('ConfirmationProviderService', () => {
 
   const DEFAULT_CONFIRM_LABEL = 'Confirm';
   const DEFAULT_CANCEL_LABEL = 'Cancel';
+  const DEFAULT_OK_LABEL = 'OK';
 
   beforeEach(() => {
     mockConfirm = jest.fn();
@@ -18,6 +19,7 @@ describe('ConfirmationProviderService', () => {
       const translations: Record<string, string> = {
         'components.dialog.confirmation.confirm_btn': DEFAULT_CONFIRM_LABEL,
         'components.dialog.confirmation.cancel_btn': DEFAULT_CANCEL_LABEL,
+        'components.dialog.confirmation.ok_btn': DEFAULT_OK_LABEL,
       };
       return translations[key] ?? key;
     });
@@ -224,6 +226,84 @@ describe('ConfirmationProviderService', () => {
           expect.objectContaining({reject: undefined})
         );
       });
+    });
+  });
+
+  describe('#confirmOnly', () => {
+    const buildMinimalConfig = (overrides: Partial<ConfirmationConfig> = {}): ConfirmationConfig => ({
+      message: 'Something went wrong.',
+      header: 'Info',
+      acceptHandler: jest.fn(),
+      ...overrides,
+    });
+
+    it('should call ConfirmationService.confirm once', () => {
+      service.confirmOnly(buildMinimalConfig());
+
+      expect(mockConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass message and header to the underlying service', () => {
+      service.confirmOnly(buildMinimalConfig({message: 'Done!', header: 'Success'}));
+
+      expect(mockConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({message: 'Done!', header: 'Success'})
+      );
+    });
+
+    it('should always set rejectVisible to false', () => {
+      service.confirmOnly(buildMinimalConfig({rejectVisible: true}));
+
+      expect(mockConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({rejectVisible: false})
+      );
+    });
+
+    it('should use the translated "ok" label for the accept button', () => {
+      service.confirmOnly(buildMinimalConfig());
+
+      expect(mockConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          acceptButtonProps: expect.objectContaining({label: DEFAULT_OK_LABEL})
+        })
+      );
+    });
+
+    it('should override a custom acceptButton label with the "ok" translation', () => {
+      service.confirmOnly(buildMinimalConfig({acceptButton: {label: 'Custom label'}}));
+
+      expect(mockConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          acceptButtonProps: expect.objectContaining({label: DEFAULT_OK_LABEL})
+        })
+      );
+    });
+
+    it('should preserve acceptButton.type when provided', () => {
+      service.confirmOnly(buildMinimalConfig({acceptButton: {label: 'Ok', type: 'danger'}}));
+
+      expect(mockConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          acceptButtonProps: expect.objectContaining({severity: 'danger'})
+        })
+      );
+    });
+
+    it('should preserve acceptButton.styleClass when provided', () => {
+      service.confirmOnly(buildMinimalConfig({acceptButton: {label: 'Ok', type: 'primary', styleClass: 'my-ok-btn'}}));
+
+      expect(mockConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({acceptButtonStyleClass: 'my-ok-btn'})
+      );
+    });
+
+    it('should pass the acceptHandler to the underlying service', () => {
+      const acceptHandler = jest.fn();
+      service.confirmOnly(buildMinimalConfig({acceptHandler}));
+
+      expect(mockConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({accept: acceptHandler})
+      );
     });
   });
 });

--- a/packages/workbench/src/app/services/dialog/confirmation-provider.service.ts
+++ b/packages/workbench/src/app/services/dialog/confirmation-provider.service.ts
@@ -35,6 +35,24 @@ export class ConfirmationProviderService {
       },
       accept: config.acceptHandler,
       reject: config.rejectHandler,
+      rejectVisible: config.rejectVisible ?? true,
     });
+  }
+
+  /**
+   * Displays a confirmation dialog with only an accept button, hiding the reject button. The reject button will be
+   * hidden in this dialog.
+   * @param config The configuration for the confirmation dialog.
+   */
+  confirmOnly(config: ConfirmationConfig) {
+    const resolvedConfig: ConfirmationConfig = {
+      ...config,
+      rejectVisible: false,
+      acceptButton: {
+        ...config.acceptButton ?? {},
+        label: this.translocoService.translate('components.dialog.confirmation.ok_btn'),
+      }
+    };
+    this.confirm(resolvedConfig);
   }
 }

--- a/packages/workbench/src/app/services/dialog/model/confirmation-config.ts
+++ b/packages/workbench/src/app/services/dialog/model/confirmation-config.ts
@@ -49,4 +49,12 @@ export interface ConfirmationConfig {
    * for what should happen when the user cancels the confirmation, such as closing the dialog or preventing navigation.
    */
   rejectHandler?: () => void;
+  /**
+   * An optional flag to indicate whether the reject (cancel) button should be hidden. If set to false, only the accept
+   * button will be displayed in the confirmation dialog, and the reject button will be completely removed from the UI.
+   * This can be useful in scenarios where a cancellation option is not applicable or desired, such as when confirming a
+   * non-destructive action or when you want to force the user to acknowledge a message without providing an option to
+   * cancel.
+   */
+  rejectVisible?: boolean;
 }

--- a/packages/workbench/src/app/services/repository-url-sync.service.spec.ts
+++ b/packages/workbench/src/app/services/repository-url-sync.service.spec.ts
@@ -1,0 +1,330 @@
+import {TestBed} from '@angular/core/testing';
+import {ActivatedRoute, Router} from '@angular/router';
+import {
+  getCurrentRoute,
+  OntoToastrService,
+  RepositoryContextService,
+  service,
+  WindowService,
+} from '@ontotext/workbench-api';
+import {ConfirmationService} from 'primeng/api';
+import {RepositoryUrlSyncService} from './repository-url-sync.service';
+import {ConfirmationProviderService} from './dialog/confirmation-provider.service';
+import {TranslocoService} from '@jsverse/transloco';
+
+jest.mock('@ontotext/workbench-api', () => ({
+  ...jest.requireActual('@ontotext/workbench-api'),
+  service: jest.fn(),
+  getCurrentRoute: jest.fn().mockReturnValue('sparql'),
+}));
+
+const mockService = service as jest.MockedFunction<typeof service>;
+const mockGetCurrentRoute = getCurrentRoute as jest.MockedFunction<typeof getCurrentRoute>;
+
+describe('RepositoryUrlSyncService', () => {
+  let syncService: RepositoryUrlSyncService;
+  let mockNavigate: jest.Mock;
+  let mockConfirm: jest.Mock;
+  let mockConfirmOnly: jest.Mock;
+  let mockGetSelectedRepository: jest.Mock;
+  let mockRepositoryExists: jest.Mock;
+  let mockUpdateSelectedRepository: jest.Mock;
+  let mockGetLocationQueryParams: jest.SpyInstance;
+
+  const REPO_ID_PARAM = 'repositoryId';
+
+  const setUrlParam = (repoId: string | null) => {
+    const search = repoId ? `?${REPO_ID_PARAM}=${repoId}` : '';
+    mockGetLocationQueryParams.mockReturnValue(search);
+  };
+
+  beforeEach(() => {
+    mockNavigate = jest.fn().mockResolvedValue(true);
+    mockConfirm = jest.fn();
+    mockConfirmOnly = jest.fn();
+    mockGetSelectedRepository = jest.fn().mockReturnValue(undefined);
+    mockRepositoryExists = jest.fn().mockReturnValue(false);
+    mockUpdateSelectedRepository = jest.fn().mockResolvedValue(undefined);
+
+    mockService.mockImplementation((serviceClass: unknown) => {
+      if (serviceClass === RepositoryContextService) {
+        return {
+          getSelectedRepository: mockGetSelectedRepository,
+          repositoryExists: mockRepositoryExists,
+          updateSelectedRepository: mockUpdateSelectedRepository,
+        } as unknown as ReturnType<typeof service>;
+      }
+      if (serviceClass === OntoToastrService) {
+        return {} as unknown as ReturnType<typeof service>;
+      }
+      return {} as unknown as ReturnType<typeof service>;
+    });
+
+    mockGetLocationQueryParams = jest.spyOn(WindowService, 'getLocationQueryParams').mockReturnValue('');
+
+    TestBed.configureTestingModule({
+      providers: [
+        RepositoryUrlSyncService,
+        ConfirmationService,
+        {provide: Router, useValue: {navigate: mockNavigate}},
+        {provide: ActivatedRoute, useValue: {}},
+        {provide: ConfirmationProviderService, useValue: {confirm: mockConfirm, confirmOnly: mockConfirmOnly}},
+        {provide: TranslocoService, useValue: {translate: (key: string) => key}},
+      ],
+    });
+
+    syncService = TestBed.inject(RepositoryUrlSyncService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be created', () => {
+    expect(syncService).toBeTruthy();
+  });
+
+  describe('#syncRepositoryIdWithUrl', () => {
+    describe('Scenario 1 – no active repo, no URL param → no action', () => {
+      it('should not call any dialog or navigation', () => {
+        mockGetSelectedRepository.mockReturnValue(undefined);
+        setUrlParam(null);
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockConfirm).not.toHaveBeenCalled();
+        expect(mockConfirmOnly).not.toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockUpdateSelectedRepository).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Scenario 2 – no active repo, URL param present, repo exists → set active repo', () => {
+      it('should call updateSelectedRepository with the URL param repo id', () => {
+        mockGetSelectedRepository.mockReturnValue(undefined);
+        setUrlParam('myRepo');
+        mockRepositoryExists.mockReturnValue(true);
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockUpdateSelectedRepository).toHaveBeenCalledWith({id: 'myRepo', location: ''});
+      });
+
+      it('should not show any dialog', () => {
+        mockGetSelectedRepository.mockReturnValue(undefined);
+        setUrlParam('myRepo');
+        mockRepositoryExists.mockReturnValue(true);
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockConfirm).not.toHaveBeenCalled();
+        expect(mockConfirmOnly).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Scenario 3 – no active repo, URL param present, repo missing → show warning dialog', () => {
+      it('should call confirmOnly with a warning header and message', () => {
+        mockGetSelectedRepository.mockReturnValue(undefined);
+        setUrlParam('unknownRepo');
+        mockRepositoryExists.mockReturnValue(false);
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockConfirmOnly).toHaveBeenCalledTimes(1);
+        expect(mockConfirmOnly).toHaveBeenCalledWith(
+          expect.objectContaining({
+            header: 'common.warnings.warning',
+            message: 'repository.url_param.invalid_repo',
+          })
+        );
+      });
+
+      it('should not navigate or update the selected repository', () => {
+        mockGetSelectedRepository.mockReturnValue(undefined);
+        setUrlParam('unknownRepo');
+        mockRepositoryExists.mockReturnValue(false);
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockUpdateSelectedRepository).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Scenario 4 – active repo, no URL param → write repo id to URL', () => {
+      it('should navigate with the active repository id as a query param', () => {
+        mockGetSelectedRepository.mockReturnValue({id: 'activeRepo', location: ''});
+        setUrlParam(null);
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenCalledWith(
+          [mockGetCurrentRoute()],
+          expect.objectContaining({
+            queryParams: expect.objectContaining({[REPO_ID_PARAM]: 'activeRepo'}),
+            replaceUrl: true,
+          })
+        );
+      });
+
+      it('should not show any dialog', () => {
+        mockGetSelectedRepository.mockReturnValue({id: 'activeRepo', location: ''});
+        setUrlParam(null);
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockConfirm).not.toHaveBeenCalled();
+        expect(mockConfirmOnly).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Scenario 5 – active repo, URL param is same repo → no action', () => {
+      it('should not call any dialog or navigation', () => {
+        mockGetSelectedRepository.mockReturnValue({id: 'myRepo', location: ''});
+        setUrlParam('myRepo');
+        mockRepositoryExists.mockReturnValue(true);
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockConfirm).not.toHaveBeenCalled();
+        expect(mockConfirmOnly).not.toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockUpdateSelectedRepository).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Scenario 6 – active repo, URL param is a different existing repo → confirm change', () => {
+      it('should call confirm with a change confirmation dialog', () => {
+        mockGetSelectedRepository.mockReturnValue({id: 'currentRepo', location: ''});
+        setUrlParam('newRepo');
+        mockRepositoryExists.mockReturnValue(true);
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockConfirm).toHaveBeenCalledTimes(1);
+        expect(mockConfirm).toHaveBeenCalledWith(
+          expect.objectContaining({
+            header: 'components.dialog.confirmation.title',
+            message: 'repository.url_param.change_active_repo',
+          })
+        );
+      });
+
+      it('should call updateSelectedRepository with the new repo id when accepted', () => {
+        mockGetSelectedRepository.mockReturnValue({id: 'currentRepo', location: ''});
+        setUrlParam('newRepo');
+        mockRepositoryExists.mockReturnValue(true);
+        mockConfirm.mockImplementation(({acceptHandler}: {acceptHandler: () => void}) => acceptHandler());
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockUpdateSelectedRepository).toHaveBeenCalledWith({id: 'newRepo', location: ''});
+      });
+
+      it('should revert URL to current repo when rejected', () => {
+        mockGetSelectedRepository.mockReturnValue({id: 'currentRepo', location: ''});
+        setUrlParam('newRepo');
+        mockRepositoryExists.mockReturnValue(true);
+        mockConfirm.mockImplementation(({rejectHandler}: {rejectHandler: () => void}) => rejectHandler());
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockNavigate).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            queryParams: expect.objectContaining({[REPO_ID_PARAM]: 'currentRepo'}),
+          })
+        );
+      });
+    });
+
+    describe('Scenario 7 – active repo, URL param repo not found anywhere → warn and fix URL', () => {
+      it('should call confirmOnly with invalid_repo_continue message key', () => {
+        mockGetSelectedRepository.mockReturnValue({id: 'currentRepo', location: ''});
+        setUrlParam('ghostRepo');
+        // repositoryExists returns false for both exact and ignore-location checks
+        mockRepositoryExists.mockReturnValue(false);
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockConfirmOnly).toHaveBeenCalledTimes(1);
+        expect(mockConfirmOnly).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: 'repository.url_param.invalid_repo_continue',
+          })
+        );
+      });
+
+      it('should fix the URL to the current repo when the user accepts', () => {
+        mockGetSelectedRepository.mockReturnValue({id: 'currentRepo', location: ''});
+        setUrlParam('ghostRepo');
+        mockRepositoryExists.mockReturnValue(false);
+        mockConfirmOnly.mockImplementation(({acceptHandler}: {acceptHandler: () => void}) => acceptHandler());
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockNavigate).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            queryParams: expect.objectContaining({[REPO_ID_PARAM]: 'currentRepo'}),
+          })
+        );
+      });
+    });
+
+    describe('Scenario 8 – active repo, URL param repo found by id (remote location) → shows warning on first resolution', () => {
+      it('should call confirmOnly with remote_location_repo_continue when isFirstResolution is true (default)', () => {
+        mockGetSelectedRepository.mockReturnValue({id: 'currentRepo', location: ''});
+        setUrlParam('remoteRepo');
+        // First call (exact match) returns false, second call (ignoreLocation) returns true
+        mockRepositoryExists
+          .mockReturnValueOnce(false)  // exact match → not found
+          .mockReturnValueOnce(true);  // ignore location → found (remote)
+
+        syncService.syncRepositoryIdWithUrl();
+
+        expect(mockConfirm).not.toHaveBeenCalled();
+        expect(mockConfirmOnly).toHaveBeenCalledTimes(1);
+        expect(mockConfirmOnly).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: 'repository.url_param.remote_location_repo_continue',
+          })
+        );
+      });
+    });
+  });
+
+  describe('#onRepositoryChanged', () => {
+    it('should navigate with the new repo id when it differs from the URL param', () => {
+      setUrlParam('oldRepo');
+
+      syncService.onRepositoryChanged('newRepo');
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(
+        [mockGetCurrentRoute()],
+        expect.objectContaining({
+          queryParams: expect.objectContaining({[REPO_ID_PARAM]: 'newRepo'}),
+          replaceUrl: true,
+        })
+      );
+    });
+
+    it('should not navigate when the new repo id matches the URL param', () => {
+      setUrlParam('sameRepo');
+
+      syncService.onRepositoryChanged('sameRepo');
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('should navigate when there is no repo id in the URL', () => {
+      setUrlParam(null);
+
+      syncService.onRepositoryChanged('newRepo');
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/workbench/src/app/services/repository-url-sync.service.ts
+++ b/packages/workbench/src/app/services/repository-url-sync.service.ts
@@ -1,0 +1,162 @@
+import {inject, Injectable} from '@angular/core';
+import {Router} from '@angular/router';
+import {
+  service,
+  getCurrentRoute,
+  REPOSITORY_ID_PARAM,
+  RepositoryContextService,
+  WindowService,
+} from '@ontotext/workbench-api';
+import {ConfirmationProviderService} from './dialog/confirmation-provider.service';
+import {TranslocoService} from '@jsverse/transloco';
+
+/**
+ * This service is responsible for synchronizing the active repository in the application state with the repository
+ * specified in the URL query parameter. It listens to navigation events and repository changes, and ensures that the
+ * URL and the active repository are consistent. It also handles various scenarios such as missing repositories,
+ * mismatches between the URL and active repository, and user confirmations for changing repositories.
+ */
+@Injectable({ providedIn: 'root' })
+export class RepositoryUrlSyncService {
+  private readonly router = inject(Router);
+  private readonly confirmationProviderService = inject(ConfirmationProviderService);
+  private readonly translocoService = inject(TranslocoService);
+
+  private readonly repositoryContextService = service(RepositoryContextService);
+
+  private isFirstResolution = true;
+
+  /**
+   * Called on every navigation event and on repository change.
+   * Reads the URL param vs active repo and reconciles them. The scenarios are as follows:
+   *  1. active repo no, repo in url no -> no action - just show repo selector
+   *  2. active repo no, repo in url yes, url repo exists -> set active repo same as the url
+   *  3. active repo no, repo in url yes, url repo missing -> show warning, keep url
+   *  4. active repo yes, repo in url no -> update url
+   *  5. active repo yes, repo in url yes, same repo -> do nothing
+   *  6. active repo yes, repo in url yes, url repo exists and is different -> confirm change
+   *  7. active repo yes, repo in url yes, url repo missing or remote -> warn and keep active repo
+   */
+  syncRepositoryIdWithUrl(): void {
+    const repositoryIdParam = this.getRepositoryIdFromUrl();
+    const selectedRepository = this.repositoryContextService.getSelectedRepository();
+    // If repository exists in current or any location. The check validates by ID and location.
+    const repositoryByLocationExists = this.repositoryContextService.repositoryExists({id: repositoryIdParam ?? '', location: ''});
+    // If requested repository exists strictly by id and location in the system.
+    const repositoryExists = repositoryIdParam ? repositoryByLocationExists : false;
+    const isSameRepository = !!selectedRepository && repositoryIdParam === selectedRepository.id;
+
+    try {
+      // --- no selected repository ---
+
+      if (!selectedRepository) {
+        // 1. active repo no, repo in url no -> no action - just show repo selector
+        if (!repositoryIdParam) {
+          return;
+        }
+
+        // 2. active repo no, repo in url yes, url repo exists -> set active repo same as the url
+        if (repositoryExists) {
+          this.repositoryContextService.updateSelectedRepository({id: repositoryIdParam, location: ''});
+          return;
+        }
+
+        // 3. active repo no, repo in url yes, url repo missing -> show warning, keep url
+        this.confirmationProviderService.confirmOnly({
+          header: this.translocoService.translate('common.warnings.warning'),
+          message: this.translocoService.translate('repository.url_param.invalid_repo', {repositoryId: repositoryIdParam}),
+          acceptHandler: () => {
+            Promise.resolve(true);
+          },
+          rejectVisible: false,
+        });
+
+        return;
+      }
+
+      // --- selected repository is present ---
+
+      // 4. active repo yes, repo in url no -> update url
+      if (!repositoryIdParam) {
+        this.writeRepositoryIdToUrl(selectedRepository.id);
+        return;
+      }
+
+      // 5. active repo yes, repo in url yes, same repo -> do nothing
+      if (isSameRepository && repositoryExists) {
+        return;
+      }
+
+      // 6. active repo yes, repo in url yes, url repo exists and is different -> confirm change
+      if (repositoryExists) {
+        this.confirmRepositoryChange(selectedRepository.id, repositoryIdParam);
+        return;
+      }
+
+      // 7. active repo yes, repo in url yes, url repo missing or on remote location -> keep active repo and fix URL
+      // - If the repository doesn't exist in any location, we can safely warn the user about that and fix the URL to
+      // point to the currently selected repository.
+      // - Otherwise, the repository might exist on a remote location, but we can't be sure about that, because we don't
+      // know the location of the repository specified in the URL. We warn the user that the repository might exist on
+      // a remote location and fix the URL to point to the currently selected repository.
+
+      // If repository id exists in any location. This check would return true for multiple repositories with the same id on different locations.
+      const repositoryByIdExists = this.repositoryContextService.repositoryExists({
+        id: repositoryIdParam,
+        location: '',
+      }, true);
+      if (!repositoryByIdExists) {
+        this.warnForMissingRepository(repositoryIdParam, selectedRepository.id, 'repository.url_param.invalid_repo_continue');
+      } else if (this.isFirstResolution) {
+        this.warnForMissingRepository(repositoryIdParam, selectedRepository.id, 'repository.url_param.remote_location_repo_continue');
+      }
+    } finally {
+      // FIXME: probably this won't work reliably here as the service is a singleton and provided in root so this flag would be set just once
+      this.isFirstResolution = false;
+    }
+  }
+
+  /**
+   * Called when the active repository changes — mirrors legacy's onSelectedRepositoryUpdated.
+   * Writes the new repo ID to the URL without adding a history entry.
+   */
+  onRepositoryChanged(repositoryId: string): void {
+    if (this.getRepositoryIdFromUrl() !== repositoryId) {
+      this.writeRepositoryIdToUrl(repositoryId);
+    }
+  }
+
+  private getRepositoryIdFromUrl(): string | undefined {
+    return new URLSearchParams(WindowService.getLocationQueryParams()).get(REPOSITORY_ID_PARAM) ?? undefined;
+  }
+
+  private writeRepositoryIdToUrl(repositoryId: string): void {
+    const currentParams = Object.fromEntries(new URLSearchParams(WindowService.getLocationQueryParams()));
+    void this.router.navigate([getCurrentRoute()], {
+      queryParams: { ...currentParams, [REPOSITORY_ID_PARAM]: repositoryId },
+      replaceUrl: true,
+    });
+  }
+
+  private warnForMissingRepository(repositoryIdParam: string, selectedRepository: string, messageKey: string): void {
+    this.confirmationProviderService.confirmOnly({
+      header: this.translocoService.translate('common.warnings.warning'),
+      message: this.translocoService.translate(messageKey, {
+        repositoryId: repositoryIdParam,
+        currentRepositoryId: selectedRepository,
+      }),
+      acceptHandler: () => this.writeRepositoryIdToUrl(selectedRepository),
+    });
+  }
+
+  private confirmRepositoryChange(currentId: string, newId: string): void {
+    // asking user to confirm switch to newId
+    this.confirmationProviderService.confirm({
+      header: this.translocoService.translate('components.dialog.confirmation.title'),
+      message: this.translocoService.translate('repository.url_param.change_active_repo', {repositoryId: newId}),
+      acceptHandler: () => this.repositoryContextService.updateSelectedRepository({ id: newId, location: '' }),
+      // revert URL param to current repo if user rejects the change
+      rejectHandler: () => this.writeRepositoryIdToUrl(currentId),
+    });
+  }
+}

--- a/packages/workbench/src/assets/i18n/en.json
+++ b/packages/workbench/src/assets/i18n/en.json
@@ -3,6 +3,9 @@
     "errors": {
       "error": "Error",
       "server_error": "Server error"
+    },
+    "warnings": {
+      "warning": "Warning"
     }
   },
   "components": {
@@ -10,7 +13,8 @@
       "confirmation": {
         "title": "Confirm",
         "confirm_btn": "Yes",
-        "cancel_btn": "Cancel"
+        "cancel_btn": "Cancel",
+        "ok_btn": "OK"
       },
       "unsaved_changes": {
         "confirmation": {
@@ -128,6 +132,14 @@
           }
         }
       }
+    }
+  },
+  "repository": {
+    "url_param": {
+      "invalid_repo": "The repository \"{{repositoryId}}\" specified in the URL does not exist. Please select an existing repository.",
+      "invalid_repo_continue": "The repository \"{{repositoryId}}\" specified in the URL does not exist. You can continue with the current repository \"{{currentRepositoryId}}\" or select another repository.",
+      "remote_location_repo_continue": "The repository \"{{repositoryId}}\" specified in the URL does not exist in current location. You can continue with the current repository \"{{currentRepositoryId}}\" or select it from the menu.",
+      "change_active_repo": "Active repository will be changed to \"{{repositoryId}}\". Do you want to proceed?"
     }
   }
 }

--- a/packages/workbench/src/assets/i18n/fr.json
+++ b/packages/workbench/src/assets/i18n/fr.json
@@ -3,6 +3,9 @@
     "errors": {
       "error": "Erreur",
       "server_error": "Erreur du serveur"
+    },
+    "warnings": {
+      "warning": "Avertissement"
     }
   },
   "components": {
@@ -10,7 +13,8 @@
       "confirmation": {
         "title": "Confirmer",
         "confirm_btn": "Oui",
-        "cancel_btn": "Annuler"
+        "cancel_btn": "Annuler",
+        "ok_btn": "OK"
       },
       "unsaved_changes": {
         "confirmation": {
@@ -128,6 +132,14 @@
           }
         }
       }
+    }
+  },
+  "repository": {
+    "url_param": {
+      "invalid_repo": "Le dépôt \"{{repositoryId}}\" spécifié dans l'URL n'existe pas. Veuillez sélectionner un dépôt existant.",
+      "invalid_repo_continue": "Le dépôt \"{{repositoryId}}\" spécifié dans l’URL n’existe pas. Vous pouvez continuer avec le dépôt actuel \"{{currentRepositoryId}}\" ou sélectionner un autre dépôt.",
+      "remote_location_repo_continue": "Le dépôt \"{{repositoryId}}\" spécifié dans l’URL n’existe pas à l’emplacement actuel. Vous pouvez continuer avec le dépôt actuel \"{{currentRepositoryId}}\" ou le sélectionner dans le menu.",
+      "change_active_repo": "Le dépôt actif sera remplacé par \"{{repositoryId}}\". Voulez-vous continuer?"
     }
   }
 }


### PR DESCRIPTION
## What
Migrated the repositoryId url handler in the new workbench.

## Why
This implementation was postponed during previous GDB release as we didn't have pages in the new workbench yet.

## How
Implemented a repository url sync service and wired it in the app component. 
Extended the confirmation provider service so one can open confirmation modal with a [confirm] button inside only.

## Testing
Added tests

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
