### PR TITLE
GDB-14800: Fix Console Errors in Class Hierarchy View After Visiting New Workbench

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@single-spa/import-map-injector": "^2.0.2",
-                "graphdb-workbench-plugins": "^0.0.1-TR35",
+                "graphdb-workbench-plugins": "^0.0.1-TR36",
                 "import-map-overrides": "^6.1.0"
             },
             "devDependencies": {
@@ -7002,9 +7002,9 @@
             "license": "ISC"
         },
         "node_modules/graphdb-workbench-plugins": {
-            "version": "0.0.1-TR35",
-            "resolved": "https://registry.npmjs.org/graphdb-workbench-plugins/-/graphdb-workbench-plugins-0.0.1-TR35.tgz",
-            "integrity": "sha512-T3b2Pl8wzbM1lT22aWqpLhq1YWCC+tJwK6WxPHj640iMNNY6j2VZrXnshZrU09xQ8PVnCzfkKoN88m207ea7PA==",
+            "version": "0.0.1-TR36",
+            "resolved": "https://registry.npmjs.org/graphdb-workbench-plugins/-/graphdb-workbench-plugins-0.0.1-TR36.tgz",
+            "integrity": "sha512-Kt3qddo/awUuAgi9xQp8kwNg38E5QMGVXOlXnqArPM27fIJW8d/6SOjbxQDWm/1s3uH4lh0jVvy/TUuzu8iOIA==",
             "license": "Apache-2.0"
         },
         "node_modules/gzip-size": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "resolutions": {},
     "dependencies": {
         "@single-spa/import-map-injector": "^2.0.2",
-        "graphdb-workbench-plugins": "^0.0.1-TR35",
+        "graphdb-workbench-plugins": "^0.0.1-TR36",
         "import-map-overrides": "^6.1.0"
     }
 }

--- a/packages/legacy-workbench/src/js/angular/graphexplore/directives/rdf-class-hierarchy.directive.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/directives/rdf-class-hierarchy.directive.js
@@ -485,7 +485,7 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
                 const focusHistoryId = $location.hash();
 
                 $window.onpopstate = function(event) {
-                    if (event.state) {
+                    if (event.state && !event.state.skipOnPopState) {
                         const focusHistoryId = event.state.id;
                         focusOnCurrentClass(focusHistoryId);
                     }
@@ -594,7 +594,9 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
                 }
 
                 if (d.data.id) {
-                    $window.history.replaceState({id: d.data.id}, "classHierarchyPage" + d.data.id, "hierarchy#" + d.data.id);
+                    // Set the `skipOnPopState` flag so the popstate handler ignores this history update,
+                    // preventing a recursive history state change triggered by the zoom operation.
+                    $window.history.replaceState({id: d.data.id, skipOnPopState: true}, "classHierarchyPage" + d.data.id, "hierarchy#" + d.data.id);
                 }
 
                 if (!d.children) {


### PR DESCRIPTION
## What
Fix console errors that occur in the Class Hierarchy view after navigating through pages in the new Workbench.

## Why
A cyclic event chain triggers repeated AngularJS digest cycles. In rdf-class-hierarchy.directive, a function is executed whenever the browser history state changes. That function locates the node identified by the history state and calls the zoom method. The zoom method then updates the browser history with the ID of the zoomed node, which triggers another history state change and causes the same sequence of method calls to repeat indefinitely.

## How
Add a flag to the browser history state when it is updated by the zoom method. When processing history state changes, check for this flag and skip handling if it is present, preventing the recursive event chain.

## Screenshots
<img width="2558" height="1328" alt="image" src="https://github.com/user-attachments/assets/9a5f71b9-e67f-4217-8abb-54c797f6dfc0" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
