### PR TITLE
Cherry pick: GDB-14677 add target to loader component

### DIFF
--- a/packages/root-config/src/index.ejs
+++ b/packages/root-config/src/index.ejs
@@ -128,5 +128,7 @@
        alt="GraphDB Workbench is loading...">
 </figure>
 <onto-toastr></onto-toastr>
+<onto-tooltip></onto-tooltip>
+<onto-confirm-cancel-dialog></onto-confirm-cancel-dialog>
 </body>
 </html>

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -154,6 +154,11 @@ export namespace Components {
           * @default 100
          */
         "size": number;
+        /**
+          * CSS selector of a DOM element to attach the loader to as a centered overlay.
+          * @default ''
+         */
+        "targetSelector": string;
     }
     interface OntoNavbar {
         /**
@@ -882,6 +887,11 @@ declare namespace LocalJSX {
           * @default 100
          */
         "size"?: number;
+        /**
+          * CSS selector of a DOM element to attach the loader to as a centered overlay.
+          * @default ''
+         */
+        "targetSelector"?: string;
     }
     interface OntoNavbar {
         /**

--- a/packages/shared-components/src/components/dialogs/onto-confirm-cancel-dialog/readme.md
+++ b/packages/shared-components/src/components/dialogs/onto-confirm-cancel-dialog/readme.md
@@ -7,10 +7,6 @@
 
 ## Dependencies
 
-### Used by
-
- - [onto-layout](../../onto-layout)
-
 ### Depends on
 
 - [onto-dialog](..)
@@ -21,7 +17,6 @@
 graph TD;
   onto-confirm-cancel-dialog --> onto-dialog
   onto-confirm-cancel-dialog --> translate-label
-  onto-layout --> onto-confirm-cancel-dialog
   style onto-confirm-cancel-dialog fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/shared-components/src/components/onto-layout/onto-layout.scss
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.scss
@@ -41,20 +41,17 @@
     margin-left: 0;
   }
 
-  .main-slot-wrapper {
-    .loader-wrapper {
-      flex-grow: 1;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
+  main {
+    grid-area: main;
+  }
 
-    &.loading {
-      display: flex;
-      flex-direction: column;
+  &.loading {
+    main {
+      position: relative;
+      visibility: hidden;
 
-      .page-content {
-        visibility: hidden;
+      onto-loader {
+        visibility: visible;
       }
     }
   }
@@ -75,10 +72,6 @@
 
   header {
     grid-area: header;
-  }
-
-  main {
-    grid-area: main;
   }
 
   footer {

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -111,7 +111,8 @@ export class OntoLayout {
       <Host class={{
         'wb-layout': true,
         'is-embedded': this.isEmbedded,
-        'hide-navbar': !this.showNavbar
+        'hide-navbar': !this.showNavbar,
+        'loading': this.loading
       }}>
         {/* Default slot is explicitly defined to be able to hide the main content in the user permission check */}
         <div class="default-slot-wrapper">
@@ -128,20 +129,16 @@ export class OntoLayout {
           </nav>
         }
 
-        <div class={{'main-slot-wrapper': true, 'loading': this.loading}}>
-          {this.loading && <div class="loader-wrapper">
-            <onto-loader size={96} messageText={TranslationService.translate('common.loading')}></onto-loader>
-          </div>}
-          <slot name="main"></slot>
-        </div>
+        {this.loading &&
+          <onto-loader targetSelector={'main'} size={96} messageText={TranslationService.translate('common.loading')}></onto-loader>
+        }
+        <slot name="main"></slot>
 
         {!this.isEmbedded &&
           <footer class="wb-footer">
             <onto-footer></onto-footer>
           </footer>
         }
-        <onto-tooltip></onto-tooltip>
-        <onto-confirm-cancel-dialog></onto-confirm-cancel-dialog>
       </Host>
     );
   }
@@ -317,7 +314,10 @@ export class OntoLayout {
     this.subscriptions.add(
       this.eventService.subscribe(EventName.NAVIGATION_END, (navigationEndPayload: NavigationEndPayload) => {
         this.navigationContextService.updatePreviousRoute(navigationEndPayload.oldUrl);
-        this.loading = false;
+        // NAVIGATION_END appears to happen in the same tick as BeforeMountRouting, so the loader never gets shown
+        setTimeout(() => {
+          this.loading = false;
+        });
       }));
   }
 

--- a/packages/shared-components/src/components/onto-layout/readme.md
+++ b/packages/shared-components/src/components/onto-layout/readme.md
@@ -13,8 +13,6 @@
 - [onto-navbar](../onto-navbar)
 - [onto-loader](../onto-loader)
 - [onto-footer](../onto-footer)
