### PR TITLE
Fix loader indicator state

### DIFF
--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -95,6 +95,7 @@ export class OntoLayout {
     this.subscribeToNavigationEnd();
     this.subscribeToRuntimeConfigurationChanges();
     this.subscribeToApplicationChange();
+    this.loading = false;
   }
 
   /**


### PR DESCRIPTION
## What
Fix loader indicator state

## Why
The flag controlling the loader needs to be reset when the layout component is connected. Otherwise it might appear as active and.

## How


## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
