### PR TITLE
GDB-14691: Description field is barely visible in GDB Workbench

### DIFF
--- a/packages/legacy-workbench/src/css/repositories.css
+++ b/packages/legacy-workbench/src/css/repositories.css
@@ -304,15 +304,6 @@ span.label {
     margin-top: 0;
 }
 
-.ot-repository-id {
-    max-width: 70% !important;
-    display: inline-block;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    position: relative;
-    top: 5px
-}
 
 .main-loader {
     margin: 200px auto;
@@ -442,8 +433,50 @@ span.label {
     flex-shrink: 0;
 }
 
-.repository .select-repository-button-wrapper {
+#wb-repositories-repositoryInGetRepositories,
+#wb-repositories-repositoryInRemoteGetRepositories {
+    table-layout: fixed;
+}
+
+.select-repository-button-column {
     width: 25px;
+}
+
+.repository-actions-column {
+    width: 150px;
+}
+
+.default-repository-column {
+    width: 50px;
+}
+
+.repository .repository-info {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.repository .repository-details {
+    flex: 1;
+    overflow: hidden;
+}
+
+.repository .repository-id,
+.repository .repository-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.repository .repository-id {
+    display: inline-block;
+    /* Reserve space for the repository status displayed next to the repository ID. */
+    max-width: calc(100% - 4em);
+    vertical-align: bottom;
+}
+
+.repository .repository-title {
+    display: block;
 }
 
 .repository .inactive-repo {

--- a/packages/legacy-workbench/src/js/angular/templates/repositorySize.html
+++ b/packages/legacy-workbench/src/js/angular/templates/repositorySize.html
@@ -1,4 +1,9 @@
 <div ng-init="getRepositorySize()" style="margin: -4px 0; padding: 10px">
+    <div class="row" ng-if="popoverRepo.title" style="margin-bottom: .5rem">
+        <span>
+            {{popoverRepo.title}}
+        </span>
+    </div>
     <div class="row">
         <label style="margin-right: 10px">{{'location.label' | translate}}</label>
         <span class="text-right pull-right">

--- a/packages/legacy-workbench/src/pages/repositories.html
+++ b/packages/legacy-workbench/src/pages/repositories.html
@@ -64,6 +64,12 @@
                         <div ng-if="getRepositoriesFromLocation(location.uri).length" class="mb-1">
                             <table id="wb-repositories-repositoryInGetRepositories"
                                    class="table table-hover table-striped" aria-describedby="Repositories table">
+                                <colgroup>
+                                    <col class="select-repository-button-column">
+                                    <col class="repository-info-column">
+                                    <col class="repository-actions-column">
+                                    <col class="default-repository-column">
+                                </colgroup>
                                 <tbody>
                                 <tr class="repository"
                                     ng-repeat="repository in getRepositoriesFromLocation(location.uri) | orderBy: ['type === \'system\'', 'location', 'id'] track by repository.hash"
@@ -85,19 +91,34 @@
                                         </span>
                                     </td>
                                     <td>
-                                        <div class="lead text-overflow" ng-mouseover="setPopoverRepo(repository)">
-                                            <span popover-popup-delay="500"
-                                                  popover-trigger="mouseenter" popover-placement="bottom-right"
+                                        <div class="lead repository-lead" ng-mouseover="setPopoverRepo(repository)" ng-focus="setPopoverRepo(repository)">
+                                            <span class="repository-popover"
+                                                  popover-popup-delay="500"
+                                                  popover-trigger="mouseenter"
+                                                  popover-placement="bottom-left"
                                                   uib-popover-template="popoverTemplate"
                                                   popover-title="{{'security.repository.title' | translate}} {{repository.id}}">
-                                                <span class="icon-lg" ng-class="'icon-repo-' + repository.type"></span>
-                                                <strong class="repository-id">{{repository.id}}</strong></span>
-                                            <span class="repository-status"> &middot; <span
-                                                class="text-secondary">{{repository.state}}</span></span>
-                                            <span ng-if="repository.title"><small> &middot; {{repository.title}}</small></span>
+                                                <div class="repository-info">
+                                                    <span class="icon-lg" ng-class="'icon-repo-' + repository.type"></span>
+
+                                                    <div class="repository-details">
+                                                        <div class="repository-main-info">
+                                                            <strong class="repository-id">{{repository.id}}</strong>
+                                                            <span class="repository-status">
+                                                                &middot;
+                                                                <span class="text-secondary">{{repository.state}}</span>
+                                                            </span>
+                                                        </div>
+
+                                                        <small class="repository-title" ng-if="repository.title">
+                                                            {{repository.title}}
+                                                        </small>
+                                                    </div>
+                                                </div>
+                                            </span>
                                         </div>
                                     </td>
-                                    <td width="150" class="text-nowrap repository-actions">
+                                    <td class="text-nowrap repository-actions">
                                         <button class="btn btn-link p-0"
                                                 ng-click="copyToClipboard(repository.externalUrl)"
                                                 gdb-tooltip="{{'copy.repo.url' | translate}}">
@@ -138,7 +159,7 @@
                                             </button>
                                         </span>
                                     </td>
-                                    <td width="50">
+                                    <td>
                                         <button class="btn btn-link p-0 pin-repository-btn"
                                                 ng-if="repository.type !== 'system' && location.active"
                                                 ng-click="toggleDefaultRepository(repository.id)"
@@ -212,6 +233,12 @@
                             <div ng-if="getRepositoriesFromLocation(location.uri).length" class="mb-1">
                                 <table id="wb-repositories-repositoryInRemoteGetRepositories"
                                        class="table table-hover table-striped" aria-describedby="Repositories table">
+                                    <colgroup>
+                                        <col class="select-repository-button-column">
+                                        <col class="repository-info-column">
+                                        <col class="repository-actions-column">
+                                        <col class="default-repository-column">
+                                    </colgroup>
                                     <tbody>
                                     <tr class="repository"
                                         ng-repeat="repository in getRepositoriesFromLocation(location.uri) | orderBy: ['type === \'system\'', 'location', 'id'] track by repository.hash"
@@ -228,19 +255,34 @@
                                                   ng-if="isRepoActive(repository)"></span>
                                         </td>
                                         <td>
-                                            <div class="lead text-overflow" ng-mouseover="setPopoverRepo(repository)">
-                                                <span popover-popup-delay="500"
-                                                      popover-trigger="mouseenter" popover-placement="bottom-right"
-                                                      uib-popover-template="popoverTemplate"
-                                                      popover-title="{{'security.repository.title' | translate}} {{repository.id}}">
+                                            <div class="lead repository-lead" ng-mouseover="setPopoverRepo(repository)" ng-focus="setPopoverRepo(repository)">
+                                            <span class="repository-popover"
+                                                  popover-popup-delay="500"
+                                                  popover-trigger="mouseenter"
+                                                  popover-placement="bottom-left"
+                                                  uib-popover-template="popoverTemplate"
+                                                  popover-title="{{'security.repository.title' | translate}} {{repository.id}}">
+                                                <div class="repository-info">
                                                     <span class="icon-lg" ng-class="'icon-repo-' + repository.type"></span>
-                                                    <strong class="repository-id">{{repository.id}}</strong></span>
-                                                <span class="repository-status"> &middot; <span
-                                                    class="text-secondary">{{repository.state}}</span></span>
-                                                <span ng-if="repository.title"><small> &middot; {{repository.title}}</small></span>
+
+                                                    <div class="repository-details">
+                                                        <div class="repository-main-info">
+                                                            <strong class="repository-id">{{repository.id}}</strong>
+                                                            <span class="repository-status">
+                                                                &middot;
+                                                                <span class="text-secondary">{{repository.state}}</span>
+                                                            </span>
+                                                        </div>
+
+                                                        <small class="repository-title" ng-if="repository.title">
+                                                            {{repository.title}}
+                                                        </small>
+                                                    </div>
+                                                </div>
+                                            </span>
                                             </div>
                                         </td>
-                                        <td width="150" class="text-nowrap repository-actions">
+                                        <td class="text-nowrap repository-actions">
                                             <button class="btn btn-link p-0"
                                                     ng-click="copyToClipboard(repository.externalUrl)"
                                                     gdb-tooltip="{{'copy.repo.url' | translate}}">
@@ -281,7 +323,7 @@
                                                 </button>
                                             </span>
                                         </td>
-                                        <td width="50">
+                                        <td>
                                             <button class="btn btn-link p-0 pin-repository-btn"
                                                     ng-if="repository.type !== 'system' && location.active"
                                                     ng-click="toggleDefaultRepository(repository.id)"


### PR DESCRIPTION
## What
- Improved the layout of the repository list.
- Fixed the rendering of long repository IDs and titles.
- Added the repository title to the repository details popover.

## Why
The repository information section did not grow to fill the available space, leaving an unnecessary gap before the actions column and causing repository IDs and descriptions to be truncated prematurely. Repository descriptions were also not visible when truncated.

## How
Updated the repository layout and styles so the repository information section grows to use the available space while preserving text truncation for long values. Extended the repository details popover to display the repository title.

## Screenshots
<img width="1643" height="860" alt="image" src="https://github.com/user-attachments/assets/1aa8865d-ea3e-4254-9641-9609cfe89692" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
