### PR TITLE
GDB-14791: Add support for manage repository role in catalog

### DIFF
--- a/e2e-tests/e2e-legacy/setup/aclmanagement/create-rule.spec.js
+++ b/e2e-tests/e2e-legacy/setup/aclmanagement/create-rule.spec.js
@@ -19,7 +19,7 @@ describe('ACL Management: create rule', () => {
         cy.enableAutocomplete(repositoryId);
         AclManagementSteps.importRules(repositoryId);
         AclManagementSteps.visit();
-        ApplicationSteps.geLoader().should('not.exist');
+        ApplicationSteps.getLoader().should('not.exist');
         // ensure rules are rendered
         AclManagementSteps.getAclRules().should('have.length.gt', 0);
     });

--- a/e2e-tests/e2e-legacy/setup/aclmanagement/delete-rule.spec.js
+++ b/e2e-tests/e2e-legacy/setup/aclmanagement/delete-rule.spec.js
@@ -19,7 +19,7 @@ describe('ACL Management: delete rule', () => {
         cy.enableAutocomplete(repositoryId);
         AclManagementSteps.importRules(repositoryId);
         AclManagementSteps.visit();
-        ApplicationSteps.geLoader().should('not.exist');
+        ApplicationSteps.getLoader().should('not.exist');
         // ensure rules are rendered
         AclManagementSteps.getAclRules().should('have.length.gt', 0);
     });

--- a/e2e-tests/e2e-legacy/setup/aclmanagement/edit-rule.spec.js
+++ b/e2e-tests/e2e-legacy/setup/aclmanagement/edit-rule.spec.js
@@ -18,7 +18,7 @@ describe('ACL Management: edit rule', () => {
         cy.enableAutocomplete(repositoryId);
         AclManagementSteps.importRules(repositoryId);
         AclManagementSteps.visit();
-        ApplicationSteps.geLoader().should('not.exist');
+        ApplicationSteps.getLoader().should('not.exist');
         // ensure rules are rendered
         AclManagementSteps.getAclRules().should('have.length.gt', 0);
     });

