### PR TITLE
GDB-14755 Create reactodia page

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "dependencies": {
         "@single-spa/import-map-injector": "^2.0.2",
         "graphdb-workbench-plugins": "~1.0.0",
+        "graphwise-reactodia": "^0.0.1-TR6",
         "import-map-overrides": "^6.1.0"
     }
 }

--- a/packages/api/src/services/domain/rdf4j/rdf4j-repository.service.ts
+++ b/packages/api/src/services/domain/rdf4j/rdf4j-repository.service.ts
@@ -74,6 +74,25 @@ export class Rdf4jRepositoryService implements Service {
   }
 
   /**
+   * Executes a SPARQL query against the specified repository and returns the raw, unparsed
+   * {@link Response}.
+   *
+   * Delegates to {@link Rdf4jRestService.executeSparqlRequest} and unwraps
+   * {@link HttpResponse.originalResponse}. The caller chooses the response format via the `accept`
+   * argument (e.g. `application/sparql-results+json` for SELECT/ASK or `application/rdf+json;` for
+   * CONSTRUCT/DESCRIBE). Suits consumers that need the unparsed response, such as Reactodia.
+   *
+   * @param repositoryId - The ID of the repository to query.
+   * @param query - The SPARQL query string.
+   * @param accept - Value for the `Accept` header, selecting the response format.
+   * @returns A promise resolving to the raw {@link Response}.
+   */
+  async executeSparqlRequest(repositoryId: string, query: string, accept?: string): Promise<Response | undefined> {
+    const response = await this.rdf4jRestService.executeSparqlRequest(repositoryId, query, accept);
+    return response.originalResponse;
+  }
+
+  /**
    * Extracts the file data and filename from an HTTP response containing a Blob.
    *
    * @param response - The HTTP response object.

--- a/packages/api/src/services/domain/rdf4j/rdf4j-rest.service.ts
+++ b/packages/api/src/services/domain/rdf4j/rdf4j-rest.service.ts
@@ -1,6 +1,7 @@
 import {HttpService} from '../../http/http.service';
 import {NamespacesResponse} from './response/namespaces-response';
 import {SparqlResultsResponse} from '../../../models/sparql';
+import {HttpResponse} from '../../../models/http';
 
 /**
  * Service for interacting with the external RDF4J REST API.
@@ -91,6 +92,32 @@ export class Rdf4jRestService extends HttpService {
         'Content-Type': 'application/x-www-form-urlencoded',
         'Accept': 'application/sparql-results+json',
         'X-GraphDB-Local-Consistency': 'updating',
+      }
+    });
+  }
+
+  /**
+   * Executes a SPARQL query against the specified repository and returns the full HTTP response
+   * with the body left unparsed.
+   *
+   * Unlike {@link executeSparqlQuery}, the caller chooses the response format via the `accept`
+   * option (e.g. `application/sparql-results+json` for SELECT/ASK or `application/rdf+json;` for
+   * CONSTRUCT/DESCRIBE) and reads the raw payload from {@link HttpResponse.originalResponse}.
+   * This suits consumers that need the unparsed response, such as Reactodia.
+   *
+   * @param repositoryId - The ID of the repository to query.
+   * @param query - The SPARQL query string.
+   * @param accept - Value for the `Accept` header, selecting the response format, e.g.
+   * `application/sparql-results+json` for SELECT/ASK or `application/rdf+json;` for CONSTRUCT/DESCRIBE.
+   * @returns A promise resolving to the HTTP response.
+   */
+  executeSparqlRequest(repositoryId: string, query: string, accept = 'application/sparql-results+json'): Promise<HttpResponse> {
+    return this.post(`${this.REPOSITORIES_ENDPOINT}/${repositoryId}`, {
+      responseType: 'response',
+      body: new URLSearchParams({query}),
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Accept': accept,
       }
     });
   }

--- a/packages/api/src/services/domain/rdf4j/test/rdf4j-repository.service.spec.ts
+++ b/packages/api/src/services/domain/rdf4j/test/rdf4j-repository.service.spec.ts
@@ -3,6 +3,7 @@ import {Rdf4jRestService} from '../rdf4j-rest.service';
 import {ServiceProvider} from '../../../../providers';
 import {TestUtil} from '../../../utils/test/test-util';
 import {ResponseMock} from '../../../http/test/response-mock';
