### PR TITLE
Cherry-pick 3.5 performCleanup in release.JenkinsFile to clean the .npmrc file from the correct folder

### DIFF
--- a/release.Jenkinsfile
+++ b/release.Jenkinsfile
@@ -3,7 +3,7 @@
 def performCleanup = {
     dir("${env.WORKSPACE}") {
         sh "git restore .npmrc || git checkout HEAD -- .npmrc"
-        dir("test-cypress") {
+        dir("e2e-tests") {
             sh "rm -f .npmrc"
         }
     }


### PR DESCRIPTION
## What

Updated `performCleanup` step in `release.JenkinsFile` to remove the `.npmrc` file from the correct directory. The cleanup path was corrected from `cypress-test` to `e2e-tests`.

## Why

`.npmrc` credentials file was not being removed as part of the final release step because it was pointing to the wrong folder. This left sensitive credentials behind after pipeline execution and made the cleanup step ineffective.

## How

Adjusted cleanup logic in `release.JenkinsFile` so that `performCleanup` targets the `e2e-tests` directory instead of `cypress-test`, ensuring the `.npmrc` file is properly removed during the final stage of the pipeline.

## Testing

Have not tested due to unnecessary potential version collision with artifacts and metadata

## Screenshots
N/A

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified

(cherry picked from commit bcf56cfcbb5a69c3c958c2d423d2dd0a7438227d)