### PR TITLE
GDB-14669: Show repository description on hover

### DIFF
--- a/packages/shared-components/src/components/onto-dropdown/onto-dropdown.scss
+++ b/packages/shared-components/src/components/onto-dropdown/onto-dropdown.scss
@@ -68,7 +68,7 @@
     z-index: 1001;
     overflow-y: auto;
     max-height: 340px;
-    min-width: 100%;
+    max-width: 500px;
     color: var(--gw-tieredmenu-color);
     background-color: var(--gw-tieredmenu-background);
     border: 1px solid var(--gw-tieredmenu-border-color);

--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.scss
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.scss
@@ -3,6 +3,16 @@
 }
 
 .onto-repository-selector {
+  .repository-selection {
+    max-width: 250px;
+    display: flex;
+
+    .repository-id {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
   .onto-dropdown {
     &.closed {
       .onto-dropdown-button:not(:hover) {
@@ -22,12 +32,13 @@
 
     .item-label {
       line-height: 0.75em;
-      display: inline-block;
-      vertical-align: middle;
       text-align: left;
+      min-width: 0;
 
       .repository-id {
-        line-height: .75em;
+        line-height: 1.1em;
+        overflow-x: hidden;
+        text-overflow: ellipsis;
       }
 
       .repository-location {
@@ -62,18 +73,24 @@
     .repository-tooltip-title {
       font-size: 1rem;
       font-weight: 400;
-      padding: 8px 14px;
+      padding: 0.5rem 0.9rem 0.2rem;
       background-color: var(--gw-dialog-background);
-      border-bottom: var(--gw-dialog-border-color) 1px solid;
 
       .value {
         overflow-wrap: break-word;
       }
     }
 
+    .repository-tooltip-description {
+      padding-left: 1rem;
+      padding-right: 1rem;
+      font-size: 0.8rem;
+    }
+
     .repository-tooltip-content {
       background-color: var(--gw-dialog-background);
       padding: 1.5rem 0.5rem;
+      border-top: var(--gw-dialog-border-color) 1px solid;
       display: flex;
       flex-direction: column;
       gap: 0.8em;

--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.tsx
@@ -171,7 +171,13 @@ export class OntoRepositorySelector {
     <div class="repository-tooltip-title">
       <span class="label">${TranslationService.translate('repository-selector.tooltip.repository')}</span>
       <span class="value">${repository.id}</span>
-    </div>
+    </div>`;
+
+    if (repository.title) {
+      html += `<div class="repository-tooltip-description">${repository.title}</div>`;
+    }
+
+    html += `
     <div class="repository-tooltip-content">
       <div class="repository-tooltip-row">
         <div class="label">${TranslationService.translate('repository-selector.tooltip.location')}:</div>

--- a/packages/shared-components/src/components/onto-repository-selector/repository-selection.tsx
+++ b/packages/shared-components/src/components/onto-repository-selector/repository-selection.tsx
@@ -23,7 +23,8 @@ export const RepositorySelection: FunctionalComponent<RepositorySelectionProps> 
     <div class={className}
       data-test={'repository-selection'}>
       {/* TODO: add tooltip with repository info*/}
-      {repository && <i class={'button-icon icon-1-5x icon-repo-' + repository.type}></i>}&nbsp;{repository?.id ?? defaultToggleButtonName}{location}
+      {repository && <i class={'button-icon icon-1-5x icon-repo-' + repository.type}></i>}&nbsp;
+      <span class='repository-id'>{repository?.id ?? defaultToggleButtonName}{location}</span>
     </div>
   );
 };


### PR DESCRIPTION
## What
Add the repository description to the repository selector tooltip.

## Why
Some Workbench clients use generated repository IDs and rely on repository descriptions to identify them. Since the repository selector displays only the repository ID, it is difficult to distinguish between repositories.

## How
Extended the repository selector tooltip to display the repository description alongside the repository ID.

## Additional work
Fixes issues in the repository selector when repository names are too long.

## Screenshots
<img width="941" height="646" alt="image" src="https://github.com/user-attachments/assets/96004b58-ee4e-4cd3-acd3-8f3c1460eead" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
