### PR TITLE
Cherry-pick GDB-14779: Add a banner in the WB stating that we plan to deprecate the Solr connector in the next major version of GDB

### DIFF
--- a/packages/api/src/models/user-preference/user-preferences.ts
+++ b/packages/api/src/models/user-preference/user-preferences.ts
@@ -1,0 +1,21 @@
+/**
+ * Stores user-specific UI preferences.
+ *
+ * These preferences are persisted for authenticated users and control personalized UI behavior.
+ */
+export class UserPreferences {
+  /**
+   * Indicates whether the user has dismissed the Solr deprecation banner.
+   * When {@code true}, the banner is not shown again for the user.
+   */
+  isSolrDeprecationBannerDismissed = false;
+
+  /**
+   * Creates a new user preferences instance.
+   *
+   * @param value - Optional values used to initialize the user preferences.
+   */
+  constructor(value: Partial<UserPreferences> = {}) {
+    this.isSolrDeprecationBannerDismissed = value.isSolrDeprecationBannerDismissed ?? false;
+  }
+}

--- a/packages/api/src/models/user-preference/users-preferences.ts
+++ b/packages/api/src/models/user-preference/users-preferences.ts
@@ -1,0 +1,59 @@
+import { UserPreferences } from './user-preferences';
+
+type Preferences = Record<string, UserPreferences>;
+
+/**
+ * Represents all stored user preferences.
+ *
+ * Preferences are stored per user, where the key is the username and the value contains the preferences for that user.
+ */
+export class UsersPreferences {
+  private static readonly CURRENT_VERSION = 1;
+
+  /**
+   * Identifies the storage format version. The version can be used to migrate persisted preferences in future releases.
+   */
+  readonly version: number;
+
+  /**
+   * User preferences indexed by username.
+   */
+  preferences: Preferences = {};
+
+  /**
+   * Creates a collection of user preferences.
+   *
+   * @param value - Optional object used to initialize the collection, typically deserialized from persistent storage.
+   */
+  constructor(value?: Partial<UsersPreferences> | null) {
+    this.version = value?.version ?? UsersPreferences.CURRENT_VERSION;
+    this.preferences = value?.preferences ?? {};
+  }
+
+  /**
+   * Returns the preferences associated with the specified user.
+   *
+   * @param username - The username whose preferences should be returned.
+   * @returns The user's preferences, or {@code undefined} if no preferences are stored.
+   */
+  getUserPreferences(username: string): UserPreferences | undefined {
+    return this.preferences[username];
+  }
+
+  /**
+   * Stores the preferences for the specified user.
+   *
+   * @param username - The username whose preferences should be updated.
+   * @param userPreferences - The preferences to associate with the user.
+   */
+  setUserPreferences(username: string, userPreferences: UserPreferences): void {
+    this.preferences[username] = userPreferences;
+  }
+
+  /**
+   * @returns A JSON string representing the preferences of users.
+   */
+  toString(): string {
+    return JSON.stringify(this);
+  }
+}

--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -74,6 +74,7 @@ export * from './services/domain/sparql-template';
 export * from './services/domain/rdf4j';
 export * from './services/domain/sparql';
 export * from './services/ui';
+export * from './services/user-preferences';
 export * from './services/domain/guides';
 export * from './services/ui/dialog';
 export * from './services/domain/connector';

--- a/packages/api/src/services/user-preferences/index.ts
+++ b/packages/api/src/services/user-preferences/index.ts
@@ -1,0 +1,2 @@
+export {UserPreferencesService} from './user-preferences.service';
+export {UserPreferencesContextService} from './user-preferences-context.service';

