### PR TITLE
Cherry-pick GDB-14800: Fix Console Errors in Class Hierarchy View After Visiting New Workbench

### DIFF
--- a/packages/legacy-workbench/src/js/angular/graphexplore/directives/rdf-class-hierarchy.directive.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/directives/rdf-class-hierarchy.directive.js
@@ -485,7 +485,7 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
                 const focusHistoryId = $location.hash();
 
                 $window.onpopstate = function(event) {
-                    if (event.state) {
+                    if (event.state && !event.state.skipOnPopState) {
                         const focusHistoryId = event.state.id;
                         focusOnCurrentClass(focusHistoryId);
                     }
@@ -594,7 +594,9 @@ function classHierarchyDirective($rootScope, $location, GraphDataRestService, $w
                 }
 
                 if (d.data.id) {
-                    $window.history.replaceState({id: d.data.id}, "classHierarchyPage" + d.data.id, "hierarchy#" + d.data.id);
+                    // Set the `skipOnPopState` flag so the popstate handler ignores this history update,
+                    // preventing a recursive history state change triggered by the zoom operation.
+                    $window.history.replaceState({id: d.data.id, skipOnPopState: true}, "classHierarchyPage" + d.data.id, "hierarchy#" + d.data.id);
                 }
 
                 if (!d.children) {


### PR DESCRIPTION
## What
Fix console errors that occur in the Class Hierarchy view after navigating through pages in the new Workbench.

## Why
A cyclic event chain triggers repeated AngularJS digest cycles. In rdf-class-hierarchy.directive, a function is executed whenever the browser history state changes. That function locates the node identified by the history state and calls the zoom method. The zoom method then updates the browser history with the ID of the zoomed node, which triggers another history state change and causes the same sequence of method calls to repeat indefinitely.

## How
Add a flag to the browser history state when it is updated by the zoom method. When processing history state changes, check for this flag and skip handling if it is present, preventing the recursive event chain.

(cherry picked from commit 70b002085cea9c348a2abd6e6554d973269459c3)

## Screenshots
<img width="2558" height="1328" alt="image" src="https://github.com/user-attachments/assets/9a5f71b9-e67f-4217-8abb-54c797f6dfc0" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
