### PR TITLE
Cherry-pick GDB-14713: Show full title of SPARQL saved queries on hover

### DIFF
--- a/packages/legacy-workbench/package-lock.json
+++ b/packages/legacy-workbench/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
                 "ontotext-graphql-playground-component": "^0.0.9",
-                "ontotext-yasgui-web-component": "^1.6.4",
+                "ontotext-yasgui-web-component": "^1.6.5",
                 "single-spa-angularjs": "^4.3.1"
             },
             "devDependencies": {
@@ -5644,9 +5644,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.4.tgz",
-            "integrity": "sha512-9HLFkBSFyOFk3mO7eHawEP/Gi200iQTt5zDjaMrVtFjkIriq1mB5O64y70kusMgU5H8AIXClsd5eXoO9EIBVfw==",
+            "version": "1.6.5",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.5.tgz",
+            "integrity": "sha512-Cdc2jcAYMco1RX1mNSyFALigf8mP+4CcwJnBjCqx+BmF8S90U9lUUSWEwKSvutM5ow+AgfZgH9In2ijyJ/BjsQ==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.7.4",

--- a/packages/legacy-workbench/package.json
+++ b/packages/legacy-workbench/package.json
@@ -76,7 +76,7 @@
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
         "ontotext-graphql-playground-component": "^0.0.9",
-        "ontotext-yasgui-web-component": "^1.6.4",
+        "ontotext-yasgui-web-component": "^1.6.5",
         "single-spa-angularjs": "^4.3.1"
     },
     "resolutions": {

--- a/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
+++ b/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
@@ -975,6 +975,8 @@ yasgui-component .yasr .explain-plan-copy-btn {
     }
 }
 
+.yasgui-floating-tooltip,
+.yasgui-floating-tooltip-arrow,
 .ontotext-yasgui-tooltip .tooltip-box {
     background-color: var(--gw-tooltip-background);
     color: var(--gw-tooltip-color);

--- a/packages/workbench/package-lock.json
+++ b/packages/workbench/package-lock.json
@@ -20,7 +20,7 @@
         "@jsverse/transloco-messageformat": "^8.3.0",
         "@primeuix/themes": "^2.0.3",
         "file-saver": "^2.0.5",
-        "ontotext-yasgui-web-component": "^1.6.4",
+        "ontotext-yasgui-web-component": "^1.6.5",
         "primeng": "^20.4.0",
         "rxjs": "~7.8.2",
         "single-spa": "^6.0.3",
@@ -16391,9 +16391,9 @@
       }
     },
     "node_modules/ontotext-yasgui-web-component": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.4.tgz",
-      "integrity": "sha512-9HLFkBSFyOFk3mO7eHawEP/Gi200iQTt5zDjaMrVtFjkIriq1mB5O64y70kusMgU5H8AIXClsd5eXoO9EIBVfw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.5.tgz",
+      "integrity": "sha512-Cdc2jcAYMco1RX1mNSyFALigf8mP+4CcwJnBjCqx+BmF8S90U9lUUSWEwKSvutM5ow+AgfZgH9In2ijyJ/BjsQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -28,7 +28,7 @@
     "@jsverse/transloco-messageformat": "^8.3.0",
     "@primeuix/themes": "^2.0.3",
     "file-saver": "^2.0.5",
-    "ontotext-yasgui-web-component": "^1.6.4",
+    "ontotext-yasgui-web-component": "^1.6.5",
     "primeng": "^20.4.0",
     "rxjs": "~7.8.2",
     "single-spa": "^6.0.3",

--- a/packages/workbench/src/app/components/yasgui-component-facade/models/yasgui/ontotext-yasgui-config.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/models/yasgui/ontotext-yasgui-config.ts
@@ -183,7 +183,7 @@ export class OntotextYasguiConfig {
    * The values of the array have to be {@link YasrPluginName} options.
    * For example: ["extended_table", "response"]
    */
-  public pluginOrder: YasrPluginName[];
+  public pluginOrder?: YasrPluginName[];
   /**
    * An object containing the configuration for each plugin.
    */
@@ -307,7 +307,7 @@ export class OntotextYasguiConfig {
     this.populateFromUrl = false;
     this.prefixes = undefined;
     this.defaultPlugin = YasrPluginName.EXTENDED_TABLE;
-    this.pluginOrder = [YasrPluginName.EXTENDED_TABLE, YasrPluginName.RAW_RESPONSE];
+    this.pluginOrder = undefined;
     this.pluginsConfigurations = undefined;
     this.pageSize = 1000;
     this.paginationOn = true;

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
@@ -941,6 +941,8 @@ app-yasgui-component-facade .hidden {
   }
 }
 
+.yasgui-floating-tooltip,
+.yasgui-floating-tooltip-arrow,
 .ontotext-yasgui-tooltip .tooltip-box {
   background-color: var(--gw-tooltip-background);
   color: var(--gw-tooltip-color);


### PR DESCRIPTION
## What
- Added a tooltip for saved queries.
- Fixed incorrect positioning of the saved queries popup when the page is scrolled.

## Why
- Long saved query names are truncated, preventing users from seeing the full query name.
- The popup position was calculated using viewport coordinates returned by `getBoundingClientRect()`, while the popup itself is positioned using `position: absolute`. As a result, the popup was rendered at an incorrect location after the page was scrolled.

## How
Bump ontotext-yasgui-web-component version

(cherry picked from commit dcaaad66ddbcd7eec3c91de991da6a2eb9f15552)

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