-- [onto-tooltip](../onto-tooltip)
-- [onto-confirm-cancel-dialog](../dialogs/onto-confirm-cancel-dialog)
 
 ### Graph
 ```mermaid
@@ -23,8 +21,6 @@ graph TD;
   onto-layout --> onto-navbar
   onto-layout --> onto-loader
   onto-layout --> onto-footer
-  onto-layout --> onto-tooltip
-  onto-layout --> onto-confirm-cancel-dialog
   onto-header --> onto-search-icon
   onto-header --> onto-rdf-search
   onto-header --> onto-operations-notification
@@ -50,8 +46,6 @@ graph TD;
   onto-cookie-policy-dialog --> translate-label
   onto-cookie-policy-dialog --> onto-toggle-switch
   onto-toggle-switch --> translate-label
-  onto-confirm-cancel-dialog --> onto-dialog
-  onto-confirm-cancel-dialog --> translate-label
   style onto-layout fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/shared-components/src/components/onto-loader/onto-loader.scss
+++ b/packages/shared-components/src/components/onto-loader/onto-loader.scss
@@ -1,3 +1,14 @@
+:host(.onto-loader-attached) {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 :host {
   display: block;
 

--- a/packages/shared-components/src/components/onto-loader/onto-loader.tsx
+++ b/packages/shared-components/src/components/onto-loader/onto-loader.tsx
@@ -1,5 +1,6 @@
-import {Component, h, Host, Prop} from '@stencil/core';
+import {Component, Element, h, Host, Prop} from '@stencil/core';
 import loaderSvg from '../../assets/onto-loader.svg';
+import {LoggerProvider} from '../../services/logger-provider';
 
 @Component({
   tag: 'onto-loader',
@@ -7,6 +8,8 @@ import loaderSvg from '../../assets/onto-loader.svg';
   shadow: true
 })
 export class OntoLoader {
+  @Element() loader: HTMLElement;
+
   /**
    * Size of the loader in pixels (width and height).
    */
@@ -17,16 +20,42 @@ export class OntoLoader {
    */
   @Prop() messageText = '';
 
+  /**
+   * CSS selector of a DOM element to attach the loader to as a centered overlay.
+   */
+  @Prop() targetSelector = '';
+
+  private readonly ATTACHED_CLASS = 'onto-loader-attached';
   private readonly rawSvg = atob(loaderSvg.split(',')[1]);
+  private readonly logger = LoggerProvider.logger;
+
+  componentDidLoad() {
+    this.attachToSelector();
+  }
 
   render() {
     return (
-      <Host>
+      <Host class={{[this.ATTACHED_CLASS]: !!this.targetSelector}}>
         <div class="onto-loader" guide-selector="onto-loader">
           <div class="loader-spinner" style={{'width': this.size + 'px', 'height': this.size + 'px'}} innerHTML={this.rawSvg}></div>
           {this.messageText && <div class="loader-message" style={{'font-size': (this.size / 4) + 'px'}}>{this.messageText}</div>}
         </div>
       </Host>
     );
+  }
+
+  private attachToSelector() {
+    if (!this.targetSelector) {
+      return;
+    }
+
+    const target = document.querySelector<HTMLElement>(this.targetSelector);
+    if (!target) {
+      this.logger.warn('You tried to attach the loader to an element that does not exist: ', this.targetSelector);
+      this.loader.classList.remove(this.ATTACHED_CLASS);
+      return;
+    }
+
+    target.appendChild(this.loader);
   }
 }

--- a/packages/shared-components/src/components/onto-loader/readme.md
+++ b/packages/shared-components/src/components/onto-loader/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                        | Type     | Default |
-| ------------- | -------------- | -------------------------------------------------- | -------- | ------- |
-| `messageText` | `message-text` | Optional message text to display below the loader. | `string` | `''`    |
-| `size`        | `size`         | Size of the loader in pixels (width and height).   | `number` | `100`   |
+| Property         | Attribute         | Description                                                                  | Type     | Default |
+| ---------------- | ----------------- | ---------------------------------------------------------------------------- | -------- | ------- |
+| `messageText`    | `message-text`    | Optional message text to display below the loader.                           | `string` | `''`    |
+| `size`           | `size`            | Size of the loader in pixels (width and height).                             | `number` | `100`   |
+| `targetSelector` | `target-selector` | CSS selector of a DOM element to attach the loader to as a centered overlay. | `string` | `''`    |
 
 
 ## Dependencies

--- a/packages/shared-components/src/components/onto-tooltip/readme.md
+++ b/packages/shared-components/src/components/onto-tooltip/readme.md
@@ -5,19 +5,6 @@
 <!-- Auto Generated Below -->
 
 
-## Dependencies
-
-### Used by
-
- - [onto-layout](../onto-layout)
-
-### Graph
-```mermaid
-graph TD;
-  onto-layout --> onto-tooltip
-  style onto-tooltip fill:#f9f,stroke:#333,stroke-width:4px
-```
-
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION
## What
Add target selector to `onto-loader` component.

## Why
To decouple the loader from the layout and simplify the layout altogether

## How
- Introduced a new `targetSelector` property in `onto-loader` to specify the DOM element for attachment.
- Attached the loader to the `main` element
- Removed the main slot wrapper, the tooltip and the dialog from the layout to simplify them.
- Updated styles

## Testing
n/a

(cherry picked from commit 0d10504422da9b31ac80217939099a4618b6b12f)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