+import {HttpResponse} from '../../../../models/http';
 
 describe('Rdf4jRepositoryService', () => {
   let rdf4jRepositoryService: Rdf4jRepositoryService;
@@ -65,6 +66,26 @@ describe('Rdf4jRepositoryService', () => {
 
       // Then the REST service method should have been called with the repository ID
       expect(spy).toHaveBeenCalledWith(repositoryId);
+    });
+  });
+
+  describe('executeSparqlRequest', () => {
+    test('should delegate to Rdf4jRestService.executeSparqlRequest and return the originalResponse', async () => {
+      // Given a repository ID, query, accept header and a spy returning an HTTP response
+      const repositoryId = 'test-repo';
+      const query = 'SELECT * WHERE { ?s ?p ?o }';
+      const accept = 'application/rdf+json;';
+      const originalResponse = {ok: true} as Response;
+      const restService = ServiceProvider.get(Rdf4jRestService);
+      const spy = jest.spyOn(restService, 'executeSparqlRequest')
+        .mockResolvedValue({originalResponse} as HttpResponse);
+
+      // When I call executeSparqlRequest
+      const result = await rdf4jRepositoryService.executeSparqlRequest(repositoryId, query, accept);
+
+      // Then it should delegate with the same arguments and return the unwrapped originalResponse
+      expect(spy).toHaveBeenCalledWith(repositoryId, query, accept);
+      expect(result).toBe(originalResponse);
     });
   });
 

