### PR TITLE
Introduce a script for linking/unlinking the graphwise-styleguide for easier testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
         "prepare": "husky",
         "instrument:legacy-workbench": "npx nyc instrument --in-place --compact false --source-map --produce-source-map packages/legacy-workbench/src/js/angular",
         "watch:plugins": "nodemon --watch ../graphdb-workbench-plugins/dist --ext js,json --exec \"npm run copy-plugins\"",
-        "dev:with-plugins": "concurrently \"npm run start\" \"npm run watch:plugins\""
+        "dev:with-plugins": "concurrently \"npm run start\" \"npm run watch:plugins\"",
+        "link:styleguide": "node scripts/link-styleguide.js",
+        "unlink:styleguide": "node scripts/unlink-styleguide.js",
+        "dev:styleguide": "npm run link:styleguide && npm run start"
     },
     "files": [
         "dist/"

--- a/scripts/link-styleguide.js
+++ b/scripts/link-styleguide.js
@@ -1,0 +1,53 @@
+// Links the graphwise-styleguide project locally in the root-config module.
+// This allows you to test changes in the styleguide without needing to publish it.
+
+// Default styleguide path is resolved as a sibling directory named "graphwise-styleguide".
+// Can be overridden via STYLEGUIDE_PATH env var or CLI arg.
+
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const WORKBENCH_ROOT = path.resolve(__dirname, '..');
+const DEFAULT_STYLEGUIDE_PATH = path.resolve(WORKBENCH_ROOT, '../graphwise-styleguide');
+
+const STYLEGUIDE_PATH =
+  process.argv[2] ||
+  process.env.STYLEGUIDE_PATH ||
+  DEFAULT_STYLEGUIDE_PATH;
+
+if (!fs.existsSync(STYLEGUIDE_PATH) || !fs.statSync(STYLEGUIDE_PATH).isDirectory()) {
+  console.error(`\n[ERROR] Styleguide directory not found: ${STYLEGUIDE_PATH}`);
+  console.error('Pass the path as a CLI arg or set the STYLEGUIDE_PATH env var.\n');
+  process.exit(1);
+}
+
+const ROOT_CONFIG_PATH = path.resolve(__dirname, '../packages/root-config');
+const BRANCH = process.env.STYLEGUIDE_BRANCH || 'gw-theme';
+
+if (!/^[0-9A-Za-z._/-]+$/.test(BRANCH)) {
+  console.error(`\n[ERROR] Invalid STYLEGUIDE_BRANCH value: ${BRANCH}`);
+  process.exit(1);
+}
+function run(cmd, cwd = process.cwd()) {
+  console.log(`\n> ${cmd}  (in ${cwd})`);
+  execSync(cmd, { cwd, stdio: 'inherit' });
+}
+
+console.log(`\n=== Styleguide path: ${STYLEGUIDE_PATH} ===`);
+
+// 1. Pull latest from the branch
+run(`git fetch origin`, STYLEGUIDE_PATH);
+run(`git checkout ${BRANCH}`, STYLEGUIDE_PATH);
+run(`git pull origin ${BRANCH}`, STYLEGUIDE_PATH);
+
+// 2. Build
+run(`npm run build`, STYLEGUIDE_PATH);
+
+// 3. Register the global npm link
+run(`npm link`, STYLEGUIDE_PATH);
+
+// 4. Link into root-config
+run(`npm link graphwise-styleguide`, ROOT_CONFIG_PATH);
+
+console.log('\n=== Done. You can now run: npm run start ===\n');

--- a/scripts/unlink-styleguide.js
+++ b/scripts/unlink-styleguide.js
@@ -1,0 +1,20 @@
+// Removes the npm link for graphwise-styleguide in packages/root-config
+// and restores the published version from the registry.
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+const ROOT_CONFIG_PATH = path.resolve(__dirname, '../packages/root-config');
+
+function run(cmd, cwd = process.cwd()) {
+  console.log(`\n> ${cmd}  (in ${cwd})`);
+  execSync(cmd, { cwd, stdio: 'inherit' });
+}
+
+// 1. Unlink (removes the symlink)
+run(`npm unlink --no-save graphwise-styleguide`, ROOT_CONFIG_PATH);
+
+// 2. Reinstall the published version declared in package.json
+run(`npm ci`, ROOT_CONFIG_PATH);
+
+console.log('\n=== graphwise-styleguide restored to published version ===\n');


### PR DESCRIPTION
## What
Added two developer scripts — scripts/link-styleguide.js and scripts/unlink-styleguide.js, and corresponding npm commands (link:styleguide, unlink:styleguide, dev:styleguide) to the root package.json.

## Why
Testing local changes to the graphwise-styleguide package required a repetitive multi-step manual process: switching branches, pulling, building, running npm link in the styleguide repo, then npm link graphwise-styleguide in packages/root-config. There was no single command to set up or tear down this local override.

## How
link-styleguide.js automates the full setup: resolves the styleguide directory as a sibling of the workbench repo (overridable via CLI arg or STYLEGUIDE_PATH env var), checks out and pulls the target branch (gw-theme by default, overridable via STYLEGUIDE_BRANCH), runs npm run build, registers the global npm link, and links it into packages/root-config. Fails fast with a clear error if the styleguide directory is not found.
unlink-styleguide.js reverses the process: runs npm unlink --no-save graphwise-styleguide in packages/root-config and follows up with npm install to restore the published registry version.
Three npm script aliases are added to the root package.json: link:styleguide, unlink:styleguide, and dev:styleguide (link + start in one command).

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
