### PR TITLE
GDB-14793: Allow Access to Repository Views for Users with MANAGE_REPO Permissions

### DIFF
--- a/packages/api/src/models/repositories/repository-reference.ts
+++ b/packages/api/src/models/repositories/repository-reference.ts
@@ -7,10 +7,20 @@ export interface RepositoryReference {
    * @returns {string} The repository ID.
    */
   get id(): string;
-  
+
   /**
    * Gets the location of the repository.
    * @returns {string} The repository location.
    */
   get location(): string;
 }
+
+/**
+ * Returns a repository identifier qualified by its location.
+ *
+ * @param {RepositoryReference} repository The repository reference.
+ * @returns {string} The qualified repository identifier in the format `<id>@<location>`, or `<id>` if the location is not available.
+ */
+export const getRepositoryIdWithLocation = (repository: RepositoryReference): string => {
+  return repository.location ? `${repository.id}@${repository.location}` : repository.id;
+};

--- a/packages/api/src/models/repositories/test/repository-reference.spec.ts
+++ b/packages/api/src/models/repositories/test/repository-reference.spec.ts
@@ -1,0 +1,25 @@
+import {getRepositoryIdWithLocation, RepositoryReference} from '../repository-reference';
+
+describe('RepositoryReference', () => {
+  test('getRepositoryIdWithLocation should return only the repository ID when the location is missing', () => {
+    const repositoryId = 'repo123';
+    // WHEN: I call the function with location undefined
+    let repositoryIdWithLocation = getRepositoryIdWithLocation({id: repositoryId} as unknown as RepositoryReference);
+    // THEN: I expect the result to be only the repository id
+    expect(repositoryIdWithLocation).toEqual(repositoryId);
+
+    // WHEN: I call the function with an empty location.
+    repositoryIdWithLocation = getRepositoryIdWithLocation({id: repositoryId, location: ''});
+    // THEN: I expect the result to be only the repository id
+    expect(repositoryIdWithLocation).toEqual(repositoryId);
+  });
+
+  test('getRepositoryIdWithLocation should return the repository ID and location', () => {
+    const repositoryId = 'repo123';
+    const location = 'repo-location-123';
+    // WHEN: I call the function
+    const repositoryIdWithLocation = getRepositoryIdWithLocation({id: repositoryId, location});
+    // THEN: I expect the result to be only the repository id
+    expect(repositoryIdWithLocation).toEqual(`${repositoryId}@${location}`);
+  });
+});