--- a/packages/api/src/services/http/http.service.ts
+++ b/packages/api/src/services/http/http.service.ts
@@ -418,7 +418,7 @@ export class HttpService {
 
   private extractHeaders(response: Response): Record<string, string> {
     const headers: Record<string, string> = {};
-    response.headers.forEach((value, key) => {
+    response.headers?.forEach((value, key) => {
       headers[key] = value;
     });
     return headers;

--- a/packages/legacy-workbench/src/js/angular/graphexplore/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/plugin.js
@@ -10,7 +10,7 @@ PluginRegistry.add('route', [
         'reloadOnSearch': false,
         'helpInfo': 'view.class.hierarchy.helpInfo',
         'documentationUrl': 'explore-data-and-class-relationships.html#class-hierarchy',
-        'allowAuthorities': ['READ_REPO_{repoId}']
+        'allowAuthorities': ['READ_REPO_{repoId}'],
 
     }, {
         'url': '/domain-range-graph',
@@ -21,7 +21,7 @@ PluginRegistry.add('route', [
         'templateUrl': 'pages/domainRangeInfo.html',
         'title': 'view.domain.range.graph.title',
         'helpInfo': 'view.domain.range.graph.helpInfo',
-        'allowAuthorities': ['READ_REPO_{repoId}']
+        'allowAuthorities': ['READ_REPO_{repoId}'],
     }, {
         'url': '/relationships',
         'module': 'graphdb.framework.graphexplore',
@@ -32,7 +32,7 @@ PluginRegistry.add('route', [
         'title': 'view.class.relationships.title',
         'helpInfo': 'view.class.relationships.helpInfo',
         'documentationUrl': 'explore-data-and-class-relationships.html#class-relationships',
-        'allowAuthorities': ['READ_REPO_{repoId}']
+        'allowAuthorities': ['READ_REPO_{repoId}'],
     }, {
         'url': '/graphs-visualizations',
         'module': 'graphdb.framework.graphexplore',
@@ -44,7 +44,7 @@ PluginRegistry.add('route', [
         'reloadOnSearch': false,
         'helpInfo': 'view.visual.graph.helpInfo',
         'documentationUrl': 'visualize-and-explore.html#explore-resources-through-the-easy-graph',
-        'allowAuthorities': ['READ_REPO_{repoId}']
+        'allowAuthorities': ['READ_REPO_{repoId}'],
     }, {
         'url': '/graphs-visualizations/config/save/:configName?',
         'module': 'graphdb.framework.graphexplore',
@@ -54,8 +54,8 @@ PluginRegistry.add('route', [
         'templateUrl': 'pages/graph-config/saveGraphConfig.html',
         'title': 'view.create.visual.graph.title',
         'helpInfo': 'view.create.visual.graph.helpInfo',
-        'allowAuthorities': ['READ_REPO_{repoId}']
-    }
+        'allowAuthorities': ['READ_REPO_{repoId}'],
+    },
 ]);
 
 PluginRegistry.add('main.menu', {
@@ -67,7 +67,7 @@ PluginRegistry.add('main.menu', {
             order: 2,
             parent: 'Explore',
             guideSelector: 'sub-menu-class-relationships',
-            testSelector: 'sub-menu-class-relationships'
+            testSelector: 'sub-menu-class-relationships',
         }, {
             label: 'Class hierarchy',
             labelKey: 'menu.class.hierarchy.label',
@@ -75,7 +75,7 @@ PluginRegistry.add('main.menu', {
             order: 1,
             parent: 'Explore',
             guideSelector: 'menu-class-hierarchy',
-            testSelector:'menu-class-hierarchy'
+            testSelector:'menu-class-hierarchy',
         }, {
             label: 'Visual graph',
             labelKey: 'visual.graph.label',
@@ -87,11 +87,25 @@ PluginRegistry.add('main.menu', {
                 children: [
                     {
                         href: 'graphs-visualizations/config/save/*',
-                    }
-                ]
+                    },
+                ],
             }],
             guideSelector: 'sub-menu-visual-graph',
-            testSelector: 'sub-menu-visual-graph'
-        }
-    ]
+            testSelector: 'sub-menu-visual-graph',
+        },
+    ],
+});
+PluginRegistry.add('main.menu', {
+    disabled: true,
+    items: [
+        {
+            label: 'Reactodia',
+            labelKey: 'menu.reactodia.label',
+            href: 'reactodia',
+            order: 6,
+            parent: 'Explore',
+            guideSelector: 'menu-reactodia',
+            testSelector:'menu-reactodia',
+        },
+    ],
 });

--- a/packages/root-config/src/services/workbench-routes-provider.ts
+++ b/packages/root-config/src/services/workbench-routes-provider.ts
@@ -15,6 +15,10 @@ export function getWorkbenchRoutes(): Route[] {
       default: false,
     },
     {
+      path: 'reactodia',
+      default: false,
+    },
+    {
       default: true,
     },
   ];

--- a/packages/shared-components/src/assets/i18n/en.json
+++ b/packages/shared-components/src/assets/i18n/en.json
@@ -52,6 +52,7 @@
   "menu.graphql.label": "GraphQL",
   "menu.graphql-endpoint-management.label": "Endpoint Management",
   "menu.graphql-playground.label": "GraphQL Playground",
+  "menu.reactodia.label": "Reactodia",
   "visual.graph.label": "Visual graph",
   "view.rdf.rank.title": "RDF Rank",
   "language_selector": {

--- a/packages/shared-components/src/assets/i18n/fr.json
+++ b/packages/shared-components/src/assets/i18n/fr.json
@@ -52,6 +52,7 @@
   "menu.graphql.label": "GraphQL",
   "menu.graphql-endpoint-management.label": "Gestion des points de terminaison",
   "menu.graphql-playground.label": "GraphQL Playground",
+  "menu.reactodia.label": "Reactodia ",
   "visual.graph.label": "Graphique visuel",
   "view.rdf.rank.title": "Rang RDF",
   "language_selector": {

--- a/packages/workbench/src/app/app.routes.ts
+++ b/packages/workbench/src/app/app.routes.ts
@@ -21,6 +21,10 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/ux-test/ux-test-page.component').then(m => m.UxTestPageComponent)
   },
   {
+    path: 'reactodia',
+    loadComponent: () => import('./pages/reactodia/reactodia-page.component').then(m => m.ReactodiaPageComponent)
+  },
+  {
     path: '**',
     loadComponent: () => import('./pages/not-found/not-found-page.component').then(m => m.NotFoundPageComponent)
   }

--- a/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.html
+++ b/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.html
@@ -1,0 +1,5 @@
+<graphwise-reactodia
+  [queryFunction]="queryFunction"
+  [currentRepository]="currentRepository()"
+  [language]="language()">
+</graphwise-reactodia>

--- a/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.scss
+++ b/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.scss
@@ -1,0 +1,5 @@
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}

--- a/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.spec.ts
+++ b/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.spec.ts
@@ -1,0 +1,34 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {ReactodiaComponentFacadeComponent} from './reactodia-component-facade.component';
+import {provideTranslocoForTesting} from '../../../testing-utils/transloco-utils';
+
+jest.mock('graphwise-reactodia/loader', () => ({
+  defineCustomElements: jest.fn()
+}));
+
+describe('ReactodiaComponentFacadeComponent', () => {
+  let component: ReactodiaComponentFacadeComponent;
+  let fixture: ComponentFixture<ReactodiaComponentFacadeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        ReactodiaComponentFacadeComponent,
+        provideTranslocoForTesting()
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ReactodiaComponentFacadeComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('currentRepository', 'test-repo');
+    fixture.componentRef.setInput('language', 'en');
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.ts
+++ b/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.ts
@@ -1,0 +1,53 @@
+import {Component, CUSTOM_ELEMENTS_SCHEMA, input} from '@angular/core';
+import {defineCustomElements} from 'graphwise-reactodia/loader';
+import {Rdf4jRepositoryService, service} from '@ontotext/workbench-api';
+import {LoggerProvider} from '../../services/logger/logger-provider';
+
+/**
+ * The request descriptor Reactodia's `SparqlQueryFunction` passes to the transport. Declared
+ * locally so the facade does not depend on `@reactodia/workspace`; it mirrors that contract.
+ */
+interface SparqlQueryParams {
+  url: string;
+  body: string;
+  headers: Record<string, string>;
+  method: string;
+  signal?: AbortSignal;
+}
+
+defineCustomElements();
+
+/**
+ * Hosts the Reactodia graph (`graphwise-reactodia`) web component and wires it to the active
+ * repository. This replaces the legacy AngularJS `reactodia-sparql-graph` directive: it injects a
+ * `queryFunction` that routes Reactodia's SPARQL requests through the workbench HTTP layer (auth
+ * interceptors included). The `currentRepository`/`language` it renders with are provided by the
+ * page; this component holds no context subscriptions of its own.
+ */
+@Component({
+  selector: 'app-reactodia-component-facade',
+  standalone: true,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  templateUrl: './reactodia-component-facade.component.html',
+  styleUrl: './reactodia-component-facade.component.scss'
+})
+export class ReactodiaComponentFacadeComponent {
+  private readonly rdf4jRepositoryService = service(Rdf4jRepositoryService);
+  private readonly logger = LoggerProvider.logger;
+
+  /** The active repository id; re-points (and resets) the diagram when it changes at runtime. */
+  readonly currentRepository = input.required<string>();
+  /** The selected UI language passed to the web component. */
+  readonly language = input<string>();
+
+  /**
+   * Transport for Reactodia's SPARQL requests. Reactodia chooses the `Accept` per query
+   * (SPARQL-results JSON for SELECT lookups, RDF/Turtle for CONSTRUCT element info) and passes
+   * it in `params.headers`; we forward it so GraphDB returns the matching format, then hand back
+   * the raw `Response` which Reactodia expects.
+   */
+  readonly queryFunction = (params: SparqlQueryParams) =>
+    this.rdf4jRepositoryService
+      .executeSparqlRequest(params.url, params.body ?? '', params.headers['Accept'])
+      .catch((error) => this.logger.error('Failed to execute query', error));
+}

--- a/packages/workbench/src/app/pages/reactodia/reactodia-page.component.html
+++ b/packages/workbench/src/app/pages/reactodia/reactodia-page.component.html
@@ -1,0 +1,10 @@
+<app-page-layout class="sparql-editor-page">
+  <div>
+    @if (language() && currentRepository()) {
+      <app-reactodia-component-facade
+        [currentRepository]="currentRepository()"
+        [language]="language()">
+      </app-reactodia-component-facade>
+    }
+  </div>
+</app-page-layout>

--- a/packages/workbench/src/app/pages/reactodia/reactodia-page.component.scss
+++ b/packages/workbench/src/app/pages/reactodia/reactodia-page.component.scss
@@ -1,0 +1,5 @@
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}

--- a/packages/workbench/src/app/pages/reactodia/reactodia-page.component.spec.ts
+++ b/packages/workbench/src/app/pages/reactodia/reactodia-page.component.spec.ts
@@ -1,0 +1,44 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {ReactodiaPageComponent} from './reactodia-page.component';
+import {provideTranslocoForTesting} from '../../../testing-utils/transloco-utils';
+import {LanguageContextService, ServiceProvider} from '@ontotext/workbench-api';
+import {provideRouter} from '@angular/router';
+
+jest.mock('graphwise-reactodia/loader', () => ({
+  defineCustomElements: jest.fn()
+}));
+
+describe('ReactodiaPageComponent', () => {
+  let component: ReactodiaPageComponent;
+  let fixture: ComponentFixture<ReactodiaPageComponent>;
+
+  beforeEach(async () => {
+    jest.spyOn(ServiceProvider.get(LanguageContextService), 'getSelectedLanguage')
+      .mockReturnValue('en');
+    jest.spyOn(ServiceProvider.get(LanguageContextService), 'onSelectedLanguageChanged')
+      .mockImplementation(() => () => {
+        // No-op subscription that doesn't call the callback immediately.
+      });
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ReactodiaPageComponent,
+        provideTranslocoForTesting()
+      ],
+      providers: [
+        provideRouter([])
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ReactodiaPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/workbench/src/app/pages/reactodia/reactodia-page.component.ts
+++ b/packages/workbench/src/app/pages/reactodia/reactodia-page.component.ts
@@ -1,0 +1,58 @@
+import {Component, OnDestroy, OnInit, signal} from '@angular/core';
+import {LanguageContextService, RepositoryContextService, service, SubscriptionList} from '@ontotext/workbench-api';
+import {
+  ReactodiaComponentFacadeComponent
+} from '../../components/reactodia-component-facade/reactodia-component-facade.component';
+import {PageLayoutComponent} from '../../components/page-layout/page-layout.component';
+
+/**
+ * Page that hosts the Reactodia graph. It owns the context subscriptions (repository and language),
+ * gates between the "repository required" banner and the {@link ReactodiaComponentFacadeComponent}
+ * (which owns the `graphwise-reactodia` web component and its wiring) based on the active
+ * repository, and feeds the current repository/language down to the facade.
+ */
+@Component({
+  selector: 'app-reactodia-page',
+  standalone: true,
+  templateUrl: './reactodia-page.component.html',
+  imports: [
+    ReactodiaComponentFacadeComponent,
+    PageLayoutComponent,
+  ],
+  styleUrl: './reactodia-page.component.scss'
+})
+export class ReactodiaPageComponent implements OnInit, OnDestroy {
+  private readonly repositoryContextService = service(RepositoryContextService);
+  private readonly languageContextService = service(LanguageContextService);
+
+  private readonly subscriptions = new SubscriptionList();
+
+  /** The active repository id; gates the banner vs. the Reactodia component. */
+  readonly currentRepository = signal('');
+  readonly language = signal(this.languageContextService.getSelectedLanguage());
+
+  ngOnInit(): void {
+    this.subscriptions.addAll([
+      this.subscribeToRepositoryChanged(),
+      this.subscribeToLanguageChanged()
+    ]);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribeAll();
+  }
+
+  private subscribeToLanguageChanged() {
+    return this.languageContextService.onSelectedLanguageChanged((language) => {
+      if (language) {
+        this.language.set(language);
+      }
+    });
+  }
+
+  private subscribeToRepositoryChanged() {
+    return this.repositoryContextService.onSelectedRepositoryChanged((repository) => {
+      this.currentRepository.set(repository?.id || '');
+    });
+  }
+}


### PR DESCRIPTION
## What
Create reactodia page

## Why
To implement reactodia as a custom web component inside the workbench

## How
- Added `reactodia-page.component` which will house the new custom web component wrapper.
- Added new endpoint which allows a dynamic `accept` header. This is needed by reactodia to make SPQRQL requests using the host http client, also different sparql requests may have different accept headers

## Testing
n/a

## Screenshots
<img width="1602" height="917" alt="image" src="https://github.com/user-attachments/assets/b83d974e-4e81-4bf9-806a-50c28cb63ff0" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