--- a/e2e-tests/e2e-legacy/setup/aclmanagement/render-rules.spec.js
+++ b/e2e-tests/e2e-legacy/setup/aclmanagement/render-rules.spec.js
@@ -17,7 +17,7 @@ describe('ACL Management: render rules', () => {
             cy.presetRepository(repositoryId);
             cy.initializeRepository(repositoryId);
             AclManagementSteps.visit();
-            ApplicationSteps.geLoader().should('not.exist');
+            ApplicationSteps.getLoader().should('not.exist');
         });
 
         it('Should render empty ACL rules table', () => {

--- a/e2e-tests/e2e-legacy/setup/aclmanagement/reorder-rules.spec.js
+++ b/e2e-tests/e2e-legacy/setup/aclmanagement/reorder-rules.spec.js
@@ -17,7 +17,7 @@ describe('ACL Management: reorder rules', () => {
         cy.initializeRepository(repositoryId);
         AclManagementSteps.importRules(repositoryId);
         AclManagementSteps.visit();
-        ApplicationSteps.geLoader().should('not.exist');
+        ApplicationSteps.getLoader().should('not.exist');
         // ensure rules are rendered
         AclManagementSteps.getAclRules().should('have.length.gt', 0);
     });

--- a/e2e-tests/e2e-legacy/setup/aclmanagement/revert-rules.spec.js
+++ b/e2e-tests/e2e-legacy/setup/aclmanagement/revert-rules.spec.js
@@ -18,7 +18,7 @@ describe('ACL Management: revert rules', () => {
         cy.enableAutocomplete(repositoryId);
         AclManagementSteps.importRules(repositoryId);
         AclManagementSteps.visit();
-        ApplicationSteps.geLoader().should('not.exist');
+        ApplicationSteps.getLoader().should('not.exist');
         // ensure rules are rendered
         AclManagementSteps.getAclRules().should('have.length.gt', 0);
     });

--- a/e2e-tests/e2e-legacy/setup/aclmanagement/scopes.spec.js
+++ b/e2e-tests/e2e-legacy/setup/aclmanagement/scopes.spec.js
@@ -16,7 +16,7 @@ describe('ACL Management: rule scopes', () => {
         cy.initializeRepository(repositoryId);
         cy.enableAutocomplete(repositoryId);
         AclManagementSteps.visit();
-        ApplicationSteps.geLoader().should('not.exist');
+        ApplicationSteps.getLoader().should('not.exist');
     });
 
 
@@ -171,7 +171,7 @@ describe('ACL Management: rule scopes', () => {
             expect(interception.request.body).to.deep.eq(expectedPayload);
         });
 
-        ApplicationSteps.geLoader().should('not.exist');
+        ApplicationSteps.getLoader().should('not.exist');
         // Then I expect the ACL to be saved
         ApplicationSteps.getSuccessNotifications().should('be.visible');
 

--- a/e2e-tests/e2e-legacy/setup/aclmanagement/update-rules.spec.js
+++ b/e2e-tests/e2e-legacy/setup/aclmanagement/update-rules.spec.js
@@ -18,7 +18,7 @@ describe('ACL Management: update rules', () => {
         cy.enableAutocomplete(repositoryId);
         AclManagementSteps.importRules(repositoryId);
         AclManagementSteps.visit();
-        ApplicationSteps.geLoader().should('not.exist');
+        ApplicationSteps.getLoader().should('not.exist');
         // ensure rules are rendered
         AclManagementSteps.getAclRules().should('have.length.gt', 0);
     });
@@ -51,7 +51,7 @@ describe('ACL Management: update rules', () => {
         ModalDialogSteps.clickOnConfirmButton();
         // And I save the ACL list
         AclManagementSteps.saveAcl();
-        ApplicationSteps.geLoader().should('not.exist');
+        ApplicationSteps.getLoader().should('not.exist');
         // Then I expect the ACL to be saved
         ApplicationSteps.getSuccessNotifications().should('be.visible');
         AclManagementSteps.getAclRules().should('have.length', 5);

--- a/e2e-tests/e2e-legacy/setup/jdbc/jdbc-create.spec.js
+++ b/e2e-tests/e2e-legacy/setup/jdbc/jdbc-create.spec.js
@@ -64,7 +64,7 @@ describe('JDBC configuration', () => {
         JdbcCreateSteps.clickOnPreviewButton();
 
         // Then I expect to see loader,
-        ApplicationSteps.geLoader().should('contain', 'Preview of first 100 rows of table');
+        ApplicationSteps.getLoader().should('contain', 'Preview of first 100 rows of table');
         // and see the generated preview.
         YasrSteps.getResults().should('be.visible');
     });

--- a/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
+++ b/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
@@ -23,7 +23,6 @@ describe('User and Access', () => {
         before(() => {
             repoName = 'user-access-repo1-' + Date.now();
             cy.createRepository({id: repoName});
-            SecurityStubs.spyOnUserGet();
         });
 
         after(() => {
@@ -35,6 +34,7 @@ describe('User and Access', () => {
         });
 
         beforeEach(() => {
+            SecurityStubs.spyOnUserGet();
             UserAndAccessSteps.visit();
             // Users table should be visible
             UserAndAccessSteps.getUsersTable().should('be.visible');
@@ -511,6 +511,7 @@ describe('User and Access', () => {
 
                 MENU_ITEMS_WITHOUT_GRAPHQL.forEach(({path, expectedUrl, checks, expectedTitle}) => {
                     navigateMenuPath(path, expectedUrl, expectedTitle);
+
                     if (checks) {
                         runChecks(checks);
                     }
@@ -539,6 +540,7 @@ describe('User and Access', () => {
                     navigateMenuPath(['Import'], '/import', 'Import');
                 });
             });
+
             it('Should have all access to endpoints management when have REPO_MANAGER role', () => {
                 cy.wait('@getRepositories');
                 cy.wait('@getRepositories');
@@ -558,6 +560,7 @@ describe('User and Access', () => {
                     navigateMenuPath(['Import'], '/import', 'Import');
                 });
             });
+
             it('Can have Free Access and GraphQL working together', () => {
                 cy.wait('@getRepositories');
                 cy.wait('@getRepositories');
@@ -601,14 +604,6 @@ describe('User and Access', () => {
         });
     });
 
-    function clickGraphqlAccessForRepo(repoName) {
-        if (repoName === '*') {
-            UserAndAccessSteps.clickGraphqlAccessAny();
-        } else {
-            UserAndAccessSteps.clickGraphqlAccessRepo(repoName);
-        }
-    }
-
     function createUser(username, password, role, opts = {}) {
         UserAndAccessSteps.clickCreateNewUserButton();
         cy.url().should('include', '/user/create');
@@ -644,18 +639,7 @@ describe('User and Access', () => {
 
     function setRoles(opts = {}) {
         const {read = false, readWrite = false, graphql = false, manage = false, repoName = '*'} = opts;
-        if (manage) {
-            UserAndAccessSteps.toggleManageRepoForRepo(repoName);
-        }
-        if (read) {
-            UserAndAccessSteps.toggleReadAccessForRepo(repoName);
-        }
-        if (readWrite) {
-            UserAndAccessSteps.toggleWriteAccessForRepo(repoName);
-        }
-        if (graphql) {
-            clickGraphqlAccessForRepo(repoName);
-        }
+        setUserAuths({repo: repoName, read, write: readWrite, graphql, manage});
     }
 
     function testForUser(name, isAdmin) {
@@ -749,6 +733,9 @@ describe('User and Access', () => {
         pathArray.forEach((label, index) => {
             if (index === 0) {
                 MainMenuSteps.clickOnMenu(label);
+                if (pathArray.length > 1) {
+                    MainMenuSteps.getSubmenuFor(label).scrollIntoView().should('be.visible');
+                }
             } else {
                 MainMenuSteps.clickOnSubMenu(label);
                 const title = expectedTitle ? expectedTitle : label;

--- a/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
+++ b/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
@@ -16,19 +16,23 @@ describe('User and Access', () => {
     const ROLE_CUSTOM_ADMIN = '#roleAdmin';
     const DEFAULT_ADMIN_PASSWORD = 'root';
 
-    // eslint-disable-next-line no-undef
-    context('', () => {
+    context('User and access management', () => {
         const user = 'user';
         let repoName;
 
         before(() => {
             repoName = 'user-access-repo1-' + Date.now();
             cy.createRepository({id: repoName});
-        })
+            SecurityStubs.spyOnUserGet();
+        });
 
         after(() => {
+            cy.loginAsAdmin().then(() => {
+                cy.switchOffSecurity(true);
+                cy.switchOffFreeAccess(false);
+            });
             cy.deleteRepository(repoName, true);
-        })
+        });
 
         beforeEach(() => {
             UserAndAccessSteps.visit();
@@ -45,218 +49,226 @@ describe('User and Access', () => {
             });
         });
 
-        it('Initial state', () => {
-            // Create new user button should be visible
-            UserAndAccessSteps.getCreateNewUserButton().should('be.visible');
-            // Security should be disabled
-            UserAndAccessSteps.getSecuritySwitchLabel().should('be.visible').and('contain', 'Security is OFF');
-            UserAndAccessSteps.getSecurityCheckbox().should('not.be.checked');
-            // Only admin user should be created by default
-            UserAndAccessSteps.getTableRow().should('have.length', 1);
-            UserAndAccessSteps.findUserInTable('admin');
-            UserAndAccessSteps.getUserType().should('be.visible').and('contain', 'Administrator');
-            // The admin should have unrestricted rights
-            UserAndAccessSteps.getRepositoryRights().should('be.visible').and('contain', 'Unrestricted');
-            // And can be edited
-            UserAndAccessSteps.getEditUserButton().should('be.visible').and('not.be.disabled');
-            // And cannot be deleted
-            UserAndAccessSteps.getDeleteUserButton().should('not.exist');
-            // Date created should be visible
-            UserAndAccessSteps.getDateCreated().should('be.visible');
+        context('Initial state', () => {
+            it('Initial state', () => {
+                // Create new user button should be visible
+                UserAndAccessSteps.getCreateNewUserButton().should('be.visible');
+                // Security should be disabled
+                UserAndAccessSteps.getSecuritySwitchLabel().should('be.visible').and('contain', 'Security is OFF');
+                UserAndAccessSteps.getSecurityCheckbox().should('not.be.checked');
+                // Only admin user should be created by default
+                UserAndAccessSteps.getTableRow().should('have.length', 1);
+                UserAndAccessSteps.findUserInTable('admin');
+                UserAndAccessSteps.getUserType().should('be.visible').and('contain', 'Administrator');
+                // The admin should have unrestricted rights
+                UserAndAccessSteps.getRepositoryRights().should('be.visible').and('contain', 'Unrestricted');
+                // And can be edited
+                UserAndAccessSteps.getEditUserButton().should('be.visible').and('not.be.disabled');
+                // And cannot be deleted
+                UserAndAccessSteps.getDeleteUserButton().should('not.exist');
+                // Date created should be visible
+                UserAndAccessSteps.getDateCreated().should('be.visible');
+            });
         });
 
-        it('Create user', () => {
-            //create a normal read/write user
-            createUser(user, PASSWORD, ROLE_USER, {readWrite: true});
-            testForUser(user, false);
-        });
-
-        it('Create repo-manager', () => {
-            //create a repo-manager
-            createUser(user, PASSWORD, ROLE_REPO_MANAGER);
-            testForUser(user, false);
-        });
-
-        it('Create second admin', () => {
-            //create a custom admin
-            createUser(user, PASSWORD, ROLE_CUSTOM_ADMIN);
-            testForUser(user, true);
-        });
-
-        it('Create user with custom role', () => {
-            // When I create a read/write user
-            UserAndAccessSteps.clickCreateNewUserButton();
-            UserAndAccessSteps.typeUsername(user);
-            UserAndAccessSteps.typePassword(PASSWORD);
-            UserAndAccessSteps.typeConfirmPasswordField(PASSWORD);
-            UserAndAccessSteps.selectRoleRadioButton(ROLE_USER);
-            // And add a custom role of 1 letter
-            UserAndAccessSteps.addTextToCustomRoleField('A');
-            UserAndAccessSteps.toggleWriteAccessAny();
-
-            // Then the 'create' button should be disabled
-            UserAndAccessSteps.getConfirmUserCreateButton().should('be.disabled');
-            // And the field should show an error
-            UserAndAccessSteps.getCustomRoleFieldError().should('contain.text', 'Must be at least 2 symbols long');
-            // When I add more text to the custom role tag
-            UserAndAccessSteps.addTextToCustomRoleField('A{enter}');
-            // Then the 'create' button should be enabled
-            UserAndAccessSteps.getConfirmUserCreateButton().should('be.enabled');
-            // And the field error should not exist
-            UserAndAccessSteps.getCustomRoleFieldError().should('not.be.visible');
-
-            // When I type an invalid tag
-            UserAndAccessSteps.addTextToCustomRoleField('B{enter}');
-            // And the field shows an error
-            UserAndAccessSteps.getCustomRoleFieldError().should('contain.text', 'Must be at least 2 symbols long');
-            // When I delete the invalid text
-            UserAndAccessSteps.addTextToCustomRoleField('{backspace}');
-            // Then the error should not be visible
-            UserAndAccessSteps.getCustomRoleFieldError().should('not.be.visible');
-
-            // When I create the user with a valid custom role
-            UserAndAccessSteps.toggleWriteAccessAny();
-            SecurityStubs.spyOnUserCreate();
-            UserAndAccessSteps.confirmUserCreate();
-            // Then the user should be created with that custom role
-            cy.wait('@create-user').its('request.body').then((body) => {
-                expect(body).to.deep.eq({
-                    'password': 'password',
-                    'grantedAuthorities': [
-                        'ROLE_USER',
-                        'CUSTOM_AA',
-                        'WRITE_REPO_*',
-                        'READ_REPO_*',
-                    ],
-                    'appSettings': {
-                        'DEFAULT_VIS_GRAPH_SCHEMA': true,
-                        'DEFAULT_INFERENCE': true,
-                        'DEFAULT_SAMEAS': true,
-                        'IGNORE_SHARED_QUERIES': false,
-                        'EXECUTE_COUNT': true,
-                    },
-                });
+        context('User creation', () => {
+            it('Create user', () => {
+                //create a normal read/write user
+                createUser(user, PASSWORD, ROLE_USER, {readWrite: true});
+                testForUser(user, false);
             });
 
-            cy.url().should('include', '/users');
-            UserAndAccessSteps.findUserInTable(user).should('be.visible');
-            UserAndAccessSteps.getUserCustomRoles('@user')
-                .should('have.length', 1)
-                .eq(0).and('have.text', 'AA');
-            // And when I open the edit page for that user, the custom role should be visible in the field without the prefix
-            UserAndAccessSteps.openEditUserPage(user);
-            UserAndAccessSteps.getCustomRoleField().find('.tag-item span')
-                .should('have.length', 1)
-                .eq(0).and('have.text', 'AA');
-        });
-
-        it('Adding a role with a CUSTOM_ prefix shows a warning message', () => {
-            // When I create a user
-            UserAndAccessSteps.clickCreateNewUserButton();
-            // And I add a custom role tag with prefix CUSTOM_
-            UserAndAccessSteps.addTextToCustomRoleField('CUSTOM_USER{Enter}');
-            // There should be a warning text
-            UserAndAccessSteps.getPrefixWarning(0).should('contain', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
-        });
-
-        it('Warn users when setting no password when creating new user admin', () => {
-            UserAndAccessSteps.getUsersTable().should('be.visible');
-            createUser(user, PASSWORD, ROLE_CUSTOM_ADMIN, {noPassword: true});
-            UserAndAccessSteps.getUsersTable().should('be.visible');
-            UserAndAccessSteps.getSplashLoader().should('not.be.visible');
-        });
-
-        it('should toggle free access after Admin has logged in', () => {
-            // Given I have available repositories to allow Free Access for
-            RepositoriesStubs.stubRepositories();
-            RepositoriesStubs.stubFreeAccess();
-            // When I enable security
-            UserAndAccessSteps.toggleSecurity();
-            // When I log in as an Admin
-            LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);
-            // Then the page should load
-            UserAndAccessSteps.getSplashLoader().should('not.be.visible');
-            UserAndAccessSteps.getUsersTable().should('be.visible');
-            // The Free Access toggle should be OFF
-            UserAndAccessSteps.getFreeAccessSwitchInput().should('not.be.checked');
-            // When I toggle Free Access ON
-            UserAndAccessSteps.toggleFreeAccess();
-            // And I allow free access to a repository
-            ModalDialogSteps.getDialog().should('be.visible');
-            // Then I click OK in the modal
-            ModalDialogSteps.clickOKButton();
-            // Then the toggle button should be ON
-            UserAndAccessSteps.getFreeAccessSwitchInput().should('be.checked');
-            // And I should see a success message
-            ToasterSteps.verifySuccess('Free access has been enabled.');
-            ToasterSteps.getToast().should('not.exist');
-            UserAndAccessSteps.getUsersTable().should('be.visible');
-            // When I toggle Free Access OFF
-            UserAndAccessSteps.toggleFreeAccess();
-            // Then I should see a success message
-            ToasterSteps.getToast().should('exist');
-            ToasterSteps.getToasterMessage().should('contain', 'Free access has been disabled.');
-        });
-
-        it('should redirect to previous page after logout and then login', () => {
-            UserAndAccessSteps.toggleSecurity();
-            LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);
-            MainMenuSteps.clickOnSparqlMenu();
-            cy.url().should('include', '/sparql');
-
-            LoginSteps.logout();
-            cy.url().should('include', '/login');
-            LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);
-            cy.url().should('include', '/sparql');
-        });
-
-        it('should redirect to correct return url when user is authenticated and on login page', () => {
-            UserAndAccessSteps.visit();
-            UserAndAccessSteps.toggleSecurity();
-            LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);
-            UserAndAccessSteps.getUsersTable().should('be.visible');
-
-            cy.visit('/login?r=%252Fsparql');
-            cy.reload();
-            UserAndAccessSteps.getUrl().should('include', '/sparql');
-        });
-
-        // Skipped until image with GDB implementation is available
-        it.skip('should create user with manage repo rights for specific repo', () => {
-            SecurityStubs.spyOnUserCreate();
-            UserAndAccessSteps.getUsersCatalogContainer().should('be.visible');
-            createUser(user, PASSWORD, ROLE_USER, {manage: true, repoName: repoName});
-            // Then the user should be created with that custom role
-            cy.wait('@create-user').its('request.body').then((body) => {
-                expect(body).to.deep.eq({
-                    "password": "password",
-                    "grantedAuthorities": [
-                        "ROLE_USER",
-                        `MANAGE_REPO_${repoName}`,
-                        `WRITE_REPO_${repoName}`,
-                        `READ_REPO_${repoName}`
-                    ],
-                    "appSettings": {
-                        "DEFAULT_VIS_GRAPH_SCHEMA": true,
-                        "DEFAULT_INFERENCE": true,
-                        "DEFAULT_SAMEAS": true,
-                        "IGNORE_SHARED_QUERIES": false,
-                        "EXECUTE_COUNT": true
-                    }
-                });
+            it('Create repo-manager', () => {
+                //create a repo-manager
+                createUser(user, PASSWORD, ROLE_REPO_MANAGER);
+                testForUser(user, false);
             });
-            UserAndAccessSteps.getUsersCatalogContainer().should('be.visible');
-            // TODO: Uncomment when catalog rights are amended
-            // assertUserAuthsInCatalog(user, {repo: repoName, read: true, graphql: true});
 
-            UserAndAccessSteps.openEditUserPage(user);
-            UserAndAccessSteps.getRepositoryRightsList().should('be.visible');
-            verifyCheckedUserAuth(repoName, {read: true, write: true, manage: true, graphql: false});
-            verifyDisabledUserAuth(repoName, {read: true, write: true, manage: false, graphql: true});
+            it('Create second admin', () => {
+                //create a custom admin
+                createUser(user, PASSWORD, ROLE_CUSTOM_ADMIN);
+                testForUser(user, true);
+            });
+
+            it('Create user with custom role', () => {
+                // When I create a read/write user
+                UserAndAccessSteps.clickCreateNewUserButton();
+                UserAndAccessSteps.typeUsername(user);
+                UserAndAccessSteps.typePassword(PASSWORD);
+                UserAndAccessSteps.typeConfirmPasswordField(PASSWORD);
+                UserAndAccessSteps.selectRoleRadioButton(ROLE_USER);
+                // And add a custom role of 1 letter
+                UserAndAccessSteps.addTextToCustomRoleField('A');
+                UserAndAccessSteps.toggleWriteAccessAny();
+
+                // Then the 'create' button should be disabled
+                UserAndAccessSteps.getConfirmUserCreateButton().should('be.disabled');
+                // And the field should show an error
+                UserAndAccessSteps.getCustomRoleFieldError().should('contain.text', 'Must be at least 2 symbols long');
+                // When I add more text to the custom role tag
+                UserAndAccessSteps.addTextToCustomRoleField('A{enter}');
+                // Then the 'create' button should be enabled
+                UserAndAccessSteps.getConfirmUserCreateButton().should('be.enabled');
+                // And the field error should not exist
+                UserAndAccessSteps.getCustomRoleFieldError().should('not.be.visible');
+
+                // When I type an invalid tag
+                UserAndAccessSteps.addTextToCustomRoleField('B{enter}');
+                // And the field shows an error
+                UserAndAccessSteps.getCustomRoleFieldError().should('contain.text', 'Must be at least 2 symbols long');
+                // When I delete the invalid text
+                UserAndAccessSteps.addTextToCustomRoleField('{backspace}');
+                // Then the error should not be visible
+                UserAndAccessSteps.getCustomRoleFieldError().should('not.be.visible');
+
+                // When I create the user with a valid custom role
+                UserAndAccessSteps.toggleWriteAccessAny();
+                SecurityStubs.spyOnUserCreate();
+                UserAndAccessSteps.confirmUserCreate();
+                // Then the user should be created with that custom role
+                cy.wait('@create-user').its('request.body').then((body) => {
+                    expect(body).to.deep.eq({
+                        'password': 'password',
+                        'grantedAuthorities': [
+                            'ROLE_USER',
+                            'CUSTOM_AA',
+                            'WRITE_REPO_*',
+                            'READ_REPO_*',
+                        ],
+                        'appSettings': {
+                            'DEFAULT_VIS_GRAPH_SCHEMA': true,
+                            'DEFAULT_INFERENCE': true,
+                            'DEFAULT_SAMEAS': true,
+                            'IGNORE_SHARED_QUERIES': false,
+                            'EXECUTE_COUNT': true,
+                        },
+                    });
+                });
+
+                cy.url().should('include', '/users');
+                UserAndAccessSteps.findUserInTable(user).should('be.visible');
+                UserAndAccessSteps.getUserCustomRoles('@user')
+                    .should('have.length', 1)
+                    .eq(0).and('have.text', 'AA');
+                // And when I open the edit page for that user, the custom role should be visible in the field without the prefix
+                UserAndAccessSteps.openEditUserPage(user);
+                cy.wait('@get-user');
+                UserAndAccessSteps.getCustomRoleField().find('.tag-item span')
+                    .should('have.length', 1)
+                    .eq(0).and('have.text', 'AA');
+            });
+
+            it('Adding a role with a CUSTOM_ prefix shows a warning message', () => {
+                // When I create a user
+                UserAndAccessSteps.clickCreateNewUserButton();
+                // And I add a custom role tag with prefix CUSTOM_
+                UserAndAccessSteps.addTextToCustomRoleField('CUSTOM_USER{Enter}');
+                // There should be a warning text
+                UserAndAccessSteps.getPrefixWarning(0).should('contain', 'Custom roles should be entered without the "CUSTOM_" prefix in Workbench');
+            });
+
+            it('Warn users when setting no password when creating new user admin', () => {
+                UserAndAccessSteps.getUsersTable().should('be.visible');
+                createUser(user, PASSWORD, ROLE_CUSTOM_ADMIN, {noPassword: true});
+                UserAndAccessSteps.getUsersTable().should('be.visible');
+                UserAndAccessSteps.getSplashLoader().should('not.be.visible');
+            });
+
+            // Skipped until image with GDB implementation is available
+            it.skip('should create user with manage repo rights for specific repo', () => {
+                SecurityStubs.spyOnUserCreate();
+                UserAndAccessSteps.getUsersCatalogContainer().should('be.visible');
+                createUser(user, PASSWORD, ROLE_USER, {manage: true, repoName: repoName});
+                // Then the user should be created with that custom role
+                cy.wait('@create-user').its('request.body').then((body) => {
+                    expect(body).to.deep.eq({
+                        'password': 'password',
+                        'grantedAuthorities': [
+                            'ROLE_USER',
+                            `MANAGE_REPO_${repoName}`,
+                            `WRITE_REPO_${repoName}`,
+                            `READ_REPO_${repoName}`,
+                        ],
+                        'appSettings': {
+                            'DEFAULT_VIS_GRAPH_SCHEMA': true,
+                            'DEFAULT_INFERENCE': true,
+                            'DEFAULT_SAMEAS': true,
+                            'IGNORE_SHARED_QUERIES': false,
+                            'EXECUTE_COUNT': true,
+                        },
+                    });
+                });
+                UserAndAccessSteps.getUsersCatalogContainer().should('be.visible');
+                assertUserAuthsInCatalog(user, {repo: repoName, read: false, manage: true, graphql: false});
+
+                UserAndAccessSteps.openEditUserPage(user);
+                cy.wait('@get-user');
+                UserAndAccessSteps.getRepositoryRightsList().should('be.visible');
+                verifyCheckedUserAuth(repoName, {read: true, write: true, manage: true, graphql: false});
+                verifyDisabledUserAuth(repoName, {read: true, write: true, manage: false, graphql: true});
+            });
+        });
+
+        context('Free access', () => {
+            it('should toggle free access after Admin has logged in', () => {
+                // Given I have available repositories to allow Free Access for
+                RepositoriesStubs.stubRepositories();
+                RepositoriesStubs.stubFreeAccess();
+                // When I enable security
+                UserAndAccessSteps.toggleSecurity();
+                // When I log in as an Admin
+                LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);
+                // Then the page should load
+                UserAndAccessSteps.getSplashLoader().should('not.be.visible');
+                UserAndAccessSteps.getUsersTable().should('be.visible');
+                // The Free Access toggle should be OFF
+                UserAndAccessSteps.getFreeAccessSwitchInput().should('not.be.checked');
+                // When I toggle Free Access ON
+                UserAndAccessSteps.toggleFreeAccess();
+                // And I allow free access to a repository
+                ModalDialogSteps.getDialog().should('be.visible');
+                // Then I click OK in the modal
+                ModalDialogSteps.clickOKButton();
+                // Then the toggle button should be ON
+                UserAndAccessSteps.getFreeAccessSwitchInput().should('be.checked');
+                // And I should see a success message
+                ToasterSteps.verifySuccess('Free access has been enabled.');
+                ToasterSteps.getToast().should('not.exist');
+                UserAndAccessSteps.getUsersTable().should('be.visible');
+                // When I toggle Free Access OFF
+                UserAndAccessSteps.toggleFreeAccess();
+                // Then I should see a success message
+                ToasterSteps.getToast().should('exist');
+                ToasterSteps.getToasterMessage().should('contain', 'Free access has been disabled.');
+            });
+        });
+
+        context('Login / return URL redirects', () => {
+            it('should redirect to previous page after logout and then login', () => {
+                UserAndAccessSteps.toggleSecurity();
+                LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);
+                MainMenuSteps.clickOnSparqlMenu();
+                cy.url().should('include', '/sparql');
+
+                LoginSteps.logout();
+                cy.url().should('include', '/login');
+                LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);
+                cy.url().should('include', '/sparql');
+            });
+
+            it('should redirect to correct return url when user is authenticated and on login page', () => {
+                UserAndAccessSteps.visit();
+                UserAndAccessSteps.toggleSecurity();
+                LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);
+                UserAndAccessSteps.getUsersTable().should('be.visible');
+
+                cy.visit('/login?r=%252Fsparql');
+                cy.reload();
+                UserAndAccessSteps.getUrl().should('include', '/sparql');
+            });
         });
     });
 
-    // eslint-disable-next-line no-undef
     context('Verify access states', () => {
         let repoName;
 
@@ -264,13 +276,14 @@ describe('User and Access', () => {
             repoName = 'user-access-repo1-' + Date.now();
             cy.createRepository({id: repoName});
             cy.switchOffSecurity(true);
+            SecurityStubs.spyOnUserGet();
         });
 
         beforeEach(() => {
             UserAndAccessSteps.visit();
             // Users table should be visible
             UserAndAccessSteps.getUsersTable().should('be.visible');
-        })
+        });
 
         after(() => {
             cy.loginAsAdmin().then(() => {
@@ -286,9 +299,8 @@ describe('User and Access', () => {
             verifyDisabledUserAuth('*', {read: false, write: false, manage: true, graphql: true});
             verifyCheckedUserAuth(repoName, {read: false, write: false, manage: false, graphql: false});
             verifyDisabledUserAuth(repoName, {read: false, write: false, manage: false, graphql: true});
-        })
+        });
 
-        // eslint-disable-next-line no-undef
         context('for non user roles', () => {
             it('admin', () => {
                 UserAndAccessSteps.clickCreateNewUserButton();
@@ -310,9 +322,8 @@ describe('User and Access', () => {
                 verifyCheckedUserAuth(repoName, {read: true, write: true, manage: true, graphql: false});
                 verifyDisabledUserAuth(repoName, {read: true, write: true, manage: true, graphql: true});
             });
-        })
+        });
 
-        // eslint-disable-next-line no-undef
         context('for specific repo', () => {
             it('read', () => {
                 UserAndAccessSteps.clickCreateNewUserButton();
@@ -350,7 +361,6 @@ describe('User and Access', () => {
             });
         });
 
-        // eslint-disable-next-line no-undef
         context('for any repo', () => {
             let anyRepo = '*';
 
@@ -396,15 +406,13 @@ describe('User and Access', () => {
         });
     });
 
-    // eslint-disable-next-line no-undef
-    context('GraphQL only', () => {
+    context('GraphQL access', () => {
         let repositoryId1;
         let repositoryId2;
         let repositoryId3;
         const graphqlUser = 'graphqlUser';
 
         beforeEach(() => {
-            cy.viewport(1280, 1000);
             RepositoriesStubs.spyGetRepositories();
             repositoryId1 = 'user-access-repo1-' + Date.now();
             repositoryId2 = 'user-access-repo2-' + Date.now();
@@ -416,6 +424,7 @@ describe('User and Access', () => {
             UserAndAccessSteps.visit();
             // Users table should be visible
             UserAndAccessSteps.getUsersTable().should('be.visible');
+            SecurityStubs.spyOnUserGet();
         });
 
         afterEach(() => {
@@ -430,144 +439,164 @@ describe('User and Access', () => {
 
         });
 
-        it('Create user with GraphQL-only access', () => {
-            cy.wait('@getRepositories');
-            createUser(graphqlUser, PASSWORD, ROLE_USER, {read: true, graphql: true, repoName: repositoryId2});
-        });
+        context('GraphQL checkbox behavior', () => {
+            it('Create user with GraphQL-only access', () => {
+                cy.wait('@getRepositories');
+                createUser(graphqlUser, PASSWORD, ROLE_USER, {read: true, graphql: true, repoName: repositoryId2});
+            });
 
-        // Fails for unknown reason only in CI
-        it.skip('Can create user with different auth combinations', () => {
-            cy.wait('@getRepositories');
-            // WHEN I create a user with read + GraphQL for repository #2
-            createUser(graphqlUser, PASSWORD, ROLE_USER, {read: true, graphql: true, repoName: repositoryId2});
-            // THEN the user should have read + GraphQL on that repo
-            assertUserAuthsInCatalog(graphqlUser, {repo: repositoryId2, read: true, graphql: true});
-            // WHEN I open the edit page for that user
-            UserAndAccessSteps.openEditUserPage(graphqlUser);
-            // THEN for repository #1, the GraphQL checkbox should be disabled initially
-            UserAndAccessSteps.validateGraphqlAccessForRepo(repositoryId1, {disabled: true});
-            // WHEN I enable "read" for repository #1
-            editUserAuths({repo: repositoryId1, read: true});
-            // THEN GraphQL for repository #1 should become enabled
-            UserAndAccessSteps.validateGraphqlAccessForRepo(repositoryId1, {disabled: false});
-            // WHEN I enable GraphQL and read
-            editUserAuths({repo: repositoryId1, graphql: true});
-            editUserAuths({repo: repositoryId1, read: true});
-            // THEN GraphQL should be checked and disabled
-            UserAndAccessSteps.validateGraphqlAccessForRepo(repositoryId1, {checked: true, disabled: true});
-            // THEN for repository #3, GraphQL should be disabled initially
-            UserAndAccessSteps.validateGraphqlAccessForRepo(repositoryId3, {disabled: true});
-            // WHEN I enable "write" for repository #3
-            editUserAuths({repo: repositoryId3, write: true});
-            // THEN GraphQL for repository #3 should become enabled
-            UserAndAccessSteps.validateGraphqlAccessForRepo(repositoryId3, {disabled: false});
-            // And I expect "read" to be checked and disabled
-            UserAndAccessSteps.validateReadAccessForRepo(repositoryId3, {checked: true, disabled: true});
-            // I enable GraphQL for repository #3
-            editUserAuths({repo: repositoryId3, graphql: true});
+            // Fails for unknown reason only in CI
+            it('Can create user with different auth combinations', () => {
+                cy.wait('@getRepositories');
+                cy.wait('@getRepositories');
+                UserAndAccessSteps.getUsersCatalogContainer().should('be.visible');
+                // WHEN I create a user with read + GraphQL for repository #2
+                createUser(graphqlUser, PASSWORD, ROLE_USER, {read: true, graphql: true, repoName: repositoryId2});
+                // THEN the user should have read + GraphQL on that repo
+                assertUserAuthsInCatalog(graphqlUser, {repo: repositoryId2, read: true, graphql: true});
+                // WHEN I open the edit page for that user
+                UserAndAccessSteps.openEditUserPage(graphqlUser);
+                cy.wait('@get-user');
+                // THEN for repository #1, the GraphQL checkbox should be disabled initially
+                UserAndAccessSteps.validateGraphqlAccessForRepo(repositoryId1, {disabled: true});
+                // WHEN I enable "read" for repository #1
+                setUserAuths({repo: repositoryId1, read: true});
+                // THEN GraphQL for repository #1 should become enabled
+                UserAndAccessSteps.validateGraphqlAccessForRepo(repositoryId1, {disabled: false});
+                // WHEN I enable GraphQL with read
+                setUserAuths({repo: repositoryId1, graphql: true});
+                // THEN GraphQL should be checked and enabled
+                UserAndAccessSteps.validateGraphqlAccessForRepo(repositoryId1, {checked: true, disabled: false});
+                // THEN for repository #3, GraphQL should be disabled initially
+                UserAndAccessSteps.validateGraphqlAccessForRepo(repositoryId3, {disabled: true});
+                // WHEN I enable "write" for repository #3
+                setUserAuths({repo: repositoryId3, write: true});
+                // THEN GraphQL for repository #3 should become enabled
+                UserAndAccessSteps.validateGraphqlAccessForRepo(repositoryId3, {disabled: false});
+                // And I expect "read" to be checked and disabled
+                UserAndAccessSteps.validateReadAccessForRepo(repositoryId3, {checked: true, disabled: true});
+                // I enable GraphQL for repository #3
+                setUserAuths({repo: repositoryId3, graphql: true});
+                // THEN GraphQL should be checked and enabled
+                UserAndAccessSteps.validateGraphqlAccessForRepo(repositoryId1, {checked: true, disabled: false});
+                // When I remove "read" for repository #2
+                UserAndAccessSteps.toggleReadAccessForRepo(repositoryId2);
+                // THEN I expect "graphql" to be unchecked and disabled for repository #2
+                UserAndAccessSteps.validateGraphqlAccessForRepo(repositoryId2, {checked: false, disabled: true});
 
-            // WHEN I confirm the user edit
-            UserAndAccessSteps.confirmUserEdit();
-            // THEN verify the final rights:
-            //  - repo #1 has no read/write/graphql
-            //  - repo #2 has read + graphql
-            //  - repo #3 has write + graphql (and read was auto-checked but disabled)
-            assertUserAuthsInCatalog(graphqlUser, {repo: repositoryId1, read: false, write: false, graphql: false});
-            assertUserAuthsInCatalog(graphqlUser, {repo: repositoryId2, read: true, write: false, graphql: true});
-            assertUserAuthsInCatalog(graphqlUser, {repo: repositoryId3, read: false, write: true, graphql: true});
-        });
-
-        // TODO remove skipped flag from all tests after merge of https://github.com/Ontotext-AD/graphdb-workbench/pull/2042
-        it.skip('Should have access to 5 pages when have graphql only rights', () => {
-            cy.wait('@getRepositories');
-            // WHEN I create a user with read + GraphQL for repository #2
-            createUser(graphqlUser, PASSWORD, ROLE_USER, {readWrite: true, graphql: true, repoName: repositoryId1});
-            //enable security
-            UserAndAccessSteps.toggleSecurity();
-            //login new user
-            LoginSteps.loginWithUser(graphqlUser, PASSWORD);
-            RepositorySelectorSteps.selectRepository(repositoryId1);
-
-            MENU_ITEMS_WITHOUT_GRAPHQL.forEach(({path, expectedUrl, checks, expectedTitle}) => {
-                navigateMenuPath(path, expectedUrl, expectedTitle);
-                if (checks) {
-                    runChecks(checks);
-                }
+                // WHEN I confirm the user edit
+                UserAndAccessSteps.confirmUserEdit();
+                // THEN verify the final rights:
+                //  - repo #1 has no read/write/graphql
+                //  - repo #2 has read + graphql
+                //  - repo #3 has write + graphql (and read was auto-checked but disabled)
+                assertUserAuthsInCatalog(graphqlUser, {repo: repositoryId1, read: true, write: false, graphql: true});
+                assertUserAuthsInCatalog(graphqlUser, {repo: repositoryId2, read: false, write: false, graphql: false});
+                assertUserAuthsInCatalog(graphqlUser, {repo: repositoryId3, read: false, write: true, graphql: true});
             });
         });
 
-        it.skip('Should not have access endpoints management when have read graphql only rights', () => {
-            cy.wait('@getRepositories');
-            // WHEN I create a user with read + GraphQL for repository #2
-            createUser(graphqlUser, PASSWORD, ROLE_USER, {read: true, graphql: true, repoName: repositoryId1});
-            //enable security
-            UserAndAccessSteps.toggleSecurity();
-            //login new user
-            LoginSteps.loginWithUser(graphqlUser, PASSWORD);
-            RepositorySelectorSteps.selectRepository(repositoryId1);
+        context('Menu navigation based on permissions', () => {
+            it('Should have access to 5 pages when have graphql only rights', () => {
+                cy.wait('@getRepositories');
+                cy.wait('@getRepositories');
+                // WHEN I create a user with read + GraphQL for repository #2
+                createUser(graphqlUser, PASSWORD, ROLE_USER, {readWrite: true, graphql: true, repoName: repositoryId1});
+                //enable security
+                UserAndAccessSteps.toggleSecurity();
+                //login new user
+                LoginSteps.loginWithUser(graphqlUser, PASSWORD);
+                cy.wait('@getRepositories');
+                cy.wait('@getRepositories');
 
-            GRAPHQL_READ_MENU_ITEMS.forEach(({path, expectedUrl, checks, expectedTitle}) => {
-                navigateMenuPath(path, expectedUrl, expectedTitle);
-                if (checks) {
-                    runChecks(checks);
-                }
+                MENU_ITEMS_WITHOUT_GRAPHQL.forEach(({path, expectedUrl, checks, expectedTitle}) => {
+                    navigateMenuPath(path, expectedUrl, expectedTitle);
+                    if (checks) {
+                        runChecks(checks);
+                    }
+                    navigateMenuPath(['Import'], '/import', 'Import');
+                });
             });
-        });
 
-        it.skip('Should have all access to endpoints management when have REPO_MANAGER role', () => {
-            cy.wait('@getRepositories');
-            createUser(graphqlUser, PASSWORD, ROLE_REPO_MANAGER);
-            //enable security
-            UserAndAccessSteps.toggleSecurity();
-            HomeSteps.visit();
-            //login new user
-            LoginSteps.loginWithUser(graphqlUser, PASSWORD);
-            GRAPHQL_REPO_MANAGER_MENU_ITEMS.forEach(({path, expectedUrl, checks, expectedTitle}) => {
-                navigateMenuPath(path, expectedUrl, expectedTitle);
-                if (checks) {
-                    runChecks(checks);
-                }
+            it('Should not have access endpoints management when have read graphql only rights', () => {
+                cy.wait('@getRepositories');
+                cy.wait('@getRepositories');
+                // WHEN I create a user with read + GraphQL for repository #2
+                createUser(graphqlUser, PASSWORD, ROLE_USER, {read: true, graphql: true, repoName: repositoryId1});
+                //enable security
+                UserAndAccessSteps.toggleSecurity();
+                //login new user
+                LoginSteps.loginWithUser(graphqlUser, PASSWORD);
+                cy.wait('@getRepositories');
+                cy.wait('@getRepositories');
+                // RepositorySelectorSteps.selectRepository(repositoryId1);
+
+                GRAPHQL_READ_MENU_ITEMS.forEach(({path, expectedUrl, checks, expectedTitle}) => {
+                    navigateMenuPath(path, expectedUrl, expectedTitle);
+                    if (checks) {
+                        runChecks(checks);
+                    }
+                    navigateMenuPath(['Import'], '/import', 'Import');
+                });
             });
-        });
-
-        it.skip('Can have Free Access and GraphQL working together', () => {
-            cy.wait('@getRepositories');
-            //enable security
-            UserAndAccessSteps.toggleSecurity();
-            //login with the admin
-            LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);
-            // The Free Access toggle should be OFF
-            UserAndAccessSteps.getFreeAccessSwitchInput().should('not.be.checked');
-            // When I toggle Free Access ON
-            UserAndAccessSteps.toggleFreeAccess();
-            // Then I set repo auths
-            UserAndAccessSteps.clickFreeReadAccessRepo(repositoryId1);
-            UserAndAccessSteps.clickFreeWriteAccessRepo(repositoryId2);
-            UserAndAccessSteps.clickFreeWriteAccessRepo(repositoryId3);
-            UserAndAccessSteps.clickFreeGraphqlAccessRepo(repositoryId3);
-            // Then I click OK in the modal
-            ModalDialogSteps.clickOKButton();
-            // Then the toggle button should be ON
-            UserAndAccessSteps.getFreeAccessSwitchInput().should('be.checked');
-            // And I should see a success message
-            ToasterSteps.verifySuccess('Free access has been enabled.');
-            UserAndAccessSteps.getUsersTable().should('be.visible');
-
-            // Then I logout
-            LoginSteps.logout();
-            HomeSteps.visit();
-            //  I change the repository to this with GraphQL only rights
-            RepositorySelectorSteps.selectRepository(repositoryId3);
-            // Then I should have GraphQL only rights
-            FREE_ACCESS_MENU_ITEMS_WITHOUT_GRAPHQL.forEach(({path, expectedUrl, checks, expectedTitle}) => {
-                navigateMenuPath(path, expectedUrl, expectedTitle);
-                if (checks) {
-                    runChecks(checks);
-                }
+            it('Should have all access to endpoints management when have REPO_MANAGER role', () => {
+                cy.wait('@getRepositories');
+                cy.wait('@getRepositories');
+                createUser(graphqlUser, PASSWORD, ROLE_REPO_MANAGER);
+                //enable security
+                UserAndAccessSteps.toggleSecurity();
+                HomeSteps.visitAndWaitLoader();
+                //login new user
+                LoginSteps.loginWithUser(graphqlUser, PASSWORD);
+                cy.wait('@getRepositories');
+                cy.wait('@getRepositories');
+                GRAPHQL_REPO_MANAGER_MENU_ITEMS.forEach(({path, expectedUrl, checks, expectedTitle}) => {
+                    navigateMenuPath(path, expectedUrl, expectedTitle);
+                    if (checks) {
+                        runChecks(checks);
+                    }
+                    navigateMenuPath(['Import'], '/import', 'Import');
+                });
             });
-            // Turn free access off
-            cy.loginAsAdmin().then(() => {
-                cy.switchOffFreeAccess(true);
+            it('Can have Free Access and GraphQL working together', () => {
+                cy.wait('@getRepositories');
+                cy.wait('@getRepositories');
+                //enable security
+                UserAndAccessSteps.toggleSecurity();
+                //login with the admin
+                LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);
+                cy.wait('@getRepositories');
+                cy.wait('@getRepositories');
+                // The Free Access toggle should be OFF
+                UserAndAccessSteps.getFreeAccessSwitchInput().should('not.be.checked');
+                // When I toggle Free Access ON
+                UserAndAccessSteps.toggleFreeAccess();
+                // Then I set repo auths
+                UserAndAccessSteps.clickFreeReadAccessRepo(repositoryId1);
+                UserAndAccessSteps.clickFreeWriteAccessRepo(repositoryId2);
+                UserAndAccessSteps.clickFreeWriteAccessRepo(repositoryId3);
+                UserAndAccessSteps.clickFreeGraphqlAccessRepo(repositoryId3);
+                // Then I click OK in the modal
+                ModalDialogSteps.clickOKButton();
+                // Then the toggle button should be ON
+                UserAndAccessSteps.getFreeAccessSwitchInput().should('be.checked');
+                // And I should see a success message
+                ToasterSteps.verifySuccess('Free access has been enabled.');
+                UserAndAccessSteps.getUsersTable().should('be.visible');
+
+                // Then I logout
+                LoginSteps.logout();
+                HomeSteps.visit();
+                //  I change the repository to this with GraphQL only rights
+                RepositorySelectorSteps.selectRepository(repositoryId3);
+                // Then I should have GraphQL only rights
+                FREE_ACCESS_MENU_ITEMS_WITHOUT_GRAPHQL.forEach(({path, expectedUrl, checks, expectedTitle}) => {
+                    navigateMenuPath(path, expectedUrl, expectedTitle);
+                    if (checks) {
+                        runChecks(checks);
+                    }
+                    navigateMenuPath(['Import'], '/import', 'Import');
+                });
             });
         });
     });
@@ -582,6 +611,8 @@ describe('User and Access', () => {
 
     function createUser(username, password, role, opts = {}) {
         UserAndAccessSteps.clickCreateNewUserButton();
+        cy.url().should('include', '/user/create');
+        UserAndAccessSteps.getUsernameField().should('be.visible').and('be.enabled').and('not.be.disabled');
         UserAndAccessSteps.typeUsername(username);
         UserAndAccessSteps.typePassword(password);
         UserAndAccessSteps.typeConfirmPasswordField(password);
@@ -643,10 +674,10 @@ describe('User and Access', () => {
         }
     }
 
-    function assertUserAuthsInCatalog(username, {repo, read = false, write = false, graphql = false} = {}) {
+    function assertUserAuthsInCatalog(username, {repo, read = false, write = false, manage = false, graphql = false} = {}) {
         UserAndAccessSteps.findUserRowAlias(username, 'userRow');
 
-        if (!read && !write) {
+        if (!read && !write && !manage) {
             return UserAndAccessSteps.getRepoLine('@userRow', repo).should('not.exist');
         }
 
@@ -665,6 +696,12 @@ describe('User and Access', () => {
             UserAndAccessSteps.findWriteIconAlias('@repoLine').should('not.exist');
         }
 
+        if (manage) {
+            UserAndAccessSteps.findManageIconAlias('@repoLine').should('be.visible');
+        } else {
+            UserAndAccessSteps.findManageIconAlias('@repoLine').should('not.exist');
+        }
+
         if (graphql) {
             UserAndAccessSteps.findGraphqlIconAlias('@repoLine').should('exist');
         } else {
@@ -672,21 +709,25 @@ describe('User and Access', () => {
         }
     }
 
-    function editUserAuths({repo, read = false, write = false, graphql = false, manage = false} = {}) {
+    function setUserAuths({repo, read = false, write = false, graphql = false, manage = false} = {}) {
         if (read === true) {
             UserAndAccessSteps.toggleReadAccessForRepo(repo);
+            UserAndAccessSteps.validateReadAccessForRepo(repo, {checked: read});
         }
 
         if (write === true) {
             UserAndAccessSteps.toggleWriteAccessForRepo(repo);
+            UserAndAccessSteps.validateWriteAccessForRepo(repo, {checked: write});
         }
 
         if (graphql === true) {
             UserAndAccessSteps.toggleGraphqlAccessForRepo(repo);
+            UserAndAccessSteps.validateGraphqlAccessForRepo(repo, {checked: graphql});
         }
 
         if (manage === true) {
             UserAndAccessSteps.toggleManageRepoForRepo(repo);
+            UserAndAccessSteps.validateManageAccessForRepo(repo, {checked: manage});
         }
     }
 
@@ -749,9 +790,6 @@ describe('User and Access', () => {
     }
 
     const noAuthChecks = {
-        'div[role="main]': [
-            'not.exist',
-        ],
         '.no-authority-panel .alert-warning': [
             'be.visible',
             ['contains.text', 'Some functionalities are not available because'],
@@ -760,10 +798,6 @@ describe('User and Access', () => {
     };
 
     const hasAuthChecks = {
-        'div[role="main"]': [
-            'exist',
-            'be.visible',
-        ],
         '.no-authority-panel .alert-warning': [
             'not.exist',
         ],
@@ -1003,14 +1037,6 @@ describe('User and Access', () => {
             path: ['Setup', 'SPARQL Templates'],
             expectedUrl: '/sparql-templates',
             checks: noAuthChecks,
-        },
-
-        // 7) Help
-        {
-            path: ['Help', 'REST API'],
-            expectedUrl: '/webapi',
-            expectedTitle: 'REST API documentation',
-            checks: hasAuthChecks,
         },
     ];
 });

--- a/e2e-tests/eslint.config.js
+++ b/e2e-tests/eslint.config.js
@@ -20,6 +20,7 @@ export default [
                 cy: 'readonly',
                 Cypress: 'readonly',
                 describe: 'readonly',
+                context: 'readonly',
                 it: 'readonly',
                 beforeEach: 'readonly',
                 afterEach: 'readonly',

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -13,7 +13,7 @@
     "cy:open-guides": "cypress open --config-file cypress-guides.config.js",
     "cy:run-guides": "cypress run --config-file cypress-guides.config.js",
     "cy:run": "npm run cy:run-legacy && cypress run",
-    "cy:run:partial": "cypress run --config-file cypress-legacy.config.js --spec \"e2e-legacy/**/jdbc-create.spec.js\" --browser chrome",
+    "cy:run:partial": "cypress run --config-file cypress-legacy.config.js --spec \"e2e-legacy/ttyg/**/*.spec.js\" --browser chrome",
     "cy:run-legacy": "cypress run --config-file cypress-legacy.config.js --browser chrome",
     "cy:run-security": "cypress run --config-file cypress-security.config.js --browser chrome",
     "cy:run-legacy:coverage": "cypress run --config-file cypress-legacy.config.js --browser chrome",

--- a/e2e-tests/steps/application-steps.js
+++ b/e2e-tests/steps/application-steps.js
@@ -28,7 +28,7 @@ export class ApplicationSteps {
         cy.get('onto-navbar .menu-element').eq(0).click();
     }
 
-    static geLoader() {
+    static getLoader() {
         return cy.get('.ot-loader-new-content');
     }
 

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -53,7 +53,11 @@ export class MainMenuSteps {
 
     static clickOnMenu(menuName) {
         // Forced it because some element as "Explore" for example has CSS pointer-events: none
-        MainMenuSteps.getMenuButton(menuName).click({force: true});
+        MainMenuSteps.getMenuButton(menuName).realClick();
+    }
+
+    static getSubmenuFor(menuName) {
+        return MainMenuSteps.getMainMenu().contains('.menu-element', menuName).find('.sub-menu');
     }
 
     static clickOnSubmenuTriggerElement(menuName) {

--- a/e2e-tests/steps/setup/user-and-access-steps.js
+++ b/e2e-tests/steps/setup/user-and-access-steps.js
@@ -269,6 +269,10 @@ export class UserAndAccessSteps {
         return cy.get(repoLineAlias).find('.ri-edit-line');
     }
 
+    static findManageIconAlias(repoLineAlias) {
+        return cy.get(repoLineAlias).find('.ri-folder-settings-line');
+    }
+
     static findGraphqlIconAlias(repoLineAlias) {
         return cy.get(repoLineAlias).find('.icon-graphql');
     }
@@ -276,6 +280,8 @@ export class UserAndAccessSteps {
     static openEditUserPage(username) {
         this.findUserInTable(username); // sets @user
         cy.get('@user').find('.edit-user-btn').click();
+        cy.url().should('include', `/user/${username}`);
+        UserAndAccessSteps.getUsernameField().should('be.visible');
     }
 
     static confirmUserEdit() {

--- a/e2e-tests/stubs/security-stubs.js
+++ b/e2e-tests/stubs/security-stubs.js
@@ -14,6 +14,10 @@ export class SecurityStubs {
         cy.intercept('POST', 'rest/security/users/*').as('create-user');
     }
 
+    static spyOnUserGet() {
+        cy.intercept('GET', 'rest/security/users/*').as('get-user');
+    }
+
     static stubInferAndSameAsDefaults() {
         cy.intercept('rest/security/all', (req) => {
             req.reply(SecurityStubs.getResponseSecurityEnabled());

--- a/packages/api/src/models/security/authorization/authority-list.ts
+++ b/packages/api/src/models/security/authorization/authority-list.ts
@@ -135,7 +135,9 @@ export class AuthorityList extends ModelList<string> {
           permissions.write = true;
         } else if (prefix === Authority.MANAGE_REPO_PREFIX) {
           permissions.manage = true;
-        } else if (prefix === Authority.GRAPHQL_PREFIX) {
+        }
+
+        if (repo.split(':')[1] === Authority.GRAPHQL && !permissions.manage) {
           permissions.graphql = true;
         }
         repositories[repo] = permissions;

--- a/packages/api/src/models/security/authorization/authority-list.ts
+++ b/packages/api/src/models/security/authorization/authority-list.ts
@@ -4,12 +4,8 @@ import {GraphdbAuthoritiesModel} from './graphdb-authorities-model';
 import {AuthoritiesUiModel} from './authorities-ui-model';
 import {RepositoriesPermissions} from './repositories-permissions';
 import {AuthoritiesUtil} from '../../../services/domain/security/utils/authorities-util';
-import {
-  mapGraphdbAuthoritiesResponseToModel
-} from '../../../services/domain/security/mappers/graphdb-authorities-model-mapper';
-import {
-  mapGrantedAuthoritiesResponseToModel
-} from '../../../services/domain/security/mappers/granted-authorities-ui-model.mapper';
+import {mapGraphdbAuthoritiesResponseToModel} from '../../../services/domain/security/mappers/graphdb-authorities-model-mapper';
+import {mapGrantedAuthoritiesResponseToModel} from '../../../services/domain/security/mappers/granted-authorities-ui-model.mapper';
 
 /**
  * Represents a list of authorities in an authenticated user.
@@ -132,11 +128,13 @@ export class AuthorityList extends ModelList<string> {
       const repoData = AuthoritiesUtil.getRepoFromAuthority(authority);
       if (repoData) {
         const {prefix, repo} = repoData;
-        const permissions = repositories[repo] ?? {read: false, write: false, graphql: false};
+        const permissions = repositories[repo] ?? {read: false, write: false, manage:false, graphql: false};
         if (prefix === Authority.READ_REPO_PREFIX) {
           permissions.read = true;
         } else if (prefix === Authority.WRITE_REPO_PREFIX) {
           permissions.write = true;
+        } else if (prefix === Authority.MANAGE_REPO_PREFIX) {
+          permissions.manage = true;
         } else if (prefix === Authority.GRAPHQL_PREFIX) {
           permissions.graphql = true;
         }

--- a/packages/api/src/models/security/authorization/repositories-permissions.ts
+++ b/packages/api/src/models/security/authorization/repositories-permissions.ts
@@ -3,4 +3,4 @@
  * Used in the users catalog component to display user's authorities.
  */
 export type RepositoriesPermissions = Record<string, Permissions>
-type Permissions = { read: boolean, write: boolean, graphql: boolean };
+type Permissions = { read: boolean, write: boolean, manage: boolean, graphql: boolean };

--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -1727,6 +1727,7 @@
     "security.has.read.access": "Has read access",
     "security.no.read.access": "Does not have read access",
     "security.has.write.access": "Has write access",
+    "security.has.manage.access": "Has repository manage access",
     "security.has.mutation_rights": "Has mutation rights",
     "security.no.mutation_rights": "Does not have mutation rights",
     "security.no.write.access": "Does not have write access",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -1726,6 +1726,7 @@
     "security.has.read.access": "A accès en lecture",
     "security.no.read.access": "N'a pas l'accès en lecture",
     "security.has.write.access": "Accès en écriture",
+    "security.has.manage.access": "A un accès de gestion du dépôt",
     "security.has.mutation_rights": "A des droits de mutation",
     "security.no.mutation_rights": "N'a pas de droits de mutation",
     "security.no.write.access": "N'a pas d'accès en écriture",

--- a/packages/legacy-workbench/src/js/angular/security/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/security/controllers.js
@@ -345,7 +345,6 @@ securityModule.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 't
             }
 
             $scope.user.grantedAuthorities = [];
-
             $scope.repositoryCheckError = true;
             if ($scope.userType === UserType.ADMIN) {
                 $scope.repositoryCheckError = false;
@@ -375,8 +374,12 @@ securityModule.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 't
                     }
                 }
                 for (const index in $scope.grantedAuthorities.GRAPHQL) {
-                    if ($scope.grantedAuthorities.GRAPHQL[index] && ($scope.grantedAuthorities.READ_REPO[index] || $scope.grantedAuthorities.READ_REPO['*'])) {
-                        pushAuthority(GRAPHQL_PREFIX + index);
+                    if ($scope.grantedAuthorities.GRAPHQL[index]) {
+                        const hasReadPermission = $scope.grantedAuthorities.READ_REPO[index] || $scope.grantedAuthorities.READ_REPO['*'];
+                        const hasWritePermission = $scope.grantedAuthorities.WRITE_REPO[index] || $scope.grantedAuthorities.WRITE_REPO['*'];
+                        if (hasReadPermission || hasWritePermission) {
+                                pushAuthority(GRAPHQL_PREFIX + index);
+                            }
                     }
                 }
             }

--- a/packages/legacy-workbench/src/js/angular/security/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/security/controllers.js
@@ -375,7 +375,7 @@ securityModule.controller('CommonUserCtrl', ['$rootScope', '$scope', '$http', 't
                     }
                 }
                 for (const index in $scope.grantedAuthorities.GRAPHQL) {
-                    if ($scope.grantedAuthorities.GRAPHQL[index] && $scope.grantedAuthorities.READ_REPO[index]) {
+                    if ($scope.grantedAuthorities.GRAPHQL[index] && ($scope.grantedAuthorities.READ_REPO[index] || $scope.grantedAuthorities.READ_REPO['*'])) {
                         pushAuthority(GRAPHQL_PREFIX + index);
                     }
                 }

--- a/packages/legacy-workbench/src/js/angular/security/templates/users.html
+++ b/packages/legacy-workbench/src/js/angular/security/templates/users.html
@@ -65,10 +65,11 @@
 				<td class="username"><span>{{user.username}}</span></td>
 				<td ng-if="!hasExternalAuth()" class="user-type">{{user.userTypeDescription}}</td>
 				<td ng-if="!hasExternalAuth()" class="repository-rights">
-					<div ng-show="user.userType === 'user'" ng-repeat="(repo, rights) in user.repositories track by $index">
+					<div ng-if="user.userType === 'user'" ng-repeat="(repo, rights) in user.repositories track by $index">
 
                         <em class="ri-eye-line text-tertiary" ng-if="rights.read && !rights.write" gdb-tooltip="{{'security.has.read.access' | translate}}"></em>
-                        <em class="ri-edit-line text-tertiary" ng-if="rights.write" gdb-tooltip="{{'security.has.write.access' | translate}}"></em>
+                        <em class="ri-edit-line text-tertiary" ng-if="rights.write && !rights.manage" gdb-tooltip="{{'security.has.write.access' | translate}}"></em>
+                        <em class="ri-folder-settings-line text-tertiary" ng-if="rights.manage" gdb-tooltip="{{'security.has.manage.access' | translate}}"></em>
                         {{repo}}
                         <em class="icon-graphql text-info" ng-if="rights.graphql" gdb-tooltip="{{rights.write ? 'security.has.mutation_rights' : 'security.no.mutation_rights' | translate}}"></em>
 
@@ -76,7 +77,7 @@
 
 
 					</div>
-					<div ng-show="user.userType !== 'user'">{{'security.unrestricted' | translate}}</div>
+					<div ng-if="user.userType !== 'user'">{{'security.unrestricted' | translate}}</div>
                     <div data-test="custom-roles">
                         <span ng-repeat="role in user.customRoles" >
                             <span class="tag tag-primary" data-test="custom-role">{{ role }}</span>


### PR DESCRIPTION
## What
Enhanced the Ui to show repo manage role for repositories.

## Why
This change allows users to see the manage repo role in the catalog

## How
- Modified `Permissions` type to include `manage` boolean.
- Updated `users.html` to display manage permission with a new icon.
- Added French and English translations for manage access messages in `locale-fr.json` and `locale-en.json`.

## Also
- Adjusted logic in `CommonUserCtrl` to handle GraphQL:* correct

## Testing


## Screenshots
<img width="1373" height="125" alt="image" src="https://github.com/user-attachments/assets/48d01903-2a79-4649-aca1-9d57c092f8d7" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