--- a/packages/api/src/services/user-preferences/test/user-preferences.service.spec.ts
+++ b/packages/api/src/services/user-preferences/test/user-preferences.service.spec.ts
@@ -1,0 +1,160 @@
+import { service } from '../../../providers';
+import { UserPreferencesService } from '../user-preferences.service';
+import { AuthenticationService, SecurityContextService } from '../../domain/security';
+import {AuthenticatedUser,} from '../../../models/security';
+import {UserPreferencesStorageService} from '../user-preferences-storage.service';
+import {StorageData} from '../../../models/storage';
+import {UserPreferencesContextService} from '../user-preferences-context.service';
+import {UserPreferences} from '../../../models/user-preference/user-preferences';
+import {UsersPreferences} from '../../../models/user-preference/users-preferences';
+
+/**
+ * Holds persisted user preferences stored in local storage.
+ */
+const STORAGE_PREFERENCES = '{"preferences":{"admin":{"isSolrDeprecationBannerDismissed":true}},"version":1}';
+
+const ADMIN_STORED_PREFERENCES = new UserPreferences({isSolrDeprecationBannerDismissed: true});
+const DEFAULT_PREFERENCES = new UserPreferences({isSolrDeprecationBannerDismissed: false});
+const SOLR_BANNER_DISMISSED_USER_PREFERENCES = new UserPreferences({isSolrDeprecationBannerDismissed: true});
+const SOLR_BANNER_NOT_DISMISSED_USER_PREFERENCES = new UserPreferences({isSolrDeprecationBannerDismissed: false});
+
+const mockAuthenticatedUser = (username: string): void => {
+  jest.spyOn(service(SecurityContextService), 'getAuthenticatedUser')
+    .mockReturnValue(new AuthenticatedUser({username}));
+};
+
+const mockIsLoggedIn = (isLoggedIn: boolean): void => {
+  jest.spyOn(service(AuthenticationService), 'isLoggedIn')
+    .mockReturnValue(isLoggedIn);
+};
+
+const mockUserPreferencesContext = (userPreferences?: UserPreferences): void => {
+  jest.spyOn(service(UserPreferencesContextService), 'getUserPreferences')
+    .mockReturnValue(userPreferences);
+};
+
+describe('UserPreferencesService', () => {
+  let userPreferencesService: UserPreferencesService;
+  let updateUserPreferencesSpy: jest.SpyInstance<void, [UserPreferences]>;
+  let setUsersPreferencesSpy: jest.SpyInstance<void, [UsersPreferences]>;
+
+  beforeEach(() => {
+    updateUserPreferencesSpy = jest.spyOn(service(UserPreferencesContextService), 'updateUserPreferences');
+    setUsersPreferencesSpy = jest.spyOn(service(UserPreferencesStorageService), 'setUsersPreferences');
+    jest.spyOn(service(UserPreferencesStorageService), 'get').mockReturnValue(new StorageData(STORAGE_PREFERENCES));
+    userPreferencesService = new UserPreferencesService();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('dismissSolrDeprecationBanner', () => {
+    it('should persist preference and update context when user is logged in', () => {
+      // GIVEN: A user is authenticated.
+      mockIsLoggedIn(true);
+      mockAuthenticatedUser('user');
+      const expectedStorageObject = new UsersPreferences({
+        preferences: {
+          admin: ADMIN_STORED_PREFERENCES,
+          user: SOLR_BANNER_DISMISSED_USER_PREFERENCES
+        }
+      });
+
+      // WHEN: The Solr deprecation banner is dismissed.
+      userPreferencesService.dismissSolrDeprecationBanner();
+
+      // THEN: I expect the preference to be persisted.
+      expect(setUsersPreferencesSpy).toHaveBeenCalledWith(expectedStorageObject);
+      // AND: I expect the context to be updated.
+      expect(updateUserPreferencesSpy).toHaveBeenCalledWith(SOLR_BANNER_DISMISSED_USER_PREFERENCES);
+    });
+
+    it('should update only context when user is not logged in', () => {
+      // GIVEN: No user is authenticated.
+      mockIsLoggedIn(false);
+
+      // WHEN: The Solr deprecation banner is dismissed.
+      userPreferencesService.dismissSolrDeprecationBanner();
+
+      // THEN: I expect the preference not to be persisted.
+      expect(setUsersPreferencesSpy).not.toHaveBeenCalled();
+      // AND: I expect only the context to be updated.
+      expect(updateUserPreferencesSpy).toHaveBeenCalledWith(SOLR_BANNER_DISMISSED_USER_PREFERENCES);
+    });
+  });
+
+  describe('loadUserPreferences', () => {
+    it('should load persisted preferences when user is logged in', () => {
+      // GIVEN: Persisted preferences exist for the authenticated user.
+      mockAuthenticatedUser('admin');
+      // AND: The user is logged in.
+      mockIsLoggedIn(true);
+
+      // WHEN: User preferences are loaded.
+      userPreferencesService.loadUserPreferences();
+
+      // THEN: I expect the persisted preferences to be loaded into the context.
+      expect(updateUserPreferencesSpy).toHaveBeenCalledWith(ADMIN_STORED_PREFERENCES);
+    });
+
+    it('should load default preferences when user is logged in but no persisted preferences exist', () => {
+      // GIVEN: No persisted preferences exist for the authenticated user.
+      mockAuthenticatedUser('user');
+      // AND: The user is logged in.
+      mockIsLoggedIn(true);
+
+      // WHEN: User preferences are loaded.
+      userPreferencesService.loadUserPreferences();
+
+      // THEN: I expect the default preferences to be loaded into the context.
+      expect(updateUserPreferencesSpy).toHaveBeenCalledWith(DEFAULT_PREFERENCES);
+    });
+
+    it('should load default in-memory preferences when user is not logged in', () => {
+      // GIVEN: No user is authenticated.
+      mockIsLoggedIn(false);
+
+      // WHEN: User preferences are loaded.
+      userPreferencesService.loadUserPreferences();
+
+      // THEN: I expect the default preferences to be loaded into the context.
+      expect(updateUserPreferencesSpy).toHaveBeenCalledWith(DEFAULT_PREFERENCES);
+    });
+  });
+
+  describe('isSolrDeprecationBannerDismissed', () => {
+    it('should return true when banner is dismissed', () => {
+      // GIVEN: The banner is marked as dismissed in the current context.
+      mockUserPreferencesContext(SOLR_BANNER_DISMISSED_USER_PREFERENCES);
+
+      // WHEN: The banner state is requested.
+      const isSolrDeprecationBannerDismissed = userPreferencesService.isSolrDeprecationBannerDismissed();
+
+      // THEN: The service reports that the banner is dismissed.
+      expect(isSolrDeprecationBannerDismissed).toBe(true);
+    });
+
+    it('should return false when banner is not dismissed', () => {
+      // GIVEN: The banner is not dismissed.
+      mockUserPreferencesContext(SOLR_BANNER_NOT_DISMISSED_USER_PREFERENCES);
+
+      // WHEN: The banner state is requested.
+      const isSolrDeprecationBannerDismissed = userPreferencesService.isSolrDeprecationBannerDismissed();
+
+      // THEN: The service reports that the banner is not dismissed.
+      expect(isSolrDeprecationBannerDismissed).toBe(false);
+    });
+
+    it('should return false when preferences are not loaded', () => {
+      // GIVEN: No user preferences are available in the context.
+      mockUserPreferencesContext(undefined);
+
+      // WHEN: The banner state is requested.
+      const isSolrDeprecationBannerDismissed = userPreferencesService.isSolrDeprecationBannerDismissed();
+
+      // THEN: The service reports that the banner is not dismissed.
+      expect(isSolrDeprecationBannerDismissed).toBe(false);
+    });
+  });
+});

--- a/packages/api/src/services/user-preferences/user-preferences-context.service.ts
+++ b/packages/api/src/services/user-preferences/user-preferences-context.service.ts
@@ -1,0 +1,48 @@
+import { ContextService } from '../context';
+import { DeriveContextServiceContract } from '../../models/context/update-context-method';
+import { LifecycleHooks } from '../../providers/service/lifecycle-hooks';
+import { ValueChangeCallback } from '../../models/context/value-change-callback';
+import { UserPreferences } from '../../models/user-preference/user-preferences';
+
+type UserPreferencesContextFields = {
+  readonly USER_PREFERENCES: string;
+};
+
+type UserPreferencesContextFieldParams = {
+  readonly USER_PREFERENCES: UserPreferences;
+};
+
+/**
+ * Context service responsible for storing user-specific data for the current application session.
+ */
+export class UserPreferencesContextService extends ContextService<UserPreferencesContextFields> implements DeriveContextServiceContract<UserPreferencesContextFields, UserPreferencesContextFieldParams>, LifecycleHooks {
+  readonly USER_PREFERENCES = 'userPreferences';
+
+  /**
+   * Returns the current user's preferences.
+   *
+   * @returns The current user's preferences, or {@code undefined} if they have not been initialized.
+   */
+  getUserPreferences(): UserPreferences | undefined {
+    return this.getContextPropertyValue(this.USER_PREFERENCES);
+  }
+
+  /**
+   * Updates the current user's preferences.
+   *
+   * @param userPreferences - The preferences to store for the current user.
+   */
+  updateUserPreferences(userPreferences: UserPreferences): void {
+    this.updateContextProperty(this.USER_PREFERENCES, userPreferences);
+  }
+
+  /**
+   * Registers a callback invoked whenever the current user's preferences are updated.
+   *
+   * @param callbackFunction - The function to invoke when the preferences change.
+   * @returns A function that unsubscribes the callback.
+   */
+  onUserPreferencesChanged(callbackFunction: ValueChangeCallback<UserPreferences | undefined>): () => void {
+    return this.subscribe(this.USER_PREFERENCES, callbackFunction);
+  }
+}

--- a/packages/api/src/services/user-preferences/user-preferences-storage.service.ts
+++ b/packages/api/src/services/user-preferences/user-preferences-storage.service.ts
@@ -1,0 +1,57 @@
+import { LocalStorageService } from '../storage';
+import { UsersPreferences } from '../../models/user-preference/users-preferences';
+
+/**
+ * Service for storing and retrieving user preferences data from local storage.
+ */
+export class UserPreferencesStorageService extends LocalStorageService {
+  /**
+   * Namespace used for user-related local storage entries.
+   */
+  readonly NAMESPACE = 'userPreferences';
+
+  /**
+   * Local storage key used for persisted preferences of users.
+   */
+  private readonly USER_PREFERENCES = 'preferences';
+
+  /**
+   * Stores a value in local storage.
+   *
+   * @param key - The storage key.
+   * @param value - The value to store.
+   */
+  set(key: string, value: string): void {
+    this.storeValue(key, value);
+  }
+
+  /**
+   * Stores the preferences of all known users.
+   *
+   * @param userPreferences - The user preferences collection to persist.
+   */
+  setUsersPreferences(userPreferences: UsersPreferences): void {
+    this.set(this.USER_PREFERENCES, userPreferences.toString());
+  }
+
+  /**
+   * Returns the persisted preferences of all known users.
+   *
+   * If no preferences are stored, an empty preferences collection is returned.
+   *
+   * @returns The stored user preferences collection.
+   */
+  getPreferences(): UsersPreferences {
+    const usersPreferences = this.get(this.USER_PREFERENCES).getValue();
+
+    if (!usersPreferences) {
+      return new UsersPreferences();
+    }
+
+    try {
+      return new UsersPreferences(JSON.parse(usersPreferences));
+    } catch {
+      return new UsersPreferences();
+    }
+  }
+}

--- a/packages/api/src/services/user-preferences/user-preferences.service.ts
+++ b/packages/api/src/services/user-preferences/user-preferences.service.ts
@@ -1,0 +1,114 @@
+import { service } from '../../providers';
+import { UserPreferencesStorageService } from './user-preferences-storage.service';
+import {AuthenticationService, SecurityContextService} from '../domain/security';
+import { UserPreferencesContextService } from './user-preferences-context.service';
+import { UserPreferences } from '../../models/user-preference/user-preferences';
+
+/**
+ * Service for loading, updating, and persisting user preferences.
+ *
+ * Preferences are persisted only when the current user is authenticated.
+ * Anonymous users keep their preferences only in the current application context,
+ * so their choices are reset after a page refresh.
+ */
+export class UserPreferencesService {
+  private readonly userPreferencesStorageService = service(UserPreferencesStorageService);
+  private readonly userPreferencesContextService = service(UserPreferencesContextService);
+  private readonly securityContextService = service(SecurityContextService);
+  private readonly authenticationService = service(AuthenticationService);
+
+  /**
+   * Marks the Solr deprecation banner as dismissed.
+   *
+   * For authenticated users, the preference is persisted and restored after refresh.
+   * For anonymous users, including non-secured access and free-access mode, the preference is stored
+   * only in the current application context.
+   */
+  dismissSolrDeprecationBanner(): void {
+    const userPreferences = this.getCurrentUserPreferences();
+    userPreferences.isSolrDeprecationBannerDismissed = true;
+    this.userPreferencesContextService.updateUserPreferences(userPreferences);
+
+    if (this.authenticationService.isLoggedIn()) {
+      this.persistCurrentUserPreferences(userPreferences);
+    }
+  }
+
+  /**
+   * Checks whether the Solr deprecation banner has been dismissed.
+   *
+   * @returns {@code true} if the banner was dismissed, otherwise {@code false}.
+   */
+  isSolrDeprecationBannerDismissed(): boolean {
+    return this.userPreferencesContextService.getUserPreferences()?.isSolrDeprecationBannerDismissed ?? false;
+  }
+
+  /**
+   * Loads the preferences for the current user into the application context.
+   *
+   * Authenticated users receive their persisted preferences.
+   * Anonymous users receive a new in-memory preferences instance.
+   */
+  loadUserPreferences(): void {
+    if (this.authenticationService.isLoggedIn()) {
+      this.userPreferencesContextService.updateUserPreferences(this.loadCurrentUserPreferences() ?? new UserPreferences());
+    } else {
+      this.userPreferencesContextService.updateUserPreferences(new UserPreferences());
+    }
+  }
+
+  /**
+   * Loads preferences for the current user.
+   *
+   * @returns Persisted preferences for authenticated users, or a new preferences instance for anonymous users.
+   */
+  private loadCurrentUserPreferences(): UserPreferences | undefined {
+    const username = this.getAuthenticatedUsername();
+
+    // The username is expected to be available for authenticated users, but the service API allows it to be undefined.
+    if (!username) {
+      return new UserPreferences();
+    }
+
+    return this.userPreferencesStorageService
+      .getPreferences()
+      .getUserPreferences(username);
+  }
+
+  /**
+   * Returns the current user preferences from the context.
+   *
+   * If no preferences exist in the context, a new preferences instance is created.
+   *
+   * @returns The current user preferences.
+   */
+  private getCurrentUserPreferences(): UserPreferences {
+    return this.userPreferencesContextService.getUserPreferences() ?? new UserPreferences();
+  }
+
+  /**
+   * Persists the preferences for the current authenticated user.
+   *
+   * @param userPreferences - Preferences to persist for the authenticated user.
+   */
+  private persistCurrentUserPreferences(userPreferences: UserPreferences): void {
+    const username = this.getAuthenticatedUsername();
+
+    if (!username) {
+      return;
+    }
+
+    const usersPreferences = this.userPreferencesStorageService.getPreferences();
+    usersPreferences.setUserPreferences(username, userPreferences);
+    this.userPreferencesStorageService.setUsersPreferences(usersPreferences);
+  }
+
+  /**
+   * Returns the username of the authenticated user.
+   *
+   * @returns The authenticated username, or {@code undefined} if no user is authenticated.
+   */
+  private getAuthenticatedUsername(): string | undefined {
+    return this.securityContextService.getAuthenticatedUser()?.toUser().username;
+  }
+}

--- a/packages/root-config/src/bootstrap/bootstrap.ts
+++ b/packages/root-config/src/bootstrap/bootstrap.ts
@@ -16,6 +16,7 @@ import {
   ApplicationLifecycleContextService,
   ApplicationSettingsStorageService,
   LifecycleState,
+  UserPreferencesService,
 } from '@ontotext/workbench-api';
 import {start} from 'single-spa';
 import {defineCustomElements} from '../../../shared-components/loader';
@@ -98,6 +99,8 @@ const subscribeToAuthenticatedUserChange = () => {
       }
       isInitialBootstrap = false;
     }
+    // Updates user preferences when the authenticated user changes.
+    service(UserPreferencesService).loadUserPreferences();
   });
 };
 

