### PR TITLE
Update test command for core tests in package.json

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -18,7 +18,7 @@
     "cy:run-legacy:coverage": "cypress run --config-file cypress-legacy.config.js --browser chrome",
     "cy:run-flaky": "cypress run --config-file cypress-flaky.config.js --browser chrome",
     "test": "npm run cy:run-legacy",
-    "test:core": "cypress run --config-file cypress-core.config.js --browser chrome",
+    "test:core": "cypress run --config-file cypress-core.config.js",
     "lint": "eslint '**/*.{js,mjs,cjs}'"
   },
   "author": {


### PR DESCRIPTION
## What
Modified the test command for core tests in package.json to remove the browser specification.

## Why
This will execute using electron

## How
- Removed the `--browser chrome` option from the `test:core` script in package.json.

## Testing

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
