### PR TITLE
Add loading property inside the onto-loader component directly.

### DIFF
--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -145,6 +145,11 @@ export namespace Components {
     }
     interface OntoLoader {
         /**
+          * Whether the loader is currently active and should be displayed.
+          * @default false
+         */
+        "loading": boolean;
+        /**
           * Optional message text to display below the loader.
           * @default ''
          */
@@ -877,6 +882,11 @@ declare namespace LocalJSX {
         "license"?: License;
     }
     interface OntoLoader {
+        /**
+          * Whether the loader is currently active and should be displayed.
+          * @default false
+         */
+        "loading"?: boolean;
         /**
           * Optional message text to display below the loader.
           * @default ''

--- a/packages/shared-components/src/components/onto-layout/onto-layout.scss
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.scss
@@ -49,10 +49,6 @@
     main {
       position: relative;
       visibility: hidden;
-
-      onto-loader {
-        visibility: visible;
-      }
     }
   }
 

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -129,10 +129,10 @@ export class OntoLayout {
           </nav>
         }
 
-        {this.loading &&
-          <onto-loader targetSelector={'main'} size={96} messageText={TranslationService.translate('common.loading')}></onto-loader>
-        }
-        <slot name="main"></slot>
+        <slot name="main">
+          <onto-loader loading={this.loading} targetSelector={'main'} size={96}
+            messageText={TranslationService.translate('common.loading')}></onto-loader>
+        </slot>
 
         {!this.isEmbedded &&
           <footer class="wb-footer">

--- a/packages/shared-components/src/components/onto-loader/onto-loader.scss
+++ b/packages/shared-components/src/components/onto-loader/onto-loader.scss
@@ -1,16 +1,16 @@
 :host(.onto-loader-attached) {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: center;
 }
 
 :host {
-  display: block;
+  display: none;
 
   .onto-loader {
     white-space: nowrap;
@@ -29,4 +29,9 @@
       text-align: center;
     }
   }
+}
+
+:host(.onto-loader-active) {
+  display: flex;
+  visibility: visible !important;
 }

--- a/packages/shared-components/src/components/onto-loader/onto-loader.tsx
+++ b/packages/shared-components/src/components/onto-loader/onto-loader.tsx
@@ -16,6 +16,11 @@ export class OntoLoader {
   @Prop() size = 100;
 
   /**
+   * Whether the loader is currently active and should be displayed.
+   */
+  @Prop() loading = false;
+
+  /**
    * Optional message text to display below the loader.
    */
   @Prop() messageText = '';
@@ -35,7 +40,7 @@ export class OntoLoader {
 
   render() {
     return (
-      <Host class={{[this.ATTACHED_CLASS]: !!this.targetSelector}}>
+      <Host class={{[this.ATTACHED_CLASS]: !!this.targetSelector, 'onto-loader-active': this.loading}}>
         <div class="onto-loader" guide-selector="onto-loader">
           <div class="loader-spinner" style={{'width': this.size + 'px', 'height': this.size + 'px'}} innerHTML={this.rawSvg}></div>
           {this.messageText && <div class="loader-message" style={{'font-size': (this.size / 4) + 'px'}}>{this.messageText}</div>}

--- a/packages/shared-components/src/components/onto-loader/readme.md
+++ b/packages/shared-components/src/components/onto-loader/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property         | Attribute         | Description                                                                  | Type     | Default |
-| ---------------- | ----------------- | ---------------------------------------------------------------------------- | -------- | ------- |
-| `messageText`    | `message-text`    | Optional message text to display below the loader.                           | `string` | `''`    |
-| `size`           | `size`            | Size of the loader in pixels (width and height).                             | `number` | `100`   |
-| `targetSelector` | `target-selector` | CSS selector of a DOM element to attach the loader to as a centered overlay. | `string` | `''`    |
+| Property         | Attribute         | Description                                                                  | Type      | Default |
+| ---------------- | ----------------- | ---------------------------------------------------------------------------- | --------- | ------- |
+| `loading`        | `loading`         | Whether the loader is currently active and should be displayed.              | `boolean` | `false` |
+| `messageText`    | `message-text`    | Optional message text to display below the loader.                           | `string`  | `''`    |
+| `size`           | `size`            | Size of the loader in pixels (width and height).                             | `number`  | `100`   |
+| `targetSelector` | `target-selector` | CSS selector of a DOM element to attach the loader to as a centered overlay. | `string`  | `''`    |
 
 
 ## Dependencies


### PR DESCRIPTION
## What
Add `loading` property inside the onto-loader component directly.

## Why
So the component can manage its own state

## How 
Added the `loading property directly inside onto-loader

## Testing 
n/a

(cherry picked from commit 9970462598adb73d180aa06e04c7c561522242ac)


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
