### PR TITLE
Fix loader not hiding on slow networks

### DIFF
--- a/e2e-tests/e2e-legacy/ttyg/ttyg-permission.spec.js
+++ b/e2e-tests/e2e-legacy/ttyg/ttyg-permission.spec.js
@@ -13,8 +13,7 @@ const PASSWORD = 'root';
 const ENABLED = true;
 const DISABLED = false;
 
-// FIXME: There is a problem with the loader not hiding. Problem is reproducable on GDB build on branch 11.4 (commit 0ebd95d6) with 3.4.1-RC1
-describe.skip('TTYG permissions', () => {
+describe('TTYG permissions', () => {
 
     before(() => {
         cy.loginAsAdmin();

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -101,7 +101,11 @@ export class OntoLayout {
     this.subscribeToNavigationEnd();
     this.subscribeToRuntimeConfigurationChanges();
     this.subscribeToUserPreferencesChange();
-    this.loading = false;
+    setTimeout(() => {
+      // Must be in timeout, because the order of events and component loading is not guaranteed, and on
+      // slow networks the loader might not be hidden if the navigation end event is fired before the component is loaded.
+      this.loading = false;
+    });
     this.subscribeToBeforeMountRouting();
   }
 


### PR DESCRIPTION
## What
On slow network the initial booting loader is shown and never disapears

## Why
The SingleSPA events and the component loading order are not guaranteed

## How
- put the clearing of the loading flag inside a timeout

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
