### PR TITLE
GDB-14762: Fix query abort handling

### DIFF
--- a/packages/workbench/src/app/components/yasgui-component-facade/models/event/count-query-request-event.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/models/event/count-query-request-event.ts
@@ -1,29 +1,31 @@
 import {EventDataType} from './event-data-type';
-import {OntotextYasguiEvent} from './ontotext-yasgui-event';
 import {QueryRequest} from '../query-request';
+import {CountQueryRequestEventPayload} from './event-payload';
 
 /**
  * Model for event of type {@link EventDataType.COUNT_QUERY} emitted by "ontotext-yasgui-web-component".
  */
 export class CountQueryRequestEvent {
   public type = EventDataType.COUNT_QUERY as const;
-  public query: string | undefined;
-  public queryMode: string | undefined;
-  public queryType: string | undefined;
-  public pageSize: number | undefined;
+  public query: string;
+  public queryMode: string;
+  public queryType: string;
+  public pageSize: number;
   public request: QueryRequest;
 
   /**
    * Constructs the model for {@link EventDataType.DOWNLOAD_AS} event.
    *
-   * @param eventData - event emitted by "ontotext-yasgui-web-component".
+   * @param eventPayload - event payload emitted by "ontotext-yasgui-web-component" when coun query is executed.
+   * The count query is executed to retrieve the total number of results when the actual result set contains more
+   * results than those currently displayed in YASR.
    */
-  constructor(eventData: OntotextYasguiEvent) {
-    this.query = eventData.detail.payload.query;
-    this.queryMode = eventData.detail.payload.queryMode;
-    this.queryType = eventData.detail.payload.queryType;
-    this.pageSize = eventData.detail.payload.pageSize;
-    this.request = eventData.detail.payload.request;
+  constructor(eventPayload: CountQueryRequestEventPayload) {
+    this.query = eventPayload.query;
+    this.queryMode = eventPayload.queryMode;
+    this.queryType = eventPayload.queryType;
+    this.pageSize = eventPayload.pageSize;
+    this.request = eventPayload.request;
   }
 
   setPageSize(pageSize?: string) {

--- a/packages/workbench/src/app/components/yasgui-component-facade/models/event/count-query-response-event.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/models/event/count-query-response-event.ts
@@ -1,6 +1,6 @@
 import {EventDataType} from './event-data-type';
 import {NumericHolder, QueryResponse, QueryResponseData, TextArrayResponse} from '../query-response';
-import {OntotextYasguiEvent} from './ontotext-yasgui-event';
+import {CountQueryResponseEventPayload} from './event-payload';
 
 /**
  * Model for event of type {@link EventDataType.COUNT_QUERY_RESPONSE} emitted by "ontotext-yasgui-web-component".
@@ -12,10 +12,11 @@ export class CountQueryResponseEvent {
   /**
    * Constructs the model for {@link EventDataType.COUNT_QUERY_RESPONSE} event.
    *
-   * @param eventData - event emitted by "ontotext-yasgui-web-component".
+   * @param eventPayload - event payload emitted by "ontotext-yasgui-web-component" when a count query has been exected.
+   * It holds the response of the count query, which must be processed to extract the total number of results.
    */
-  constructor(eventData: OntotextYasguiEvent) {
-    this.response = eventData.detail.payload.response ?? {} as QueryResponse;
+  constructor(eventPayload: CountQueryResponseEventPayload) {
+    this.response = eventPayload.response ?? {} as QueryResponse;
   }
 
   hasResponse() {

--- a/packages/workbench/src/app/components/yasgui-component-facade/models/event/download-as-event.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/models/event/download-as-event.ts
@@ -1,27 +1,27 @@
 import {EventDataType} from './event-data-type';
-import {OntotextYasguiEvent} from './ontotext-yasgui-event';
+import {DownloadAsEventPayload} from './event-payload';
 
 /**
  * Model for event of type {@link EventDataType.DOWNLOAD_AS} emitted by "ontotext-yasgui-web-component".
  */
 export class DownloadAsEvent {
   public readonly type = EventDataType.DOWNLOAD_AS as const;
-  public contentType: string | undefined;
-  public pluginName: string | undefined;
-  public query: string | undefined;
-  public infer: boolean | undefined;
-  public sameAs: boolean | undefined;
+  public contentType: string;
+  public pluginName: string;
+  public query: string;
+  public infer: boolean;
+  public sameAs: boolean;
 
   /**
    * Constructs the model for {@link EventDataType.DOWNLOAD_AS} event.
    *
-   * @param eventData - event emitted by "ontotext-yasgui-web-component".
+   * @param eventPayload - event payload emitted by "ontotext-yasgui-web-component" when the DownloadAs button is clicked.
    */
-  constructor(eventData: OntotextYasguiEvent) {
-    this.contentType = eventData.detail.payload.value;
-    this.pluginName = eventData.detail.payload.pluginName;
-    this.query = eventData.detail.payload.query;
-    this.infer = eventData.detail.payload.infer;
-    this.sameAs = eventData.detail.payload.sameAs;
+  constructor(eventPayload: DownloadAsEventPayload) {
+    this.contentType = eventPayload.value;
+    this.pluginName = eventPayload.pluginName;
+    this.query = eventPayload.query;
+    this.infer = eventPayload.infer;
+    this.sameAs = eventPayload.sameAs;
   }
 }

--- a/packages/workbench/src/app/components/yasgui-component-facade/models/event/event-payload.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/models/event/event-payload.ts
@@ -1,29 +1,101 @@
-import {QueryResponse} from '../query-response';
-import {QueryRequest} from '../query-request';
-import {Tab} from '../yasgui/yasgui';
-import {RequestAbortedRequest} from '../request-aborted-request';
+import { Tab } from '../yasgui/yasgui';
+import { QueryRequest } from '../query-request';
+import { QueryResponse } from '../query-response';
+
 /**
- * The payload of an event emitted by the YasguiComponentFacade.
+ * Represents the payload of an event emitted by the YasguiComponentFacade.
  */
-export class EventPayload {
-  constructor(
-    public duration: number,
-    public tabId: string,
-    public request: QueryRequest,
-    public queryMode: string,
-    public value?: string,
-    public pluginName?: string,
-    public query?: string,
-    public infer?: boolean,
-    public sameAs?: boolean,
-    public message?: string,
-    public code?: string,
-    public messageType?: string,
-    public queryType?: string,
-    public tab?: Tab,
-    public pageSize?: number,
-    public response?: QueryResponse,
-    public requestAbortedRequest?: RequestAbortedRequest,
-  ) {
-  }
+export interface EventPayload {}
+
+/**
+ * Represents the payload of an event emitted by "ontotext-yasgui-web-component"
+ * when the Abort Query button is clicked.
+ */
+export interface RequestAbortedEventPayload extends EventPayload {
+  request: {
+    headers: Record<string, string>;
+    url: string;
+    queryType: string;
+  };
+  queryMode: string;
+}
+
+/**
+ * Represents the payload of an event of type {@link EventDataType.SAVE_QUERY_OPENED}
+ * emitted by "ontotext-yasgui-web-component" when a saved query is opened in a tab.
+ */
+export interface SaveQueryOpenedEventPayload extends EventPayload {
+  tab: Tab;
+}
+
+/**
+ * Represents the payload of an event of type {@link EventDataType.QUERY_EXECUTED}
+ * emitted by "ontotext-yasgui-web-component" when a query is executed.
+ */
+export interface QueryExecutedEventPayload extends EventPayload {
+  duration: number;
+  tabId: string;
+}
+
+/**
+ * Represents the payload of an event of type {@link EventDataType.QUERY}
+ * emitted by "ontotext-yasgui-web-component" when a query is executed.
+ *
+ * Holds the request, which must be updated with additional information such as
+ * the repository ID and location.
+ */
+export interface QueryRequestEventPayload extends EventPayload {
+  query: string;
+  queryMode: string;
+  queryType: string;
+  pageSize: number;
+  request: QueryRequest;
+}
+
+/**
+ * Represents the payload of an event of type {@link EventDataType.COUNT_QUERY_RESPONSE}
+ * emitted by "ontotext-yasgui-web-component" when a count query has been executed.
+ *
+ * Holds the response of the count query, which must be processed to extract
+ * the total number of results.
+ */
+export interface CountQueryResponseEventPayload extends EventPayload {
+  response: QueryResponse;
+}
+
+/**
+ * Represents the payload of an event of type {@link EventDataType.COUNT_QUERY}
+ * emitted by "ontotext-yasgui-web-component" when a count query is executed.
+ *
+ * The count query is executed to retrieve the total number of results when the
+ * actual result set contains more results than those currently displayed in YASR.
+ */
+export interface CountQueryRequestEventPayload extends EventPayload {
+  query: string;
+  queryMode: string;
+  queryType: string;
+  pageSize: number;
+  request: QueryRequest;
+}
+
+/**
+ * Represents the payload of an event of type {@link EventDataType.NOTIFICATION_MESSAGE}
+ * emitted by "ontotext-yasgui-web-component" when a notification message needs to be displayed.
+ */
+export interface NotificationMessageEventPayload extends EventPayload {
+  message: string;
+  code: string;
+  messageType: string;
+}
+
+/**
+ * Represents the payload of an event of type {@link EventDataType.DOWNLOAD_AS}
+ * emitted by "ontotext-yasgui-web-component" when the Download As button is clicked.
+ */
+export interface DownloadAsEventPayload extends EventPayload {
+  value: string;
+  pluginName: string;
+  query: string;
+  infer: boolean;
+  sameAs: boolean;
 }

--- a/packages/workbench/src/app/components/yasgui-component-facade/models/event/notification-message-event.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/models/event/notification-message-event.ts
@@ -1,23 +1,23 @@
 import {EventDataType} from './event-data-type';
-import {OntotextYasguiEvent} from './ontotext-yasgui-event';
+import {NotificationMessageEventPayload} from './event-payload';
 
 /**
  * Model for event of type {@link EventDataType.NOTIFICATION_MESSAGE} emitted by "ontotext-yasgui-web-component".
  */
 export class NotificationMessageEvent {
   public type = EventDataType.NOTIFICATION_MESSAGE as const;
-  public message: string | undefined;
-  public code: string | undefined;
-  public messageType: string | undefined;
+  public message: string;
+  public code: string;
+  public messageType: string;
 
   /**
    * Constructs the model for {@link EventDataType.NOTIFICATION_MESSAGE} event.
    *
-   * @param eventData - event emitted by "ontotext-yasgui-web-component".
+   * @param eventPayload - event payload emitted by "ontotext-yasgui-web-component" when a notification message is need to be displayed.
    */
-  constructor(eventData: OntotextYasguiEvent) {
-    this.message = eventData.detail.payload.message;
-    this.code = eventData.detail.payload.code;
-    this.messageType = eventData.detail.payload.messageType;
+  constructor(eventPayload: NotificationMessageEventPayload) {
+    this.message = eventPayload.message;
+    this.code = eventPayload.code;
+    this.messageType = eventPayload.messageType;
   }
 }

--- a/packages/workbench/src/app/components/yasgui-component-facade/models/event/query-executed-event.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/models/event/query-executed-event.ts
@@ -1,5 +1,5 @@
-import {OntotextYasguiEvent} from './ontotext-yasgui-event';
 import {EventDataType} from './event-data-type';
+import {QueryExecutedEventPayload} from './event-payload';
 
 /**
  * Model for event of type {@link EventDataType.QUERY_EXECUTED} emitted by "ontotext-yasgui-web-component".
@@ -12,10 +12,10 @@ export class QueryExecutedEvent {
   /**
    * Constructs the model for {@link EventDataType.QUERY_EXECUTED} event.
    *
-   * @param eventData - event emitted by "ontotext-yasgui-web-component".
+   * @param eventPayload - event payload emitted by "ontotext-yasgui-web-component" when a query is executed.
    */
-  constructor(eventData: OntotextYasguiEvent) {
-    this.duration = eventData.detail.payload.duration;
-    this.tabId = eventData.detail.payload.tabId;
+  constructor(eventPayload: QueryExecutedEventPayload) {
+    this.duration = eventPayload.duration;
+    this.tabId = eventPayload.tabId;
   }
 }

--- a/packages/workbench/src/app/components/yasgui-component-facade/models/event/query-request-event.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/models/event/query-request-event.ts
@@ -1,29 +1,30 @@
 import {EventDataType} from './event-data-type';
 import {QueryRequest} from '../query-request';
-import {OntotextYasguiEvent} from './ontotext-yasgui-event';
+import {QueryRequestEventPayload} from './event-payload';
 
 /**
  * Model for event of type {@link EventDataType.QUERY} emitted by "ontotext-yasgui-web-component".
  */
 export class QueryRequestEvent {
   public type = EventDataType.QUERY as const;
-  public query: string | undefined;
+  public query: string;
   public queryMode: string;
-  public queryType: string | undefined;
-  public pageSize: number | undefined;
+  public queryType: string;
+  public pageSize: number;
   public request: QueryRequest;
 
   /**
    * Constructs the model for {@link EventDataType.QUERY} event.
    *
-   * @param eventData - event emitted by "ontotext-yasgui-web-component".
+   * @param eventPayload - event payload emitted by "ontotext-yasgui-web-component" when a qeury is executed.
+   * Holds the request, which must be updated with additional information such as the repository ID and location.
    */
-  constructor(eventData: OntotextYasguiEvent) {
-    this.query = eventData.detail.payload.query;
-    this.queryMode = eventData.detail.payload.queryMode;
-    this.queryType = eventData.detail.payload.queryType;
-    this.pageSize = eventData.detail.payload.pageSize;
-    this.request = eventData.detail.payload.request;
+  constructor(eventPayload: QueryRequestEventPayload) {
+    this.query = eventPayload.query;
+    this.queryMode = eventPayload.queryMode;
+    this.queryType = eventPayload.queryType;
+    this.pageSize = eventPayload.pageSize;
+    this.request = eventPayload.request;
   }
 
   setPageSize(pageSize?: string) {

--- a/packages/workbench/src/app/components/yasgui-component-facade/models/event/request-aborted-event.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/models/event/request-aborted-event.ts
@@ -1,6 +1,6 @@
-import {OntotextYasguiEvent} from './ontotext-yasgui-event';
 import {RequestAbortedRequest} from '../request-aborted-request';
 import {EventDataType} from './event-data-type';
+import {RequestAbortedEventPayload} from './event-payload';
 
 /**
  * Model for event of type {@link EventDataType.REQUEST_ABORTED} emitted by "ontotext-yasgui-web-component".
@@ -13,11 +13,11 @@ export class RequestAbortedEvent {
   /**
    * Constructs the model for {@link EventDataType.REQUEST_ABORTED} event.
    *
-   * @param eventData - event emitted by "ontotext-yasgui-web-component".
+   * @param eventPayload - event payload emitted by "ontotext-yasgui-web-component" when the Abort query button is clicked.
    */
-  constructor(eventData: OntotextYasguiEvent) {
-    this.request = eventData.detail.payload.requestAbortedRequest!;
-    this.queryMode = eventData.detail.payload.queryMode;
+  constructor(eventPayload: RequestAbortedEventPayload) {
+    this.request = eventPayload.request;
+    this.queryMode = eventPayload.queryMode;
   }
 
   getQueryTrackAlias() {

--- a/packages/workbench/src/app/components/yasgui-component-facade/models/event/save-query-opened.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/models/event/save-query-opened.ts
@@ -1,13 +1,21 @@
 import {Tab} from '../yasgui/yasgui';
-import {OntotextYasguiEvent} from './ontotext-yasgui-event';
 import {EventDataType} from './event-data-type';
+import {SaveQueryOpenedEventPayload} from './event-payload';
 
+/**
+ * Model for event of type {@link EventDataType.SAVE_QUERY_OPENED} emitted by "ontotext-yasgui-web-component".
+ */
 export class SaveQueryOpened {
   public type = EventDataType.SAVE_QUERY_OPENED as const;
   public tab: Tab;
 
-  constructor(eventData: OntotextYasguiEvent) {
-    this.tab = eventData.detail.payload.tab!;
+  /**
+   * Constructs the model for {@link EventDataType.SAVE_QUERY_OPENED} event.
+   *
+   * @param eventPayload - event payload emitted by "ontotext-yasgui-web-component" when a saved query is opened in a tab.
+   */
+  constructor(eventPayload: SaveQueryOpenedEventPayload) {
+    this.tab = eventPayload.tab;
   }
 
   getTab() {

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.ts
@@ -69,6 +69,13 @@ import {LoggerProvider} from '../../services/logger/logger-provider';
 import {DownloadSettingsDialogComponent} from '../download-settings-dialog/download-settings-dialog.component';
 import {DialogProviderService} from '../../services/dialog/dialog-provider.service';
 import {DownloadSettingsDialogFooterComponent} from '../download-settings-dialog/footer/download-settings-dialog-footer/download-settings-dialog-footer.component';
+import {
+  CountQueryRequestEventPayload,
+  CountQueryResponseEventPayload, DownloadAsEventPayload, NotificationMessageEventPayload,
+  QueryExecutedEventPayload, QueryRequestEventPayload,
+  RequestAbortedEventPayload,
+  SaveQueryOpenedEventPayload
+} from './models/event/event-payload';
 
 defineCustomElements();
 
@@ -364,7 +371,7 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
    * @param event The event payload containing the data of the saved query.
    */
   saveQueryOpened(event: Event) {
-    const saveQueryOpenedEvent = this.toYasguiOutputModel(event) as SaveQueryOpened;
+    const saveQueryOpenedEvent = this.toYasguiOutputModel(event as OntotextYasguiEvent) as SaveQueryOpened;
     YasguiComponentUtil.highlightTabName(saveQueryOpenedEvent.getTab());
   }
 
@@ -374,7 +381,7 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
    * @param event - the event fired from ontotext-yasgui component
    */
   output(event: Event) {
-    const outputModel = this.toYasguiOutputModel(event);
+    const outputModel = this.toYasguiOutputModel(event as OntotextYasguiEvent);
     const handlers = this.outputHandlers();
     this.callOutputEventHandler(handlers, outputModel.type, outputModel);
   }
@@ -731,12 +738,12 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
       this.getOntotextYasguiComponent().getEmbeddedResultAsJson()
         .then((response) => {
           const content = JSON.stringify(response, null, '\t');
-          FileUtils.downloadAsFile(`${this.getFileTimePrefix()}_queryResults.json`, downloadAsEvent.contentType!, content);
+          FileUtils.downloadAsFile(`${this.getFileTimePrefix()}_queryResults.json`, downloadAsEvent.contentType, content);
         });
     } else if ('text/csv' === downloadAsEvent.contentType) {
       this.getOntotextYasguiComponent().getEmbeddedResultAsCSV()
         .then((response) => {
-          FileUtils.downloadAsFile(`${this.getFileTimePrefix()}_queryResults.csv`, downloadAsEvent.contentType!, response as string);
+          FileUtils.downloadAsFile(`${this.getFileTimePrefix()}_queryResults.csv`, downloadAsEvent.contentType, response as string);
         });
     }
   }
@@ -747,10 +754,10 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
    * and other necessary data for the download.
    */
   private downloadThroughServer(downloadAsEvent: DownloadAsEvent) {
-    const query = downloadAsEvent.query!;
-    const infer = downloadAsEvent.infer!;
-    const sameAs = downloadAsEvent.sameAs!;
-    const accept = downloadAsEvent.contentType!;
+    const query = downloadAsEvent.query;
+    const infer = downloadAsEvent.infer;
+    const sameAs = downloadAsEvent.sameAs;
+    const accept = downloadAsEvent.contentType;
     const authToken = this.authenticationStorageService.getAuthToken().getValue()!;
 
     if (downloadAsEvent.contentType === 'application/ld+json' || downloadAsEvent.contentType === 'application/x-ld+ndjson') {
@@ -863,29 +870,28 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
     return url.toString();
   }
 
-  private toYasguiOutputModel(event: Event): YasguiOutputEvent {
-    const eventData = event as unknown as OntotextYasguiEvent;
-    switch (eventData.detail.TYPE) {
+  private toYasguiOutputModel(event: OntotextYasguiEvent): YasguiOutputEvent {
+    switch (event.detail.TYPE) {
     case EventDataType.DOWNLOAD_AS:
-      return new DownloadAsEvent(eventData);
+      return new DownloadAsEvent(event.detail.payload as DownloadAsEventPayload);
     case EventDataType.NOTIFICATION_MESSAGE:
-      return new NotificationMessageEvent(eventData);
+      return new NotificationMessageEvent(event.detail.payload as NotificationMessageEventPayload);
     case EventDataType.COUNT_QUERY:
-      return new CountQueryRequestEvent(eventData);
+      return new CountQueryRequestEvent(event.detail.payload as CountQueryRequestEventPayload);
     case EventDataType.COUNT_QUERY_RESPONSE:
-      return new CountQueryResponseEvent(eventData);
+      return new CountQueryResponseEvent(event.detail.payload as CountQueryResponseEventPayload);
     case EventDataType.QUERY:
-      return new QueryRequestEvent(eventData);
+      return new QueryRequestEvent(event.detail.payload as QueryRequestEventPayload);
     case EventDataType.QUERY_EXECUTED:
-      return new QueryExecutedEvent(eventData);
+      return new QueryExecutedEvent(event.detail.payload as QueryExecutedEventPayload);
     case EventDataType.SAVE_QUERY_OPENED:
-      return new SaveQueryOpened(eventData);
+      return new SaveQueryOpened(event.detail.payload as SaveQueryOpenedEventPayload);
     case EventDataType.REQUEST_ABORTED:
-      return new RequestAbortedEvent(eventData);
+      return new RequestAbortedEvent(event.detail.payload as RequestAbortedEventPayload);
     default: {
       // This branch should never be reached if EventDataType is exhaustive.
       // The cast to never forces a compile error if a new enum value is added without a matching case.
-      const unhandled = eventData.detail.TYPE;
+      const unhandled = event.detail.TYPE;
       throw new Error(`Unhandled yasgui event type: ${unhandled}`);
     }
     }


### PR DESCRIPTION
## What
When a long-running query is executing, several user actions trigger a confirmation dialog warning about the running query. However, after the user confirms the action, the running query is not aborted as expected.

## Why
The RequestAbortedEvent object was initialized incorrectly.

## How
Fixed the initialization of the RequestAbortedEvent object.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
