### PR TITLE
GDB-14684 install and configure bootstrap

### DIFF
--- a/packages/workbench/angular.json
+++ b/packages/workbench/angular.json
@@ -38,7 +38,10 @@
             "customWebpackConfig": {
               "path": "extra-webpack.config.js",
               "libraryName": "workbench",
-              "libraryTarget": "module"
+              "libraryTarget": "module",
+              "mergeStrategies": {
+                "module.rules": "replace"
+              }
             }
           },
           "configurations": {

--- a/packages/workbench/extra-webpack.config.js
+++ b/packages/workbench/extra-webpack.config.js
@@ -1,12 +1,27 @@
+const {resolve} = require('node:path');
 const singleSpaAngularWebpack = require('single-spa-angular/lib/webpack').default;
+
+function patchSassLoader(rules) {
+  if (!Array.isArray(rules)) return;
+  rules.forEach(rule => {
+    patchSassLoader(rule.rules);
+    patchSassLoader(rule.oneOf);
+    (rule.use || []).forEach(use => {
+      if (typeof use === 'object' && use.loader && use.loader.includes('sass-loader')) {
+        use.options = {
+          ...use.options,
+          sassOptions: {
+            silenceDeprecations: ['color-functions', 'global-builtin', 'import', 'if-function'],
+            loadPaths: [resolve(__dirname)]
+          }
+        };
+      }
+    });
+  });
+}
 
 module.exports = (config, options) => {
   const singleSpaWebpackConfig = singleSpaAngularWebpack(config, options);
-
-  // Ensure Zone.js is included
-  // singleSpaWebpackConfig.externals = singleSpaWebpackConfig.externals || {};
-  // delete singleSpaWebpackConfig.externals['zone.js'];
-  // Feel free to modify this webpack config however you'd like to
 
   singleSpaWebpackConfig.externals = [...singleSpaWebpackConfig.externals, "@ontotext/workbench-api"];
   singleSpaWebpackConfig.experiments.outputModule = true;
@@ -30,6 +45,7 @@ module.exports = (config, options) => {
   // singleSpaWebpackConfig.devServer.client.overlay = false;
   // singleSpaWebpackConfig.devServer.liveReload = false;
 
-  // console.log('=============', JSON.stringify(singleSpaWebpackConfig, null, 2));
+  patchSassLoader(singleSpaWebpackConfig.module.rules);
+
   return singleSpaWebpackConfig;
 };

--- a/packages/workbench/package-lock.json
+++ b/packages/workbench/package-lock.json
@@ -19,6 +19,7 @@
         "@jsverse/transloco": "^8.3.0",
         "@jsverse/transloco-messageformat": "^8.3.0",
         "@primeuix/themes": "^2.0.3",
+        "bootstrap": "^5.3.8",
         "file-saver": "^2.0.5",
         "ontotext-yasgui-web-component": "^1.6.4",
         "primeng": "^21.1.8",
@@ -6977,6 +6978,17 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@primeuix/motion": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/@primeuix/motion/-/motion-0.0.10.tgz",
@@ -9659,6 +9671,25 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "5.0.6",

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -27,6 +27,7 @@
     "@jsverse/transloco": "^8.3.0",
     "@jsverse/transloco-messageformat": "^8.3.0",
     "@primeuix/themes": "^2.0.3",
+    "bootstrap": "^5.3.8",
     "file-saver": "^2.0.5",
     "ontotext-yasgui-web-component": "^1.6.4",
     "primeng": "^21.1.8",

--- a/packages/workbench/src/styles.scss
+++ b/packages/workbench/src/styles.scss
@@ -1,2 +1,21 @@
 /* You can add global styles to this file, and also import other style files */
 @use "styles/primeng-overrides";
+
+app-root {
+  @import "../node_modules/bootstrap/scss/functions";
+  // Required Bootstrap imports
+  @import "../node_modules/bootstrap/scss/variables";
+  @import "../node_modules/bootstrap/scss/variables-dark";
+  @import "../node_modules/bootstrap/scss/maps";
+  @import "../node_modules/bootstrap/scss/mixins";
+  // Probably not needed and leaking properties to :root
+  //@import "../node_modules/bootstrap/scss/root";
+  // Optional components
+  @import "../node_modules/bootstrap/scss/utilities";
+  // Probably not needed as well
+  //@import "../node_modules/bootstrap/scss/reboot";
+  @import "../node_modules/bootstrap/scss/containers";
+  @import "../node_modules/bootstrap/scss/grid";
+  @import "../node_modules/bootstrap/scss/helpers";
+  @import "../node_modules/bootstrap/scss/utilities/api";
+}


### PR DESCRIPTION
## What
Install and configure bootstrap in the new workbench Angular app.

## Why
Primeng components that we use in the new workbench are styled by our styleguide, but outside of them, on a page level we usually need to apply some additional styles. To style the new workbench application consistently we need some utility css classes and helpers for easy creating layouts, grids, controlling spacing, etc. That's why we introduce the bootstrap library and scope it to work in the new angular app only.

## How
- Added `bootstrap` dependency in `packages/workbench`.
- Imported selected Bootstrap SCSS partials in `packages/workbench/src/styles.scss` under `app-root` scope.
- Resolved merge conflicts with latest `master` updates in `styles.scss` and kept both:
  - Bootstrap scoped imports
  - `@use "styles/primeng-overrides";`

## Testing
- Reproduced and resolved merge conflicts locally by merging latest `master` and latest remote PR branch.
- Ran targeted checks/build in `packages/workbench` to validate the merged stylesheet changes.

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified