### PR TITLE
Add configuration for Cypress core tests

### DIFF
--- a/e2e-tests/cypress-core.config.js
+++ b/e2e-tests/cypress-core.config.js
@@ -1,0 +1,45 @@
+import { defineConfig } from 'cypress';
+import setupPlugins from './plugins/index.js';
+
+const isCoverage = process.env.COVERAGE === 'true';
+
+const loadCodeCoverage = async (on, config) => {
+    const mod = await import('@bahmutov/cypress-code-coverage/plugin');
+    const plugin = ('default' in mod) ? mod.default : mod;
+    plugin(on, config);
+};
+
+export default defineConfig({
+    projectId: 'v35btb',
+    fixturesFolder: 'fixtures',
+    video: false,
+    defaultCommandTimeout: 25000,
+    numTestsKeptInMemory: 10,
+    viewportWidth: 1600,
+    viewportHeight: 1200,
+    e2e: {
+        retries: {
+            runMode: 2,
+            openMode: 0
+        },
+        // We've imported your old cypress plugins here.
+        // You may want to clean this up later by importing these.
+        async setupNodeEvents(on, config) {
+            setupPlugins(on, config);
+            if (isCoverage) {
+                await loadCodeCoverage(on, config);
+            }
+            return config;
+        },
+        baseUrl: 'http://localhost:9000',
+        specPattern: ['e2e-legacy/repository/**', 'e2e-legacy/import/**', 'e2e-legacy/sparql-editor/**', 'e2e-legacy/monitor/**', 'e2e-legacy/cluster/**', 'e2e-legacy/ttyg/**'],
+        supportFile: 'support/e2e.js',
+        reporter: "cypress-multi-reporters",
+        reporterOptions: {
+            configFile: 'cypress-reporter-config.json'
+        }
+    },
+    env: {
+        set_default_user_data: true
+    }
+});

--- a/e2e-tests/e2e-legacy/sparql-editor/saved-query/readonly-query.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/saved-query/readonly-query.spec.js
@@ -32,7 +32,7 @@ describe('Readonly saved query', () => {
     });
 
     it('Should not allow modifying a saved query if it is readonly', () => {
-        SparqlEditorSteps.visitSparqlEditorPage()
+        SparqlEditorSteps.visitSparqlEditorPage();
         // Given: There is a public saved query created by a user.
         LoginSteps.loginWithUser(USER_NAME, PASSWORD);
         YasguiSteps.getYasgui().should('be.visible');

--- a/e2e-tests/e2e-legacy/ttyg/edit-agent.spec.js
+++ b/e2e-tests/e2e-legacy/ttyg/edit-agent.spec.js
@@ -145,8 +145,8 @@ describe('TTYG edit an agent', () => {
 
     it('should show Context size if not openai-assistants API', () => {
         // Open TTYG page and select first agent
-        TTYGViewSteps.visit();
         TTYGStubs.stubForApiType('default');
+        TTYGViewSteps.visit();
         cy.wait('@get-agent-list');
         TTYGViewSteps.openAgentSettingsModalForAgent(0);
 
@@ -168,8 +168,8 @@ describe('TTYG edit an agent', () => {
 
     it('should NOT show Context size if openai-assistants API', () => {
         // Open TTYG page and select first agent
-        TTYGViewSteps.visit();
         TTYGStubs.stubForApiType('assistants');
+        TTYGViewSteps.visit();
         cy.wait('@get-agent-list');
         TTYGViewSteps.openAgentSettingsModalForAgent(0);
         // Then I should see the Context size field

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -18,7 +18,7 @@
     "cy:run-legacy:coverage": "cypress run --config-file cypress-legacy.config.js --browser chrome",
     "cy:run-flaky": "cypress run --config-file cypress-flaky.config.js --browser chrome",
     "test": "npm run cy:run-legacy",
-    "test:core": "cypress run --spec e2e-legacy/repository/**,e2e-legacy/import/**,e2e-legacy/sparql-editor/**,e2e-legacy/monitor/**,e2e-legacy/cluster/**,e2e-legacy/ttyg/**",
+    "test:core": "cypress run --config-file cypress-core.config.js --browser chrome",
     "lint": "eslint '**/*.{js,mjs,cjs}'"
   },
   "author": {


### PR DESCRIPTION
## What
Introduced a new Cypress configuration file (`cypress-core.config.js`) to streamline testing processes and updated the `package.json` to utilize this new configuration.

## Why
This change enhances the testing framework by providing a dedicated configuration for core tests, which is what runs on GDB build

## How
- Created `cypress-core.config.js` with essential Cypress settings.
- Updated the `test:core` script in `package.json` to reference the new configuration file.


## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
