### PR TITLE
GDB-14779: Add a banner in the WB stating that we plan to deprecate the Solr connector in the next major version of GDB

### DIFF
--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -74,6 +74,7 @@ export * from './services/domain/sparql-template';
 export * from './services/domain/rdf4j';
 export * from './services/domain/sparql';
 export * from './services/ui';
+export * from './services/user-preference';
 export * from './services/domain/guides';
 export * from './services/ui/dialog';
 export * from './services/domain/connector';

--- a/packages/api/src/services/user-preference/index.ts
+++ b/packages/api/src/services/user-preference/index.ts
@@ -1,0 +1,1 @@
+export {UserPreferencesStorageService} from './user-preferences-storage.service';

--- a/packages/api/src/services/user-preference/test/user-preferences-storage.service.spec.ts
+++ b/packages/api/src/services/user-preference/test/user-preferences-storage.service.spec.ts
@@ -1,0 +1,70 @@
+import { UserPreferencesStorageService } from '../user-preferences-storage.service';
+import { createMockStorage, MutableStorage } from '../../utils/test/local-storage-mock';
+
+const USER_PREFERENCES_NAMESPACE = 'ontotext.gdb.userPreferences';
+const SOLR_DEPRECATION_BANNER_DISMISSED_KEY = `${USER_PREFERENCES_NAMESPACE}.solrDeprecationBannerDismissed`;
+
+describe('UserPreferencesStorageService', () => {
+  let userPreferencesStorageService: UserPreferencesStorageService;
+  let storage: MutableStorage;
+
+  beforeEach(() => {
+    storage = createMockStorage();
+    userPreferencesStorageService = new UserPreferencesStorageService();
+
+    jest
+      .spyOn(UserPreferencesStorageService.prototype, 'getStorage')
+      .mockReturnValue(storage);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('set', () => {
+    it('should store a value under the prefixed key', () => {
+      // WHEN: A value is stored in the user preferences.
+      userPreferencesStorageService.set('someKey', 'someValue');
+      // THEN: I expect the value to be stored under the prefixed key.
+      expect(storage.getItem(`${USER_PREFERENCES_NAMESPACE}.someKey`)).toBe('someValue');
+    });
+  });
+
+  describe('dismissSolrDeprecationBanner', () => {
+    it('should store that the Solr deprecation banner is dismissed', () => {
+      // WHEN: The Solr deprecation banner is dismissed.
+      userPreferencesStorageService.dismissSolrDeprecationBanner();
+      // THEN: I expect the dismissed state to be stored.
+      expect(storage.getItem(SOLR_DEPRECATION_BANNER_DISMISSED_KEY)).toBe('true');
+    });
+  });
+
+  describe('isSolrDeprecationBannerDismissed', () => {
+    it('should return true when the Solr deprecation banner is dismissed', () => {
+      // GIVEN: The Solr deprecation banner is marked as dismissed.
+      storage.setItem(SOLR_DEPRECATION_BANNER_DISMISSED_KEY, 'true');
+
+      // WHEN: I check whether the banner is dismissed.
+      const result = userPreferencesStorageService.isSolrDeprecationBannerDismissed();
+      // THEN: I expect the banner to be reported as dismissed.
+      expect(result).toBe(true);
+    });
+
+    it('should return false when the Solr deprecation banner is not dismissed', () => {
+      // WHEN: I check whether the banner is dismissed.
+      const result = userPreferencesStorageService.isSolrDeprecationBannerDismissed();
+      // THEN: I expect the banner to not be reported as dismissed.
+      expect(result).toBe(false);
+    });
+
+    it('should return false when the stored value is not true', () => {
+      // GIVEN: The stored value is not equal to true.
+      storage.setItem(SOLR_DEPRECATION_BANNER_DISMISSED_KEY, 'false');
+
+      // WHEN: I check whether the banner is dismissed.
+      const result = userPreferencesStorageService.isSolrDeprecationBannerDismissed();
+      // THEN: I expect the banner to not be reported as dismissed.
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/api/src/services/user-preference/user-preferences-storage.service.ts
+++ b/packages/api/src/services/user-preference/user-preferences-storage.service.ts
@@ -1,0 +1,32 @@
+import {LocalStorageService} from '../storage';
+
+/**
+ * Service for storing and retrieving user-specific preferences in local storage.
+ *
+ * Preferences may include UI-related settings such as dismissed banners,
+ * view configuration, and other user customizations.
+ */
+export class UserPreferencesStorageService extends LocalStorageService {
+  readonly NAMESPACE = 'userPreferences';
+  readonly PREFERENCE_KEY_SOLR_DEPRECATION_BANNER_DISMISSED = 'solrDeprecationBannerDismissed';
+
+  set(key: string, value: string) {
+    this.storeValue(key, value);
+  }
+
+  /**
+   * Marks the Solr deprecation banner as dismissed.
+   */
+  dismissSolrDeprecationBanner(): void {
+    this.set(this.PREFERENCE_KEY_SOLR_DEPRECATION_BANNER_DISMISSED, 'true');
+  }
+
+  /**
+   * Checks whether the Solr deprecation banner has been dismissed.
+   *
+   * @returns `true` if the banner has been dismissed; otherwise `false`.
+   */
+  isSolrDeprecationBannerDismissed(): boolean {
+    return this.get(this.PREFERENCE_KEY_SOLR_DEPRECATION_BANNER_DISMISSED).getValue() === 'true';
+  }
+}

--- a/packages/shared-components/cypress/e2e/deprecation-banner/deprecation-steps.js
+++ b/packages/shared-components/cypress/e2e/deprecation-banner/deprecation-steps.js
@@ -1,0 +1,13 @@
+export class DeprecationSteps {
+  static getDeprecationBanner() {
+    return cy.get('onto-deprecation-banner');
+  }
+
+  static getCloseButton() {
+    return DeprecationSteps.getDeprecationBanner().find('.close-button');
+  }
+
+  static closeBanner() {
+    DeprecationSteps.getCloseButton().click();
+  }
+}

--- a/packages/shared-components/cypress/e2e/layout/layout.cy.js
+++ b/packages/shared-components/cypress/e2e/layout/layout.cy.js
@@ -1,6 +1,7 @@
 import {NavbarSteps} from "../../steps/navbar/navbar-steps";
 import {LayoutSteps} from "../../steps/layout/layout-steps";
 import {HeaderSteps} from "../../steps/header/header-steps";
+import {DeprecationSteps} from '../deprecation-banner/deprecation-steps';
 
 function assertSubmenuItems(menuIndex, expectedItems) {
   NavbarSteps.getSubmenuItems(menuIndex)
@@ -13,6 +14,8 @@ function assertSubmenuItems(menuIndex, expectedItems) {
 
 describe('Layout', () => {
   it('Should filter menu items, based on role', () => {
+    // Increase the viewport size because the Help menu becomes invisible and the test fails.
+    cy.viewport(1280, 1000);
     // Given I've visited the layout page and loaded menu items for the navbar
     LayoutSteps.visit();
     LayoutSteps.disableSecurity();
@@ -159,5 +162,27 @@ describe('Layout', () => {
     // Then I should see the header and navbar
     HeaderSteps.getHeader().should('exist');
     NavbarSteps.getRootMenuItems().should('have.length', 7);
-  })
+  });
+
+  it('should hide the Solr deprecation notice', () => {
+    // GIVEN: I have visited the layout page.
+    LayoutSteps.visit();
+
+    // THEN: I expect the Solr deprecation banner to be visible.
+    DeprecationSteps.getDeprecationBanner()
+      .should('be.visible')
+      .should('contain.text', 'Solr Connector Deprecation Notice');
+
+    // WHEN: I click the close button.
+    DeprecationSteps.closeBanner();
+    // THEN: I expect the Solr deprecation banner to not be visible.
+    DeprecationSteps.getDeprecationBanner().should('not.exist');
+
+    // WHEN: I refresh the page.
+    LayoutSteps.visit();
+    // THEN: I wait for the page to load.
+    HeaderSteps.getHeader().should('exist');
+    // AND: I expect the Solr deprecation banner to remain hidden, because the user choice is persisted.
+    DeprecationSteps.getDeprecationBanner().should('not.exist');
+  });
 });

--- a/packages/shared-components/src/assets/i18n/en.json
+++ b/packages/shared-components/src/assets/i18n/en.json
@@ -222,5 +222,11 @@
       "create_graph_configuration": "Create one",
       "create_graph_configuration_link": "here"
     }
+  },
+  "deprecation-banner": {
+    "solr": {
+      "header": "Solr Connector Deprecation Notice",
+      "content": "The Solr connector has been deprecated and will be removed in version 12 of GraphDB. If you are using it, please contact us via the available support channels to discuss the alternatives."
+    }
   }
 }

--- a/packages/shared-components/src/assets/i18n/fr.json
+++ b/packages/shared-components/src/assets/i18n/fr.json
@@ -222,5 +222,11 @@
       "create_graph_configuration": "En créer une",
       "create_graph_configuration_link": "ici"
     }
+  },
+  "deprecation-banner": {
+    "solr": {
+      "header": "Avis de dépréciation du connecteur Solr",
+      "content": "Le connecteur Solr est obsolète et sera supprimé dans la version 12 de GraphDB. Si vous l'utilisez, veuillez nous contacter via les canaux de support disponibles afin de discuter des alternatives."
+    }
   }
 }

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -33,6 +33,8 @@ export namespace Components {
     }
     interface OntoCookiePolicyDialog {
     }
+    interface OntoDeprecationBanner {
+    }
     interface OntoDialog {
         /**
           * Configuration object for the dialog.
@@ -415,6 +417,10 @@ export interface OntoCookiePolicyDialogCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLOntoCookiePolicyDialogElement;
 }
+export interface OntoDeprecationBannerCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLOntoDeprecationBannerElement;
+}
 export interface OntoDropdownCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLOntoDropdownElement;
@@ -476,6 +482,23 @@ declare global {
     var HTMLOntoCookiePolicyDialogElement: {
         prototype: HTMLOntoCookiePolicyDialogElement;
         new (): HTMLOntoCookiePolicyDialogElement;
+    };
+    interface HTMLOntoDeprecationBannerElementEventMap {
+        "closeBanner": void;
+    }
+    interface HTMLOntoDeprecationBannerElement extends Components.OntoDeprecationBanner, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLOntoDeprecationBannerElementEventMap>(type: K, listener: (this: HTMLOntoDeprecationBannerElement, ev: OntoDeprecationBannerCustomEvent<HTMLOntoDeprecationBannerElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLOntoDeprecationBannerElementEventMap>(type: K, listener: (this: HTMLOntoDeprecationBannerElement, ev: OntoDeprecationBannerCustomEvent<HTMLOntoDeprecationBannerElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLOntoDeprecationBannerElement: {
+        prototype: HTMLOntoDeprecationBannerElement;
+        new (): HTMLOntoDeprecationBannerElement;
     };
     interface HTMLOntoDialogElement extends Components.OntoDialog, HTMLStencilElement {
     }
@@ -714,6 +737,7 @@ declare global {
         "onto-confirm-cancel-dialog": HTMLOntoConfirmCancelDialogElement;
         "onto-cookie-consent": HTMLOntoCookieConsentElement;
         "onto-cookie-policy-dialog": HTMLOntoCookiePolicyDialogElement;
+        "onto-deprecation-banner": HTMLOntoDeprecationBannerElement;
         "onto-dialog": HTMLOntoDialogElement;
         "onto-dropdown": HTMLOntoDropdownElement;
         "onto-footer": HTMLOntoFooterElement;
@@ -758,6 +782,12 @@ declare namespace LocalJSX {
           * Event emitted when the dialog is closed, allowing parent components to react accordingly.
          */
         "onCloseDialog"?: (event: OntoCookiePolicyDialogCustomEvent<void>) => void;
+    }
+    interface OntoDeprecationBanner {
+        /**
+          * Emitted when the banner is closed.
+         */
+        "onCloseBanner"?: (event: OntoDeprecationBannerCustomEvent<void>) => void;
     }
     interface OntoDialog {
         /**
@@ -1065,6 +1095,7 @@ declare namespace LocalJSX {
         "onto-confirm-cancel-dialog": OntoConfirmCancelDialog;
         "onto-cookie-consent": OntoCookieConsent;
         "onto-cookie-policy-dialog": OntoCookiePolicyDialog;
+        "onto-deprecation-banner": OntoDeprecationBanner;
         "onto-dialog": OntoDialog;
         "onto-dropdown": OntoDropdown;
         "onto-footer": OntoFooter;
@@ -1102,6 +1133,7 @@ declare module "@stencil/core" {
              */
             "onto-cookie-consent": LocalJSX.OntoCookieConsent & JSXBase.HTMLAttributes<HTMLOntoCookieConsentElement>;
             "onto-cookie-policy-dialog": LocalJSX.OntoCookiePolicyDialog & JSXBase.HTMLAttributes<HTMLOntoCookiePolicyDialogElement>;
+            "onto-deprecation-banner": LocalJSX.OntoDeprecationBanner & JSXBase.HTMLAttributes<HTMLOntoDeprecationBannerElement>;
             "onto-dialog": LocalJSX.OntoDialog & JSXBase.HTMLAttributes<HTMLOntoDialogElement>;
             /**
              * A reusable dropdown component built using StencilJS. This component supports configurable labels, tooltips, icons,

--- a/packages/shared-components/src/components/onto-deprecation-banner/onto-deprecation-banner.scss
+++ b/packages/shared-components/src/components/onto-deprecation-banner/onto-deprecation-banner.scss
@@ -1,0 +1,29 @@
+:host {
+  display: block;
+}
+
+.deprecation-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1rem;
+  background: #384252;
+  color: #FFF;
+
+  .banner-content {
+    flex: 1;
+    text-align: center;
+
+    .banner-message {
+      font-size: 1.2em;
+    }
+  }
+
+  .close-button {
+    border: none;
+    outline: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+  }
+}

--- a/packages/shared-components/src/components/onto-deprecation-banner/onto-deprecation-banner.tsx
+++ b/packages/shared-components/src/components/onto-deprecation-banner/onto-deprecation-banner.tsx
@@ -1,0 +1,45 @@
+import { Component, h, Host, Event, EventEmitter } from '@stencil/core';
+
+@Component({
+  tag: 'onto-deprecation-banner',
+  styleUrl: 'onto-deprecation-banner.scss',
+  shadow: false
+})
+export class OntoDeprecationBanner {
+
+  /**
+   * Emitted when the banner is closed.
+   */
+  @Event() closeBanner: EventEmitter<void>;
+
+  private readonly onClose = () => {
+    this.closeBanner.emit();
+  };
+
+  render() {
+    return (
+      <Host>
+        <div class="deprecation-banner">
+          <div class="banner-content">
+            <h3 class="banner-header">
+              <slot name="header"></slot>
+            </h3>
+
+            <div class="banner-message">
+              <slot name="content"></slot>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            class="close-button"
+            aria-label="Close banner"
+            onClick={this.onClose}
+          >
+            <i class="ri-close-line"></i>
+          </button>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/packages/shared-components/src/components/onto-deprecation-banner/readme.md
+++ b/packages/shared-components/src/components/onto-deprecation-banner/readme.md
@@ -1,0 +1,30 @@
+# deprecation-banner
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Events
+
+| Event         | Description                        | Type                |
+| ------------- | ---------------------------------- | ------------------- |
+| `closeBanner` | Emitted when the banner is closed. | `CustomEvent<void>` |
+
+
+## Dependencies
+
+### Used by
+
+ - [onto-layout](../onto-layout)
+
+### Graph
+```mermaid
+graph TD;
+  onto-layout --> onto-deprecation-banner
+  style onto-deprecation-banner fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/shared-components/src/components/onto-layout/onto-layout.scss
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.scss
@@ -6,6 +6,7 @@
 .wb-layout {
   display: grid;
   grid-template:
+    "deprecation-banner deprecation-banner" auto
     "header header" auto
     "nav main" 1fr
     "nav footer" auto / 15rem minmax(200px, 1fr);
@@ -26,6 +27,7 @@
 
   &.hide-navbar {
     grid-template:
+    "deprecation-banner" auto
     "header" auto
     "main" 1fr
     "footer" auto / 1fr;
@@ -64,6 +66,10 @@
 
   nav {
     grid-area: nav;
+  }
+
+  .onto-deprecation-banner {
+    grid-area: deprecation-banner;
   }
 
   header {

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -24,7 +24,8 @@ import {
   WindowService,
   MainMenuPlugin,
   MainMenuItem,
-  MainMenuExtensionPoint
+  MainMenuExtensionPoint,
+  UserPreferencesStorageService
 } from '@ontotext/workbench-api';
 import {TranslationService} from '../../services/translation.service';
 
@@ -44,6 +45,7 @@ export class OntoLayout {
   private readonly runtimeConfigurationContextService = service(RuntimeConfigurationContextService);
   private readonly eventService = service(EventService);
   private readonly applicationLifecycleContextService = service(ApplicationLifecycleContextService);
+  private readonly userPreferencesStorageService = service(UserPreferencesStorageService);
 
   private readonly fullJwtKey = `${StorageKey.GLOBAL_NAMESPACE}.${this.authStorageService.NAMESPACE}.${this.authStorageService.jwtKey}`;
   private readonly fullAuthenticatedKey = `${StorageKey.GLOBAL_NAMESPACE}.${this.authStorageService.NAMESPACE}.${this.authStorageService.authenticatedKey}`;
@@ -66,6 +68,7 @@ export class OntoLayout {
   @State() showNavbar = false;
   @State() private isEmbedded = false;
   @State() private loading = true;
+  @State() private hideSolrDeprecationBanner = false;
 
   // ========================
   // Private
@@ -86,6 +89,7 @@ export class OntoLayout {
   }
 
   componentDidLoad() {
+    this.updateShowSolrDeprecationBanner();
     this.windowResizeHandler();
   }
 
@@ -118,6 +122,16 @@ export class OntoLayout {
         <div class="default-slot-wrapper">
           <slot name="default"></slot>
         </div>
+        {!this.hideSolrDeprecationBanner &&
+          <onto-deprecation-banner class='onto-deprecation-banner' onCloseBanner={this.onSolrDeprecationBannerClosedHandler()}>
+            <span slot='header'>
+              <translate-label labelKey='deprecation-banner.solr.header'></translate-label>
+            </span>
+            <span slot='content'>
+              <translate-label labelKey='deprecation-banner.solr.content'></translate-label>
+            </span>
+          </onto-deprecation-banner>
+        }
         {!this.isEmbedded &&
           <header class="wb-header">
             {this.showHeader && <onto-header></onto-header>}
@@ -168,6 +182,13 @@ export class OntoLayout {
   @Listen('resize', {target: 'window'})
   onResize() {
     this.windowResizeObserver();
+  }
+
+  private onSolrDeprecationBannerClosedHandler(): () => void {
+    return () => {
+      this.userPreferencesStorageService.dismissSolrDeprecationBanner();
+      this.updateShowSolrDeprecationBanner();
+    };
   }
 
   // ========================
@@ -328,5 +349,9 @@ export class OntoLayout {
           this.loading = true;
         }
       }));
+  }
+
+  private updateShowSolrDeprecationBanner(): void {
+    this.hideSolrDeprecationBanner = this.userPreferencesStorageService.isSolrDeprecationBannerDismissed();
   }
 }

--- a/packages/shared-components/src/components/onto-layout/readme.md
+++ b/packages/shared-components/src/components/onto-layout/readme.md
@@ -9,6 +9,8 @@
 
 ### Depends on
 
+- [onto-deprecation-banner](../onto-deprecation-banner)
+- [translate-label](../translate-label)
 - [onto-header](../onto-header)
 - [onto-navbar](../onto-navbar)
 - [onto-loader](../onto-loader)
@@ -17,6 +19,8 @@
 ### Graph
 ```mermaid
 graph TD;
+  onto-layout --> onto-deprecation-banner
+  onto-layout --> translate-label
   onto-layout --> onto-header
   onto-layout --> onto-navbar
   onto-layout --> onto-loader

--- a/packages/shared-components/src/components/translate-label/readme.md
+++ b/packages/shared-components/src/components/translate-label/readme.md
@@ -33,6 +33,7 @@ Example of usage:
  - [onto-cookie-policy-dialog](../dialogs/onto-cookie-policy-dialog)
  - [onto-footer](../onto-footer)
  - [onto-graph-explore-split-button](../onto-graph-explore-split-button)
+ - [onto-layout](../onto-layout)
  - [onto-license-alert](../onto-license-alert)
  - [onto-navbar](../onto-navbar)
  - [onto-operations-notification](../onto-operations-notification)
@@ -49,6 +50,7 @@ graph TD;
   onto-cookie-policy-dialog --> translate-label
   onto-footer --> translate-label
   onto-graph-explore-split-button --> translate-label
+  onto-layout --> translate-label
   onto-license-alert --> translate-label
   onto-navbar --> translate-label
   onto-operations-notification --> translate-label


### PR DESCRIPTION
## What
- Added a deprecation banner for the Solr connector.
- Added an option to dismiss the banner.
- Persisted the dismissed state in user preferences to prevent the banner from being shown again after it is closed.

## Why
The Solr connector is planned for deprecation in the next major GraphDB release. Users should be informed in advance so they can evaluate alternative solutions and prepare for the upcoming change.

## How
- Implemented a reusable deprecation banner component with customizable content and support for dismissal events.
- Introduced user preference storage for persisting the banner's dismissed state.
- Configured the banner to be displayed only until the user dismisses it.

## Screenshots
<img width="1912" height="431" alt="image" src="https://github.com/user-attachments/assets/7142bdc6-81f1-4b72-a28d-1e20d441b914" />
<img width="1912" height="431" alt="image" src="https://github.com/user-attachments/assets/d4be4cab-15ae-43ae-913c-35d46128fb75" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
