### PR TITLE
Revert GDB-14821 fix warnings before guide startup in sandbox

### DIFF
--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -101,8 +101,8 @@ export class OntoLayout {
     this.subscribeToNavigationEnd();
     this.subscribeToRuntimeConfigurationChanges();
     this.subscribeToUserPreferencesChange();
-    this.loading = false;
     this.subscribeToBeforeMountRouting();
+    this.loading = false;
   }
 
   /**


### PR DESCRIPTION
## What
Revert warnings before guide startup in sandbox

## Why
It causes other issues with the loader and breaks the release build

## How
Reverted changes

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
