### PR TITLE
GDB-14762: Fix query abort handling

### DIFF
--- a/e2e-tests/e2e-legacy/monitor/global-operation-statuses-component.spec.js
+++ b/e2e-tests/e2e-legacy/monitor/global-operation-statuses-component.spec.js
@@ -2,7 +2,6 @@ import HomeSteps from "../../steps/home-steps";
 import {OperationsStatusesComponentSteps} from "../../steps/operations-statuses-component-steps";
 import {GlobalOperationsStatusesStub} from "../../stubs/global-operations-statuses-stub";
 import {ImportUserDataSteps} from "../../steps/import/import-user-data-steps";
-import {BrowserStubs} from "../../stubs/browser-stubs";
 
 describe('Operations Status Component', () => {
 
@@ -141,8 +140,8 @@ describe('Operations Status Component', () => {
     });
 
     function checkOperationElementUrl(expectedUrl, operationIndex = 0) {
-        BrowserStubs.spyNavigateToUrl();
-        OperationsStatusesComponentSteps.getOperationStatuses().eq(operationIndex).click();
-        cy.get(BrowserStubs.NAVIGATE_TO_URL_ALIAS()).should('have.been.calledWithMatch', expectedUrl)
+        OperationsStatusesComponentSteps.getOperationStatuses().eq(operationIndex)
+            .should('have.attr', 'href', expectedUrl)
+            .should('have.attr', 'target', '_blank');
     }
 });

--- a/e2e-tests/e2e-legacy/sparql-editor/sparql-editor-navigation.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/sparql-editor-navigation.spec.js
@@ -1,0 +1,212 @@
+import {QueryStubs} from '../../stubs/yasgui/query-stubs.js';
+import {SparqlEditorSteps} from '../../steps/sparql-editor-steps.js';
+import {YasqeSteps} from '../../steps/yasgui/yasqe-steps.js';
+import ImportSteps from '../../steps/import/import-steps.js';
+import {MainMenuSteps} from '../../steps/main-menu-steps.js';
+import {ModalDialogSteps} from '../../steps/modal-dialog-steps.js';
+import {RepositorySelectorSteps} from '../../steps/repository-selector-steps.js';
+import {LanguageSelectorSteps} from '../../steps/language-selector-steps.js';
+import {UserAndAccessSteps} from '../../steps/setup/user-and-access-steps.js';
+import {LoginSteps} from '../../steps/login-steps.js';
+
+const LONG_RUNNING_QUERY_DELAY = 10000;
+
+describe('SPARQL Editor Navigation', () => {
+    let repositoryId;
+    let secondRepositoryId;
+    beforeEach(() => {
+        repositoryId = 'sparql-editor-' + Date.now();
+        QueryStubs.stubQueryCountResponse();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        QueryStubs.spyAbortQuery();
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+        if (secondRepositoryId) {
+            cy.deleteRepository(secondRepositoryId);
+        }
+    });
+
+    it('should navigate to other view if user confirmed navigation', () => {
+        // GIVEN: I visit a page with the ontotext-yasgui-web-component on it.
+        SparqlEditorSteps.visitSparqlEditorPage();
+        MainMenuSteps.getMainMenu().should('be.visible');
+
+        // WHEN: I try to go to another view
+        MainMenuSteps.clickOnMenuImport();
+        // THEN: I expect to navigate because there is no running query
+        ImportSteps.getView().should('exist');
+
+        // WHEN: I return to the view with the ontotext-yasgui-web-component.
+        SparqlEditorSteps.visitSparqlEditorPage();
+        // AND: I run a long-running query
+        QueryStubs.stubLongRunningQuery(repositoryId, LONG_RUNNING_QUERY_DELAY);
+        YasqeSteps.executeQueryWithoutWaiteResult();
+        // AND: I try to leave the page
+        MainMenuSteps.clickOnMenuImport();
+        // THEN: I expect to see a confirmation dialog
+        ModalDialogSteps.getDialog().should('exist');
+        ModalDialogSteps.getDialogBody().should('contain.text', 'You have running 1 query, that will be aborted.');
+
+        // WHEN: I cancel the dialog
+        ModalDialogSteps.cancel();
+        // THEN: I expect to stay on the same view
+        SparqlEditorSteps.verifyUrl();
+        ImportSteps.getView().should('not.exist');
+        // AND: I expect the query not to be aborted
+        cy.get('@abortQuery.all').should('have.length', 0);
+
+        // WHEN: I confirm leaving the page
+        MainMenuSteps.clickOnMenuImport();
+        ModalDialogSteps.getDialog().should('exist');
+        ModalDialogSteps.getDialogBody().should('contain.text', 'You have running 1 query, that will be aborted.');
+        ModalDialogSteps.confirm();
+        // THEN: I expect to navigate to the other view
+        ImportSteps.verifyUrl();
+        ImportSteps.getView().should('exist');
+        // AND: I expect the query to be aborted
+        cy.get('@abortQuery.all').should('have.length', 1);
+    });
+
+    it('should change active repository if user confirmed', () => {
+        // GIVEN: There are at least two repositories and one is selected
+        secondRepositoryId = 'sparql-editor-' + Date.now();
+        cy.createRepository({id: secondRepositoryId});
+
+        // WHEN: I visit a page with the ontotext-yasgui-web-component on it.
+        SparqlEditorSteps.visitSparqlEditorPage();
+        // AND: I change the repository
+        RepositorySelectorSteps.selectRepository(secondRepositoryId);
+        // THEN: I expect the repository to be changed without confirmation, because there are no running queries.
+        RepositorySelectorSteps.getSelectedRepository().should('contain', secondRepositoryId);
+
+        // WHEN: I run a long-running query
+        QueryStubs.stubLongRunningQuery(secondRepositoryId, LONG_RUNNING_QUERY_DELAY);
+        YasqeSteps.executeQueryWithoutWaiteResult();
+        // AND: I try to change the repository
+        RepositorySelectorSteps.selectRepository(repositoryId);
+        // THEN: I expect to see a confirmation dialog
+        ModalDialogSteps.getDialog().should('exist');
+        ModalDialogSteps.getDialogBody().should('contain.text', 'You have running 1 query, that will be aborted.');
+
+        // WHEN: I cancel the dialog
+        ModalDialogSteps.cancel();
+        // THEN: I expect the repository not to be changed.
+        RepositorySelectorSteps.getSelectedRepository().should('contain', secondRepositoryId);
+        // AND: I expect the query not to be aborted
+        cy.get('@abortQuery.all').should('have.length', 0);
+
+        // WHEN: I confirm changing of repository
+        RepositorySelectorSteps.selectRepository(repositoryId);
+        ModalDialogSteps.getDialog().should('exist');
+        ModalDialogSteps.getDialogBody().should('contain.text', 'You have running 1 query, that will be aborted.');
+        ModalDialogSteps.confirm();
+        // THEN: I expect the active repository to be changed
+        RepositorySelectorSteps.getSelectedRepository().should('contain', repositoryId);
+        // AND: I expect the query to be aborted
+        cy.get('@abortQuery.all').should('have.length', 1);
+    });
+
+    it('should change application language if user confirmed', () => {
+        // GIVEN: I visit a page with the ontotext-yasgui-web-component on it.
+        SparqlEditorSteps.visitSparqlEditorPage();
+        // Execute and wait for result give chance to application to be ready for the test, otherwise listeners are not
+        // attached and the test will fail
+        YasqeSteps.executeQuery();
+        LanguageSelectorSteps.getLanguageSelectorDropdownButton().should('contain', 'en');
+
+        // WHEN: I run a long-running query
+        QueryStubs.stubLongRunningQuery(repositoryId, LONG_RUNNING_QUERY_DELAY);
+        YasqeSteps.executeQueryWithoutWaiteResult();
+        // AND: I try to change the application language
+        LanguageSelectorSteps.switchToFr();
+        // THEN: I expect to see a confirmation dialog
+        ModalDialogSteps.getDialog().should('exist');
+        ModalDialogSteps.getDialogBody().should('contain.text', 'You have running 1 query, that will be aborted.');
+
+        // WHEN: I cancel the dialog
+        ModalDialogSteps.cancel();
+        // THEN: I expect the application language not to be changed.
+        LanguageSelectorSteps.getLanguageSelectorDropdownButton().should('contain', 'en');
+        // AND: I expect the query not to be aborted
+        cy.get('@abortQuery.all').should('have.length', 0);
+
+        // WHEN: I confirm changing the language
+        LanguageSelectorSteps.switchToFr();
+        ModalDialogSteps.getDialog().should('exist');
+        ModalDialogSteps.getDialogBody().should('contain.text', 'You have running 1 query, that will be aborted.');
+        ModalDialogSteps.confirm();
+        // THEN: I expect the query to be aborted
+        cy.get('@abortQuery.all').should('have.length', 1);
+        // AND: I expect the application language to be changed
+        LanguageSelectorSteps.getLanguageSelectorDropdownButton().should('contain', 'fr');
+    });
+
+    it('should abort query when page is reloaded', () => {
+        // GIVEN: I visit a page with the ontotext-yasgui-web-component on it.
+        SparqlEditorSteps.visitSparqlEditorPage();
+        // AND: I run a long-running query
+        QueryStubs.stubLongRunningQuery(repositoryId, LONG_RUNNING_QUERY_DELAY);
+        YasqeSteps.executeQueryWithoutWaiteResult();
+
+        // WHEN: I reload the page
+        SparqlEditorSteps.visitSparqlEditorPage();
+        // THEN: I expect the query to be aborted
+        cy.get('@abortQuery.all').should('have.length', 1);
+    });
+
+    context('Security', () => {
+
+        beforeEach(() => {
+            UserAndAccessSteps.visit();
+            UserAndAccessSteps.toggleSecurity();
+            LoginSteps.loginWithUser('admin', 'root');
+        });
+
+        afterEach(() => {
+            cy.loginAsAdmin().then(() => {
+                cy.switchOffSecurity(true);
+            });
+        });
+
+        it('should logged out if user confirmed navigation', () => {
+            // GIVEN: The security is on
+            // AND: I visit a page with the ontotext-yasgui-web-component on it.
+            SparqlEditorSteps.visitSparqlEditorPage();
+
+            // WHEN: I log out
+            LoginSteps.logout();
+            // THEN: I expect to navigate to the login page, because there are no long-running queries.
+            LoginSteps.verifyUrl();
+
+            // WHEN: I am logged in
+            LoginSteps.loginWithUser('admin', 'root');
+            // AND: I run a long-running query
+            QueryStubs.stubLongRunningQuery(repositoryId, LONG_RUNNING_QUERY_DELAY);
+            YasqeSteps.executeQueryWithoutWaiteResult();
+            // AND: I try to log out
+            LoginSteps.logout();
+            // THEN: I expect to see a confirmation dialog
+            ModalDialogSteps.getDialog().should('exist');
+            ModalDialogSteps.getDialogBody().should('contain.text', 'You have running 1 query, that will be aborted.');
+
+            // WHEN: I cancel the dialog
+            ModalDialogSteps.cancel();
+            // THEN: I expect to stay logged in
+            // AND: I expect the query not to be aborted
+            cy.get('@abortQuery.all').should('have.length', 0);
+
+            // WHEN: I confirm leaving the page
+            LoginSteps.logout();
+            ModalDialogSteps.getDialog().should('exist');
+            ModalDialogSteps.getDialogBody().should('contain.text', 'You have running 1 query, that will be aborted.');
+            ModalDialogSteps.confirm();
+            // THEN: I expect to navigate to the login page.
+            LoginSteps.verifyUrl();
+            // AND: I expect the query to be aborted
+            cy.get('@abortQuery.all').should('have.length', 1);
+        });
+    });
+});

