### PR TITLE
Fix failing test for selectign an agent

### DIFF
--- a/e2e-tests/e2e-legacy/ttyg/agent-select-menu.spec.js
+++ b/e2e-tests/e2e-legacy/ttyg/agent-select-menu.spec.js
@@ -7,6 +7,10 @@ describe('TTYG agent select menu', () => {
 
     const repositoryId = 'starwars';
 
+    before(() => {
+        cy.clearLocalStorage('ls.ttyg');
+    });
+
     beforeEach(() => {
         RepositoriesStubs.stubRepositories(0, '/repositories/get-ttyg-repositories.json');
         RepositoriesStubs.stubBaseEndpoints(repositoryId);
@@ -91,6 +95,7 @@ describe('TTYG agent select menu', () => {
         TTYGViewSteps.triggerDeleteAgentActionMenu(0);
         ModalDialogSteps.confirm();
         ModalDialogSteps.getDialog().should('not.exist');
+        cy.wait('@delete-agent');
         // TODO: the agents list filter brakes after deleting an agent!!!
         TTYGViewSteps.selectAllAgentsFilter();
         TTYGViewSteps.getAgents().should('have.length', 3);


### PR DESCRIPTION
## What
A test is failing to find the agent select dropdown when there is not prior selection

## Why
Because the last used agent is kept in the local storage and it is not cleared beforehand

## How
- Cleared the local storage since it was not

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