--- a/packages/shared-components/cypress/e2e/deprecation-banner/deprecation-steps.js
+++ b/packages/shared-components/cypress/e2e/deprecation-banner/deprecation-steps.js
@@ -1,0 +1,13 @@
+export class DeprecationSteps {
+  static getDeprecationBanner() {
+    return cy.get('onto-deprecation-banner');
+  }
+
+  static getCloseButton() {
+    return DeprecationSteps.getDeprecationBanner().find('.close-button');
+  }
+
+  static closeBanner() {
+    DeprecationSteps.getCloseButton().click();
+  }
+}

--- a/packages/shared-components/cypress/e2e/layout/layout.cy.js
+++ b/packages/shared-components/cypress/e2e/layout/layout.cy.js
@@ -1,6 +1,7 @@
 import {NavbarSteps} from "../../steps/navbar/navbar-steps";
 import {LayoutSteps} from "../../steps/layout/layout-steps";
 import {HeaderSteps} from "../../steps/header/header-steps";
+import {DeprecationSteps} from '../deprecation-banner/deprecation-steps';
 
 function assertSubmenuItems(menuIndex, expectedItems) {
   NavbarSteps.getSubmenuItems(menuIndex)
@@ -13,6 +14,8 @@ function assertSubmenuItems(menuIndex, expectedItems) {
 
 describe('Layout', () => {
   it('Should filter menu items, based on role', () => {
+    // Increase the viewport size because the Help menu becomes invisible and the test fails.
+    cy.viewport(1280, 1000);
     // Given I've visited the layout page and loaded menu items for the navbar
     LayoutSteps.visit();
     LayoutSteps.disableSecurity();
@@ -159,5 +162,27 @@ describe('Layout', () => {
     // Then I should see the header and navbar
     HeaderSteps.getHeader().should('exist');
     NavbarSteps.getRootMenuItems().should('have.length', 7);
-  })
+  });
+
+  it('should hide the Solr deprecation notice until the page is refreshed when security is disabled', () => {
+    // GIVEN: I have visited the layout page with security disabled.
+    LayoutSteps.visit();
+
+    // THEN: I expect the Solr deprecation banner to be visible.
+    DeprecationSteps.getDeprecationBanner()
+      .should('be.visible')
+      .should('contain.text', 'Solr Connector Deprecation Notice');
+
+    // WHEN: I click the close button.
+    DeprecationSteps.closeBanner();
+    // THEN: I expect the Solr deprecation banner to not be visible.
+    DeprecationSteps.getDeprecationBanner().should('not.exist');
+
+    // WHEN: I refresh the page.
+    LayoutSteps.visit();
+    // THEN: I expect the Solr deprecation banner to be visible again.
+    DeprecationSteps.getDeprecationBanner()
+      .should('be.visible')
+      .should('contain.text', 'Solr Connector Deprecation Notice');
+  });
 });

--- a/packages/shared-components/src/assets/i18n/en.json
+++ b/packages/shared-components/src/assets/i18n/en.json
@@ -222,5 +222,11 @@
       "create_graph_configuration": "Create one",
       "create_graph_configuration_link": "here"
     }
+  },
+  "deprecation-banner": {
+    "solr": {
+      "header": "Solr Connector Deprecation Notice",
+      "content": "The Solr connector has been deprecated and will be removed in version 12 of GraphDB. If you are using it, please contact us via the available support channels to discuss the alternatives."
+    }
   }
 }