--- a/e2e-tests/e2e-security/setup/home/cookie-policy.spec.js
+++ b/e2e-tests/e2e-security/setup/home/cookie-policy.spec.js
@@ -133,6 +133,10 @@ describe('Cookie policy', () => {
         cy.reload();
         // Then I expect the banner to be hidden
         CookieConsentBannerSteps.getCookieConsentBanner().should('not.exist');
+        // Wait for the page to be fully loaded.
+        // Cypress executes actions very quickly, and without this wait the logout subscribers may not be registered yet.
+        // As a result, the logout event is not handled correctly and the logout operation may fail.
+        SettingsSteps.getCookiePolicyButton().should('be.visible');
         // When I logout
         LoginSteps.logout();
         // Then I should see the login page

--- a/e2e-tests/steps/import/import-steps.js
+++ b/e2e-tests/steps/import/import-steps.js
@@ -1,5 +1,6 @@
 import {ModalDialogSteps} from "../modal-dialog-steps";
 
+const VIEW_URL = '/import';
 /**
  * Reusable functions for interacting with the import page.
  */
@@ -21,9 +22,13 @@ class ImportSteps {
     }
 
     static visit() {
-        cy.visit('/import');
-        cy.url().should('include', '/import');
+        cy.visit(VIEW_URL);
+        cy.url().should('include', VIEW_URL);
         cy.get('#wb-import h1').should('be.visible');
+    }
+
+    static verifyUrl() {
+        cy.url().should('include', `${Cypress.config('baseUrl')}${VIEW_URL}`);
     }
 
     static getView() {

--- a/e2e-tests/steps/language-selector-steps.js
+++ b/e2e-tests/steps/language-selector-steps.js
@@ -7,6 +7,10 @@ export class LanguageSelectorSteps {
         LanguageSelectorSteps.getLanguageSelectorDropdown().should('be.visible').click();
     }
 
+    static getLanguageSelectorDropdownButton() {
+        return LanguageSelectorSteps.getLanguageSelectorDropdown().find('.onto-dropdown-button');
+    }
+
     static changeLanguage(language) {
         LanguageSelectorSteps.openLanguageSelectorDropdown();
         this.getLanguageSelectorDropdown().find(`button.${language}`).click();

--- a/e2e-tests/steps/login-steps.js
+++ b/e2e-tests/steps/login-steps.js
@@ -1,12 +1,12 @@
 import {EnvironmentStubs} from "../stubs/environment-stubs";
-
+const VIEW_URL = '/login';
 export class LoginSteps {
     static visitLoginPage() {
-        cy.visit('/login');
+        cy.visit(VIEW_URL);
     }
 
     static visitInProdMode() {
-        cy.visit('/login', {
+        cy.visit(VIEW_URL, {
             onBeforeLoad: () => {
                 EnvironmentStubs.stubWbProdMode();
             }
@@ -16,6 +16,10 @@ export class LoginSteps {
     static visitLoginPageWithReturnUrl(returnURL) {
         const returnURLEncoded = encodeURIComponent(returnURL);
         cy.visit(`/login?r=${returnURLEncoded}`);
+    }
+
+    static verifyUrl() {
+        cy.url().should('include', `${Cypress.config('baseUrl')}${VIEW_URL}`);
     }
 
     static getLoginPage() {

--- a/e2e-tests/stubs/yasgui/query-stubs.js
+++ b/e2e-tests/stubs/yasgui/query-stubs.js
@@ -225,6 +225,11 @@ export class QueryStubs {
     static interceptSavedQueryCreation() {
         cy.intercept('POST', '/rest/sparql/saved-queries').as('saveQuery');
     }
+
+    static spyAbortQuery() {
+        cy.intercept('DELETE', /\/rest\/monitor\/repository\/[^/]+\/query\?query=yasgui-component-.*/)
+            .as('abortQuery');
+    }
 }
 
 export class QueryStubDescription {

--- a/packages/api/src/models/events/auth/logged-out.ts
+++ b/packages/api/src/models/events/auth/logged-out.ts
@@ -1,0 +1,13 @@
+import {Event} from '../event';
+import {EventName} from '../event-name';
+
+/**
+ * Represents an {@link EventName.LOGGED_OUT} event.
+ *
+ * This event is triggered when user logged out.
+ */
+export class LoggedOut extends Event<undefined> {
+  constructor() {
+    super(EventName.LOGGED_OUT);
+  }
+}

--- a/packages/api/src/models/events/event-name.ts
+++ b/packages/api/src/models/events/event-name.ts
@@ -10,6 +10,7 @@ export const EventName = {
   NAVIGATION_START: 'navigationStart',
   LOGIN: 'login',
   LOGOUT: 'logout',
+  LOGGED_OUT: 'loggedOut',
   APP_DATA_LOADED: 'applicationDataLoaded',
   APPLICATION_MOUNTED: 'applicationMounted',
   APPLICATION_UNMOUNTED: 'applicationUnmounted',

--- a/packages/api/src/models/events/event-observer.ts
+++ b/packages/api/src/models/events/event-observer.ts
@@ -1,18 +1,35 @@
+import { EventSubscriptionCancelHandler } from './event-subscription-cancel-handler';
+import { EventSubscriptionCallback } from './event-subscription-callback';
+
 /**
- * Represents an observer for events, encapsulating a callback to handle event notifications.
+ * Represents an observer for events, encapsulating a callback to handle event notifications
+ * and an optional handler that can prevent the event from being emitted.
  *
  * @template T - The type of the event payload.
  */
 export class EventObserver<T> {
 
   /**
-   * A callback function to notify the observer of an event.
-   *
-   * @param eventPayload - The payload of the event to notify the observer about.
+   * Callback invoked when the event is emitted.
    */
-  notify: (eventPayload: T) => void;
+  notify: EventSubscriptionCallback<T>;
 
-  constructor(callback: (payload: T) => void) {
+  /**
+   * Handler evaluated before the event is emitted.
+   *
+   * If the handler resolves to <code>true</code>, the event emission is canceled.
+   * If the handler resolves to <code>false</code>, the event emission is allowed to proceed.
+   */
+  shouldCancelEventHandler?: EventSubscriptionCancelHandler;
+
+  /**
+   * Creates a new event observer.
+   *
+   * @param callback - Callback invoked when the event is emitted.
+   * @param shouldCancelEventHandler - Handler used to determine whether the event emission should be canceled.
+   */
+  constructor(callback: EventSubscriptionCallback<T>, shouldCancelEventHandler?: EventSubscriptionCancelHandler) {
     this.notify = callback;
+    this.shouldCancelEventHandler = shouldCancelEventHandler;
   }
 }

--- a/packages/api/src/models/events/event-subscription-callback.ts
+++ b/packages/api/src/models/events/event-subscription-callback.ts
@@ -1,0 +1,7 @@
+/**
+ * Represents a callback function invoked when an event is emitted.
+ *
+ * @template T - The type of the event payload.
+ * @param payload - The payload associated with the emitted event.
+ */
+export type EventSubscriptionCallback<T> = (payload: T) => void;

--- a/packages/api/src/models/events/event-subscription-cancel-handler.ts
+++ b/packages/api/src/models/events/event-subscription-cancel-handler.ts
@@ -1,0 +1,7 @@
+/**
+ * Represents a handler that determines whether an event emission should be canceled.
+ *
+ * The handler resolves to <code>true</code> when the event emission should be canceled,
+ * or <code>false</code> when the event should be allowed to proceed.
+ */
+export type EventSubscriptionCancelHandler = () => Promise<boolean>;

--- a/packages/api/src/models/events/event-subscription-cancel-handler.ts
+++ b/packages/api/src/models/events/event-subscription-cancel-handler.ts
@@ -4,4 +4,4 @@
  * The handler resolves to <code>true</code> when the event emission should be canceled,
  * or <code>false</code> when the event should be allowed to proceed.
  */
-export type EventSubscriptionCancelHandler = () => Promise<boolean>;
+export type EventSubscriptionCancelHandler = <T extends {} | undefined>(eventPayload: T) => Promise<boolean>;

--- a/packages/api/src/services/domain/guides/guide-api.ts
+++ b/packages/api/src/services/domain/guides/guide-api.ts
@@ -6,7 +6,7 @@ import {LoggerProvider} from '../../logging/logger-provider';
 import {GuideStepBridge} from './guide-step-bridge';
 import {WindowService} from '../../window';
 import {ScrollLocation} from '../../../models/interactive-guide/scroll-location';
-import {getCurrentRoute, HtmlUtil, navigate, UriUtil} from '../../utils';
+import {getCurrentRoute, HtmlUtil, navigate, TranslationUtil, UriUtil} from '../../utils';
 import {ProductInfoContextService} from '../product-info';
 
 /**
@@ -56,42 +56,64 @@ export class GuideApi implements Service, GuideStepBridge {
    * @returns The translated string, or the key itself if no translation is found.
    */
   _translate(bundle: TranslationBundle | undefined, key: string | Record<string, string>, parameters: Record<string, string> = {}): string {
-    const currentLanguage = this.languageContextService.getSelectedLanguage() ?? this.languageContextService.getDefaultLanguage();
+    const defaultLanguage = this.languageContextService.getDefaultLanguage();
+    const currentLanguage = this.languageContextService.getSelectedLanguage() ?? defaultLanguage;
 
     if (typeof key === 'object') {
-      const translation = key[currentLanguage] ?? key[this.languageContextService.getDefaultLanguage()];
-      if (translation) {
-        return HtmlUtil.sanitize(this.applyParameters(translation, parameters));
+      const translation = key[currentLanguage] ?? key[defaultLanguage];
+
+      if (!translation) {
+        this.logger.warn(
+          `Missing translation for language [${currentLanguage}] in message object`,
+        );
+
+        return '';
       }
-      this.logger.warn(`Missing translation for language [${currentLanguage}] in message object`);
-      return '';
+
+      return HtmlUtil.sanitize(
+        TranslationUtil.applyParameters(translation, parameters),
+      );
     }
 
-    let languageBundle: TranslationBundle | undefined;
-    if (bundle) {
-      const byLanguage = bundle[currentLanguage];
-      languageBundle = (typeof byLanguage === 'object' ? byLanguage : undefined) ?? bundle;
-    } else {
-      languageBundle = this.languageContextService.getLanguageBundle() ?? this.languageContextService.getDefaultBundle();
+    const serviceBundle =
+      this.languageContextService.getLanguageBundle() ??
+      this.languageContextService.getDefaultBundle();
+
+    const currentBundle = bundle
+      ? this.resolveLanguageBundle(bundle, currentLanguage)
+      : serviceBundle;
+
+    if (!currentBundle) {
+      this.logger.warn(
+        `Translation bundle is not provided for translation key: ${JSON.stringify(key)}`,
+      );
+
+      return key;
     }
 
-    if (!languageBundle) {
-      this.logger.warn('Translation bundle is not provided for translation key: ' + JSON.stringify(key));
-      return key?.toString() ?? '';
-    }
+    const translation =
+      TranslationUtil.translate(currentBundle, key, parameters) ??
+      (bundle
+        ? TranslationUtil.translate(serviceBundle, key, parameters)
+        : undefined);
 
-    let translation = languageBundle[key];
-    if (!translation && bundle) {
-      // Fallback to the language service bundle when the provided bundle does not contain the key
-      translation = (this.languageContextService.getLanguageBundle() ?? this.languageContextService.getDefaultBundle())?.[key];
-    }
-
-    if (translation) {
-      return HtmlUtil.sanitize(this.applyParameters(translation as string, parameters));
+    if (translation !== undefined) {
+      return translation;
     }
 
     this.logger.warn(`Missing translation for [${key}] key`);
-    return key?.toString();
+    return key;
+  }
+
+  private resolveLanguageBundle(
+    bundle: TranslationBundle,
+    language: string,
+  ): TranslationBundle {
+    const languageBundle = bundle[language];
+
+    return typeof languageBundle === 'object'
+      ? languageBundle
+      : bundle;
   }
 
   private _resolveDocumentationUrl(endpoint: string): string {
@@ -115,14 +137,11 @@ export class GuideApi implements Service, GuideStepBridge {
    * @returns The translation with parameters applied.
    */
   applyParameters(translation: string, parameters: Record<string, string> = {}): string {
-    return Object.entries(parameters).reduce(
-      (result, [paramKey, paramValue]) => this.replaceAll(result, paramKey, paramValue),
-      translation,
-    );
+    return TranslationUtil.applyParameters(translation, parameters);
   }
 
   replaceAll(translation: string, key: string, value: string): string {
-    return translation.split(`{{${key}}}`).join(value);
+    return TranslationUtil.replaceAll(translation, key, value);
   };
 
   /**

--- a/packages/api/src/services/domain/guides/guide-api.ts
+++ b/packages/api/src/services/domain/guides/guide-api.ts
@@ -75,10 +75,7 @@ export class GuideApi implements Service, GuideStepBridge {
       );
     }
 
-    const serviceBundle =
-      this.languageContextService.getLanguageBundle() ??
-      this.languageContextService.getDefaultBundle();
-
+    const serviceBundle = this.languageContextService.getLanguageBundleOrDefault();
     const currentBundle = bundle
       ? this.resolveLanguageBundle(bundle, currentLanguage)
       : serviceBundle;

--- a/packages/api/src/services/domain/guides/guide-api.ts
+++ b/packages/api/src/services/domain/guides/guide-api.ts
@@ -56,11 +56,10 @@ export class GuideApi implements Service, GuideStepBridge {
    * @returns The translated string, or the key itself if no translation is found.
    */
   _translate(bundle: TranslationBundle | undefined, key: string | Record<string, string>, parameters: Record<string, string> = {}): string {
-    const defaultLanguage = this.languageContextService.getDefaultLanguage();
-    const currentLanguage = this.languageContextService.getSelectedLanguage() ?? defaultLanguage;
+    const currentLanguage = this.languageContextService.getSelectedLanguage();
 
     if (typeof key === 'object') {
-      const translation = key[currentLanguage] ?? key[defaultLanguage];
+      const translation = key[currentLanguage];
 
       if (!translation) {
         this.logger.warn(
@@ -75,7 +74,7 @@ export class GuideApi implements Service, GuideStepBridge {
       );
     }
 
-    const serviceBundle = this.languageContextService.getLanguageBundleOrDefault();
+    const serviceBundle = this.languageContextService.getLanguageBundle();
     const currentBundle = bundle
       ? this.resolveLanguageBundle(bundle, currentLanguage)
       : serviceBundle;

--- a/packages/api/src/services/domain/guides/test/guide-api.spec.ts
+++ b/packages/api/src/services/domain/guides/test/guide-api.spec.ts
@@ -11,9 +11,7 @@ describe('GuideApi', () => {
   const logger = LoggerProvider.logger;
 
   beforeEach(() => {
-    jest.spyOn(languageContextService, 'getLanguageBundle').mockReturnValue(undefined);
     jest.spyOn(languageContextService, 'getDefaultBundle').mockReturnValue(undefined);
-    jest.spyOn(languageContextService, 'getSelectedLanguage').mockReturnValue('en');
     jest.spyOn(languageContextService, 'getDefaultLanguage').mockReturnValue('en');
     guideApi = new GuideApi();
   });
@@ -61,7 +59,6 @@ describe('GuideApi', () => {
     });
 
     test('should fall back to default language when per-language object does not have the current language', () => {
-      jest.spyOn(languageContextService, 'getSelectedLanguage').mockReturnValue(undefined);
       jest.spyOn(languageContextService, 'getDefaultLanguage').mockReturnValue('en');
 
       const key = {language: 'test', 'en': 'Hello'};
@@ -98,7 +95,6 @@ describe('GuideApi', () => {
 
     test('should warn with a styled message and return the key when no bundle is available at all', () => {
       const warnSpy = jest.spyOn(logger, 'warn');
-      // beforeEach already mocks getLanguageBundle and getDefaultBundle to return undefined
 
       const result = guideApi.translate(undefined, 'missing-key');
 

--- a/packages/api/src/services/domain/security/authentication.service.ts
+++ b/packages/api/src/services/domain/security/authentication.service.ts
@@ -2,7 +2,7 @@ import {Service} from '../../../providers/service/service';
 import {AuthenticatedUser, SecurityConfig} from '../../../models/security';
 import {service} from '../../../providers';
 import {EventService} from '../../event-service';
-import {Logout} from '../../../models/events';
+import {LoggedOut} from '../../../models/events/auth/logged-out';
 import {SecurityContextService} from './security-context.service';
 import {AuthStrategyResolver} from './auth-strategy-resolver';
 import {Login} from '../../../models/events/auth/login';
@@ -83,7 +83,7 @@ export class AuthenticationService implements Service {
           this.eventService.emit(new Login());
         } else {
           navigate('login');
-          this.eventService.emit(new Logout());
+          this.eventService.emit(new LoggedOut());
         }
       });
   }

--- a/packages/api/src/services/domain/security/authentication.service.ts
+++ b/packages/api/src/services/domain/security/authentication.service.ts
@@ -61,7 +61,7 @@ export class AuthenticationService implements Service {
     const authUser = await authStrategy.login(loginData);
     this.securityContextService.updateIsLoggedIn(true);
     this.securityContextService.updateAuthenticatedUser(authUser);
-    this.eventService.emit(new Login());
+    await this.eventService.emit(new Login());
   }
 
   /**
@@ -80,10 +80,10 @@ export class AuthenticationService implements Service {
         this.securityContextService.updateIsLoggedIn(false);
         if (this.authorizationService.hasFreeAccess()) {
           this.authorizationService.initializeFreeAccess();
-          this.eventService.emit(new Login());
+          void this.eventService.emit(new Login());
         } else {
           navigate('login');
-          this.eventService.emit(new LoggedOut());
+          void this.eventService.emit(new LoggedOut());
         }
       });
   }

--- a/packages/api/src/services/domain/security/openid/openid-service.ts
+++ b/packages/api/src/services/domain/security/openid/openid-service.ts
@@ -12,7 +12,7 @@ import {OpenidTokenUtils} from './openid-token-utils';
 import {OpenIdUtils} from './openid-utils';
 import {AuthenticationStorageService} from '../authentication-storage.service';
 import {EventService} from '../../../event-service';
-import {Logout} from '../../../../models/events';
+import {LoggedOut} from '../../../../models/events/auth/logged-out';
 import {OpenIdError} from '../errors/openid/openid-error';
 import {WindowService} from '../../../window';
 import {MissingOpenidConfiguration} from '../errors/openid/missing-openid-configuration';
@@ -92,7 +92,7 @@ export class OpenIdService implements Service {
       notify(notification);
 
       this.softLogout();
-      service(EventService).emit(new Logout());
+      service(EventService).emit(new LoggedOut());
     }
   }
 

--- a/packages/api/src/services/domain/security/openid/openid-service.ts
+++ b/packages/api/src/services/domain/security/openid/openid-service.ts
@@ -92,7 +92,7 @@ export class OpenIdService implements Service {
       notify(notification);
 
       this.softLogout();
-      service(EventService).emit(new LoggedOut());
+      void service(EventService).emit(new LoggedOut());
     }
   }
 

--- a/packages/api/src/services/domain/security/openid/test/openid-service.spec.ts
+++ b/packages/api/src/services/domain/security/openid/test/openid-service.spec.ts
@@ -9,7 +9,7 @@ import {WindowService} from '../../../../window';
 import {service} from '../../../../../providers';
 import {OpenidSecurityConfig, SecurityConfig} from '../../../../../models/security';
 import {OpenIdAuthFlowType, OpenIdTokens} from '../../../../../models/security/authentication/openid-auth-flow-models';
-import {Logout} from '../../../../../models/events';
+import {LoggedOut} from '../../../../../models/events/auth/logged-out';
 import {MissingOpenidConfiguration} from '../../errors/openid/missing-openid-configuration';
 import {ResponseMock} from '../../../../http/test/response-mock';
 import {TestUtil} from '../../../../utils/test/test-util';
@@ -194,7 +194,7 @@ describe('OpenIdService', () => {
       await openIdService.refreshTokens('invalid-token');
 
       expect(clearAuthenticationSpy).toHaveBeenCalled();
-      expect(emitSpy).toHaveBeenCalledWith(expect.any(Logout));
+      expect(emitSpy).toHaveBeenCalledWith(expect.any(LoggedOut));
     });
 
     it('should throw MissingOpenidConfiguration when config is missing', async () => {

--- a/packages/api/src/services/domain/security/test/authentication.service.spec.ts
+++ b/packages/api/src/services/domain/security/test/authentication.service.spec.ts
@@ -4,7 +4,7 @@ import {service} from '../../../../providers';
 import {AuthenticationStorageService} from '../authentication-storage.service';
 import {SecurityContextService} from '../security-context.service';
 import {EventService} from '../../../event-service';
-import {Logout} from '../../../../models/events';
+import {LoggedOut} from '../../../../models/events/auth/logged-out';
 import {WindowService} from '../../../window';
 import {AuthStrategy, AuthStrategyType} from '../../../../models/security/authentication';
 import {AuthStrategyResolver} from '../auth-strategy-resolver';
@@ -108,7 +108,7 @@ describe('AuthenticationService', () => {
       const testAuthStrategySpy = jest.spyOn(testAuthStrategy, 'logout');
       await authService.logout();
       expect(emitSpy).toHaveBeenCalledTimes(1);
-      expect(emitSpy).toHaveBeenCalledWith(expect.any(Logout));
+      expect(emitSpy).toHaveBeenCalledWith(expect.any(LoggedOut));
       expect(testAuthStrategySpy).toHaveBeenCalled();
     });
 

--- a/packages/api/src/services/event-service/event.service.ts
+++ b/packages/api/src/services/event-service/event.service.ts
@@ -2,6 +2,8 @@ import {Event} from '../../models/events';
 import {Service} from '../../providers/service/service';
 import {ObjectUtil} from '../utils';
 import {EventObserver} from '../../models/events/event-observer';
+import {EventSubscriptionCancelHandler} from '../../models/events/event-subscription-cancel-handler';
+import {EventSubscriptionCallback} from '../../models/events/event-subscription-callback';
 
 /**
  * A service that manages event subscriptions and emissions.
@@ -19,16 +21,47 @@ export class EventService implements Service {
   /**
    * Emits an event to all subscribers of the specified event type.
    *
+   * Before notifying subscribers, registered cancellation handlers are evaluated.
+   * If any handler requests cancellation, the event is not emitted.
+   *
    * @template T - The type of the event payload.
    * @param event - The event to emit, containing its name and payload.
    */
   emit<T extends {} | undefined>(event: Event<T>): void {
     const subscribers = this.eventSubscribers.get(event.NAME);
-    if (subscribers) {
-      subscribers.forEach((subscriber) => {
-        subscriber.notify(ObjectUtil.deepCopy(event.payload));
-      });
+    if (!subscribers) {
+      return;
     }
+
+    this.shouldCancelEvent(subscribers)
+      .then((cancelEvent) => {
+        if (!cancelEvent) {
+          subscribers.forEach((subscriber) => {
+            subscriber.notify(ObjectUtil.deepCopy(event.payload));
+          });
+        }
+      });
+  }
+
+  /**
+   * Evaluates cancellation handlers for the provided observers.
+   *
+   * Handlers are evaluated sequentially until one of them requests cancellation of the event.
+   *
+   * @param observers - The observers whose cancellation handlers should be evaluated.
+   *
+   * @returns A promise that resolves to <code>true</code> if the event should be canceled,
+   * or <code>false</code> if no handler requests cancellation.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async shouldCancelEvent(observers: EventObserver<any>[]): Promise<boolean> {
+    for (const observer of observers) {
+      const shouldCancel = await observer.shouldCancelEventHandler?.();
+      if (shouldCancel) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -36,12 +69,14 @@ export class EventService implements Service {
    *
    * @template T - The type of the event payload.
    * @param eventName - The name of the event to subscribe to.
-   * @param callback - A callback function to handle the event notifications.
+   * @param callback - A callback function invoked when the event is emitted.
+   * @param shouldCancelEventHandler - Optional handler that resolves to <code>true</code> when the event emission should be canceled,
+   * or <code>false</code> when it should proceed.
    *
-   * @returns A function to unsubscribe from the event.
+   * @returns A function that unsubscribes the observer from the event.
    */
-  subscribe<T extends {} | undefined>(eventName: string, callback: (payload: T) => void): () => void {
-    const observer = new EventObserver<T>(callback);
+  subscribe<T extends {} | undefined>(eventName: string, callback: EventSubscriptionCallback<T>, shouldCancelEventHandler?: EventSubscriptionCancelHandler): () => void {
+    const observer = new EventObserver<T>(callback, shouldCancelEventHandler);
     const eventSubscribers = this.eventSubscribers.get(eventName);
 
     if (eventSubscribers) {

--- a/packages/api/src/services/event-service/event.service.ts
+++ b/packages/api/src/services/event-service/event.service.ts
@@ -27,19 +27,20 @@ export class EventService implements Service {
    * @template T - The type of the event payload.
    * @param event - The event to emit, containing its name and payload.
    */
-  emit<T extends {} | undefined>(event: Event<T>): void {
+  emit<T extends {} | undefined>(event: Event<T>): Promise<boolean> {
     const subscribers = this.eventSubscribers.get(event.NAME);
     if (!subscribers) {
-      return;
+      return Promise.resolve(false);
     }
 
-    this.shouldCancelEvent(subscribers)
+    return this.shouldCancelEvent(subscribers, event)
       .then((cancelEvent) => {
         if (!cancelEvent) {
           subscribers.forEach((subscriber) => {
             subscriber.notify(ObjectUtil.deepCopy(event.payload));
           });
         }
+        return Promise.resolve(cancelEvent);
       });
   }
 
@@ -54,9 +55,9 @@ export class EventService implements Service {
    * or <code>false</code> if no handler requests cancellation.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async shouldCancelEvent(observers: EventObserver<any>[]): Promise<boolean> {
+  private async shouldCancelEvent<T extends {} | undefined>(observers: EventObserver<any>[], event: Event<T>): Promise<boolean> {
     for (const observer of observers) {
-      const shouldCancel = await observer.shouldCancelEventHandler?.();
+      const shouldCancel = await observer.shouldCancelEventHandler?.(event.payload);
       if (shouldCancel) {
         return true;
       }

--- a/packages/api/src/services/event-service/test/event.service.spec.ts
+++ b/packages/api/src/services/event-service/test/event.service.spec.ts
@@ -1,5 +1,5 @@
 import {EventService} from '../event.service';
-import {Event} from '../../../models/events';
+import {Event, Logout} from '../../../models/events';
 import {EventName, NavigationEnd} from '../../../models/events';
 
 const TEST_EVENT_NAME = 'testEventName';
@@ -11,7 +11,7 @@ describe('EventService', () => {
     eventService = new EventService();
   });
 
-  it('emit should notify observers of a given event', () => {
+  it('emit should notify observers of a given event', async () => {
 
     const oldUrl = '/import';
     const newUrl = '/graphql';
@@ -23,40 +23,40 @@ describe('EventService', () => {
     eventService.subscribe(EventName.NAVIGATION_END, callBackFunctionTwo);
 
     // When: the navigation end event is emitted.
-    eventService.emit(new NavigationEnd(oldUrl, newUrl));
+    await emitAndWait(eventService, new NavigationEnd(oldUrl, newUrl));
 
     // Then: I expect the registered callback functions to be called.
     expect(callBackFunction).toHaveBeenLastCalledWith({oldUrl, newUrl});
     expect(callBackFunctionTwo).toHaveBeenLastCalledWith({oldUrl, newUrl});
   });
 
-  it('emit should notify observers of a given event if emitted value is undefined', () => {
+  it('emit should notify observers of a given event if emitted value is undefined', async () => {
 
     // Given: there is a registered callback function for an event.
     const callBackFunction = jest.fn();
     eventService.subscribe(TEST_EVENT_NAME, callBackFunction);
 
     // When: the event is emitted with undefined value.
-    eventService.emit(new TestEvent(undefined));
+    await emitAndWait(eventService, new TestEvent(undefined));
 
     // Then: I expect the registered callback function to be called.
     expect(callBackFunction).toHaveBeenLastCalledWith(undefined);
   });
 
-  it('emit shouldn\'t notify observers if they are registered for another event', () => {
+  it('emit shouldn\'t notify observers if they are registered for another event', async () => {
 
     // Given: there is a registered callback function for the navigation end event.
     const callBackFunction = jest.fn();
     eventService.subscribe(EventName.NAVIGATION_END, callBackFunction);
 
     // When: an event different of the navigation end event is emitted.
-    eventService.emit(new TestEvent(undefined));
+    await emitAndWait(eventService, new TestEvent(undefined));
 
     // I expect the registered callback function not to be called
     expect(callBackFunction).toHaveBeenCalledTimes(0);
   });
 
-  it('emit shouldn\'t notify observers that are unsubscribed', () => {
+  it('emit shouldn\'t notify observers that are unsubscribed', async () => {
 
     // Given there is a registered callback function for an event.
     const callBackFunction = jest.fn();
@@ -65,15 +65,39 @@ describe('EventService', () => {
     const unsubscribe = eventService.subscribe(TEST_EVENT_NAME, callBackFunctionTwo);
 
     // When the event is emitted,
-    eventService.emit(new TestEvent(undefined));
+    await emitAndWait(eventService, new TestEvent(undefined));
     // and unregister one of the functions (for example, the second one).
     unsubscribe();
     // and second event is emitted
-    eventService.emit(new TestEvent('test'));
+    await emitAndWait(eventService, new TestEvent('test'));
 
     // Then I expect the first registered callback function to be called twice.
     expect(callBackFunction).toHaveBeenCalledTimes(2);
     // and the second one to be called only one
+    expect(callBackFunctionTwo).toHaveBeenCalledTimes(1);
+  });
+
+  test('should not emit an event if a cancellation handler prevents the notification', async () => {
+    // GIVEN: There is a registered event observer that cancels emission of the logout event.
+    const callBackFunction = jest.fn();
+    const shouldCancelHandler = () => Promise.resolve(true);
+    const unsubscribeCanceledObserver = eventService.subscribe(EventName.LOGOUT, callBackFunction, shouldCancelHandler);
+    // AND: There is a registered event observer that does not cancel emission of the logout event.
+    const callBackFunctionTwo = jest.fn();
+    const shouldCancelHandlerTwo = () => Promise.resolve(false);
+    eventService.subscribe(EventName.LOGOUT, callBackFunctionTwo, shouldCancelHandlerTwo);
+
+    // WHEN: I emit the logout event.
+    await emitAndWait(eventService, new Logout());
+    // THEN: I expect the callback functions not to be notified because a cancellation handler blocks the event emission.
+    expect(callBackFunction).toHaveBeenCalledTimes(0);
+    expect(callBackFunctionTwo).toHaveBeenCalledTimes(0);
+
+    // WHEN: I unsubscribe the observer that cancels the event.
+    unsubscribeCanceledObserver();
+    // AND: I emit the logout event.
+    await emitAndWait(eventService, new Logout());
+    // THEN: I expect the callback function to be called because there is no cancellation handler that blocks the event emission.
     expect(callBackFunctionTwo).toHaveBeenCalledTimes(1);
   });
 });
@@ -82,4 +106,18 @@ class TestEvent extends Event<string> {
   constructor(payload: string | undefined) {
     super(TEST_EVENT_NAME, payload);
   }
+}
+
+/**
+ * Emits the provided event and waits for all asynchronous event processing to complete before returning.
+ *
+ * @template T - The type of the event payload.
+ * @param eventService - The event service used to emit the event.
+ * @param event - The event to emit.
+ */
+export async function emitAndWait<T extends {} | undefined>(eventService: EventService, event: Event<T>): Promise<void> {
+  eventService.emit(event);
+  // emit() returns void, but it performs an asynchronous cancellation check before notifying subscribers.
+  // Wait for the pending promise chain to complete before verifying that the callbacks were called.
+  await new Promise(process.nextTick);
 }

--- a/packages/api/src/services/event-service/test/event.service.spec.ts
+++ b/packages/api/src/services/event-service/test/event.service.spec.ts
@@ -116,7 +116,7 @@ class TestEvent extends Event<string> {
  * @param event - The event to emit.
  */
 export async function emitAndWait<T extends {} | undefined>(eventService: EventService, event: Event<T>): Promise<void> {
-  eventService.emit(event);
+  await eventService.emit(event);
   // emit() returns void, but it performs an asynchronous cancellation check before notifying subscribers.
   // Wait for the pending promise chain to complete before verifying that the callbacks were called.
   await new Promise(process.nextTick);

--- a/packages/api/src/services/language/language-context.service.ts
+++ b/packages/api/src/services/language/language-context.service.ts
@@ -94,6 +94,10 @@ export class LanguageContextService extends ContextService<LanguageContextFields
     return this.getContextPropertyValue(this.LANGUAGE_BUNDLE);
   }
 
+  getLanguageBundleOrDefault(): TranslationBundle | undefined {
+    return this.getLanguageBundle() ?? this.getDefaultBundle();
+  }
+
   /**
    * Updates the default language bundle in the context.
    *

--- a/packages/api/src/services/language/language-context.service.ts
+++ b/packages/api/src/services/language/language-context.service.ts
@@ -91,11 +91,7 @@ export class LanguageContextService extends ContextService<LanguageContextFields
    * @returns {TranslationBundle | undefined} The current language bundle, or undefined if no bundle is set.
    */
   getLanguageBundle(): TranslationBundle | undefined {
-    return this.getContextPropertyValue(this.LANGUAGE_BUNDLE);
-  }
-
-  getLanguageBundleOrDefault(): TranslationBundle | undefined {
-    return this.getLanguageBundle() ?? this.getDefaultBundle();
+    return this.getContextPropertyValue(this.LANGUAGE_BUNDLE) ?? this.getDefaultBundle();
   }
 
   /**
@@ -152,8 +148,8 @@ export class LanguageContextService extends ContextService<LanguageContextFields
    *          Returns undefined if no language has been selected or set in the context.
    *
    */
-  getSelectedLanguage(): string | undefined {
-    return this.getContextPropertyValue(this.SELECTED_LANGUAGE);
+  getSelectedLanguage(): string {
+    return this.getContextPropertyValue(this.SELECTED_LANGUAGE) ?? this.getDefaultLanguage();
   }
 
   getDefaultLanguage(): string {

--- a/packages/api/src/services/language/test/language-context.service.spec.ts
+++ b/packages/api/src/services/language/test/language-context.service.spec.ts
@@ -119,6 +119,42 @@ describe('LanguageContextService', () => {
     expect(returnedBundle).toEqual(defaultBundle);
   });
 
+  test('should return the language bundle when getLanguageBundleOrDefault is called and a language bundle is set', () => {
+    // Given I have both a language bundle and a default bundle
+    const languageBundle: TranslationBundle = {key: 'language-value', language: 'en'} as TranslationBundle;
+    const defaultBundle: TranslationBundle = {key: 'default-value', language: 'en'} as TranslationBundle;
+    languageContextService.updateLanguageBundle(languageBundle);
+    languageContextService.updateDefaultBundle(defaultBundle);
+
+    // When I call getLanguageBundleOrDefault
+    const returnedBundle = languageContextService.getLanguageBundleOrDefault();
+
+    // Then I expect the returned bundle to be the language bundle
+    expect(returnedBundle).toEqual(languageBundle);
+  });
+
+  test('should return the default bundle when getLanguageBundleOrDefault is called and no language bundle is set', () => {
+    // Given I have a default bundle but no language bundle
+    const defaultBundle: TranslationBundle = {key: 'default-value', language: 'en'} as TranslationBundle;
+    languageContextService.updateDefaultBundle(defaultBundle);
+
+    // When I call getLanguageBundleOrDefault
+    const returnedBundle = languageContextService.getLanguageBundleOrDefault();
+
+    // Then I expect the returned bundle to be the default bundle
+    expect(returnedBundle).toEqual(defaultBundle);
+  });
+
+  test('should return undefined when getLanguageBundleOrDefault is called and neither bundle is set', () => {
+    // Given neither the language bundle nor the default bundle is set
+
+    // When I call getLanguageBundleOrDefault
+    const returnedBundle = languageContextService.getLanguageBundleOrDefault();
+
+    // Then I expect the returned bundle to be undefined
+    expect(returnedBundle).toBeUndefined();
+  });
+
   test('should return the language configuration when getLanguageConfig is called', () => {
     // Given I have a language configuration
     languageContextService.setLanguageConfig(createlanguageConfig());

--- a/packages/api/src/services/language/test/language-context.service.spec.ts
+++ b/packages/api/src/services/language/test/language-context.service.spec.ts
@@ -119,42 +119,6 @@ describe('LanguageContextService', () => {
     expect(returnedBundle).toEqual(defaultBundle);
   });
 
-  test('should return the language bundle when getLanguageBundleOrDefault is called and a language bundle is set', () => {
-    // Given I have both a language bundle and a default bundle
-    const languageBundle: TranslationBundle = {key: 'language-value', language: 'en'} as TranslationBundle;
-    const defaultBundle: TranslationBundle = {key: 'default-value', language: 'en'} as TranslationBundle;
-    languageContextService.updateLanguageBundle(languageBundle);
-    languageContextService.updateDefaultBundle(defaultBundle);
-
-    // When I call getLanguageBundleOrDefault
-    const returnedBundle = languageContextService.getLanguageBundleOrDefault();
-
-    // Then I expect the returned bundle to be the language bundle
-    expect(returnedBundle).toEqual(languageBundle);
-  });
-
-  test('should return the default bundle when getLanguageBundleOrDefault is called and no language bundle is set', () => {
-    // Given I have a default bundle but no language bundle
-    const defaultBundle: TranslationBundle = {key: 'default-value', language: 'en'} as TranslationBundle;
-    languageContextService.updateDefaultBundle(defaultBundle);
-
-    // When I call getLanguageBundleOrDefault
-    const returnedBundle = languageContextService.getLanguageBundleOrDefault();
-
-    // Then I expect the returned bundle to be the default bundle
-    expect(returnedBundle).toEqual(defaultBundle);
-  });
-
-  test('should return undefined when getLanguageBundleOrDefault is called and neither bundle is set', () => {
-    // Given neither the language bundle nor the default bundle is set
-
-    // When I call getLanguageBundleOrDefault
-    const returnedBundle = languageContextService.getLanguageBundleOrDefault();
-
-    // Then I expect the returned bundle to be undefined
-    expect(returnedBundle).toBeUndefined();
-  });
-
   test('should return the language configuration when getLanguageConfig is called', () => {
     // Given I have a language configuration
     languageContextService.setLanguageConfig(createlanguageConfig());

--- a/packages/api/src/services/utils/index.ts
+++ b/packages/api/src/services/utils/index.ts
@@ -7,3 +7,4 @@ export {BuildUtil} from './build-util';
 export * from './enum-util';
 export {DateUtil} from './date-util';
 export {HtmlUtil} from './html-util';
+export {TranslationUtil} from './translation-util';

--- a/packages/api/src/services/utils/test/translation-util.spec.ts
+++ b/packages/api/src/services/utils/test/translation-util.spec.ts
@@ -1,0 +1,220 @@
+import {TranslationUtil} from '../translation-util';
+
+describe('TranslationUtil', () => {
+  describe('translate', () => {
+    test('should return a translation from the provided bundle', () => {
+      // GIVEN: I have a bundle containing the requested translation.
+      const bundle = {
+        language: 'en',
+        greeting: 'Hello',
+      };
+
+      // WHEN: I translate the key using the bundle.
+      const result = TranslationUtil.translate(bundle, 'greeting');
+      // THEN: I expect the translation from the bundle.
+      expect(result).toBe('Hello');
+    });
+
+    test('should return undefined when no bundle is provided', () => {
+      // GIVEN: I have no translation bundle.
+      const bundle = undefined;
+
+      // WHEN: I try to translate a key.
+      const result = TranslationUtil.translate(bundle, 'greeting');
+      // THEN: I expect no translation to be returned.
+      expect(result).toBeUndefined();
+    });
+
+    test('should return undefined when the key is missing from the bundle', () => {
+      // GIVEN: I have a bundle without the requested translation.
+      const bundle = {
+        language: 'en',
+        greeting: 'Hello',
+      };
+
+      // WHEN: I try to translate a missing key.
+      const result = TranslationUtil.translate(bundle, 'missing-key');
+      // THEN: I expect no translation to be returned.
+      expect(result).toBeUndefined();
+    });
+
+    test('should return undefined when the value is not a string', () => {
+      // GIVEN: I have a bundle in which the requested key contains a nested bundle.
+      const bundle = {
+        language: 'root',
+        en: {
+          language: 'en',
+          greeting: 'Hello',
+        },
+      };
+
+      // WHEN: I try to translate the nested-bundle key directly.
+      const result = TranslationUtil.translate(bundle, 'en');
+      // THEN: I expect no translation to be returned.
+      expect(result).toBeUndefined();
+    });
+
+    test('should replace a single placeholder in the translation', () => {
+      // GIVEN: I have a translation containing a placeholder.
+      const bundle = {
+        language: 'en',
+        greeting: 'Hello {{name}}',
+      };
+
+      // WHEN: I translate the key with a replacement value.
+      const result = TranslationUtil.translate(bundle, 'greeting', {name: 'Alice'});
+      // THEN: I expect the placeholder to be replaced.
+      expect(result).toBe('Hello Alice');
+    });
+
+    test('should replace multiple placeholders in the translation', () => {
+      // GIVEN: I have a translation containing multiple placeholders.
+      const bundle = {
+        language: 'en',
+        introduction: '{{name}} is {{age}} years old',
+      };
+
+      // WHEN: I translate the key with the replacement values.
+      const result = TranslationUtil.translate(bundle, 'introduction', {name: 'Alice', age: '30',});
+      // THEN: I expect all matching placeholders to be replaced.
+      expect(result).toBe('Alice is 30 years old');
+    });
+
+    test('should replace all occurrences of the same placeholder', () => {
+      // GIVEN: I have a translation containing the same placeholder multiple times.
+      const bundle = {
+        language: 'en',
+        greeting: 'Hello {{name}}, goodbye {{name}}',
+      };
+
+      // WHEN: I translate the key with a replacement value.
+      const result = TranslationUtil.translate(bundle, 'greeting', {name: 'Alice'},);
+      // THEN: I expect every occurrence of the placeholder to be replaced.
+      expect(result).toBe('Hello Alice, goodbye Alice');
+    });
+
+    test('should leave placeholders without matching parameters unchanged', () => {
+      // GIVEN: I have a translation containing two placeholders and a replacement value for only one of them.
+      const bundle = {
+        language: 'en',
+        greeting: 'Hello {{firstName}} {{lastName}}',
+      };
+
+      // WHEN: I translate the key with the available parameter.
+      const result = TranslationUtil.translate(bundle, 'greeting', {firstName: 'Alice'});
+      // THEN: I expect only the matching placeholder to be replaced.
+      expect(result).toBe('Hello Alice {{lastName}}');
+    });
+
+    test('should return the translation unchanged when parameters are not provided', () => {
+      // GIVEN: I have a translation containing a placeholder.
+      const bundle = {
+        language: 'en',
+        greeting: 'Hello {{name}}',
+      };
+
+      // WHEN: I translate the key without parameters.
+      const result = TranslationUtil.translate(bundle, 'greeting');
+      // THEN: I expect the original translation to be returned.
+      expect(result).toBe('Hello {{name}}');
+    });
+
+    test('should sanitize the translated value', () => {
+      // GIVEN: I have a translation containing unsafe HTML.
+      const bundle = {
+        language: 'en',
+        content: '<script>alert("unsafe")</script><strong>Hello</strong>',
+      };
+
+      // WHEN: I translate the key.
+      const result = TranslationUtil.translate(bundle, 'content');
+      // THEN: I expect the unsafe HTML to be removed.
+      expect(result).not.toContain('<script>');
+      expect(result).toContain('<strong>Hello</strong>');
+    });
+  });
+
+  describe('applyParameters', () => {
+    test('should replace a single placeholder', () => {
+      // GIVEN: I have a translation with one placeholder.
+      const translation = 'Hello {{name}}';
+
+      // WHEN: I apply a matching parameter.
+      const result = TranslationUtil.applyParameters(translation, {name: 'Alice'});
+      // THEN: I expect the placeholder to be replaced.
+      expect(result).toBe('Hello Alice');
+    });
+
+    test('should replace multiple placeholders', () => {
+      // GIVEN: I have a translation with multiple placeholders.
+      const translation = '{{first}} and {{second}}';
+
+      // WHEN: I apply matching parameters.
+      const result = TranslationUtil.applyParameters(translation, {first: 'foo', second: 'bar',});
+      // THEN: I expect all matching placeholders to be replaced.
+      expect(result).toBe('foo and bar');
+    });
+
+    test('should replace every occurrence of the same placeholder', () => {
+      // GIVEN: I have a translation containing the same placeholder multiple times.
+      const translation = '{{value}} {{value}}';
+
+      // WHEN: I apply the matching parameter.
+      const result = TranslationUtil.applyParameters(translation, {value: 'hello'});
+      // THEN: I expect every occurrence to be replaced.
+      expect(result).toBe('hello hello');
+    });
+
+    test('should leave unknown placeholders unchanged', () => {
+      // GIVEN: I have a translation with a placeholder that has no matching parameter.
+      const translation = 'Hello {{firstName}} {{lastName}}';
+
+      // WHEN: I apply only one matching parameter.
+      const result = TranslationUtil.applyParameters(translation, {firstName: 'Alice'});
+      // THEN: I expect the unknown placeholder to remain unchanged.
+      expect(result).toBe('Hello Alice {{lastName}}');
+    });
+
+    test('should return the original translation when parameters are empty', () => {
+      // GIVEN: I have a translation and no replacement parameters.
+      const translation = 'Hello {{name}}';
+
+      // WHEN: I apply the empty parameters.
+      const result = TranslationUtil.applyParameters(translation);
+      // THEN: I expect the original translation to be returned.
+      expect(result).toBe(translation);
+    });
+  });
+
+  describe('replaceAll', () => {
+    test('should replace every occurrence of a placeholder', () => {
+      // GIVEN: I have a translation containing the same placeholder multiple times.
+      const translation = '{{name}} says hello to {{name}}';
+
+      // WHEN: I replace every occurrence of the placeholder.
+      const result = TranslationUtil.replaceAll(translation, 'name', 'Alice');
+      // THEN: I expect every occurrence to be replaced.
+      expect(result).toBe('Alice says hello to Alice');
+    });
+
+    test('should return the original translation when the placeholder is absent', () => {
+      // GIVEN: I have a translation without the specified placeholder.
+      const translation = 'Hello world';
+
+      // WHEN: I try to replace the missing placeholder.
+      const result = TranslationUtil.replaceAll(translation, 'name', 'Alice');
+      // THEN: I expect the original translation to be returned.
+      expect(result).toBe(translation);
+    });
+
+    test('should treat the key as plain text', () => {
+      // GIVEN: I have a placeholder whose name contains regular-expression characters.
+      const translation = 'Value: {{item.key[0]}}';
+
+      // WHEN: I replace the placeholder.
+      const result = TranslationUtil.replaceAll(translation, 'item.key[0]', 'first');
+      // THEN: I expect the placeholder to be replaced literally.
+      expect(result).toBe('Value: first');
+    });
+  });
+});

--- a/packages/api/src/services/utils/translation-util.ts
+++ b/packages/api/src/services/utils/translation-util.ts
@@ -1,0 +1,48 @@
+import {TranslationBundle} from '../../models/language';
+import {HtmlUtil} from './html-util';
+
+export class TranslationUtil {
+  /**
+   * Resolves, interpolates, and sanitizes a translation from a bundle.
+   *
+   * @param bundle - The bundle containing the translations.
+   * @param key - The translation key.
+   * @param parameters - Values used to replace placeholders such as `{{name}}`.
+   * @returns The sanitized translation, or `undefined` if it is unavailable.
+   */
+  static translate(bundle: TranslationBundle | undefined, key: string, parameters: Record<string, string> = {}): string | undefined {
+    if (!bundle) {
+      return undefined;
+    }
+
+    const translation = bundle[key];
+    if (typeof translation !== 'string') {
+      return undefined;
+    }
+
+    return HtmlUtil.sanitize(TranslationUtil.applyParameters(translation, parameters));
+  }
+
+  /**
+   * Replaces placeholders with the corresponding parameter values.
+   *
+   * @param translation - The translation containing placeholders.
+   * @param parameters - Values mapped to placeholder names.
+   * @returns The translation with all matching placeholders replaced.
+   */
+  static applyParameters(translation: string, parameters: Record<string, string> = {}): string {
+    return Object.entries(parameters).reduce((result, [key, value]) => TranslationUtil.replaceAll(result, key, value), translation);
+  }
+
+  /**
+   * Replaces every occurrence of a placeholder with the provided value.
+   *
+   * @param translation - The translation containing the placeholder.
+   * @param key - The placeholder name without braces.
+   * @param value - The replacement value.
+   * @returns The translation with every matching placeholder replaced.
+   */
+  static replaceAll(translation: string, key: string, value: string): string {
+    return translation.split(`{{${key}}}`).join(value);
+  }
+}

--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -3202,7 +3202,6 @@
     "choose.repo": "Choose repository",
     "no.accessible.repos.warning": "No accessible repositories",
     "sign.out.label": "Sign out",
-    "sign.out.success": "Signed out",
     "logout.label": "Logout",
     "open.external.page": "Open external page",
     "no.access.permission.to.functionality.error": "You have no permission to access this functionality with your current credentials.",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -3200,7 +3200,6 @@
     "choose.repo": "Choisissez le dépôt",
     "no.accessible.repos.warning": "Aucun dépôt accessible",
     "sign.out.label": "Se déconnecter",
-    "sign.out.success": "Déconnecté",
     "logout.label": "Déconnexion",
     "open.external.page": "Ouvrir une page externe",
     "no.access.permission.to.functionality.error": "Vous n'avez pas la permission d'accéder à cette fonctionnalité avec vos informations d'identification actuelles.",

--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -220,6 +220,8 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $location, $repositories,
     const authenticationService = service(AuthenticationService);
     const securityContextService = service(SecurityContextService);
     const repositoryContextService = service(RepositoryContextService);
+    const eventService = service(EventService);
+    const applicationLifecycleContextService = service(ApplicationLifecycleContextService);
     /**
      * When the timeout finishes, the popover will open.
      */
@@ -754,7 +756,6 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $location, $repositories,
         }
         // clearAuthentication() triggers broadcast of `securityInit` which triggers $rootScope.redirectToLogin()
         $jwtAuth.clearAuthentication();
-        toastrService.success($translate.instant('sign.out.success'));
     }
 
     const closeActiveRepoPopoverEventHandler = function(event) {
@@ -1093,13 +1094,13 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $location, $repositories,
     };
     subscribeToRouteChangeStart();
 
-    service(EventService).subscribe(EventName.APPLICATION_MOUNTED, (payload) => {
+    eventService.subscribe(EventName.APPLICATION_MOUNTED, (payload) => {
         isApplicationMounted = true;
         subscribeToRouteChangeStart();
         onRouteChangeStart();
     });
 
-    service(EventService).subscribe(EventName.APPLICATION_UNMOUNTED, (payload) => {
+    eventService.subscribe(EventName.APPLICATION_UNMOUNTED, (payload) => {
         routeChangeStartSubscription?.();
     });
 
@@ -1108,13 +1109,13 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $location, $repositories,
         LocalStorageAdapter.clearClassHieararchyState();
     });
 
-    const onLoginSubscription = service(EventService).subscribe(EventName.LOGIN, () => {
+    const onLoginSubscription = eventService.subscribe(EventName.LOGIN, () => {
         $jwtAuth.initSecurity();
     });
 
-    const onLogoutSubscription = service(EventService).subscribe(EventName.LOGOUT, () => logout());
+    const onLoggedOutSubscription = eventService.subscribe(EventName.LOGGED_OUT, () => logout());
 
-    service(EventService).subscribe(EventConstants.RDF_SEARCH_ICON_CLICKED, () => {
+    eventService.subscribe(EventConstants.RDF_SEARCH_ICON_CLICKED, () => {
         $rootScope.$broadcast('rdfResourceSearchExpanded');
     });
 
@@ -1130,8 +1131,8 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $location, $repositories,
      */
     window.addEventListener('storage', localStoreChangeHandler);
 
-    const onAppStateBeforeChangeSubscription = service(ApplicationLifecycleContextService).onApplicationsStateBeforeChange(onApplicationsStateBeforeChangedHandler);
-    const onAppDataLoaded = service(ApplicationLifecycleContextService).onApplicationDataStateChanged(onApplicationDataStateChangedHandler);
+    const onAppStateBeforeChangeSubscription = applicationLifecycleContextService.onApplicationsStateBeforeChange(onApplicationsStateBeforeChangedHandler);
+    const onAppDataLoaded = applicationLifecycleContextService.onApplicationDataStateChanged(onApplicationDataStateChangedHandler);
 
     // subscribe to repository changes, once we are certain they are loaded
     const licenseUpdatedSubscription = service(LicenseContextService).onLicenseChanged(onLicenseUpdated);
@@ -1144,7 +1145,7 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $location, $repositories,
         licenseUpdatedSubscription?.();
         onAppStateBeforeChangeSubscription?.();
         onAppDataLoaded?.();
-        onLogoutSubscription?.();
+        onLoggedOutSubscription?.();
         onLoginSubscription?.();
         securityConfigChangedSubscription?.();
         document.removeEventListener('click', closeActiveRepoPopoverEventHandler);

--- a/packages/legacy-workbench/src/js/angular/models/sparql/cancel-aborting-query.js
+++ b/packages/legacy-workbench/src/js/angular/models/sparql/cancel-aborting-query.js
@@ -1,1 +1,0 @@
-export class CancelAbortingQuery extends Error {}

--- a/packages/legacy-workbench/src/js/angular/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/plugin.js
@@ -47,7 +47,7 @@ PluginRegistry.add('main.menu', {
     },
 );
 PluginRegistry.add('main.menu', {
-        disabled: true,
+        disabled: false,
         items: [
             {
                 label: 'New YASGUI',

--- a/packages/legacy-workbench/src/js/angular/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/plugin.js
@@ -47,7 +47,7 @@ PluginRegistry.add('main.menu', {
     },
 );
 PluginRegistry.add('main.menu', {
-        disabled: false,
+        disabled: true,
         items: [
             {
                 label: 'New YASGUI',

--- a/packages/legacy-workbench/src/js/angular/sparql-editor/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/sparql-editor/controllers.js
@@ -7,24 +7,27 @@ import 'angular/externalsync/controllers';
 import {YasguiComponentDirectiveUtil} from '../core/directives/yasgui-component/yasgui-component-directive.util';
 import {QueryType} from '../models/ontotext-yasgui/query-type';
 import {ConnectorCommand} from '../models/connectors/connector-command';
-import {BeforeUpdateQueryResult, BeforeUpdateQueryResultStatus} from '../models/ontotext-yasgui/before-update-query-result';
+import {
+    BeforeUpdateQueryResult,
+    BeforeUpdateQueryResultStatus,
+} from '../models/ontotext-yasgui/before-update-query-result';
 import {EventDataType} from '../models/ontotext-yasgui/event-data-type';
 import {decodeHTML} from '../../../app';
 import {toBoolean} from '../utils/string-utils';
 import {VIEW_SPARQL_EDITOR} from '../models/sparql/constants';
-import {CancelAbortingQuery} from '../models/sparql/cancel-aborting-query';
 import {QueryMode} from '../models/ontotext-yasgui/query-mode';
 import 'angular/core/services/event-emitter-service';
 import {LoggerProvider} from '../core/services/logger-provider';
 import {
     ParentWindowMessageService,
-    navigateTo,
     openInNewTab,
     LanguageContextService,
     ServiceProvider,
     EventService,
+    navigateTo,
     EventName,
     SecurityContextService,
+    SparqlStorageService,
     GraphConfigService,
     service,
     RepositoryContextService,
@@ -68,21 +71,21 @@ SparqlEditorCtrl.$inject = [
     'LSKeys'];
 
 function SparqlEditorCtrl($rootScope,
-    $scope,
-    $q,
-    $location,
-    $languageService,
-    $repositories,
-    $uibModal,
-    toastr,
-    $translate,
-    SparqlRestService,
-    ConnectorsRestService,
-    ModalService,
-    MonitoringRestService,
-    EventEmitterService,
-    LocalStorageAdapter,
-    LSKeys) {
+                          $scope,
+                          $q,
+                          $location,
+                          $languageService,
+                          $repositories,
+                          $uibModal,
+                          toastr,
+                          $translate,
+                          SparqlRestService,
+                          ConnectorsRestService,
+                          ModalService,
+                          MonitoringRestService,
+                          EventEmitterService,
+                          LocalStorageAdapter,
+                          LSKeys) {
     const securityContextService = service(SecurityContextService);
     const guidesService = service(GuidesService);
     const parentWindowMessageService = service(ParentWindowMessageService);
@@ -90,14 +93,13 @@ function SparqlEditorCtrl($rootScope,
     const languageContextService = ServiceProvider.get(LanguageContextService);
     const repositoryContextService = service(RepositoryContextService);
     const eventService = service(EventService);
+    const sparqlStorageService = service(SparqlStorageService);
 
     this.repository = '';
 
     const QUERY_EDITOR_ID = '#query-editor';
     let activeRepository = $repositories.getActiveRepository();
     let isOntopRepo = $repositories.isActiveRepoOntopType();
-    let initialRepositoryChange = true;
-    let skipLocationChangeHandler = false;
     // This is used to determine whether the view is embedded in another application. When embedded, we want to hide
     // some elements and disable the "go to home" functionality, as it doesn't make sense in that context.
     $scope.embedded = $location.search().embedded;
@@ -592,35 +594,12 @@ function SparqlEditorCtrl($rootScope,
             });
         // TODO: we should also watch for changes in namespaces
         // scope.$watch('namespaces', function () {});
-        initialRepositoryChange = false;
     };
 
     // =========================
     // Event handlers
     // =========================
     const subscriptions = [];
-
-    const repositoryWillChangeHandler = () => {
-        return new Promise((resolve) => {
-            confirmAbortQueries('view.sparql-editor.repository_change.run_queries.confirmation', () => resolve(true), () => resolve(false));
-        });
-    };
-
-    const repositoryChangedHandler = (object) => {
-        if (!object) {
-            return;
-        }
-
-        activeRepository = $repositories.getActiveRepository();
-        isOntopRepo = $repositories.isActiveRepoOntopType(object);
-        skipLocationChangeHandler = !initialRepositoryChange;
-        if (LocalStorageAdapter.get(LSKeys.SPARQL_LAST_REPO) !== activeRepository) {
-            init(true);
-            persistLasstUsedRepository();
-        } else {
-            init(false);
-        }
-    };
 
     const beforeunloadHandler = (event) => {
         const ontotextYasguiElement = YasguiComponentDirectiveUtil.getOntotextYasguiElement(QUERY_EDITOR_ID);
@@ -633,87 +612,176 @@ function SparqlEditorCtrl($rootScope,
         ontotextYasguiElement.abortAllRequests().then(() => {
         });
     };
-    window.addEventListener('beforeunload', beforeunloadHandler);
 
-    // First, we check if there are any ongoing requests initiated by the user.
-    // If the user has ongoing requests, we request confirmation to abort them.
-    // If the user confirms or there are no ongoing requests, we call the "abortAllRequests" method. This method will abort all requests.
-    const confirmAbortQueries = (messageKey, successCallback, errorCallback, alwaysShowConfirm = false) => {
-        const ontotextYasguiElement = YasguiComponentDirectiveUtil.getOntotextYasguiElement(QUERY_EDITOR_ID);
-        if (!ontotextYasguiElement) {
-            successCallback();
+    /**
+     * Determines whether a repository change should be allowed to proceed.
+     *
+     * Prompts the user for confirmation before switching repositories. If the user confirms, any running queries are aborted
+     * and the repository change is allowed.
+     *
+     * If the user does not confirm, or if aborting the running queries fails, the repository change is not allowed.
+     *
+     * @returns A promise that resolves to
+     *    <code>true</code> if the repository changeshould be allowed, or
+     *    <code>false</code> otherwise.
+     */
+    const shouldAllowRepositoryChanged = () => {
+        return new Promise((resolveAllowRepositoryChange) => {
+            confirmAndAbortRunningQueries('view.sparql-editor.repository_change.run_queries.confirmation', (confirmed) => resolveAllowRepositoryChange(confirmed), () => resolveAllowRepositoryChange(false));
+        });
+    };
+
+    const repositoryChangedHandler = (repositoryReference) => {
+        if (!repositoryReference) {
             return;
         }
-
-        ontotextYasguiElement
-            .getOngoingRequestsInfo()
-            .then((hasRunQuery) => confirmAbortQueriesDialog(messageKey, hasRunQuery, alwaysShowConfirm))
-            .then(() => ontotextYasguiElement.abortAllRequests())
-            .then(() => {
-                successCallback();
-            })
-            .catch((error) => {
-                if (!(error instanceof CancelAbortingQuery)) {
-                    logger.error(error);
-                    errorCallback();
-                }
-            });
+        activeRepository = repositoryReference.id;
+        isOntopRepo = repositoryContextService.isActiveRepoOntopType();
+        const lastUsedRepositoryId = sparqlStorageService.getLastUsedRepository();
+        if (lastUsedRepositoryId === activeRepository) {
+            init(false);
+        } else {
+            init(true);
+            persistLasstUsedRepository(activeRepository);
+        }
     };
 
     /**
-     * Displays a confirmation dialog asking whether running queries should be aborted before the logout action is performed.
+     * Determines whether a language change should be allowed to proceed.
      *
-     * @returns A promise that resolves to <code>true</code> if the user confirms the action, or <code>false</code> if the action is canceled.
+     * Always prompts the user for confirmation before changing the language, regardless of whether there are running queries.
+     * If the user confirms, any running queries are aborted and the language change is allowed.
+     *
+     * If the user does not confirm, or aborting the running queries fails, the language change is not allowed.
+     *
+     * @returns A promise that resolves to <code>true</code> if the language change
+     * should be allowed, or <code>false</code> otherwise.
      */
-    const confirmLogout = () => {
-        return new Promise((resolve) => {
-            confirmAbortQueries('view.sparql-editor.language_change.run_queries.confirmation', () => resolve(false), () => resolve(true));
+    const shouldAllowLanguageChanged = () => {
+        return new Promise((resolveAllowLanguageChanged) => {
+            confirmAndAbortRunningQueries('view.sparql-editor.language_change.run_queries.confirmation', (confirmed) => resolveAllowLanguageChanged(confirmed), () => resolveAllowLanguageChanged(false), true);
         });
     };
 
-    const confirmAbortQueriesDialog = (messageKey, ongoingRequestsInfo, alwaysShowConfirm = false) => new Promise((resolve, reject) => {
-        if (!alwaysShowConfirm && (!ongoingRequestsInfo || ongoingRequestsInfo.queriesCount < 1 && ongoingRequestsInfo.updatesCount < 1)) {
-            resolve();
-            return;
-        }
+    const onLanguageChangeHandler = () => {
+        // The page needs to be reloaded, because of the Google charts and Pivot table scripts. When the language is
+        // changed, the correct language for these components is loaded only on the page reload, but we can't be sure
+        // that the user will reload the page by themselves, so we need to do it programmatically. We can't just change
+        // the src of the existing script, because these components don't react to it, so we need to reload the whole page.
+        WindowService.reloadPage();
+    };
 
-        const title = $translate.instant('common.confirm');
-        const message = decodeHTML(getExitPageConfirmMessage(messageKey, ongoingRequestsInfo));
-        ModalService.openSimpleModal({
-            title,
-            message,
-            warning: true,
-        }).result.then(function() {
-            resolve();
-        }, function() {
-            reject(new CancelAbortingQuery());
-        });
-    });
-
-    const locationChangeHandler = (eventPayload) => {
-        if (internallyReloaded || skipLocationChangeHandler) {
+    let bypassNextCancellation = false;
+    /**
+     * Determines whether a location-change navigation should be canceled.
+     *
+     * In this single-spa AngularJS setup, canceling navigation asynchronously
+     * (i.e.resolving cancelNavigation's promise only after the user responds to the confirmation dialog) does not work as expected:
+     *  the page navigates away first, and only afterward does click "Cancel" in the dialog send the user back to
+     * the previous page.
+     * This produces a visible flash of navigation before the cancellation takes effect.
+     *
+     * To avoid this, navigation is canceled immediately and synchronously (this always resolves to true), before the confirmation dialog is even shown.
+     * The user is then asked to confirm via confirmAndAbortRunningQueries. If they confirm, running queries are aborted and navigation to the originally
+     * requested URL is triggered manually via navigateTo.
+     *
+     * Because that manual re-navigation is intercepted and canceled by this same handler, bypassNextCancellation is set beforehand so the re-triggered navigation
+     * is allowed to proceed without prompting the user again.
+     *
+     * @param eventPayload - The single-spa navigation event payload, containing the target URL.
+     * @returns A promise that resolves to <code>true</code>, always canceling the current navigation attempt synchronously.
+     * The actual navigation, if confirmed by the user, is re-triggered separately via navigateTo.
+     */
+    const shouldCancelNavigationOnLocationChange = (eventPayload) => {
+        if (internallyReloaded || bypassNextCancellation) {
             internallyReloaded = false;
-            skipLocationChangeHandler = false;
-            return;
+            bypassNextCancellation = false;
+            return Promise.resolve(false);
         }
 
         const url = new URL(eventPayload.newUrl);
         const newUrl = url.pathname + url.search + url.hash;
-        eventPayload.cancelNavigation();
-        const handler = () => {
-            skipLocationChangeHandler = true;
+
+        /**
+         * Handles the user's confirmation decision. If confirmed, re-triggers navigation
+         * to the originally requested URL after the current call stack clears, marking
+         * the next navigation attempt to bypass this cancellation check.
+         *
+         * @param confirmed - Whether the user confirmed leaving the page.
+         */
+        const onConfirmationResult = (confirmed) => {
             // Use setTimeout to ensure that the navigation is triggered after the current call stack is cleared.
             setTimeout(() => {
-                navigateTo(newUrl)();
+                if (confirmed) {
+                    bypassNextCancellation = true;
+                    navigateTo(newUrl)();
+                }
             });
         };
-        confirmAbortQueries('view.sparql-editor.leave_page.run_queries.confirmation', handler, handler);
+
+        // On error, navigation stays canceled (already resolved true below) — no further action needed.
+        confirmAndAbortRunningQueries('view.sparql-editor.leave_page.run_queries.confirmation', onConfirmationResult, () => {});
+
+        return Promise.resolve(true);
     };
 
-    subscriptions.push(
-        eventService.subscribe(EventName.NAVIGATION_START, (eventPayload) => locationChangeHandler(eventPayload)),
-        eventService.subscribe(EventName.LOGOUT, () => {}, confirmLogout),
-    );
+    /**
+     * Determines whether navigation away from the current page should be canceled, based on the user's confirmation
+     * and the outcome of aborting any running queries.
+     *
+     * Prompts the user for confirmation before leaving the page. If the user confirms, any running queries are aborted
+     * and navigation is allowed to proceed. If the user does not confirm, or if aborting the running queries fails,
+     * navigation is canceled.
+     *
+     * @returns A promise that resolves to
+     *    <code>true</code> if navigation should be canceled,or
+     *    <code>false</code> if the user confirmed and navigation may proceed.
+     */
+    const shouldCancelNavigationOnLogout = () => {
+        return new Promise((resolveCancelNavigation) => {
+            confirmAndAbortRunningQueries('view.sparql-editor.language_change.run_queries.confirmation', (confirmed) => resolveCancelNavigation(!confirmed), () => resolveCancelNavigation(true));
+        });
+    };
+
+    const confirmAndAbortRunningQueries = (messageKey, onDecisionCallback, errorCallback, alwaysShowConfirm = false) => {
+        const ontotextYasguiElement = YasguiComponentDirectiveUtil.getOntotextYasguiElement(QUERY_EDITOR_ID);
+        if (!ontotextYasguiElement) {
+            onDecisionCallback(true);
+            return;
+        }
+
+        // First, we check if there are any ongoing requests initiated by the user.
+        // If the user has ongoing requests, we request confirmation to abort them.
+        // If the user confirms or there are no ongoing requests, we call the "abortAllRequests" method. This method will abort all requests.
+        ontotextYasguiElement
+            .getOngoingRequestsInfo()
+            .then((hasRunQuery) => confirmIfHaveRunQueryNew(messageKey, hasRunQuery, alwaysShowConfirm))
+            .then((confirm) => confirm ? ontotextYasguiElement.abortAllRequests().then(() => confirm) : confirm)
+            .then((confirm) => onDecisionCallback(confirm))
+            .catch((error) => errorCallback(error));
+    };
+
+    const confirmIfHaveRunQueryNew = (messageKey, ongoingRequestsInfo, alwaysShowConfirm = false) => {
+        return new Promise((resolve) => {
+            if (!alwaysShowConfirm && (!ongoingRequestsInfo || ongoingRequestsInfo.queriesCount < 1 && ongoingRequestsInfo.updatesCount < 1)) {
+                resolve(true);
+                return;
+            }
+
+            const title = $translate.instant('common.confirm');
+            const message = decodeHTML(getExitPageConfirmMessage(messageKey, ongoingRequestsInfo));
+            ModalService.openSimpleModal({
+                title,
+                message,
+                warning: true,
+            }).result.then(function() {
+                resolve(true);
+            }, function() {
+                logger.warn('Cancel Aborting Query');
+                resolve(false);
+            });
+        });
+    };
 
     const removeAllListeners = () => {
         subscriptions.forEach((subscription) => subscription());
@@ -739,25 +807,14 @@ function SparqlEditorCtrl($rootScope,
         LocalStorageAdapter.set(LSKeys.SPARQL_LAST_REPO, activeRepository);
     };
 
-    const onLanguageChange = () => {
-        WindowService.reloadPage();
-    };
-
-    const showLanguageChangeConfirmation = () => {
-        return new Promise((resolve) => {
-            confirmAbortQueries('view.sparql-editor.language_change.run_queries.confirmation', () => resolve(true), () => resolve(false), true);
-        });
-    };
-
+    window.addEventListener('beforeunload', beforeunloadHandler);
     subscriptions.push(
+        repositoryContextService.onSelectedRepositoryChanged((repositoryReference) => repositoryChangedHandler(repositoryReference), () => shouldAllowRepositoryChanged()),
         // Subscribe to language change and ask to reload the page
-        languageContextService.onSelectedLanguageChanged(onLanguageChange, showLanguageChangeConfirmation, true),
+        languageContextService.onSelectedLanguageChanged(() => onLanguageChangeHandler(), () => shouldAllowLanguageChanged(), true),
+        eventService.subscribe(EventName.NAVIGATION_START, () => {}, (event) => shouldCancelNavigationOnLocationChange(event)),
+        eventService.subscribe(EventName.LOGOUT, () => {}, () => shouldCancelNavigationOnLogout()),
         // Deregister the watcher when the scope/directive is destroyed
         $scope.$on('$destroy', finalizeAndDestroy),
     );
-
-    // Wait until the active repository object is set, otherwise "canWriteActiveRepo()" may return a wrong result and the "ontotext-yasgui"
-    // readOnly configuration may be incorrect.
-    const repositoryChangeSubscription = repositoryContextService.onSelectedRepositoryChanged(repositoryChangedHandler, repositoryWillChangeHandler);
-    subscriptions.push(repositoryChangeSubscription);
 }

--- a/packages/legacy-workbench/src/js/angular/sparql-editor/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/sparql-editor/controllers.js
@@ -89,6 +89,7 @@ function SparqlEditorCtrl($rootScope,
     const graphConfigService = service(GraphConfigService);
     const languageContextService = ServiceProvider.get(LanguageContextService);
     const repositoryContextService = service(RepositoryContextService);
+    const eventService = service(EventService);
 
     this.repository = '';
 
@@ -659,6 +660,17 @@ function SparqlEditorCtrl($rootScope,
             });
     };
 
+    /**
+     * Displays a confirmation dialog asking whether running queries should be aborted before the logout action is performed.
+     *
+     * @returns A promise that resolves to <code>true</code> if the user confirms the action, or <code>false</code> if the action is canceled.
+     */
+    const confirmLogout = () => {
+        return new Promise((resolve) => {
+            confirmAbortQueries('view.sparql-editor.language_change.run_queries.confirmation', () => resolve(false), () => resolve(true));
+        });
+    };
+
     const confirmAbortQueriesDialog = (messageKey, ongoingRequestsInfo, alwaysShowConfirm = false) => new Promise((resolve, reject) => {
         if (!alwaysShowConfirm && (!ongoingRequestsInfo || ongoingRequestsInfo.queriesCount < 1 && ongoingRequestsInfo.updatesCount < 1)) {
             resolve();
@@ -699,7 +711,8 @@ function SparqlEditorCtrl($rootScope,
     };
 
     subscriptions.push(
-        ServiceProvider.get(EventService).subscribe(EventName.NAVIGATION_START, (eventPayload) => locationChangeHandler(eventPayload)),
+        eventService.subscribe(EventName.NAVIGATION_START, (eventPayload) => locationChangeHandler(eventPayload)),
+        eventService.subscribe(EventName.LOGOUT, () => {}, confirmLogout),
     );
 
     const removeAllListeners = () => {

--- a/packages/root-config/src/assets/i18n/en.json
+++ b/packages/root-config/src/assets/i18n/en.json
@@ -13,5 +13,6 @@
   "guide.step-type.info": "This step provides some information. No action required other than clicking the Next button.",
   "guide.step-type.mouse": "This step expects user action with the mouse, typically clicking on something.",
   "guide.step-type.input": "This step expects user input, typically typing or pasting a piece of text.",
-  "guides.error.guide-not-found": "The requested guide could not be found."
+  "guides.error.guide-not-found": "The requested guide could not be found.",
+  "logout.success": "Signed out"
 }

--- a/packages/root-config/src/assets/i18n/fr.json
+++ b/packages/root-config/src/assets/i18n/fr.json
@@ -13,5 +13,6 @@
   "guide.step-type.info": "Cette étape fournit des informations. Aucune action requise autre que de cliquer sur le bouton Suivant.",
   "guide.step-type.mouse": "Cette étape attend une action de l'utilisateur avec la souris, généralement un clic sur quelque chose.",
   "guide.step-type.input": "Cette étape attend une entrée de l'utilisateur, généralement en tapant ou en collant un morceau de texte.",
-  "guides.error.guide-not-found": "Le guide demandé est introuvable."
+  "guides.error.guide-not-found": "Le guide demandé est introuvable.",
+  "logout.success": "Déconnecté"
 }

--- a/packages/root-config/src/bootstrap/bootstrap.ts
+++ b/packages/root-config/src/bootstrap/bootstrap.ts
@@ -22,6 +22,7 @@ import {start} from 'single-spa';
 import {defineCustomElements} from '../../../shared-components/loader';
 import {registerInterceptors} from './interceptors/interceptors-registration';
 import {runtimeConfigurationBootstrap} from './runtime-configuration/runtime-configuration';
+import {registerAuthenticationEventHandlers} from './security/authentication-event-handlers';
 
 const logger = LoggerProvider.logger;
 let isInitialBootstrap = true;
@@ -136,6 +137,7 @@ export const bootstrapWorkbench = (): Promise<void> => {
     .then(() => {
       subscribeToAuthenticatedUserChange();
       defineCustomElements();
+      registerAuthenticationEventHandlers();
       return start();
     });
 };

--- a/packages/root-config/src/bootstrap/security/authentication-event-handlers.ts
+++ b/packages/root-config/src/bootstrap/security/authentication-event-handlers.ts
@@ -21,7 +21,7 @@ export const registerAuthenticationEventHandlers = (): void => {
   service(EventService).subscribe(EventName.LOGOUT, () => service(AuthenticationService).logout());
   service(EventService).subscribe(EventName.LOGGED_OUT, () => {
     const languageContextService = service(LanguageContextService);
-    const bundle = languageContextService.getLanguageBundleOrDefault();
+    const bundle = languageContextService.getLanguageBundle();
     const title = TranslationUtil.translate(bundle, 'logout.success') ?? 'logout.success';
     notify(
       new Notification('')

--- a/packages/root-config/src/bootstrap/security/authentication-event-handlers.ts
+++ b/packages/root-config/src/bootstrap/security/authentication-event-handlers.ts
@@ -1,0 +1,35 @@
+import {
+  service,
+  EventService,
+  AuthenticationService,
+  LanguageContextService,
+  TranslationUtil,
+  EventName,
+  notify,
+  Notification, NotificationType, NotificationParam,
+} from '@ontotext/workbench-api';
+
+/**
+ * Registers handlers for authentication-related events.
+ *
+ * When a logout is requested, the current user is logged out through the authentication service.
+ * After the logout completes, a localized success notification is displayed as a toast.
+ *
+ * This function should be called once during application bootstrap to avoid registering duplicate event subscriptions.
+ */
+export const registerAuthenticationEventHandlers = (): void => {
+  service(EventService).subscribe(EventName.LOGOUT, () => service(AuthenticationService).logout());
+  service(EventService).subscribe(EventName.LOGGED_OUT, () => {
+    const languageContextService = service(LanguageContextService);
+    const bundle = languageContextService.getLanguageBundle() ?? languageContextService.getDefaultBundle();
+    const title = TranslationUtil.translate(bundle, 'logout.success') ?? 'logout.success';
+    notify(
+      new Notification('')
+        .withType(NotificationType.SUCCESS)
+        .withTitle(title)
+        .withParameters({
+          [NotificationParam.SHOULD_TOAST]: true,
+        }),
+    );
+  });
+};

--- a/packages/root-config/src/bootstrap/security/authentication-event-handlers.ts
+++ b/packages/root-config/src/bootstrap/security/authentication-event-handlers.ts
@@ -21,7 +21,7 @@ export const registerAuthenticationEventHandlers = (): void => {
   service(EventService).subscribe(EventName.LOGOUT, () => service(AuthenticationService).logout());
   service(EventService).subscribe(EventName.LOGGED_OUT, () => {
     const languageContextService = service(LanguageContextService);
-    const bundle = languageContextService.getLanguageBundle() ?? languageContextService.getDefaultBundle();
+    const bundle = languageContextService.getLanguageBundleOrDefault();
     const title = TranslationUtil.translate(bundle, 'logout.success') ?? 'logout.success';
     notify(
       new Notification('')

--- a/packages/root-config/src/bootstrap/security/security-bootstrap.ts
+++ b/packages/root-config/src/bootstrap/security/security-bootstrap.ts
@@ -78,12 +78,12 @@ const resolveNavigation = (): void => {
     const returnUrl = returnUrlParam ? decodeURIComponent(returnUrlParam) : './';
 
     navigate(returnUrl);
-    eventService.emit(new Login());
+    void eventService.emit(new Login());
   } else if (isLoginPage() && !isLoggedIn) {
     // On login page but not logged in, do nothing and let the user log in
   } else if (authorizationService.hasFreeAccess() || isLoggedIn) {
     // Not on login page and has access, do nothing and let the user see the page
-    eventService.emit(new Login());
+    void eventService.emit(new Login());
   } else if (!authStrategy.isAuthenticated()) {
     // Not on login page and not authenticated, navigate to login page with return url
     const returnUrl = encodeURIComponent(getLocationPathWithQueryParams());

--- a/packages/root-config/src/models/models.ts
+++ b/packages/root-config/src/models/models.ts
@@ -17,7 +17,8 @@ export interface NavigationEvent extends CustomEvent {
   detail: {
     oldUrl: string;
     newUrl: string;
-    cancelNavigation?: () => void;
+    // eslint-disable-next-line no-unused-vars
+    cancelNavigation?: (cancel?: boolean | Promise<boolean>) => void;
   };
 }
 

--- a/packages/root-config/src/ontotext-root-config.ts
+++ b/packages/root-config/src/ontotext-root-config.ts
@@ -96,7 +96,8 @@ function registerSingleSpaRouterListeners(): void {
   WindowService.getWindow().addEventListener('single-spa:before-routing-event', (evt: Event) => {
     // 2nd event emitted by SingleSpa, next is single-spa:before-mount-routing-event
     const d = (evt as NavigationEvent).detail;
-    service(EventService).emit(new NavigationStart(d.oldUrl, d.newUrl, d.cancelNavigation));
+    const cancelNavigation = service(EventService).emit(new NavigationStart(d.oldUrl, d.newUrl, d.cancelNavigation));
+    (evt as NavigationEvent).detail.cancelNavigation(cancelNavigation);
   });
 
   WindowService.getWindow().addEventListener('single-spa:before-mount-routing-event', (evt: Event) => {

--- a/packages/shared-components/cypress/e2e/operations-notification/operations-notification.cy.js
+++ b/packages/shared-components/cypress/e2e/operations-notification/operations-notification.cy.js
@@ -1,5 +1,4 @@
 import {OperationsNotificationSteps} from "../../steps/operations-notification/operations-notification.steps";
-import {HeaderSteps} from "../../steps/header/header-steps";
 
 const assertGroupCount = (index, textValue) => {
   OperationsNotificationSteps.getHeaderGroups()
@@ -9,13 +8,9 @@ const assertGroupCount = (index, textValue) => {
 };
 
 const assertRedirectLink = (index, textValue) => {
-  OperationsNotificationSteps.getDropdownButton().click();
-  OperationsNotificationSteps.getOperationsDropdownElements().eq(index).click();
-
-  OperationsNotificationSteps.getRedirectUrl()
-    .last()
-    .invoke('text')
-    .should('equal', `redirect to ${textValue}`);
+  OperationsNotificationSteps.getOperationsDropdownElements().eq(index)
+    .should('have.attr', 'href', textValue)
+    .should('have.attr', 'target', '_blank');
 }
 
 describe('onto-operations-notification', () => {
@@ -62,6 +57,7 @@ describe('onto-operations-notification', () => {
     OperationsNotificationSteps.loadRepositories();
     OperationsNotificationSteps.getRepositoryItems().should('have.length', 6);
     OperationsNotificationSteps.setMarvelRepo();
+    OperationsNotificationSteps.getDropdownButton().click();
 
     const operationLinks = ['cluster', 'monitor/backup-and-restore', 'import', 'monitor/queries', 'monitor/queries'];
 

--- a/packages/shared-components/src/components/onto-header/onto-header.tsx
+++ b/packages/shared-components/src/components/onto-header/onto-header.tsx
@@ -426,7 +426,7 @@ export class OntoHeader {
     this.toastrService.info(TranslationService.translate('rdf_search.toasts.use_view_resource'));
     this.shouldShowSearch = false;
     HtmlUtil.focusElement('#search-resource-input-home input');
-    this.eventService.emit({NAME: ResourceSearchConstants.RDF_SEARCH_ICON_CLICKED});
+    void this.eventService.emit({NAME: ResourceSearchConstants.RDF_SEARCH_ICON_CLICKED});
   };
 
   // ========================

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -267,7 +267,7 @@ export class OntoLayout {
     );
 
     this.subscriptions.add(
-      this.eventService.subscribe(EventName.LOGOUT, () => {
+      this.eventService.subscribe(EventName.LOGGED_OUT, () => {
         this.setNavbarItemVisibility();
         this.updateVisibility();
         navigate('login');

--- a/packages/shared-components/src/components/onto-operations-notification/onto-operations-notification.tsx
+++ b/packages/shared-components/src/components/onto-operations-notification/onto-operations-notification.tsx
@@ -3,7 +3,7 @@ import {
   OperationGroup,
   OperationStatus,
   OperationStatusSummary,
-  OperationGroupSummaryList, navigateTo
+  OperationGroupSummaryList,
 } from '@ontotext/workbench-api';
 
 const operationGroupToIcon = {
@@ -74,7 +74,7 @@ export class OntoOperationsNotification {
                   <li key={operation.id}>
                     <a class={`operation-status-content onto-btn no-underline ${operationStatusToWarningClass[operation.status]}`}
                       target="_blank"
-                      onClick={navigateTo(operation.href)}>
+                      href={operation.href}>
                       <i class={operationGroupToIcon[operation.group]}></i>
                       <span class="operation-status-label">
                         <translate-label

--- a/packages/shared-components/src/components/onto-search-resource-input/onto-search-resource-input.tsx
+++ b/packages/shared-components/src/components/onto-search-resource-input/onto-search-resource-input.tsx
@@ -241,7 +241,7 @@ export class OntoSearchResourceInput {
 
   private notifyRdfResourceSelected(suggestion: Suggestion) {
     this.searchResult = this.searchResult?.selectSuggestion(suggestion);
-    this.eventService.emit({
+    void this.eventService.emit({
       NAME: ResourceSearchConstants.SUGGESTION_SELECTED_EVENT,
       payload: new SuggestionSelectedPayload(suggestion, this.context)
     });

--- a/packages/shared-components/src/components/onto-user-menu/onto-user-menu.tsx
+++ b/packages/shared-components/src/components/onto-user-menu/onto-user-menu.tsx
@@ -2,6 +2,8 @@ import {Component, h, Prop, State, Element} from '@stencil/core';
 import {
   AuthenticatedUser,
   AuthenticationService,
+  EventService,
+  Logout,
   navigateTo,
   SecurityConfig,
   service
@@ -17,6 +19,7 @@ import {
 })
 export class OntoUserMenu {
   private readonly authenticationService = service(AuthenticationService);
+  private readonly eventService = service(EventService);
   /** Whether the dropdown menu is open or closed */
   @State() private isOpen: boolean;
 
@@ -62,7 +65,7 @@ export class OntoUserMenu {
   * Log out the current user.
   */
   private readonly logout = (): void => {
-    this.authenticationService.logout();
+    this.eventService.emit(new Logout());
   };
 
   /**

--- a/packages/shared-components/src/components/onto-user-menu/onto-user-menu.tsx
+++ b/packages/shared-components/src/components/onto-user-menu/onto-user-menu.tsx
@@ -65,7 +65,7 @@ export class OntoUserMenu {
   * Log out the current user.
   */
   private readonly logout = (): void => {
-    this.eventService.emit(new Logout());
+    void this.eventService.emit(new Logout());
   };
 
   /**

--- a/packages/workbench/src/app/bootstrap/transloco/transloco-bootstrap.ts
+++ b/packages/workbench/src/app/bootstrap/transloco/transloco-bootstrap.ts
@@ -14,12 +14,11 @@ import {environment} from '../../../environments/environment';
 const translocoInitializeProvider = provideAppInitializer(() => {
   const translocoService = inject(TranslocoService);
   const languageContextService = ServiceProvider.get(LanguageContextService);
-  const languageService = ServiceProvider.get(LanguageService);
 
   return new Promise<void>((resolve) => {
     languageContextService.onLanguageBundleChanged((languageBundle?: TranslationBundle) => {
       if (languageBundle) {
-        const languageCode = languageContextService.getSelectedLanguage() || languageService.getDefaultLanguage();
+        const languageCode = languageContextService.getSelectedLanguage();
         translocoService.setTranslation(languageBundle, languageCode);
         translocoService.setActiveLang(languageCode);
         resolve();

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.ts
@@ -175,7 +175,7 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
    * The currently selected language in the application. This is used to set the language of the ontotext-yasgui
    * component and to update it when the selected language changes in the application.
    */
-  language = signal<string | undefined>(this.languageContextService.getSelectedLanguage() || this.languageContextService.getDefaultLanguage());
+  language = signal<string | undefined>(this.languageContextService.getSelectedLanguage());
 
   // ===================================
   // Outputs

--- a/packages/workbench/src/app/pages/sparql-editor/error/cancel-abort-query.ts
+++ b/packages/workbench/src/app/pages/sparql-editor/error/cancel-abort-query.ts
@@ -1,1 +1,0 @@
-export class CancelAbortingQuery extends Error {}

--- a/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.ts
+++ b/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.ts
@@ -187,6 +187,8 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
       this.repositoryContextService.onSelectedRepositoryChanged((repositoryReference) => this.repositoryChangedHandler(repositoryReference), () => this.repositoryBeforeChangeHandler()),
       this.languageContextService.onSelectedLanguageChanged(() => this.onLanguageChangeHandler(), () => this.onBeforeLanguageChange(), true),
       this.eventService.subscribe(EventName.NAVIGATION_START, (eventPayload: NavigationStartPayload) => this.locationChangeHandler(eventPayload)),
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      this.eventService.subscribe(EventName.LOGOUT, ()=> {}, () => this.confirmLogout()),
     ]);
   }
 
@@ -707,6 +709,19 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
         }
       });
   }
+
+  /**
+   * Displays a confirmation dialog asking whether running queries should be aborted
+   * before the logout action is performed.
+   *
+   * @returns A promise that resolves to <code>true</code> if the user confirms the action,
+   * or <code>false</code> if the action is canceled.
+   */
+  private confirmLogout(): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      this.confirmAbortQueries('sparql_editor.confirmation.on_page_leave', () => resolve(false), () => resolve(true));
+    });
+  };
 
   /**
    * Initializes the SPARQL editor page.

--- a/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.ts
+++ b/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.ts
@@ -23,9 +23,7 @@ import {
   MonitoringService,
   NamespaceMap,
   NamespacesService,
-  navigateTo,
   openInNewTab,
-  NavigationStartPayload,
   OntoToastrService,
   ParentWindowMessageService,
   Rdf4jRepositoryService,
@@ -57,7 +55,6 @@ import {YasguiComponent} from '../../components/yasgui-component-facade/models/y
 import {ConnectorCommand} from '../../models/connectors/connector-command';
 import {mapSavedQueryToTabQueryModel} from './mappers/saved-query-to-tab-query-model.mapper';
 import {OngoingRequestsInfo} from '../../components/yasgui-component-facade/models/ongoing-requests-info';
-import {CancelAbortingQuery} from './error/cancel-abort-query';
 import {DialogProviderService} from '../../services/dialog/dialog-provider.service';
 import {DynamicDialogRef} from 'primeng/dynamicdialog';
 import {ConnectorProgressDialogComponent} from '../../components/connector-progress/connector-progress-dialog.component';
@@ -167,8 +164,6 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
   private isExternalClickHandlerOperationEnabled = false;
   private selectedPlugin?: string;
   private readonly boundBeforeunloadHandler = () => this.beforeunloadHandler();
-  private initialRepositoryChange = true;
-  private skipLocationChangeHandler = false;
 
   // ================================
   // Public variables
@@ -180,30 +175,6 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.subscribeHandlers();
     window.addEventListener('beforeunload', this.boundBeforeunloadHandler);
-  }
-
-  private subscribeHandlers() {
-    this.subscriptions.addAll([
-      this.repositoryContextService.onSelectedRepositoryChanged((repositoryReference) => this.repositoryChangedHandler(repositoryReference), () => this.repositoryBeforeChangeHandler()),
-      this.languageContextService.onSelectedLanguageChanged(() => this.onLanguageChangeHandler(), () => this.onBeforeLanguageChange(), true),
-      this.eventService.subscribe(EventName.NAVIGATION_START, (eventPayload: NavigationStartPayload) => this.locationChangeHandler(eventPayload)),
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      this.eventService.subscribe(EventName.LOGOUT, ()=> {}, () => this.confirmLogout()),
-    ]);
-  }
-
-  private onLanguageChangeHandler() {
-    // The page needs to be reloaded, because of the Google charts and Pivot table scripts. When the language is
-    // changed, the correct language for these components is loaded only on the page reload, but we can't be sure
-    // that the user will reload the page by themselves, so we need to do it programmatically. We can't just change
-    // the src of the existing script, because these components don't react to it, so we need to reload the whole page.
-    WindowService.reloadPage();
-  }
-
-  private onBeforeLanguageChange() {
-    return new Promise<boolean>((resolve) => {
-      this.confirmAbortQueries('sparql_editor.confirmation.on_language_change', () => resolve(true), () => resolve(false), true);
-    });
   }
 
   /**
@@ -610,28 +581,6 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
     this.sparqlStorageService.setLastUsedRepository(repositoryId);
   }
 
-  private repositoryBeforeChangeHandler(): Promise<boolean> {
-    return new Promise((resolve) => {
-      this.confirmAbortQueries('sparql_editor.confirmation.on_repository_change', () => resolve(true), () => resolve(false));
-    });
-  }
-
-  private repositoryChangedHandler(repositoryReference: RepositoryReference | undefined) {
-    if (!repositoryReference) {
-      return;
-    }
-    this.activeRepositoryReference = repositoryReference;
-    this.isOntopRepo = this.repositoryContextService.isActiveRepoOntopType();
-    const lastUsedRepositoryId = this.sparqlStorageService.getLastUsedRepository();
-    this.skipLocationChangeHandler = !this.initialRepositoryChange;
-    if (lastUsedRepositoryId === this.activeRepositoryReference.id) {
-      this.init(false);
-    } else {
-      this.init(true);
-      this.persistLastUsedRepository(this.activeRepositoryReference.id);
-    }
-  }
-
   private beforeunloadHandler() {
     const ontotextYasguiElement = YasguiComponentUtil.getOntotextYasguiElement(this.QUERY_EDITOR_ID);
     if (!ontotextYasguiElement) {
@@ -644,84 +593,6 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
       // After all requests are aborted, we can allow the page to be unloaded without prompting the user for confirmation.
     });
   }
-
-  private confirmIfHaveRunQuery(messageKey: string, ongoingRequestsInfo: OngoingRequestsInfo, alwaysShowConfirm = false): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      if (!alwaysShowConfirm && (!ongoingRequestsInfo || ongoingRequestsInfo.queriesCount < 1 && ongoingRequestsInfo.updatesCount < 1)) {
-        resolve(false);
-        return;
-      }
-
-      this.confirmationProviderService.confirm({
-
-        header: this.translocoService.translate(`${messageKey}.title`),
-        message: this.getExitPageConfirmMessage(messageKey, ongoingRequestsInfo),
-        target: event!.target as EventTarget,
-        acceptHandler: () => {
-          resolve(true);
-        },
-        rejectHandler: () => {
-          reject(new CancelAbortingQuery());
-        }
-      });
-    });
-  }
-
-  locationChangeHandler(eventPayload: NavigationStartPayload) {
-    if (this.internallyReloaded || this.skipLocationChangeHandler) {
-      this.internallyReloaded = false;
-      this.skipLocationChangeHandler = false;
-      return;
-    }
-
-    const url = new URL(eventPayload.newUrl!);
-    const newUrl = url.pathname + url.search + url.hash;
-    eventPayload.cancelNavigation(true);
-    const handler = () => {
-      this.skipLocationChangeHandler = true;
-      // Use setTimeout to ensure that the navigation is triggered after the current call stack is cleared.
-      setTimeout(() => {
-        navigateTo(newUrl)();
-      });
-    };
-    this.confirmAbortQueries('sparql_editor.confirmation.on_page_leave', handler, handler);
-  }
-
-  private confirmAbortQueries(messageKey: string, successCallback: () => void, errorCallback: () => void, alwaysShowConfirm = false) {
-    const ontotextYasguiElement = YasguiComponentUtil.getOntotextYasguiElement(this.QUERY_EDITOR_ID);
-    if (!ontotextYasguiElement) {
-      successCallback();
-      return;
-    }
-
-    // First, we check if there are any ongoing requests initiated by the user.
-    // If the user has ongoing requests, we request confirmation to abort them.
-    // If the user confirms or there are no ongoing requests, we call the "abortAllRequests" method. This method will abort all requests.
-    ontotextYasguiElement
-      .getOngoingRequestsInfo()
-      .then((hasRunQuery) => this.confirmIfHaveRunQuery(messageKey, hasRunQuery, alwaysShowConfirm))
-      .then(() => ontotextYasguiElement.abortAllRequests())
-      .then(() => successCallback())
-      .catch((error) => {
-        if (!(error instanceof CancelAbortingQuery)) {
-          this.logger.error(error);
-          errorCallback();
-        }
-      });
-  }
-
-  /**
-   * Displays a confirmation dialog asking whether running queries should be aborted
-   * before the logout action is performed.
-   *
-   * @returns A promise that resolves to <code>true</code> if the user confirms the action,
-   * or <code>false</code> if the action is canceled.
-   */
-  private confirmLogout(): Promise<boolean> {
-    return new Promise<boolean>((resolve) => {
-      this.confirmAbortQueries('sparql_editor.confirmation.on_page_leave', () => resolve(false), () => resolve(true));
-    });
-  };
 
   /**
    * Initializes the SPARQL editor page.
@@ -767,7 +638,157 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
         this.updateConfig(clearYasguiState);
         this.initViewFromUrlParams(clearYasguiState);
       });
-    this.initialRepositoryChange = false;
+  }
+
+  private subscribeHandlers() {
+    this.subscriptions.addAll([
+      this.repositoryContextService.onSelectedRepositoryChanged((repositoryReference) => this.repositoryChangedHandler(repositoryReference), () => this.shouldAllowRepositoryChanged()),
+      this.languageContextService.onSelectedLanguageChanged(() => this.onLanguageChangeHandler(), () => this.shouldAllowLanguageChanged(), true),
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      this.eventService.subscribe(EventName.NAVIGATION_START, () => ()=> {}, () => this.shouldCancelNavigationOnLocationChange()),
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      this.eventService.subscribe(EventName.LOGOUT, ()=> {}, () => this.shouldCancelNavigationOnLogout()),
+    ]);
+  }
+
+  /**
+   * Determines whether a repository change should be allowed to proceed.
+   *
+   * Prompts the user for confirmation before switching repositories. If the user confirms, any running queries are aborted
+   * and the repository change is allowed.
+   *
+   * If the user does not confirm, or if aborting the running queries fails, the repository change is not allowed.
+   *
+   * @returns A promise that resolves to
+   *    <code>true</code> if the repository changeshould be allowed, or
+   *    <code>false</code> otherwise.
+   */
+  private shouldAllowRepositoryChanged(): Promise<boolean> {
+    return new Promise<boolean>((resolveAllowRepositoryChange) => {
+      this.confirmAndAbortRunningQueries('sparql_editor.confirmation.on_repository_change', (confirmed) => resolveAllowRepositoryChange(confirmed), () => resolveAllowRepositoryChange(false));
+    });
+  }
+
+  private repositoryChangedHandler(repositoryReference: RepositoryReference | undefined) {
+    if (!repositoryReference) {
+      return;
+    }
+    this.activeRepositoryReference = repositoryReference;
+    this.isOntopRepo = this.repositoryContextService.isActiveRepoOntopType();
+    const lastUsedRepositoryId = this.sparqlStorageService.getLastUsedRepository();
+    if (lastUsedRepositoryId === this.activeRepositoryReference.id) {
+      this.init(false);
+    } else {
+      this.init(true);
+      this.persistLastUsedRepository(this.activeRepositoryReference.id);
+    }
+  }
+
+  /**
+   * Determines whether a language change should be allowed to proceed.
+   *
+   * Always prompts the user for confirmation before changing the language, regardless of whether there are running queries.
+   * If the user confirms, any running queries are aborted and the language change is allowed.
+   *
+   * If the user does not confirm, or aborting the running queries fails, the language change is not allowed.
+   *
+   * @returns A promise that resolves to <code>true</code> if the language change
+   * should be allowed, or <code>false</code> otherwise.
+   */
+  private shouldAllowLanguageChanged(): Promise<boolean> {
+    return new Promise<boolean>((resolveAllowLanguageChanged) => {
+      this.confirmAndAbortRunningQueries('sparql_editor.confirmation.on_language_change', (confirmed) => resolveAllowLanguageChanged(confirmed), () => resolveAllowLanguageChanged(false), true);
+    });
+  }
+
+  private onLanguageChangeHandler() {
+    // The page needs to be reloaded, because of the Google charts and Pivot table scripts. When the language is
+    // changed, the correct language for these components is loaded only on the page reload, but we can't be sure
+    // that the user will reload the page by themselves, so we need to do it programmatically. We can't just change
+    // the src of the existing script, because these components don't react to it, so we need to reload the whole page.
+    WindowService.reloadPage();
+  }
+
+  /**
+   * Determines whether navigation triggered by a location change should be canceled.
+   *
+   * If the navigation was triggered internally (a reload initiated by the application itself),
+   * it is always allowed to proceed and the internal-reload flags are reset.
+   *
+   * Otherwise, prompts the user for confirmation before leaving the page. If the user confirms,
+   * any running queries are aborted, navigation is allowed to proceed,
+   * and subsequent location-change handling is skipped.
+   * If the user does not confirm, or if aborting the running queries fails, navigation is canceled.
+   *
+   * @returns A promise that resolves to
+   *    <code>true</code> if navigation should be canceled, or
+   *    <code>false</code> if navigation may proceed.
+   */
+  private shouldCancelNavigationOnLocationChange(): Promise<boolean> {
+    if (this.internallyReloaded) {
+      this.internallyReloaded = false;
+      return Promise.resolve(false);
+    }
+
+    return new Promise<boolean>((resolveCancelNavigation) => {
+      this.confirmAndAbortRunningQueries('sparql_editor.confirmation.on_page_leave', (confirmed) => resolveCancelNavigation(!confirmed), () => resolveCancelNavigation(true));
+    });
+  };
+
+  /**
+   * Determines whether navigation away from the current page should be canceled, based on the user's confirmation
+   * and the outcome of aborting any running queries.
+   *
+   * Prompts the user for confirmation before leaving the page. If the user confirms, any running queries are aborted
+   * and navigation is allowed to proceed. If the user does not confirm, or if aborting the running queries fails,
+   * navigation is canceled.
+   *
+   * @returns A promise that resolves to
+   *    <code>true</code> if navigation should be canceled,or
+   *    <code>false</code> if the user confirmed and navigation may proceed.
+   */
+  private shouldCancelNavigationOnLogout(): Promise<boolean> {
+    return new Promise<boolean>((resolveCancelNavigation) => {
+      this.confirmAndAbortRunningQueries('sparql_editor.confirmation.on_page_leave', (confirmed) => resolveCancelNavigation(!confirmed), () => resolveCancelNavigation(true));
+    });
+  }
+
+  private confirmAndAbortRunningQueries(messageKey: string, onDecisionCallback: (confirm: boolean) => void, errorCallback: (error: Error) => void, alwaysShowConfirm = false) {
+    const ontotextYasguiElement = YasguiComponentUtil.getOntotextYasguiElement(this.QUERY_EDITOR_ID);
+    if (!ontotextYasguiElement) {
+      onDecisionCallback(true);
+      return;
+    }
+
+    // First, we check if there are any ongoing requests initiated by the user.
+    // If the user has ongoing requests, we request confirmation to abort them.
+    // If the user confirms or there are no ongoing requests, we call the "abortAllRequests" method. This method will abort all requests.
+    ontotextYasguiElement
+      .getOngoingRequestsInfo()
+      .then((hasRunQuery) => this.confirmIfHaveRunQueryNew(messageKey, hasRunQuery, alwaysShowConfirm))
+      .then((confirm) => confirm ? ontotextYasguiElement.abortAllRequests().then(() => confirm) : confirm)
+      .then((confirm) => onDecisionCallback(confirm))
+      .catch((error: Error) => errorCallback(error));
+  }
+
+  private confirmIfHaveRunQueryNew(messageKey: string, ongoingRequestsInfo: OngoingRequestsInfo, alwaysShowConfirm = false): Promise<boolean> {
+    return new Promise((resolve) => {
+      if (!alwaysShowConfirm && (!ongoingRequestsInfo || ongoingRequestsInfo.queriesCount < 1 && ongoingRequestsInfo.updatesCount < 1)) {
+        resolve(true);
+        return;
+      }
+
+      this.confirmationProviderService.confirm({
+        header: this.translocoService.translate(`${messageKey}.title`),
+        message: this.getExitPageConfirmMessage(messageKey, ongoingRequestsInfo),
+        target: event!.target as EventTarget,
+        acceptHandler: () => resolve(true),
+        rejectHandler: () => {
+          this.logger.warn('Cancel Aborting Query');
+          resolve(false);
+        }
+      });
+    });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## What
- When the Logout action was triggered while a query was executing, the application started the logout process immediately. This caused the header and sidebar to disappear before the user confirmed the action. Additionally, the running query was not aborted correctly.
- Change EventService emit signature to return Promise<boolean>.

## Why
- There was no mechanism to prevent event execution once an action was triggered. As a result, events such as Logout were emitted immediately, even when additional confirmation or asynchronous processing was required before executing the action.
- The single-spa navigation event exposes a cancelNavigation method that accepts either a boolean or a Promise<boolean>, depending on the resolved value, navigation is either canceled or allowed to proceed. Previously, emit was synchronous, so this worked correctly. After adding event cancellation support, emit became asynchronous internally (it now awaits each subscriber's cancellation check) — but its signature stayed void, so single-spa had no way to wait for that check. As a result, single-spa continued navigating immediately, and any cancellation request from a subscriber was effectively ignored.

## How
- Extended the EventService subscription mechanism with optional cancellation handlers.
Before an event is emitted, all registered cancellation handlers are evaluated. If any handler requests cancellation, the event is not emitted and the associated action is not executed.
 Implemented cancellation handlers for query-related actions in the SPARQL editor. These handlers display the running query confirmation dialog, abort the running query when the user confirms the action, and prevent the action when the user cancels it.
- emit now returns a Promise<boolean> indicating whether the event was canceled. This promise is passed directly to single-spa's cancelNavigation, so single-spa waits for the cancellation check to resolve before proceeding. If the event was canceled, navigation is prevented; otherwise, it continues.

## Additional work
Fixes Operations links to open views in a new tab.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [ ] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
