### PR TITLE
GDB-14821 fix warnings before guide startup in sandbox

### DIFF
--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -94,8 +94,8 @@ export class OntoLayout {
     this.updateVisibility();
     this.subscribeToNavigationEnd();
     this.subscribeToRuntimeConfigurationChanges();
-    this.subscribeToApplicationChange();
     this.loading = false;
+    this.subscribeToBeforeMountRouting();
   }
 
   /**
@@ -321,7 +321,7 @@ export class OntoLayout {
       }));
   }
 
-  private subscribeToApplicationChange() {
+  private subscribeToBeforeMountRouting() {
     this.subscriptions.add(
       this.applicationLifecycleContextService.onNavigationBeforeMountRouting((payload) => {
         if (payload) {


### PR DESCRIPTION
## What
Fix warnings before guide startup in sandbox.

## Why
Because untranslated errors were displayed on page load for a split second.

## How
Moved `this.loading = false` in the `connectedCallback` to be before `subscribeToBeforeMountRouting`. Previously the subscription method executed first, and the subscribe function executed immediately setting `loading` to `true`. So the very next line `this.loader = false` immediately hid the loader, which should hide the main content, until the page is loaded. Now the order is correct the issue no longer reproduces

## Testing
n/a

(cherry picked from commit ade5d524f397d177fc821714e0863f2f211dff7d)

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