--- a/packages/shared-components/src/assets/i18n/fr.json
+++ b/packages/shared-components/src/assets/i18n/fr.json
@@ -222,5 +222,11 @@
       "create_graph_configuration": "En créer une",
       "create_graph_configuration_link": "ici"
     }
+  },
+  "deprecation-banner": {
+    "solr": {
+      "header": "Avis de dépréciation du connecteur Solr",
+      "content": "Le connecteur Solr est obsolète et sera supprimé dans la version 12 de GraphDB. Si vous l'utilisez, veuillez nous contacter via les canaux de support disponibles afin de discuter des alternatives."
+    }
   }
 }

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -33,6 +33,8 @@ export namespace Components {
     }
     interface OntoCookiePolicyDialog {
     }
+    interface OntoDeprecationBanner {
+    }
     interface OntoDialog {
         /**
           * Configuration object for the dialog.
@@ -415,6 +417,10 @@ export interface OntoCookiePolicyDialogCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLOntoCookiePolicyDialogElement;
 }
+export interface OntoDeprecationBannerCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLOntoDeprecationBannerElement;
+}
 export interface OntoDropdownCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLOntoDropdownElement;
@@ -476,6 +482,23 @@ declare global {
     var HTMLOntoCookiePolicyDialogElement: {
         prototype: HTMLOntoCookiePolicyDialogElement;
         new (): HTMLOntoCookiePolicyDialogElement;
+    };
+    interface HTMLOntoDeprecationBannerElementEventMap {
+        "closeBanner": void;
+    }
+    interface HTMLOntoDeprecationBannerElement extends Components.OntoDeprecationBanner, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLOntoDeprecationBannerElementEventMap>(type: K, listener: (this: HTMLOntoDeprecationBannerElement, ev: OntoDeprecationBannerCustomEvent<HTMLOntoDeprecationBannerElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLOntoDeprecationBannerElementEventMap>(type: K, listener: (this: HTMLOntoDeprecationBannerElement, ev: OntoDeprecationBannerCustomEvent<HTMLOntoDeprecationBannerElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLOntoDeprecationBannerElement: {
+        prototype: HTMLOntoDeprecationBannerElement;
+        new (): HTMLOntoDeprecationBannerElement;
     };
     interface HTMLOntoDialogElement extends Components.OntoDialog, HTMLStencilElement {
     }
@@ -714,6 +737,7 @@ declare global {
         "onto-confirm-cancel-dialog": HTMLOntoConfirmCancelDialogElement;
         "onto-cookie-consent": HTMLOntoCookieConsentElement;
         "onto-cookie-policy-dialog": HTMLOntoCookiePolicyDialogElement;
+        "onto-deprecation-banner": HTMLOntoDeprecationBannerElement;
         "onto-dialog": HTMLOntoDialogElement;
         "onto-dropdown": HTMLOntoDropdownElement;
         "onto-footer": HTMLOntoFooterElement;
@@ -758,6 +782,12 @@ declare namespace LocalJSX {
           * Event emitted when the dialog is closed, allowing parent components to react accordingly.
          */
         "onCloseDialog"?: (event: OntoCookiePolicyDialogCustomEvent<void>) => void;
+    }
+    interface OntoDeprecationBanner {
+        /**
+          * Emitted when the banner is closed.
+         */
+        "onCloseBanner"?: (event: OntoDeprecationBannerCustomEvent<void>) => void;
     }
     interface OntoDialog {
         /**
@@ -1065,6 +1095,7 @@ declare namespace LocalJSX {
         "onto-confirm-cancel-dialog": OntoConfirmCancelDialog;
         "onto-cookie-consent": OntoCookieConsent;
         "onto-cookie-policy-dialog": OntoCookiePolicyDialog;
+        "onto-deprecation-banner": OntoDeprecationBanner;
         "onto-dialog": OntoDialog;
         "onto-dropdown": OntoDropdown;
         "onto-footer": OntoFooter;
@@ -1102,6 +1133,7 @@ declare module "@stencil/core" {
              */
             "onto-cookie-consent": LocalJSX.OntoCookieConsent & JSXBase.HTMLAttributes<HTMLOntoCookieConsentElement>;
             "onto-cookie-policy-dialog": LocalJSX.OntoCookiePolicyDialog & JSXBase.HTMLAttributes<HTMLOntoCookiePolicyDialogElement>;
+            "onto-deprecation-banner": LocalJSX.OntoDeprecationBanner & JSXBase.HTMLAttributes<HTMLOntoDeprecationBannerElement>;
             "onto-dialog": LocalJSX.OntoDialog & JSXBase.HTMLAttributes<HTMLOntoDialogElement>;
             /**
              * A reusable dropdown component built using StencilJS. This component supports configurable labels, tooltips, icons,

--- a/packages/shared-components/src/components/onto-deprecation-banner/onto-deprecation-banner.scss
+++ b/packages/shared-components/src/components/onto-deprecation-banner/onto-deprecation-banner.scss
@@ -1,0 +1,29 @@
+:host {
+  display: block;
+}
+
+.deprecation-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1rem;
+  background: #384252;
+  color: #FFF;
+
+  .banner-content {
+    flex: 1;
+    text-align: center;
+
+    .banner-message {
+      font-size: 1.2em;
+    }
+  }
+
+  .close-button {
+    border: none;
+    outline: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+  }
+}

--- a/packages/shared-components/src/components/onto-deprecation-banner/onto-deprecation-banner.tsx
+++ b/packages/shared-components/src/components/onto-deprecation-banner/onto-deprecation-banner.tsx
@@ -1,0 +1,45 @@
+import { Component, h, Host, Event, EventEmitter } from '@stencil/core';
+
+@Component({
+  tag: 'onto-deprecation-banner',
+  styleUrl: 'onto-deprecation-banner.scss',
+  shadow: false
+})
+export class OntoDeprecationBanner {
+
+  /**
+   * Emitted when the banner is closed.
+   */
+  @Event() closeBanner: EventEmitter<void>;
+
+  private readonly onClose = () => {
+    this.closeBanner.emit();
+  };
+
+  render() {
+    return (
+      <Host>
+        <div class="deprecation-banner">
+          <div class="banner-content">
+            <h3 class="banner-header">
+              <slot name="header"></slot>
+            </h3>
+
+            <div class="banner-message">
+              <slot name="content"></slot>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            class="close-button"
+            aria-label="Close banner"
+            onClick={this.onClose}
+          >
+            <i class="ri-close-line"></i>
+          </button>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/packages/shared-components/src/components/onto-deprecation-banner/readme.md
+++ b/packages/shared-components/src/components/onto-deprecation-banner/readme.md
@@ -1,0 +1,30 @@
+# deprecation-banner
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Events
+
+| Event         | Description                        | Type                |
+| ------------- | ---------------------------------- | ------------------- |
+| `closeBanner` | Emitted when the banner is closed. | `CustomEvent<void>` |
+
+
+## Dependencies
+
+### Used by
+
+ - [onto-layout](../onto-layout)
+
+### Graph
+```mermaid
+graph TD;
+  onto-layout --> onto-deprecation-banner
+  style onto-deprecation-banner fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/shared-components/src/components/onto-layout/onto-layout.scss
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.scss
@@ -57,6 +57,7 @@
   }
 
   .wb-header {
+    grid-area: header;
     position: sticky;
     top: 0;
     z-index: 999;
@@ -64,10 +65,6 @@
 
   nav {
     grid-area: nav;
-  }
-
-  header {
-    grid-area: header;
   }
 
   footer {

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -24,7 +24,9 @@ import {
   WindowService,
   MainMenuPlugin,
   MainMenuItem,
-  MainMenuExtensionPoint
+  MainMenuExtensionPoint,
+  UserPreferencesService,
+  UserPreferencesContextService
 } from '@ontotext/workbench-api';
 import {TranslationService} from '../../services/translation.service';
 
@@ -44,6 +46,8 @@ export class OntoLayout {
   private readonly runtimeConfigurationContextService = service(RuntimeConfigurationContextService);
   private readonly eventService = service(EventService);
   private readonly applicationLifecycleContextService = service(ApplicationLifecycleContextService);
+  private readonly userPreferencesService = service(UserPreferencesService);
+  private readonly userPreferencesContextService = service(UserPreferencesContextService);
 
   private readonly fullJwtKey = `${StorageKey.GLOBAL_NAMESPACE}.${this.authStorageService.NAMESPACE}.${this.authStorageService.jwtKey}`;
   private readonly fullAuthenticatedKey = `${StorageKey.GLOBAL_NAMESPACE}.${this.authStorageService.NAMESPACE}.${this.authStorageService.authenticatedKey}`;
@@ -66,6 +70,7 @@ export class OntoLayout {
   @State() showNavbar = false;
   @State() private isEmbedded = false;
   @State() private loading = true;
+  @State() private hideSolrDeprecationBanner = false;
 
   // ========================
   // Private
@@ -86,6 +91,7 @@ export class OntoLayout {
   }
 
   componentDidLoad() {
+    this.updateShowSolrDeprecationBanner();
     this.windowResizeHandler();
   }
 
@@ -94,6 +100,7 @@ export class OntoLayout {
     this.updateVisibility();
     this.subscribeToNavigationEnd();
     this.subscribeToRuntimeConfigurationChanges();
+    this.subscribeToUserPreferencesChange();
     this.loading = false;
     this.subscribeToBeforeMountRouting();
   }
@@ -118,10 +125,21 @@ export class OntoLayout {
         <div class="default-slot-wrapper">
           <slot name="default"></slot>
         </div>
-        {!this.isEmbedded &&
-          <header class="wb-header">
+        {!this.isEmbedded &&<div class="wb-header">
+          {!this.hideSolrDeprecationBanner &&
+            <onto-deprecation-banner class='onto-deprecation-banner' onCloseBanner={this.onSolrDeprecationBannerClosedHandler()}>
+              <span slot='header'>
+                <translate-label labelKey='deprecation-banner.solr.header'></translate-label>
+              </span>
+              <span slot='content'>
+                <translate-label labelKey='deprecation-banner.solr.content'></translate-label>
+              </span>
+            </onto-deprecation-banner>
+          }
+          <header>
             {this.showHeader && <onto-header></onto-header>}
           </header>
+        </div>
         }
         {!this.isEmbedded && this.showNavbar &&
           <nav class="wb-navbar">
@@ -168,6 +186,13 @@ export class OntoLayout {
   @Listen('resize', {target: 'window'})
   onResize() {
     this.windowResizeObserver();
+  }
+
+  private onSolrDeprecationBannerClosedHandler(): () => void {
+    return () => {
+      this.userPreferencesService.dismissSolrDeprecationBanner();
+      this.updateShowSolrDeprecationBanner();
+    };
   }
 
   // ========================
@@ -328,5 +353,16 @@ export class OntoLayout {
           this.loading = true;
         }
       }));
+  }
+
+  private subscribeToUserPreferencesChange() {
+    this.subscriptions.add(
+      this.userPreferencesContextService.onUserPreferencesChanged(() => {
+        this.updateShowSolrDeprecationBanner();
+      }));
+  }
+
+  private updateShowSolrDeprecationBanner(): void {
+    this.hideSolrDeprecationBanner = this.userPreferencesService.isSolrDeprecationBannerDismissed();
   }
 }

--- a/packages/shared-components/src/components/onto-layout/readme.md
+++ b/packages/shared-components/src/components/onto-layout/readme.md
@@ -9,6 +9,8 @@
 
 ### Depends on
 
+- [onto-deprecation-banner](../onto-deprecation-banner)
+- [translate-label](../translate-label)
 - [onto-header](../onto-header)
 - [onto-navbar](../onto-navbar)
 - [onto-loader](../onto-loader)
@@ -17,6 +19,8 @@
 ### Graph
 ```mermaid
 graph TD;
+  onto-layout --> onto-deprecation-banner
+  onto-layout --> translate-label
   onto-layout --> onto-header
   onto-layout --> onto-navbar
   onto-layout --> onto-loader

--- a/packages/shared-components/src/components/translate-label/readme.md
+++ b/packages/shared-components/src/components/translate-label/readme.md
@@ -33,6 +33,7 @@ Example of usage:
  - [onto-cookie-policy-dialog](../dialogs/onto-cookie-policy-dialog)
  - [onto-footer](../onto-footer)
  - [onto-graph-explore-split-button](../onto-graph-explore-split-button)
+ - [onto-layout](../onto-layout)
  - [onto-license-alert](../onto-license-alert)
  - [onto-navbar](../onto-navbar)
  - [onto-operations-notification](../onto-operations-notification)
@@ -49,6 +50,7 @@ graph TD;
   onto-cookie-policy-dialog --> translate-label
   onto-footer --> translate-label
   onto-graph-explore-split-button --> translate-label
+  onto-layout --> translate-label
   onto-license-alert --> translate-label
   onto-navbar --> translate-label
   onto-operations-notification --> translate-label


### PR DESCRIPTION
## What
- Added a deprecation banner for the Solr connector.
- Added an option to dismiss the banner.
- Added user preferences infrastructure for storing user-specific UI settings.
- Implemented persistence of the Solr deprecation banner dismissed state for authenticated users.

## Why
The Solr connector is planned for deprecation in the next major GraphDB release. Users should be informed in advance so they can evaluate alternative solutions and prepare for the upcoming change.

## How
- Implemented a reusable deprecation banner component with customizable content and support for dismissal events.
- Introduced models, context, storage, and service classes for managing user-specific preferences.
- Persisted the dismissed banner state per authenticated user while keeping the preference in memory for anonymous users.

(cherry picked from commit f357ceca68041014490fccbf9c3caceec5bc4461) (cherry picked from commit 701733e5519eb0c219281ba9cd00c2782e6ddd17)

## Screenshots
<img width="1912" height="431" alt="image" src="https://github.com/user-attachments/assets/7142bdc6-81f1-4b72-a28d-1e20d441b914" />
<img width="1912" height="431" alt="image" src="https://github.com/user-attachments/assets/d4be4cab-15ae-43ae-913c-35d46128fb75" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