--- a/packages/api/src/models/security/authorization/authority.ts
+++ b/packages/api/src/models/security/authorization/authority.ts
@@ -2,7 +2,21 @@ export enum Authority {
   ROLE_ADMIN = 'ROLE_ADMIN',
   ROLE_USER = 'ROLE_USER',
   ROLE_MONITORING = 'ROLE_MONITORING',
+  /**
+   * Grants full repository management permissions across all repositories, including creating and deleting repositories.
+   */
   ROLE_REPO_MANAGER = 'ROLE_REPO_MANAGER',
+  /**
+   * Grants repository management permissions only for repositories the user is authorized to manage.
+   *
+   * This authority is derived in the UI and is not returned by the backend.
+   * The backend grants repository-specific permissions using authorities in the format `MANAGE_REPO_<repositoryId>`,
+   * where `<repositoryId>` is the repository identifier. When the user has at least one such authority (or `ROLE_REPO_MANAGER`),
+   * the UI adds `ROLE_MANAGE_REPO` to simplify permission checks.
+   *
+   * This authority does not grant permission to create or delete repositories.
+   */
+  ROLE_MANAGE_REPO = 'ROLE_MANAGE_REPO',
   ROLE_CLUSTER = 'ROLE_CLUSTER',
   IS_AUTHENTICATED_FULLY = 'IS_AUTHENTICATED_FULLY',
   SYSTEM_REPO = 'SYSTEM',

--- a/packages/api/src/services/domain/security/authorization.service.ts
+++ b/packages/api/src/services/domain/security/authorization.service.ts
@@ -2,7 +2,7 @@ import {Service} from '../../../providers/service/service';
 import {AuthenticatedUser, Authority, Rights, SecurityConfig} from '../../../models/security';
 import {service} from '../../../providers';
 import {SecurityContextService} from './security-context.service';
-import {Repository} from '../../../models/repositories';
+import {getRepositoryIdWithLocation, Repository, RepositoryReference} from '../../../models/repositories';
 import {
   RepositoryAuthorityService,
   RepositoryContextService,
@@ -81,6 +81,15 @@ export class AuthorizationService implements Service {
   }
 
   /**
+   * Checks whether the current user has repository-specific management permissions for at least one repository.
+   *
+   * @returns {boolean} `true` if the user can manage at least one repository; otherwise `false`.
+   */
+  isManageRepoUser(): boolean {
+    return this.hasRole(Authority.ROLE_MANAGE_REPO);
+  }
+
+  /**
    * Checks if the user has a specific role based on the provided authority, configuration, and user details.
    * @param {Authority} role - The authority role to check.
    * @returns {boolean} True if the user has the specified role, false otherwise.
@@ -124,7 +133,7 @@ export class AuthorizationService implements Service {
       if (!user) {
         return false;
       }
-      if (this.isAdminOrRepoManager()) {
+      if (this.isAdminOrRepoManager() || this.canManageRepo(repository)) {
         return true;
       }
       if (this.repositoryAuthorityService.isSystemRepository(repository)) {
@@ -155,7 +164,7 @@ export class AuthorizationService implements Service {
       if (!user) {
         return false;
       }
-      if (this.isAdminOrRepoManager()) {
+      if (this.isAdminOrRepoManager() || this.canManageRepo(repository)) {
         return true;
       }
       if (this.repositoryAuthorityService.isSystemRepository(repository)) {
@@ -165,6 +174,26 @@ export class AuthorizationService implements Service {
     }
 
     return true;
+  }
+
+  /**
+   * Checks whether the current user can manage the specified repository.
+   *
+   * @param {RepositoryReference} repository The repository to check.
+   * @returns {boolean} `true` if the user is a repository manager or can manage at least one repository, otherwise `false`.
+   */
+  canManageRepo(repository: RepositoryReference): boolean {
+    if (this.isAdminOrRepoManager()) {
+      return true;
+    }
+
+    const config = this.getSecurityConfig();
+    if (!config?.isEnabled() && !config?.hasOverrideAuth()) {
+      return true;
+    }
+
+    const manageRepoAuthority = Authority.MANAGE_REPO_PREFIX + getRepositoryIdWithLocation(repository);
+    return !!this.getAuthenticatedUser()?.authorities.find((authority) => authority === manageRepoAuthority);
   }
 
   /**
@@ -310,7 +339,7 @@ export class AuthorizationService implements Service {
     }
 
     // Replace the "{repoId}" placeholder with the actual repository ID for specific access.
-    const authListForCurrentRepo = authoritiesList.map(authority => authority.replace('{repoId}', repo.id));
+    const authListForCurrentRepo = authoritiesList.map(authority => authority.replace('{repoId}', getRepositoryIdWithLocation(repo)));
     // Replace the "{repoId}" placeholder with a wildcard '*' to denote access to any repository.
     const authListForAllRepos = authoritiesList.map(authority => authority.replace('{repoId}', '*'));
 

--- a/packages/api/src/services/domain/security/mappers/authenticated-user.mapper.ts
+++ b/packages/api/src/services/domain/security/mappers/authenticated-user.mapper.ts
@@ -1,8 +1,8 @@
-import {AuthenticatedUser} from '../../../../models/security/authenticated-user';
-import {AuthenticatedUserResponse} from '../../../../models/security/response-models/authenticated-user-response';
-import {AuthorityList} from '../../../../models/security';
-import {AppSettings} from '../../../../models/users/app-settings';
-import {MapperFn} from '../../../../providers/mapper/mapper-fn';
+import {AuthenticatedUser} from '../../../../models/security';
+import {AuthenticatedUserResponse} from '../../../../models/security';
+import {Authority, AuthorityList} from '../../../../models/security';
+import {AppSettings} from '../../../../models/users';
+import {MapperFn} from '../../../../providers';
 
 /**
  * Mapper class for converting partial AuthenticatedUser objects to complete AuthenticatedUser models.
@@ -11,9 +11,35 @@ export const mapAuthenticatedUserResponseToModel: MapperFn<AuthenticatedUserResp
   return new AuthenticatedUser({
     username: data.username,
     password: data.password,
-    authorities: new AuthorityList(data.authorities),
+    authorities: new AuthorityList(normalizeAuthorities(data.authorities)),
     appSettings: new AppSettings(data.appSettings),
     external: data.external
   });
 };
 
+/**
+ * Normalizes the authorities returned by the backend.
+ *
+ * The backend grants repository-specific management permissions using authorities in the format `MANAGE_REPO_<repositoryId>`.
+ * To simplify permission checks in the UI, this function adds the derived `ROLE_MANAGE_REPO` authority when the user has
+ * `ROLE_REPO_MANAGER` or at least one `MANAGE_REPO_<repositoryId>` authority.
+ *
+ * @param authorities The authorities returned by the backend.
+ * @returns A normalized list of authorities, including the derived `ROLE_MANAGE_REPO` authority when applicable.
+ */
+const normalizeAuthorities = (authorities: string[]): string[] => {
+  if (!authorities) {
+    return [];
+  }
+  const normalizedAuthorities = [...authorities];
+  const canManageRepo = normalizedAuthorities.some((authority) => {
+    return authority === Authority.ROLE_REPO_MANAGER ||
+      authority.startsWith(Authority.MANAGE_REPO_PREFIX);
+  });
+
+  if (canManageRepo) {
+    normalizedAuthorities.push(Authority.ROLE_MANAGE_REPO);
+  }
+
+  return normalizedAuthorities;
+};

--- a/packages/api/src/services/domain/security/mappers/test/authenticated-user.mapper.spec.ts
+++ b/packages/api/src/services/domain/security/mappers/test/authenticated-user.mapper.spec.ts
@@ -1,0 +1,61 @@
+import {AuthenticatedUser, AuthenticatedUserResponse, Authority} from '../../../../../models/security';
+import {mapAuthenticatedUserResponseToModel} from '../authenticated-user.mapper';
+
+describe('mapAuthenticatedUserResponseToModel', () => {
+  it('should add ROLE_MANAGE_REPO when user has ROLE_REPO_MANAGER', () => {
+    // GIVEN: A repository manager user.
+    const authenticatedUserResponse: AuthenticatedUserResponse = {
+      authorities: [Authority.ROLE_REPO_MANAGER],
+      username: 'tester',
+      password: '',
+      appSettings: {},
+      external: false,
+    };
+
+    // WHEN: The authenticated user response is mapped to the UI model.
+    const authenticatedUser = mapAuthenticatedUserResponseToModel(authenticatedUserResponse);
+
+    // THEN: I expect the returned object to be an instance of the UI model.
+    expect(authenticatedUser).toBeInstanceOf(AuthenticatedUser);
+    // AND: The user has the ROLE_MANAGE_REPO authority.
+    expect(authenticatedUser.authorities.getItems()).toContain(Authority.ROLE_MANAGE_REPO);
+  });
+
+  it('should add ROLE_MANAGE_REPO when user has repository-specific management authority', () => {
+    // GIVEN: A user with management permission for a repository.
+    const authenticatedUserResponse: AuthenticatedUserResponse = {
+      authorities: [Authority.MANAGE_REPO_PREFIX + 'repositoryId-123'],
+      username: 'tester',
+      password: '',
+      appSettings: {},
+      external: false,
+    };
+
+    // WHEN: The authenticated user response is mapped to the UI model.
+    const authenticatedUser = mapAuthenticatedUserResponseToModel(authenticatedUserResponse);
+
+    // THEN: I expect the returned object to be an instance of the UI model.
+    expect(authenticatedUser).toBeInstanceOf(AuthenticatedUser);
+    // AND: The user has the ROLE_MANAGE_REPO authority.
+    expect(authenticatedUser.authorities.getItems()).toContain(Authority.ROLE_MANAGE_REPO);
+  });
+
+  it('should not add ROLE_MANAGE_REPO when user has no repository-specific management authority', () => {
+    // GIVEN: A user without repository management permissions.
+    const authenticatedUserResponse: AuthenticatedUserResponse = {
+      authorities: [Authority.ROLE_USER],
+      username: 'tester',
+      password: '',
+      appSettings: {},
+      external: false,
+    };
+
+    // WHEN: The authenticated user response is mapped to the UI model.
+    const authenticatedUser = mapAuthenticatedUserResponseToModel(authenticatedUserResponse);
+
+    // THEN: I expect the returned object to be an instance of the UI model.
+    expect(authenticatedUser).toBeInstanceOf(AuthenticatedUser);
+    // AND: The user does not have the ROLE_MANAGE_REPO authority.
+    expect(authenticatedUser.authorities.getItems()).not.toContain(Authority.ROLE_MANAGE_REPO);
+  });
+});

--- a/packages/legacy-workbench/src/css/angular-tooltips.css
+++ b/packages/legacy-workbench/src/css/angular-tooltips.css
@@ -26,6 +26,10 @@
   font-size: .875rem;
 }
 
+.angular-tooltip span {
+    overflow-wrap: anywhere;
+}
+
 .angular-tooltip.angular-tooltip-fade-in {
   opacity: 1;
 }

--- a/packages/legacy-workbench/src/js/angular/repositories/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/controllers.js
@@ -7,7 +7,12 @@ import {
 import {decodeHTML} from "../../../app";
 import './controllers/manage-remote-location-dialog.controller';
 import {RemoteLocationType} from "../models/repository/remote-location.model";
-import {service, AuthenticationStorageService, GuidesService} from '@ontotext/workbench-api';
+import {
+    service,
+    AuthenticationStorageService,
+    AuthorizationService,
+    GuidesService,
+} from '@ontotext/workbench-api';
 import {DocumentationUrlResolver} from "../utils/documentation-url-resolver";
 
 const ENTITY_INDEX_SIZE_MIN = 10000;
@@ -130,6 +135,7 @@ LocationsAndRepositoriesCtrl.$inject = ['$scope', '$rootScope', '$uibModal', 'to
 function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $repositories, ModalService, LocationsRestService, // NOSONAR
     LocalStorageAdapter, $interval, $translate, $q) {
     const guidesService = service(GuidesService);
+    const authorizationService = service(AuthorizationService);
     $scope.RemoteLocationType = RemoteLocationType;
     $scope.loader = true;
     /**
@@ -160,7 +166,15 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
             }
             return locationTypeCheck && location.local === local;
         });
-        return remoteLocationModel;
+
+        // Repository managers can access all locations.
+        if ($scope.isRepoManager()) {
+            return remoteLocationModel;
+        }
+
+        // Users without the repository manager role can access only locations where they have
+        // repository-specific management permission for at least one repository.
+        return remoteLocationModel.filter((location) => $scope.getRepositoriesFromLocation(location.uri)?.length > 0);
     };
 
     $scope.hasAnyRemoteLocation = (local, locationTypes) => {
@@ -407,8 +421,28 @@ function LocationsAndRepositoriesCtrl($scope, $rootScope, $uibModal, toastr, $re
         });
     }
 
+    /**
+     * Returns the repositories available in the specified location that the current user is allowed to access.
+     *
+     * @param {string} locationId The identifier of the location.
+     * @returns {Array<Repository>} The repositories visible to the current user in the specified location.
+     */
     $scope.getRepositoriesFromLocation = function(locationId) {
-        return $repositories.getRepositoriesFromLocation(locationId);
+        const repositoriesFromLocation = $repositories.getRepositoriesFromLocation(locationId) || [];
+
+        if ($scope.isRepoManager()) {
+            return repositoriesFromLocation;
+        }
+
+        return repositoriesFromLocation.filter((repo) => authorizationService.canReadRepo(repo));
+    };
+
+    $scope.isRepoManager = () => {
+        return authorizationService.isRepoManager();
+    };
+
+    $scope.canManageRepo = (repo) => {
+        return authorizationService.canManageRepo(repo);
     };
 }
 

--- a/packages/legacy-workbench/src/js/angular/repositories/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/plugin.js
@@ -9,7 +9,7 @@ PluginRegistry.add('route', [
         'title': 'menu.repositories.label',
         'helpInfo': 'view.repositories.helpInfo',
         'documentationUrl': 'creating-a-repository.html',
-        'allowAuthorities': ['READ_REPO_{repoId}']
+        'allowAuthorities': ['READ_REPO_{repoId}'],
     }, {
         'url': '/repository/create',
         'module': 'graphdb.framework.repositories',
@@ -18,7 +18,7 @@ PluginRegistry.add('route', [
         'controller': 'ChooseRepositoryCtrl',
         'templateUrl': 'pages/choose-repository-type.html',
         'title': 'view.choose.repo.title',
-        'allowAuthorities': ['READ_REPO_{repoId}']
+        'allowAuthorities': ['READ_REPO_{repoId}'],
     }, {
         'url': '/repository/create/:repositoryType',
         'module': 'graphdb.framework.repositories',
@@ -27,7 +27,7 @@ PluginRegistry.add('route', [
         'controller': 'AddRepositoryCtrl',
         'templateUrl': 'pages/repository.html',
         'title': 'Create Repository',
-        'allowAuthorities': ['READ_REPO_{repoId}']
+        'allowAuthorities': ['READ_REPO_{repoId}'],
     }, {
         'url': '/repository/edit/:repositoryId',
         'module': 'graphdb.framework.repositories',
@@ -36,8 +36,8 @@ PluginRegistry.add('route', [
         'controller': 'EditRepositoryCtrl',
         'templateUrl': 'pages/repository.html',
         'title': 'Edit Repository',
-        'allowAuthorities': ['READ_REPO_{repoId}']
-    }
+        'allowAuthorities': ['READ_REPO_{repoId}'],
+    },
 ]);
 
 PluginRegistry.add('main.menu', {
@@ -47,7 +47,7 @@ PluginRegistry.add('main.menu', {
             labelKey: 'menu.repositories.label',
             href: 'repository',
             order: 1,
-            role: 'ROLE_REPO_MANAGER',
+            role: 'ROLE_MANAGE_REPO',
             parent: 'Setup',
             children: [
                 {
@@ -55,14 +55,14 @@ PluginRegistry.add('main.menu', {
                     children: [
                         {
                             href: 'repository/create/*',
-                        }
-                    ]
+                        },
+                    ],
                 },
                 {
-                    href: 'repository/edit/*'
-                }
+                    href: 'repository/edit/*',
+                },
             ],
             guideSelector: 'sub-menu-repositories',
-            testSelector: 'sub-menu-repositories'
-        }]
+            testSelector: 'sub-menu-repositories',
+        }],
 });

--- a/packages/legacy-workbench/src/pages/repositories.html
+++ b/packages/legacy-workbench/src/pages/repositories.html
@@ -28,13 +28,15 @@
                         </div>
                         <div ng-if="location.local" class="actions-bar-inline pull-right">
                             <button
+                                ng-if="isRepoManager()"
                                 gdb-tooltip="{{'repos.edit.common.settings' | translate}}"
                                 tooltip-placement="top"
                                 class="btn btn-link px-0"
                                 ng-click="openActiveLocationSettings()">
                                 <span class="ri-settings-3-line"></span>
                             </button>
-                            <a class="btn btn-link px-0 pull-right" href="license"
+                            <a ng-if="isAdmin()"
+                               class="btn btn-link px-0 pull-right" href="license"
                                gdb-tooltip="{{'repos.view.update.licenses' | translate}}"
                                tooltip-placement="top">
                                 <span class="ri-key-line"></span>
@@ -119,17 +121,18 @@
                                         </div>
                                     </td>
                                     <td class="text-nowrap repository-actions">
-                                        <button class="btn btn-link p-0"
-                                                ng-click="copyToClipboard(repository.externalUrl)"
-                                                gdb-tooltip="{{'copy.repo.url' | translate}}">
-                                            <span class="ri-links-line"></span>
-                                        </button>
-                                        <span ng-if="location.degradedReason">
+                                        <div ng-if="canManageRepo(repository)">
+                                            <button class="btn btn-link p-0"
+                                                    ng-click="copyToClipboard(repository.externalUrl)"
+                                                    gdb-tooltip="{{'copy.repo.url' | translate}}">
+                                                <span class="ri-links-line"></span>
+                                            </button>
+                                            <span ng-if="location.degradedReason">
                                             <em class="ri-alert-line icon-lg text-warning"
                                                 gdb-tooltip="{{location.degradedReason}}{{'repo.not.supported.delete.or.edit' | translate}}"
                                                 tooltip-placement="top"></em>
                                         </span>
-                                        <span ng-if="repository.type !== 'system' && !location.degradedReason">
+                                            <span ng-if="repository.type !== 'system' && !location.degradedReason">
                                             <a class="btn btn-link p-0 edit-repository-btn"
                                                href="repository/edit/{{repository.id}}?location={{repository.location}}"
                                                gdb-tooltip="{{'repoTooltips.editRepository' | translate}}"
@@ -151,6 +154,7 @@
                                                     <span class="ri-reset-right-line"></span>
                                             </button>
                                             <button class="btn btn-link p-0 secondary delete-repository-btn"
+                                                    ng-if="isRepoManager()"
                                                     type="button"
                                                     gdb-tooltip="{{'delete.repo' | translate}}"
                                                     tooltip-placement="top"
@@ -158,10 +162,11 @@
                                                 <em class="ri-delete-bin-6-line"></em>
                                             </button>
                                         </span>
+                                        </div>
                                     </td>
                                     <td>
                                         <button class="btn btn-link p-0 pin-repository-btn"
-                                                ng-if="repository.type !== 'system' && location.active"
+                                                ng-if="repository.type !== 'system' && location.active && isRepoManager(repository)"
                                                 ng-click="toggleDefaultRepository(repository.id)"
                                                 ng-class="getDefaultRepository() === repository.id && location.active ? 'active' : ''"
                                                 gdb-tooltip="{{'set.as.default.repo' | translate}}">
@@ -197,13 +202,15 @@
                             </div>
                             <div ng-if="location.local" class="actions-bar-inline pull-right">
                                 <button
+                                    ng-if="isRepoManager()"
                                     gdb-tooltip="{{'repos.edit.common.settings' | translate}}"
                                     tooltip-placement="top"
                                     class="btn btn-link px-0"
                                     ng-click="openActiveLocationSettings()">
                                     <span class="ri-settings-3-line"></span>
                                 </button>
-                                <a class="btn btn-link px-0 pull-right" href="license"
+                                <a ng-if="isAdmin()"
+                                   class="btn btn-link px-0 pull-right" href="license"
                                    gdb-tooltip="{{'repos.view.update.licenses' | translate}}"
                                    tooltip-placement="top">
                                     <span class="ri-key-line"></span>
@@ -283,17 +290,18 @@
                                             </div>
                                         </td>
                                         <td class="text-nowrap repository-actions">
-                                            <button class="btn btn-link p-0"
-                                                    ng-click="copyToClipboard(repository.externalUrl)"
-                                                    gdb-tooltip="{{'copy.repo.url' | translate}}">
-                                                <span class="ri-links-line"></span>
-                                            </button>
-                                            <span ng-if="location.degradedReason">
+                                            <div ng-if="canManageRepo(repository)">
+                                                <button class="btn btn-link p-0"
+                                                        ng-click="copyToClipboard(repository.externalUrl)"
+                                                        gdb-tooltip="{{'copy.repo.url' | translate}}">
+                                                    <span class="ri-links-line"></span>
+                                                </button>
+                                                <span ng-if="location.degradedReason">
                                                 <em class="ri-alert-line icon-lg text-warning"
                                                     gdb-tooltip="{{location.degradedReason}}{{'repo.not.supported.delete.or.edit' | translate}}"
                                                     tooltip-placement="top"></em>
                                             </span>
-                                            <span ng-if="repository.type !== 'system' && !location.degradedReason">
+                                                <span ng-if="repository.type !== 'system' && !location.degradedReason">
                                                 <a class="btn btn-link p-0 edit-repository-btn"
                                                    href="repository/edit/{{repository.id}}?location={{repository.location}}"
                                                    gdb-tooltip="{{'repoTooltips.editRepository' | translate}}"
@@ -315,6 +323,7 @@
                                                         <span class="ri-reset-right-line"></span>
                                                 </button>
                                                 <button class="btn btn-link p-0 secondary delete-repository-btn"
+                                                        ng-if="isRepoManager()"
                                                         type="button"
                                                         gdb-tooltip="{{'delete.repo' | translate}}"
                                                         tooltip-placement="top"
@@ -322,10 +331,11 @@
                                                     <em class="ri-delete-bin-6-line"></em>
                                                 </button>
                                             </span>
+                                            </div>
                                         </td>
                                         <td>
                                             <button class="btn btn-link p-0 pin-repository-btn"
-                                                    ng-if="repository.type !== 'system' && location.active"
+                                                    ng-if="repository.type !== 'system' && location.active && isRepoManager(repository)"
                                                     ng-click="toggleDefaultRepository(repository.id)"
                                                     ng-class="getDefaultRepository() === repository.id && location.active ? 'active' : ''"
                                                     gdb-tooltip="{{'set.as.default.repo' | translate}}">
@@ -343,7 +353,7 @@
         </table>
     </div>
     <!-- Remote Ontopic and SPARQL instances -->
-    <div ng-if="hasAnyRemoteLocation(false, [RemoteLocationType.SPARQL, RemoteLocationType.ONTOPIC])" class="mb-1 ontopic-instances">
+    <div ng-if="isRepoManager() && hasAnyRemoteLocation(false, [RemoteLocationType.SPARQL, RemoteLocationType.ONTOPIC])" class="mb-1 ontopic-instances">
         <h4 class="remote-location-type-title">{{'repositories.location.sparql.instances' | translate}}</h4>
         <table id="wb-repositories-ontopic-sparql-repositoryInGetRepositories"
                class="table table-hover table-striped" aria-describedby="Repositories table">
@@ -398,7 +408,7 @@
         </table>
     </div>
 
-    <div class="btns-all" ng-if="getLocationError()">
+    <div class="btns-all" ng-if="isRepoManager()">
         <div class="btn-group" uib-dropdown>
             <a id="wb-repositories-addRepositoryLink" class="btn btn-primary" ng-href="repository/create" guide-selector="createRepository"><span
                 class="ri-add-circle-line"></span> {{'repository.create.btn' | translate}}</a>


### PR DESCRIPTION
## What
Allow access to repository views for users with MANAGE_REPO permissions.

## Why
We want to introduce a new type of user with extended repository permissions. An administrator can grant repository management permissions for specific repositories. A user with these permissions can manage only the repositories for which they have been granted access. However, they are not allowed to create or delete repositories, regardless of their repository-specific management permissions.

## How
- Introduced a new UI authority, ROLE_MANAGE_REPO. Users with this authority can manage only the repositories for which they have been granted management permissions. This authority does not allow creating or deleting repositories.
- ROLE_MANAGE_REPO does not exist in the backend. When the authenticated user is loaded, the UI derives and adds this authority if the user has the ROLE_REPO_MANAGER role or repository management permissions for at least one repository.
- Updated the repository view plugin configuration to use ROLE_MANAGE_REPO, making the repository views accessible to both repository managers and users with repository-specific management permissions.
- Updated the repository catalog view to apply permissions based on the user's authority:
  - Users with ROLE_REPO_MANAGER can view all repositories and perform all repository management actions.
  - Users with ROLE_MANAGE_REPO can view and manage only the repositories for which they have management permissions. They cannot create or delete repositories.

## Screenshots
<img width="1907" height="908" alt="image" src="https://github.com/user-attachments/assets/c0a5c953-2fcc-4316-a8d4-7b45d8877563" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
