### PR TITLE
Update graphdb-workbench-plugins to version 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@single-spa/import-map-injector": "^2.0.2",
-                "graphdb-workbench-plugins": "^0.0.1-TR37",
+                "graphdb-workbench-plugins": "~1.0.0",
                 "import-map-overrides": "^6.1.0"
             },
             "devDependencies": {
@@ -7002,9 +7002,9 @@
             "license": "ISC"
         },
         "node_modules/graphdb-workbench-plugins": {
-            "version": "0.0.1-TR37",
-            "resolved": "https://registry.npmjs.org/graphdb-workbench-plugins/-/graphdb-workbench-plugins-0.0.1-TR37.tgz",
-            "integrity": "sha512-of3MqXoLWBzx+FPyvLrtiGzz2puhFSn4rUmyZBrPN5cyDjqrvt8mO1i4R06Yrka7sfWMDyC6wSSA5elU2SIvwA==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/graphdb-workbench-plugins/-/graphdb-workbench-plugins-1.0.0.tgz",
+            "integrity": "sha512-bnYFVBGxR6AphR2tutjJ4+W3bHaQgpjdCGp+xZ2rqXwCmzNOAu36c/NmM4cJB1YY6OdtoXGizSqnUJU8m3W/dQ==",
             "license": "Apache-2.0"
         },
         "node_modules/gzip-size": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "resolutions": {},
     "dependencies": {
         "@single-spa/import-map-injector": "^2.0.2",
-        "graphdb-workbench-plugins": "^0.0.1-TR37",
+        "graphdb-workbench-plugins": "~1.0.0",
         "import-map-overrides": "^6.1.0"
     }
 }


### PR DESCRIPTION
## What
Update `graphdb-workbench-plugins` to version `1.0.0`.

## Why
it's the latest version

## How
Modified `package.json` and `package-lock.json` to reflect the new version of `graphdb-workbench-plugins`.

## Testing
n/a

## Checklist
- [ ] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [ ] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
