### PR TITLE
GDB-14708 fix displaced expand step with large graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@single-spa/import-map-injector": "^2.0.2",
-                "graphdb-workbench-plugins": "^0.0.1-TR32",
+                "graphdb-workbench-plugins": "^0.0.1-TR33",
                 "import-map-overrides": "^6.1.0"
             },
             "devDependencies": {
@@ -6997,9 +6997,9 @@
             "license": "ISC"
         },
         "node_modules/graphdb-workbench-plugins": {
-            "version": "0.0.1-TR32",
-            "resolved": "https://registry.npmjs.org/graphdb-workbench-plugins/-/graphdb-workbench-plugins-0.0.1-TR32.tgz",
-            "integrity": "sha512-Z83JB+5aoGL/ZMP1fp2dlu1q7BRl+HGWtcZWna20+X7y7cYTjntqDwzAj9gvDX3FmZeGq/Esc7kDUWxoSkFhUA==",
+            "version": "0.0.1-TR33",
+            "resolved": "https://registry.npmjs.org/graphdb-workbench-plugins/-/graphdb-workbench-plugins-0.0.1-TR33.tgz",
+            "integrity": "sha512-X/eOHxXxWVw3eRofBRsHZVNnxMdMs/gUBZPfwk62aySf2OyfXguK9QsJBIkP1ELwMqI9nMsT1FVZPuvp2fA6fg==",
             "license": "Apache-2.0"
         },
         "node_modules/gzip-size": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "resolutions": {},
     "dependencies": {
         "@single-spa/import-map-injector": "^2.0.2",
-        "graphdb-workbench-plugins": "^0.0.1-TR32",
+        "graphdb-workbench-plugins": "^0.0.1-TR33",
         "import-map-overrides": "^6.1.0"
     }
 }


### PR DESCRIPTION
## What
Fix displaced expand step with large graph

## Why
There was a race condition, where the defer and subsequent alpha drop resolved before the reload had began. The reload then displaced the step

## How
Added waiting for the element to be hidden, before resolving the alpha drop. Essentially ensuring the correct order of events: reload -> defer -> await alpha drop

## Testing
n/a

(cherry picked from commit 2d6dc5886836582984f40d3429eda992a2e38d3f)

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
