### PR TITLE
GDB-14677 fix flaky repository test

### DIFF
--- a/e2e-tests/e2e-legacy/home/create-repository.spec.js
+++ b/e2e-tests/e2e-legacy/home/create-repository.spec.js
@@ -1,10 +1,16 @@
 import HomeSteps from '../../steps/home-steps';
+import {RepositoriesStubs} from "../../stubs/repositories/repositories-stubs.js";
 
 describe('Create repository', () => {
 
     beforeEach(() => {
         cy.viewport(1280, 1000);
         HomeSteps.visitAndWaitLoader();
+        RepositoriesStubs.spyGetRepositories();
+        cy.wait('@getRepositories');
+        // Due to the ongoing migration, there are currently 2 requests to get repositories on init (one from the legacy and one from the new workbench).
+        // This will be removed once migration is complete (or at least the repository part of it)
+        cy.wait('@getRepositories');
     });
 
     it('Test create and select new repository via home page', () => {

--- a/e2e-tests/steps/home-steps.js
+++ b/e2e-tests/steps/home-steps.js
@@ -200,13 +200,10 @@ class HomeSteps extends BaseSteps {
     }
 
     static verifyCreateRepositoryLink() {
-        cy.get('.card.repository-errors').should('be.visible')
-            .within(() => {
-                HomeSteps.getCreateRepositoryLink()
-                    .click()
-                    .url()
-                    .should('eq', Cypress.config('baseUrl') + '/repository/create?previous=%2F');
-            });
+        HomeSteps.getCreateRepositoryLink()
+            .click()
+            .url()
+            .should('eq', Cypress.config('baseUrl') + '/repository/create?previous=%2F');
         cy.get('.big-logo').click();
     }
 


### PR DESCRIPTION
## What
Fix flaky repository test in `create-repository.spec.js`.

## Why
The test was failing, because cypress couldn't find the create repository button on the homepage

## How
Added a spy to the repositories requests and ensured they are awaited, before we continue with the test. Also removed the assertion that the button should be within the `repository-errors` component

## Testing
cypress

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified
