### PR TITLE
GDB-14785 visualize construct query

### DIFF
--- a/e2e-tests/e2e-legacy/reactodia/reactodia.spec.js
+++ b/e2e-tests/e2e-legacy/reactodia/reactodia.spec.js
@@ -6,7 +6,10 @@ const FILE_TO_IMPORT = 'resource-test-data.ttl';
 const SEED_RESOURCE_ENCODED = 'http:%2F%2Fexample.com%2Fontology%23CustomerLoyalty';
 const SEED_RESOURCE_LABEL = 'CustomerLoyalty';
 
-describe('Reactodia view', () => {
+const CONSTRUCT_QUERY = 'CONSTRUCT { <http://example.com/ontology#CustomerLoyalty> ?p ?o } WHERE { <http://example.com/ontology#CustomerLoyalty> ?p ?o }';
+const CONSTRUCT_TARGET_LABEL = 'Metric';
+
+describe('Reactodia graph explorer', () => {
     let repositoryId;
 
     beforeEach(() => {
@@ -39,6 +42,16 @@ describe('Reactodia view', () => {
         // Then I expect the start resource to be placed on the canvas as a seed element.
         ReactodiaSteps.getElements().should('have.length', 1);
         ReactodiaSteps.getElement(SEED_RESOURCE_LABEL).should('exist');
+    });
+
+    it('should seed the canvas with the graph computed from a CONSTRUCT query', () => {
+        // Given I open the reactodia view with a CONSTRUCT query, as sent from the SPARQL editor.
+        ReactodiaSteps.visitWithQuery(CONSTRUCT_QUERY);
+
+        // Then I expect the computed graph to be seeded on the canvas: the subject and its related resource.
+        ReactodiaSteps.getElements().should('have.length', 2);
+        ReactodiaSteps.getElement(SEED_RESOURCE_LABEL).should('exist');
+        ReactodiaSteps.getElement(CONSTRUCT_TARGET_LABEL).should('exist');
     });
 
     it('should keep the displayed resources when the language is switched', () => {

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphdb-workbench-tests",
-  "version": "3.4.0-RC1",
+  "version": "3.5.0-reactodia-resource-construct-TR1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "graphdb-workbench-tests",
-      "version": "3.4.0-RC1",
+      "version": "3.5.0-reactodia-resource-construct-TR1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bahmutov/cypress-code-coverage": "^2.7.2",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphdb-workbench-tests",
-  "version": "3.4.0-RC1",
+  "version": "3.5.0-reactodia-resource-construct-TR1",
   "description": "Cypress tests for GraphDB workbench",
   "type": "module",
   "scripts": {

--- a/e2e-tests/steps/reactodia-steps.js
+++ b/e2e-tests/steps/reactodia-steps.js
@@ -8,6 +8,10 @@ export class ReactodiaSteps extends BaseSteps {
         cy.visit(`${VIEW_URL}${uri ? ('?uri=' + uri) : ''}`);
     }
 
+    static visitWithQuery(query, {inference = false, sameAs = false} = {}) {
+        cy.visit(`${VIEW_URL}?query=${encodeURIComponent(query)}&inference=${inference}&sameAs=${sameAs}`);
+    }
+
     static verifyUrl() {
         this.validateUrl(`${Cypress.config('baseUrl')}${VIEW_URL}`);
     }
@@ -26,10 +30,6 @@ export class ReactodiaSteps extends BaseSteps {
 
     static getCanvas() {
         return ReactodiaSteps.getComponent().find('.reactodia-canvas');
-    }
-
-    static getSearchInput() {
-        return ReactodiaSteps.getComponent().find('.reactodia-unified-search__search-input');
     }
 
     static getElements() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
     "name": "graphdb-workbench",
-    "version": "3.4.0-RC1",
+    "version": "3.5.0-reactodia-resource-construct-TR1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "graphdb-workbench",
-            "version": "3.4.0-RC1",
+            "version": "3.5.0-reactodia-resource-construct-TR1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@single-spa/import-map-injector": "^2.0.2",
                 "graphdb-workbench-plugins": "~1.0.0",
+                "graphwise-reactodia": "^0.0.1-TR7",
                 "import-map-overrides": "^6.1.0"
             },
             "devDependencies": {
@@ -7005,6 +7006,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/graphdb-workbench-plugins/-/graphdb-workbench-plugins-1.0.0.tgz",
             "integrity": "sha512-bnYFVBGxR6AphR2tutjJ4+W3bHaQgpjdCGp+xZ2rqXwCmzNOAu36c/NmM4cJB1YY6OdtoXGizSqnUJU8m3W/dQ==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/graphwise-reactodia": {
+            "version": "0.0.1-TR7",
+            "resolved": "https://registry.npmjs.org/graphwise-reactodia/-/graphwise-reactodia-0.0.1-TR7.tgz",
+            "integrity": "sha512-h5nZINDoicQd2mmOOuZd9VUhMI+Cty/6vRYQicBsduX2E7SlfRd3cDgrEAi3g2+1ATTaRUV0DswEJ8olBucHJQ==",
             "license": "Apache-2.0"
         },
         "node_modules/gzip-size": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "graphdb-workbench",
-    "version": "3.4.0-RC1",
+    "version": "3.5.0-reactodia-resource-construct-TR1",
     "description": "The web application for GraphDB APIs",
     "engines": {
         "node": ">=22.17"
@@ -115,7 +115,7 @@
     "dependencies": {
         "@single-spa/import-map-injector": "^2.0.2",
         "graphdb-workbench-plugins": "~1.0.0",
-        "graphwise-reactodia": "^0.0.1-TR6",
+        "graphwise-reactodia": "^0.0.1-TR7",
         "import-map-overrides": "^6.1.0"
     }
 }

--- a/packages/api/src/models/graph-explore/graph-explore-link.ts
+++ b/packages/api/src/models/graph-explore/graph-explore-link.ts
@@ -1,0 +1,28 @@
+import {Model} from '../common/model';
+
+/**
+ * A pre-resolved graph edge derived from a graph-explore query result.
+ *
+ * Mirrors the neutral shape Reactodia's `config.seedGraph` expects: a source/target pair with the
+ * full predicate IRIs of the relationship(s) between them. Used to visualize the result of a
+ * CONSTRUCT query, whose relationships are computed and therefore not persisted in the repository,
+ * so they cannot be fetched lazily through the SPARQL provider and must be supplied directly.
+ */
+export class GraphExploreLink extends Model<GraphExploreLink> {
+  /** Source element IRI. */
+  source: string;
+  /** Target element IRI. */
+  target: string;
+  /** Full predicate IRIs of the relationship(s) between source and target. */
+  predicates: string[];
+  /** Raw, unresolved predicate values of the relationship(s) between source and target. */
+  rawPredicates: string[];
+
+  constructor(data: Omit<GraphExploreLink, 'copy'>) {
+    super();
+    this.source = data.source;
+    this.target = data.target;
+    this.predicates = data.predicates;
+    this.rawPredicates = data.rawPredicates;
+  }
+}

--- a/packages/api/src/models/graph-explore/graph-explore-settings.ts
+++ b/packages/api/src/models/graph-explore/graph-explore-settings.ts
@@ -1,0 +1,16 @@
+/**
+ * Graph settings used when computing the graph for a SPARQL query.
+ *
+ * In visual graph these come from the graph-config settings, which are not present for reactodia,
+ * so these mirror the legacy default settings.
+ */
+export interface GraphExploreSettings {
+  /** Whether to include inferred statements when evaluating the query. */
+  includeInferred: boolean;
+  /** Whether to enable owl:sameAs expansion when evaluating the query. */
+  sameAs: boolean;
+  /** Preferred label languages; empty means no restriction. */
+  languages: string[];
+  /** Maximum number of links to return. */
+  linksLimit: number;
+}

--- a/packages/api/src/models/graph-explore/index.ts
+++ b/packages/api/src/models/graph-explore/index.ts
@@ -1,0 +1,1 @@
+export * from './graph-explore-link';

--- a/packages/api/src/ontotext-workbench-api.ts
+++ b/packages/api/src/ontotext-workbench-api.ts
@@ -32,6 +32,7 @@ export * from './models/sparql';
 export * from './models/interactive-guide';
 export * from './models/connector';
 export * from './models/graph-config';
+export * from './models/graph-explore';
 export * from './models/http';
 
 // Export enums for external usages.
@@ -79,6 +80,7 @@ export * from './services/domain/guides';
 export * from './services/ui/dialog';
 export * from './services/domain/connector';
 export * from './services/domain/graph-config';
+export * from './services/domain/graph-explore';
 
 // Export interceptors for external usages.
 export * from './interceptor';

--- a/packages/api/src/services/domain/graph-explore/graph-explore-context.service.ts
+++ b/packages/api/src/services/domain/graph-explore/graph-explore-context.service.ts
@@ -1,0 +1,49 @@
+import {ContextService} from '../../context';
+import {DeriveContextServiceContract} from '../../../models/context/update-context-method';
+import {ValueChangeCallback} from '../../../models/context/value-change-callback';
+import {GraphExploreSettings} from '../../../models/graph-explore/graph-explore-settings';
+import {DEFAULT_GRAPH_EXPLORE_SETTINGS} from './graph-explore-settings.config';
+
+type GraphExploreContextFields = {
+  readonly SETTINGS: string;
+};
+
+type GraphExploreContextFieldParams = {
+  readonly SETTINGS: GraphExploreSettings;
+};
+
+/**
+ * Service for managing the graph-explore settings context.
+ */
+export class GraphExploreContextService extends ContextService<GraphExploreContextFields> implements DeriveContextServiceContract<GraphExploreContextFields, GraphExploreContextFieldParams> {
+  readonly SETTINGS = 'graphExploreSettings';
+
+  /**
+   * Updates the default graph-explore settings in the context.
+   *
+   * @param settings - The new default settings object to be set in the context.
+   */
+  updateSettings(settings: GraphExploreSettings): void {
+    this.updateContextProperty(this.SETTINGS, settings);
+  }
+
+  /**
+   * Subscribes to changes in the default graph-explore settings context.
+   *
+   * @param callbackFn - A callback function that will be called when the default settings change.
+   * @returns A function that, when called, will unsubscribe from the default settings changes.
+   */
+  onSettingsChanged(callbackFn: ValueChangeCallback<GraphExploreSettings | undefined>): () => void {
+    return this.subscribe(this.SETTINGS, callbackFn);
+  }
+
+  /**
+   * Retrieves the default graph-explore settings stored in the context. When the context holds no
+   * value yet, falls back to the built-in {@link DEFAULT_GRAPH_EXPLORE_SETTINGS} configuration.
+   *
+   * @return the default graph-explore settings.
+   */
+  getSettings(): GraphExploreSettings {
+    return this.getContextPropertyValue<GraphExploreSettings>(this.SETTINGS) ?? DEFAULT_GRAPH_EXPLORE_SETTINGS;
+  }
+}

--- a/packages/api/src/services/domain/graph-explore/graph-explore-rest.service.ts
+++ b/packages/api/src/services/domain/graph-explore/graph-explore-rest.service.ts
@@ -1,0 +1,23 @@
+import {HttpService} from '../../http/http.service';
+import {GraphExploreRequest} from './request/graph-explore-request';
+import {GraphExploreLinkResponse} from './response/graph-explore-response';
+
+/**
+ * Service for interacting with the graph-explore REST API.
+ */
+export class GraphExploreRestService extends HttpService {
+
+  static readonly EXPLORE_GRAPH_ENDPOINT = 'rest/explore-graph';
+
+  /**
+   * Computes the graph for the given SPARQL query.
+   *
+   * @param request - The graph-explore request payload.
+   * @returns A Promise that resolves to a {@link GraphExploreLinkResponse[]} containing the graph links.
+   */
+  loadGraph(request: GraphExploreRequest): Promise<GraphExploreLinkResponse[]> {
+    return this.post(`${GraphExploreRestService.EXPLORE_GRAPH_ENDPOINT}/graph`, {
+      body: request
+    });
+  }
+}

--- a/packages/api/src/services/domain/graph-explore/graph-explore-settings.config.ts
+++ b/packages/api/src/services/domain/graph-explore/graph-explore-settings.config.ts
@@ -1,0 +1,13 @@
+import {GraphExploreSettings} from '../../../models/graph-explore/graph-explore-settings';
+
+/**
+ * Fallback graph settings used when the caller doesn't provide a value. In visual graph these
+ * come from the graph-config settings, which are not present for reactodia, so we mirror the
+ * legacy default settings here.
+ */
+export const DEFAULT_GRAPH_EXPLORE_SETTINGS: GraphExploreSettings = {
+  includeInferred: true,
+  sameAs: true,
+  languages: ['en'],
+  linksLimit: 100,
+};

--- a/packages/api/src/services/domain/graph-explore/graph-explore.service.ts
+++ b/packages/api/src/services/domain/graph-explore/graph-explore.service.ts
@@ -1,0 +1,34 @@
+import {GraphExploreLink} from '../../../models/graph-explore';
+import {GraphExploreRestService} from './graph-explore-rest.service';
+import {GraphExploreContextService} from './graph-explore-context.service';
+import {mapGraphExploreResponseToLinks} from './mappers/graph-explore.mapper';
+import {service} from '../../../providers';
+import {Service} from '../../../providers/service/service';
+
+/**
+ * Service for computing the graph of a SPARQL query for graph visualizations.
+ */
+export class GraphExploreService implements Service {
+  private readonly graphExploreRestService = service(GraphExploreRestService);
+  private readonly graphExploreContextService = service(GraphExploreContextService);
+
+  /**
+   * Computes the graph for the given SPARQL query and maps it to a list of {@link GraphExploreLink}.
+   *
+   * @param query - The SPARQL query to compute the graph for.
+   * @param includeInferred - Whether to include inferred statements. Falls back to the default when omitted.
+   * @param sameAs - Whether to enable owl:sameAs expansion. Falls back to the default when omitted.
+   * @returns A Promise that resolves to the list of graph links.
+   */
+  async loadGraphForQuery(query: string, includeInferred?: boolean, sameAs?: boolean): Promise<GraphExploreLink[]> {
+    const defaultSettings = this.graphExploreContextService.getSettings();
+    const response = await this.graphExploreRestService.loadGraph({
+      query,
+      linksLimit: defaultSettings.linksLimit,
+      languages: defaultSettings.languages,
+      includeInferred: includeInferred ?? defaultSettings.includeInferred,
+      sameAsState: sameAs ?? defaultSettings.sameAs,
+    });
+    return mapGraphExploreResponseToLinks(response);
+  }
+}

--- a/packages/api/src/services/domain/graph-explore/index.ts
+++ b/packages/api/src/services/domain/graph-explore/index.ts
@@ -1,0 +1,1 @@
+export * from './graph-explore.service';

--- a/packages/api/src/services/domain/graph-explore/mappers/graph-explore.mapper.ts
+++ b/packages/api/src/services/domain/graph-explore/mappers/graph-explore.mapper.ts
@@ -1,0 +1,21 @@
+import {MapperFn} from '../../../../providers';
+import {GraphExploreLinkResponse} from '../response/graph-explore-response';
+import {GraphExploreLink} from '../../../../models/graph-explore';
+
+/**
+ * Maps the {@link GraphExploreLinkResponse[]} server data to a list of {@link GraphExploreLink} models.
+ *
+ * The response's `links[].predicates` are already the full predicate IRIs, so they are carried
+ * through unchanged.
+ *
+ * @param data - The server response containing the graph links.
+ * @returns A list of {@link GraphExploreLink} instances.
+ */
+export const mapGraphExploreResponseToLinks: MapperFn<GraphExploreLinkResponse[], GraphExploreLink[]> = (data: GraphExploreLinkResponse[]) => {
+  return data.map((link) => new GraphExploreLink({
+    source: link.source,
+    target: link.target,
+    predicates: link.predicates,
+    rawPredicates: link.rawPredicates,
+  }));
+};

--- a/packages/api/src/services/domain/graph-explore/request/graph-explore-request.ts
+++ b/packages/api/src/services/domain/graph-explore/request/graph-explore-request.ts
@@ -1,0 +1,15 @@
+/**
+ * Payload for the `rest/explore-graph/graph` endpoint that computes the graph for a SPARQL query.
+ */
+export interface GraphExploreRequest {
+  /** The SPARQL query to compute the graph for. */
+  query: string;
+  /** Maximum number of links to return. */
+  linksLimit?: number;
+  /** Preferred label languages; empty means no restriction. */
+  languages: string[];
+  /** Whether to include inferred statements when evaluating the query. */
+  includeInferred: boolean;
+  /** Whether to enable owl:sameAs expansion when evaluating the query. */
+  sameAsState: boolean;
+}

--- a/packages/api/src/services/domain/graph-explore/response/graph-explore-response.ts
+++ b/packages/api/src/services/domain/graph-explore/response/graph-explore-response.ts
@@ -1,0 +1,13 @@
+/**
+ * A single link (edge) in the `rest/explore-graph/graph` response.
+ */
+export interface GraphExploreLinkResponse {
+  /** Source element IRI. */
+  source: string;
+  /** Target element IRI. */
+  target: string;
+  /** Full predicate IRIs of the relationship(s) between source and target. */
+  predicates: string[];
+  /** Raw (absolute) IRIs. */
+  rawPredicates: string[];
+}

--- a/packages/api/src/services/domain/graph-explore/test/graph-explore-context.service.spec.ts
+++ b/packages/api/src/services/domain/graph-explore/test/graph-explore-context.service.spec.ts
@@ -1,0 +1,60 @@
+import {GraphExploreContextService} from '../graph-explore-context.service';
+import {DEFAULT_GRAPH_EXPLORE_SETTINGS} from '../graph-explore-settings.config';
+import {GraphExploreSettings} from '../../../../models/graph-explore/graph-explore-settings';
+
+describe('GraphExploreContextService', () => {
+  let graphExploreContextService: GraphExploreContextService;
+
+  beforeEach(() => {
+    graphExploreContextService = new GraphExploreContextService();
+  });
+
+  describe('getDefaultSettings', () => {
+    it('should fall back to the default settings config when no value has been set', () => {
+      // Then the configured defaults are returned.
+      expect(graphExploreContextService.getSettings()).toEqual(DEFAULT_GRAPH_EXPLORE_SETTINGS);
+    });
+
+    it('should return the settings stored in the context', () => {
+      // Given custom default settings are set.
+      const settings: GraphExploreSettings = {includeInferred: false, sameAs: false, languages: ['fr'], linksLimit: 50};
+      graphExploreContextService.updateSettings(settings);
+
+      // Then the stored settings are returned instead of the config defaults.
+      expect(graphExploreContextService.getSettings()).toEqual(settings);
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('should update the settings in the context and notify subscribers', () => {
+      // Given a subscriber.
+      const settings: GraphExploreSettings = {includeInferred: false, sameAs: true, languages: ['de'], linksLimit: 10};
+      const mockCallback = jest.fn();
+      graphExploreContextService.onSettingsChanged(mockCallback);
+
+      // When updating the default settings.
+      graphExploreContextService.updateSettings(settings);
+
+      // Then the subscriber is notified with the new settings.
+      expect(mockCallback).toHaveBeenLastCalledWith(settings);
+    });
+  });
+
+  describe('onSettingsChanged', () => {
+    it('should stop receiving updates after unsubscribe', () => {
+      // Given a registered subscriber.
+      const settings: GraphExploreSettings = {includeInferred: false, sameAs: false, languages: [], linksLimit: 1};
+      const mockCallback = jest.fn();
+      const unsubscribe = graphExploreContextService.onSettingsChanged(mockCallback);
+      // Clear the immediate call performed on subscription.
+      mockCallback.mockClear();
+
+      // When unsubscribed.
+      unsubscribe();
+
+      // Then the subscriber is not notified of further changes.
+      graphExploreContextService.updateSettings(settings);
+      expect(mockCallback).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/api/src/services/domain/graph-explore/test/graph-explore.service.spec.ts
+++ b/packages/api/src/services/domain/graph-explore/test/graph-explore.service.spec.ts
@@ -1,0 +1,82 @@
+import {GraphExploreService} from '../graph-explore.service';
+import {GraphExploreRestService} from '../graph-explore-rest.service';
+import {DEFAULT_GRAPH_EXPLORE_SETTINGS} from '../graph-explore-settings.config';
+import {service} from '../../../../providers';
+import {GraphExploreLink} from '../../../../models/graph-explore';
+
+describe('GraphExploreService', () => {
+  const QUERY = 'CONSTRUCT WHERE { ?s ?p ?o }';
+  let graphExploreService: GraphExploreService;
+  let loadGraphSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    graphExploreService = new GraphExploreService();
+    loadGraphSpy = jest.spyOn(service(GraphExploreRestService), 'loadGraph').mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('loadGraphForQuery', () => {
+    it('should call the rest service with the explicit flags without overriding false', async () => {
+      // WHEN: explicit inference and sameAs flags are provided.
+      await graphExploreService.loadGraphForQuery(QUERY, true, false);
+
+      // THEN: the flags are forwarded as-is; an explicit false is not replaced by the default.
+      expect(loadGraphSpy).toHaveBeenCalledWith({
+        query: QUERY,
+        linksLimit: DEFAULT_GRAPH_EXPLORE_SETTINGS.linksLimit,
+        languages: DEFAULT_GRAPH_EXPLORE_SETTINGS.languages,
+        includeInferred: true,
+        sameAsState: false,
+      });
+    });
+
+    it('should fall back to the default settings when the flags are omitted', async () => {
+      // WHEN: no inference or sameAs flags are provided.
+      await graphExploreService.loadGraphForQuery(QUERY);
+
+      // THEN: the request is built entirely from the default settings.
+      expect(loadGraphSpy).toHaveBeenCalledWith({
+        query: QUERY,
+        linksLimit: DEFAULT_GRAPH_EXPLORE_SETTINGS.linksLimit,
+        languages: DEFAULT_GRAPH_EXPLORE_SETTINGS.languages,
+        includeInferred: DEFAULT_GRAPH_EXPLORE_SETTINGS.includeInferred,
+        sameAsState: DEFAULT_GRAPH_EXPLORE_SETTINGS.sameAs,
+      });
+    });
+
+    it('should map the response links to GraphExploreLink instances', async () => {
+      // GIVEN: the rest service returns links.
+      loadGraphSpy.mockResolvedValue([
+        {source: 'urn:a', target: 'urn:b', predicates: ['urn:p1', 'urn:p2'], rawPredicates: ['p1', 'p2']},
+        {source: 'urn:b', target: 'urn:c', predicates: ['urn:p3'], rawPredicates: ['p3']},
+      ]);
+
+      // WHEN: the graph is loaded.
+      const links = await graphExploreService.loadGraphForQuery(QUERY, true, false);
+
+      // THEN: each link is mapped to a GraphExploreLink carrying the full predicate IRIs.
+      expect(links).toHaveLength(2);
+      expect(links[0]).toBeInstanceOf(GraphExploreLink);
+      expect(links[0].source).toBe('urn:a');
+      expect(links[0].target).toBe('urn:b');
+      expect(links[0].predicates).toEqual(['urn:p1', 'urn:p2']);
+      expect(links[0].rawPredicates).toEqual(['p1', 'p2']);
+      expect(links[1].predicates).toEqual(['urn:p3']);
+      expect(links[1].rawPredicates).toEqual(['p3']);
+    });
+
+    it('should return an empty list when the response has no links', async () => {
+      // GIVEN: the rest service returns no links.
+      loadGraphSpy.mockResolvedValue([]);
+
+      // WHEN: the graph is loaded.
+      const links = await graphExploreService.loadGraphForQuery(QUERY, false, false);
+
+      // THEN: the result is an empty list.
+      expect(links).toHaveLength(0);
+    });
+  });
+});

--- a/packages/api/src/services/domain/security/auth-strategies/tests/openid-auth-strategy.spec.ts
+++ b/packages/api/src/services/domain/security/auth-strategies/tests/openid-auth-strategy.spec.ts
@@ -177,7 +177,7 @@ describe('OpenidAuthProvider', () => {
 
       await strategy.initialize();
 
-      expect(window.singleSpa.navigateToUrl).toHaveBeenCalledWith('/repositories');
+      expect(window.singleSpa.navigateToUrl).toHaveBeenCalledWith('http://localhost/repositories');
       expect(openidStorageService.getReturnUrl().getValue()).toBeNull();
     });
 

--- a/packages/api/src/services/domain/security/test/authentication.service.spec.ts
+++ b/packages/api/src/services/domain/security/test/authentication.service.spec.ts
@@ -60,7 +60,8 @@ describe('AuthenticationService', () => {
       get: jest.fn()
     },
     location: {
-      pathname: '/home'
+      pathname: '/home',
+      origin: 'http://localhost'
     },
     getLocationPathname: jest.fn(),
     singleSpa: {
@@ -74,6 +75,7 @@ describe('AuthenticationService', () => {
     securityContextService.updateSecurityConfig(securityConfig);
     securityContextService.updateIsLoggedIn(false);
     jest.spyOn(WindowService, 'getWindow').mockReturnValue(windowMock);
+    jest.spyOn(WindowService, 'getBaseHref').mockReturnValue('/');
     jest.spyOn(service(AuthStrategyResolver), 'getAuthStrategy').mockReturnValue(undefined);
 
     authService = new AuthenticationService();

--- a/packages/api/src/services/utils/routing-utils.ts
+++ b/packages/api/src/services/utils/routing-utils.ts
@@ -1,4 +1,5 @@
 import {WindowService} from '../window';
+import {ObjectUtil} from './object-util';
 
 /**
  * Redirects the current page to a specified URL using the single-spa framework.
@@ -19,16 +20,37 @@ export function navigateTo(url: string): (event?: Event) => void {
  * Navigates to the specified URL using the single-spa framework.
  * Suitable for in-code navigation. If you need to navigate from a view, use <code>navigateTo</code> instead.
  * @param targetUrl - The target URL to which the page should be redirected.
+ * @param queryParams - Optional query parameters to append to the URL. Nullish values are skipped.
  */
-export function navigate(targetUrl: string) {
+export function navigate(targetUrl: string, queryParams?: Record<string, unknown>) {
   let url = targetUrl;
-  if (url.startsWith('.')) {
-    url = url.slice(1);
-  }
   if (url.startsWith('/') && !url.startsWith(getBasePath())) {
     url = getBasePath().slice(0, -1) + url;
   }
-  WindowService.navigateSingleSpa(url);
+  WindowService.navigateSingleSpa(buildUrl(url, queryParams));
+}
+
+/**
+ * Appends query parameters to a URL. Nullish values are skipped and remaining values are stringified.
+ * Existing query parameters are preserved and merged (a duplicate key is overwritten with the new value),
+ * and any URL fragment (<code>#hash</code>) is kept at the end where it belongs.
+ *
+ * @param url - The base URL to append the query parameters to.
+ * @param queryParams - The query parameters to append.
+ * @returns The URL with the query parameters appended, as an absolute URL.
+ */
+export function buildUrl(url: string, queryParams?: Record<string, unknown>): string {
+  const parsedUrl = new URL(url, getOrigin());
+
+  if (queryParams) {
+    Object.entries(queryParams).forEach(([key, value]) => {
+      if (!ObjectUtil.isNullOrUndefined(value)) {
+        parsedUrl.searchParams.set(key, String(value));
+      }
+    });
+  }
+
+  return parsedUrl.toString();
 }
 
 /**

--- a/packages/api/src/services/utils/test/routing-utils.spec.ts
+++ b/packages/api/src/services/utils/test/routing-utils.spec.ts
@@ -1,5 +1,5 @@
 import {WindowService} from '../../window';
-import {navigate, navigateTo} from '../routing-utils';
+import {navigate, navigateTo, buildUrl} from '../routing-utils';
 
 describe('Routing Util Functions', () => {
 
@@ -10,15 +10,52 @@ describe('Routing Util Functions', () => {
     });
 
     it('should remove leading dot from the URL before navigation', () => {
-      navigate('.graphs');
-      expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith('graphs');
+      navigate('./graphs');
+      expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith('http://localhost/graphs');
     });
 
-    it('should add context path to the URL before navigation', () => {
-      jest.spyOn(WindowService, 'getBaseHref').mockReturnValue('contextName/');
+    it('should add context path to the URL when the url is absolute', () => {
+      jest.spyOn(WindowService, 'getBaseHref').mockReturnValue('/contextName/');
 
       navigate('/graphs');
-      expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith('contextName/graphs');
+      expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith('http://localhost/contextName/graphs');
+    });
+
+    it('should append query parameters, stringifying values and skipping nullish ones', () => {
+      navigate('reactodia', {query: 'select *', inference: true, sameAs: false, config: undefined, owner: null});
+      expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith('http://localhost/reactodia?query=select+*&inference=true&sameAs=false');
+    });
+
+    it('should merge query parameters into a URL that already has a query string', () => {
+      navigate('reactodia?embedded=true', {query: 'x'});
+      expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith('http://localhost/reactodia?embedded=true&query=x');
+    });
+
+    it('should include the context path exactly once when deployed behind a reverse proxy', () => {
+      // A reverse proxy serves the Workbench under a context path exposed via the <base> href.
+      jest.spyOn(WindowService, 'getBaseHref').mockReturnValue('/graphdb/');
+
+      navigate('reactodia', {query: 'select *', inference: true});
+      expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith('http://localhost/graphdb/reactodia?query=select+*&inference=true');
+    });
+  });
+
+  describe('buildUrl', () => {
+    it('should return the URL unchanged when no params are provided', () => {
+      expect(buildUrl('reactodia')).toBe('http://localhost/reactodia');
+    });
+
+    it('should return the URL unchanged when all params are nullish', () => {
+      expect(buildUrl('reactodia', {config: undefined, owner: null})).toBe('http://localhost/reactodia');
+    });
+
+    it('should append params, stringifying values and skipping nullish ones', () => {
+      expect(buildUrl('reactodia', {query: 'select *', inference: true, sameAs: false, config: undefined, owner: null}))
+        .toBe('http://localhost/reactodia?query=select+*&inference=true&sameAs=false');
+    });
+
+    it('should merge params into a URL that already has a query string', () => {
+      expect(buildUrl('reactodia?embedded=true', {query: 'x'})).toBe('http://localhost/reactodia?embedded=true&query=x');
     });
   });
 
@@ -32,7 +69,7 @@ describe('Routing Util Functions', () => {
       const event = { preventDefault: jest.fn() } as unknown as Event;
       navigateTo('/graphs')(event);
       expect(event.preventDefault).toHaveBeenCalled();
-      expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith('/graphs');
+      expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith('http://localhost/graphs');
     });
   });
 });

--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -748,8 +748,8 @@ function GraphsVisualizationsCtrl(
 
     const loadGraphForQuery = (queryString, sameAsParam, inferredParam) => {
         const settings = getSettings();
-        const sendSameAs = (sameAsParam === undefined) ? (settings['sameAsState']) : sameAsParam === true;
-        const sendInferred = (inferredParam === undefined) ? (settings['includeInferred']) : inferredParam === true;
+        const sendSameAs = (sameAsParam === undefined) ? (settings['sameAsState']) : sameAsParam === 'true';
+        const sendInferred = (inferredParam === undefined) ? (settings['includeInferred']) : inferredParam === 'true';
         $scope.loading = true;
         GraphDataRestService.updateGraph({
             query: queryString,

--- a/packages/legacy-workbench/src/js/angular/sparql-editor/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/sparql-editor/controllers.js
@@ -18,7 +18,7 @@ import 'angular/core/services/event-emitter-service';
 import {LoggerProvider} from '../core/services/logger-provider';
 import {
     ParentWindowMessageService,
-    navigateTo,
+    navigate,
     openInNewTab,
     LanguageContextService,
     ServiceProvider,
@@ -50,7 +50,6 @@ angular
     .controller('SparqlEditorCtrl', SparqlEditorCtrl);
 
 SparqlEditorCtrl.$inject = [
-    '$rootScope',
     '$scope',
     '$q',
     '$location',
@@ -67,8 +66,7 @@ SparqlEditorCtrl.$inject = [
     'LocalStorageAdapter',
     'LSKeys'];
 
-function SparqlEditorCtrl($rootScope,
-    $scope,
+function SparqlEditorCtrl($scope,
     $q,
     $location,
     $languageService,
@@ -122,7 +120,7 @@ function SparqlEditorCtrl($rootScope,
      * @param {boolean} clearYasguiState if set to true, the Yasgui will reinitialize and clear all tab results. Queries will remain.
      */
     $scope.updateConfig = (clearYasguiState) => {
-        const yasrToolbarPlugins = $scope.embedded ? [] : [exploreVisualGraphYasrToolbarElementBuilder];
+        const yasrToolbarPlugins = $scope.embedded ? [] : [exploreVisualGraphYasrToolbarElementBuilder, exploreReactodiaYasrToolbarElementBuilder];
         const yasguiConfig = {
             endpoint: getEndpoint,
             componentId: VIEW_SPARQL_EDITOR,
@@ -363,20 +361,20 @@ function SparqlEditorCtrl($rootScope,
             paramsToParse.config = visGraphConfigId;
         }
 
-        const navigate = function() {
-            $location.path('graphs-visualizations').search(paramsToParse);
-        };
-        // This button is embedded in the Yasr toolbar, which is outside the Angular context, so we need to
-        // manually trigger the navigation inside the Angular context. Otherwise, the navigation will be
-        // triggered on the next digest cycle that might never happen. In our case there is a constant server
-        // polling that triggers the digest cycle, so the navigation will be triggered, but it can lead to a
-        // noticeable delay. By manually triggering the navigation inside the Angular context, we ensure that
-        // the navigation is triggered immediately.
-        if ($scope.$$phase || $rootScope.$$phase) {
-            navigate();
-        } else {
-            $scope.$apply(navigate);
-        }
+        navigate('graphs-visualizations', paramsToParse);
+    };
+
+    /**
+     * Navigates to the Reactodia visualization page, passing the current query.
+     *
+     * @param yasr - YASR result renderer instance containing the current query context.
+     */
+    const navigateToReactodia = (yasr) => {
+        navigate('reactodia', {
+            query: yasr.yasqe.getValue(),
+            sameAs: yasr.yasqe.getSameAs(),
+            inference: yasr.yasqe.getInfer(),
+        });
     };
 
     /**
@@ -434,6 +432,38 @@ function SparqlEditorCtrl($rootScope,
             if (element._exploreVisualGraphHandler) {
                 element.removeEventListener('graphExplore', element._exploreVisualGraphHandler);
             }
+            element.remove();
+        },
+    };
+
+    /**
+     * Factory for the YASR toolbar element that opens the current query in Reactodia.
+     */
+    const exploreReactodiaYasrToolbarElementBuilder = {
+        createElement: (yasr) => {
+            const exploreReactodiaButton = document.createElement('button');
+            exploreReactodiaButton.type = 'button';
+            exploreReactodiaButton.classList.add('btn', 'btn-primary', 'explore-reactodia');
+            exploreReactodiaButton.textContent = $translate.instant('query.editor.reactodia.btn');
+            exploreReactodiaButton.addEventListener('click', () => navigateToReactodia(yasr));
+            return exploreReactodiaButton;
+        },
+        updateElement: (element, yasr) => {
+            element.classList.add('hidden');
+            if (!yasr.hasResults()) {
+                return;
+            }
+            const queryType = yasr.yasqe.getQueryType();
+
+            if (QueryType.CONSTRUCT === queryType || QueryType.DESCRIBE === queryType) {
+                element.classList.remove('hidden');
+            }
+        },
+        getOrder: () => {
+            return 3;
+        },
+
+        destroy(element) {
             element.remove();
         },
     };
@@ -678,6 +708,7 @@ function SparqlEditorCtrl($rootScope,
         });
     });
 
+    let pendingReplayTimer = null;
     const locationChangeHandler = (eventPayload) => {
         if (internallyReloaded || skipLocationChangeHandler) {
             internallyReloaded = false;
@@ -691,8 +722,9 @@ function SparqlEditorCtrl($rootScope,
         const handler = () => {
             skipLocationChangeHandler = true;
             // Use setTimeout to ensure that the navigation is triggered after the current call stack is cleared.
-            setTimeout(() => {
-                navigateTo(newUrl)();
+            // Cancel it on destroy to avoid re-navigation in the timeout, after the component has been destroyed
+            pendingReplayTimer = setTimeout(() => {
+                navigate(newUrl);
             });
         };
         confirmAbortQueries('view.sparql-editor.leave_page.run_queries.confirmation', handler, handler);
@@ -703,6 +735,7 @@ function SparqlEditorCtrl($rootScope,
     );
 
     const removeAllListeners = () => {
+        clearTimeout(pendingReplayTimer);
         subscriptions.forEach((subscription) => subscription());
         window.removeEventListener('beforeunload', beforeunloadHandler);
     };

--- a/packages/shared-components/cypress/e2e/header/header.cy.js
+++ b/packages/shared-components/cypress/e2e/header/header.cy.js
@@ -159,7 +159,7 @@ describe('Header', () => {
       // When, I click it
       HeaderSteps.clickLoginButton();
       // Then, I should still not see the search
-      BaseSteps.getRedirectUrl().should('have.text', 'redirect to login?r=pages%252Fheader%252Findex.html')
+      BaseSteps.verifyRedirectUrl('login?r=pages%252Fheader%252Findex.html')
 
       // When I deactivate free access
       HeaderSteps.deactivateFreeAccess();

--- a/packages/shared-components/cypress/e2e/license-alert/license-alert.cy.js
+++ b/packages/shared-components/cypress/e2e/license-alert/license-alert.cy.js
@@ -9,6 +9,6 @@ describe('LicenseAlert', () => {
     LicenseAlertSteps.getLicenseAlert().should('be.visible').click();
 
     // Then, I should be redirected to /license
-    LicenseAlertSteps.getRedirectUrl().should('have.text', 'redirect to license');
+    LicenseAlertSteps.verifyRedirectUrl('license');
   });
 });

--- a/packages/shared-components/cypress/e2e/operations-notification/operations-notification.cy.js
+++ b/packages/shared-components/cypress/e2e/operations-notification/operations-notification.cy.js
@@ -12,10 +12,12 @@ const assertRedirectLink = (index, textValue) => {
   OperationsNotificationSteps.getDropdownButton().click();
   OperationsNotificationSteps.getOperationsDropdownElements().eq(index).click();
 
-  OperationsNotificationSteps.getRedirectUrl()
-    .last()
-    .invoke('text')
-    .should('equal', `redirect to ${textValue}`);
+  cy.location('origin').then((origin) => {
+    OperationsNotificationSteps.getRedirectUrl()
+      .last()
+      .invoke('text')
+      .should('equal', `redirect to ${origin}/${textValue}`);
+  });
 }
 
 describe('onto-operations-notification', () => {

--- a/packages/shared-components/cypress/e2e/rdf-search/rdf-search.cy.js
+++ b/packages/shared-components/cypress/e2e/rdf-search/rdf-search.cy.js
@@ -67,7 +67,7 @@ describe('RDF Search', () => {
     // Then, I expect to not see the notification anymore
     RdfSearchSteps.getToastNotification().should('not.exist');
     // And, I expect to have been redirected to the setup page
-    RdfSearchSteps.getRedirectUrl().should('have.text', `redirect to autocomplete`);
+    RdfSearchSteps.verifyRedirectUrl('autocomplete');
 
     // When, I enable autocomplete
     RdfSearchSteps.enableAutocomplete();

--- a/packages/shared-components/cypress/e2e/user-menu/user-menu.cy.js
+++ b/packages/shared-components/cypress/e2e/user-menu/user-menu.cy.js
@@ -46,7 +46,7 @@ describe('User Menu', () => {
     UserMenuSteps.selectDropdownItem(0)
 
     // Then I should be redirected to the My Settings page
-    UserMenuSteps.getRedirectUrl().should('have.text', `redirect to settings`);
+    UserMenuSteps.verifyRedirectUrl('settings');
     // And the dropdown should be closed
     UserMenuSteps.getDropdown().should('not.exist');
   });

--- a/packages/shared-components/cypress/steps/base-steps.js
+++ b/packages/shared-components/cypress/steps/base-steps.js
@@ -11,6 +11,14 @@ export class BaseSteps {
     return cy.get('.redirect-url');
   }
 
+  static verifyRedirectUrl(path) {
+    const origin = Cypress.config('baseUrl').replace(/\/$/, '');
+    cy.document().then((document) => {
+      const basePath = document.querySelector('base')?.getAttribute('href') ?? '/';
+      this.getRedirectUrl().should('have.text', `redirect to ${origin}${basePath}${path}`);
+    });
+  }
+
   static reloadPage(force = false) {
     cy.reload(force);
   }

--- a/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.ts
+++ b/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.ts
@@ -1,6 +1,6 @@
 import {Component, computed, CUSTOM_ELEMENTS_SCHEMA, input} from '@angular/core';
 import {defineCustomElements} from 'graphwise-reactodia/loader';
-import {Rdf4jRepositoryService, service} from '@ontotext/workbench-api';
+import {GraphExploreLink, Rdf4jRepositoryService, service} from '@ontotext/workbench-api';
 import {LoggerProvider} from '../../services/logger/logger-provider';
 
 /**
@@ -41,6 +41,12 @@ export class ReactodiaComponentFacadeComponent {
   readonly language = input<string>();
   /** The resource IRIs the diagram starts from (Reactodia's `seed`). */
   readonly seedIris = input<string[]>([]);
+  /**
+   * Pre-resolved edges to place on the canvas (Reactodia's `seedGraph`). Used for query-driven
+   * graphs (e.g. CONSTRUCT results) whose links are not persisted in the repository and therefore
+   * cannot be resolved lazily from the SPARQL endpoint.
+   */
+  readonly seedGraph = input<GraphExploreLink[]>([]);
 
   /**
    * Transport for Reactodia's SPARQL requests. Reactodia chooses the `Accept` per query
@@ -55,6 +61,7 @@ export class ReactodiaComponentFacadeComponent {
 
   readonly config = computed(() => ({
     queryFunction: this.queryFunction,
-    seedIris: this.seedIris()
+    seedIris: this.seedIris(),
+    seedGraph: this.seedGraph()
   }));
 }

--- a/packages/workbench/src/app/pages/reactodia/reactodia-page.component.html
+++ b/packages/workbench/src/app/pages/reactodia/reactodia-page.component.html
@@ -1,10 +1,11 @@
 <app-page-layout class="sparql-editor-page">
   <div>
-    @if (language() && currentRepository()) {
+    @if (language() && currentRepository() && !loading()) {
       <app-reactodia-component-facade
         [currentRepository]="currentRepository()"
         [language]="language()"
-        [seedIris]="seedIris()">
+        [seedIris]="seedIris()"
+        [seedGraph]="seedGraph()">
       </app-reactodia-component-facade>
     }
   </div>

--- a/packages/workbench/src/app/pages/reactodia/reactodia-page.component.spec.ts
+++ b/packages/workbench/src/app/pages/reactodia/reactodia-page.component.spec.ts
@@ -2,24 +2,31 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {ReactodiaPageComponent} from './reactodia-page.component';
 import {provideTranslocoForTesting} from '../../../testing-utils/transloco-utils';
-import {LanguageContextService, ServiceProvider} from '@ontotext/workbench-api';
-import {provideRouter} from '@angular/router';
+import {GraphExploreLink, GraphExploreService, LanguageContextService, ServiceProvider} from '@ontotext/workbench-api';
+import {ActivatedRoute} from '@angular/router';
 
 jest.mock('graphwise-reactodia/loader', () => ({
   defineCustomElements: jest.fn()
 }));
 
 describe('ReactodiaPageComponent', () => {
+  const QUERY = 'CONSTRUCT WHERE { ?s ?p ?o }';
   let component: ReactodiaPageComponent;
   let fixture: ComponentFixture<ReactodiaPageComponent>;
+  let loadGraphForQuerySpy: jest.SpyInstance;
+  const activatedRouteStub = {snapshot: {queryParams: {} as Record<string, string>, data: {}}};
 
   beforeEach(async () => {
+    activatedRouteStub.snapshot.queryParams = {};
+
     jest.spyOn(ServiceProvider.get(LanguageContextService), 'getSelectedLanguage')
       .mockReturnValue('en');
     jest.spyOn(ServiceProvider.get(LanguageContextService), 'onSelectedLanguageChanged')
       .mockImplementation(() => () => {
         // No-op subscription that doesn't call the callback immediately.
       });
+    loadGraphForQuerySpy = jest.spyOn(ServiceProvider.get(GraphExploreService), 'loadGraphForQuery')
+      .mockResolvedValue([]);
 
     await TestBed.configureTestingModule({
       imports: [
@@ -27,7 +34,7 @@ describe('ReactodiaPageComponent', () => {
         provideTranslocoForTesting()
       ],
       providers: [
-        provideRouter([])
+        {provide: ActivatedRoute, useValue: activatedRouteStub}
       ],
       schemas: [NO_ERRORS_SCHEMA]
     })
@@ -35,10 +42,86 @@ describe('ReactodiaPageComponent', () => {
 
     fixture = TestBed.createComponent(ReactodiaPageComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  describe('seeding the graph from query params', () => {
+    it('should not load a graph when no query param is present', () => {
+      // GIVEN: no query param.
+      activatedRouteStub.snapshot.queryParams = {};
+
+      // WHEN: the page initializes.
+      fixture.detectChanges();
+
+      // THEN: no graph is requested.
+      expect(loadGraphForQuerySpy).not.toHaveBeenCalled();
+    });
+
+    it('should pass undefined for a missing flag so the service applies its defaults', () => {
+      // GIVEN: a query without inference/sameAs params.
+      activatedRouteStub.snapshot.queryParams = {query: QUERY};
+
+      // WHEN: the page initializes.
+      fixture.detectChanges();
+
+      // THEN: the flags are undefined, letting the service fall back to its defaults.
+      expect(loadGraphForQuerySpy).toHaveBeenCalledWith(QUERY, undefined, undefined);
+    });
+
+    it('should treat an empty flag as undefined rather than forcing it off', () => {
+      // GIVEN: bare inference/sameAs params (present in the URL but without a value).
+      activatedRouteStub.snapshot.queryParams = {query: QUERY, inference: '', sameAs: ''};
+
+      // WHEN: the page initializes.
+      fixture.detectChanges();
+
+      // THEN: the empty flags resolve to undefined, not false.
+      expect(loadGraphForQuerySpy).toHaveBeenCalledWith(QUERY, undefined, undefined);
+    });
+
+    it('should pass false when a flag is explicitly "false"', () => {
+      // GIVEN: inference/sameAs explicitly set to false.
+      activatedRouteStub.snapshot.queryParams = {query: QUERY, inference: 'false', sameAs: 'false'};
+
+      // WHEN: the page initializes.
+      fixture.detectChanges();
+
+      // THEN: the explicit false is forwarded.
+      expect(loadGraphForQuerySpy).toHaveBeenCalledWith(QUERY, false, false);
+    });
+
+    it('should pass true when a flag is explicitly "true"', () => {
+      // GIVEN: inference/sameAs explicitly set to true.
+      activatedRouteStub.snapshot.queryParams = {query: QUERY, inference: 'true', sameAs: 'true'};
+
+      // WHEN: the page initializes.
+      fixture.detectChanges();
+
+      // THEN: the explicit true is forwarded.
+      expect(loadGraphForQuerySpy).toHaveBeenCalledWith(QUERY, true, true);
+    });
+
+    it('should set the seed graph from the loaded links', async () => {
+      // GIVEN: the service resolves with links.
+      const links = [new GraphExploreLink({source: 'urn:a', target: 'urn:b', predicates: ['urn:p'], rawPredicates: ['p']})];
+      loadGraphForQuerySpy.mockResolvedValue(links);
+      activatedRouteStub.snapshot.queryParams = {query: QUERY};
+
+      // WHEN: the page initializes and the request settles.
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // THEN: the resolved links seed the diagram and loading is cleared.
+      expect(component.seedGraph()).toEqual(links);
+      expect(component.loading()).toBe(false);
+    });
   });
 });

--- a/packages/workbench/src/app/pages/reactodia/reactodia-page.component.ts
+++ b/packages/workbench/src/app/pages/reactodia/reactodia-page.component.ts
@@ -1,6 +1,8 @@
 import {Component, inject, OnDestroy, OnInit, signal} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
 import {
+  GraphExploreLink,
+  GraphExploreService,
   LanguageContextService,
   RepositoryContextService,
   service,
@@ -10,6 +12,7 @@ import {
   ReactodiaComponentFacadeComponent
 } from '../../components/reactodia-component-facade/reactodia-component-facade.component';
 import {PageLayoutComponent} from '../../components/page-layout/page-layout.component';
+import {LoggerProvider} from '../../services/logger/logger-provider';
 
 /**
  * Page that hosts the Reactodia graph. It owns the context subscriptions (repository and language),
@@ -30,17 +33,22 @@ import {PageLayoutComponent} from '../../components/page-layout/page-layout.comp
 export class ReactodiaPageComponent implements OnInit, OnDestroy {
   private readonly repositoryContextService = service(RepositoryContextService);
   private readonly languageContextService = service(LanguageContextService);
+  private readonly graphExploreService = service(GraphExploreService);
   private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly logger = LoggerProvider.logger;
 
   private readonly subscriptions = new SubscriptionList();
 
   readonly currentRepository = signal('');
   readonly language = signal(this.languageContextService.getSelectedLanguage());
   readonly seedIris = signal<string[]>([]);
+  readonly seedGraph = signal<GraphExploreLink[]>([]);
+  readonly loading = signal(false);
 
   ngOnInit(): void {
     this.initSubscriptions();
     this.initSeedFromQueryParams();
+    this.initSeedGraphFromQueryParams();
   }
 
   private initSubscriptions() {
@@ -75,5 +83,38 @@ export class ReactodiaPageComponent implements OnInit, OnDestroy {
   private initSeedFromQueryParams(): void {
     const uri = this.activatedRoute.snapshot.queryParams['uri'];
     this.seedIris.set(uri ? [uri] : []);
+  }
+
+  /**
+   * Reads the `query` param (a SPARQL query, e.g. a CONSTRUCT sent from the SPARQL editor) together
+   * with the `sameAs`/`inference` flags, computes its graph and forwards the resulting edges as the
+   * `seedGraph` for the diagram. When no `query` is provided, the diagram is not seeded this way.
+   */
+  private initSeedGraphFromQueryParams(): void {
+    this.loading.set(true);
+    const queryParams = this.activatedRoute.snapshot.queryParams;
+    const query = queryParams['query'];
+    if (!query) {
+      this.loading.set(false);
+      return;
+    }
+    const inference = this.toOptionalBoolean(queryParams['inference']);
+    const sameAs = this.toOptionalBoolean(queryParams['sameAs']);
+    this.graphExploreService.loadGraphForQuery(query, inference, sameAs)
+      .then((links) => this.seedGraph.set(links))
+      .catch((error) => this.logger.error('Failed to load graph for query', error))
+      .finally(() => this.loading.set(false));
+  }
+
+  /**
+   * Parses a query-param flag. Query params arrive as strings, so a value is `true` only when it is
+   * exactly `'true'`. A missing or empty value resolves to `undefined` so the caller can fall back to
+   * its default rather than forcing the flag off.
+   *
+   * @param value - The raw query-param value.
+   * @returns `true`/`false` for an explicit value, or `undefined` when the param is absent or empty.
+   */
+  private toOptionalBoolean(value: string | undefined): boolean | undefined {
+    return value ? value === 'true' : undefined;
   }
 }

--- a/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.ts
+++ b/packages/workbench/src/app/pages/sparql-editor/sparql-editor-page.component.ts
@@ -159,6 +159,32 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
       element.remove();
     }
   };
+  private readonly exploreReactodiaYasrToolbarElementBuilder: YasrToolbarPlugin = {
+    createElement: (yasr: Yasr) => {
+      const exploreReactodiaButton = document.createElement('button');
+      exploreReactodiaButton.type = 'button';
+      exploreReactodiaButton.classList.add('onto-btn', 'onto-btn-primary', 'explore-reactodia');
+      exploreReactodiaButton.textContent = this.translocoService.translate('sparql_editor.yasgui.yasr.yasr_header.toolbar.btn.reactodia_btn.label');
+      exploreReactodiaButton.addEventListener('click', () => this.navigateToReactodia(yasr));
+      return exploreReactodiaButton;
+    },
+    updateElement: (element: HTMLElement, yasr: Yasr) => {
+      element.classList.add('hidden');
+      if (!yasr.hasResults()) {
+        return;
+      }
+      const queryType = yasr.yasqe.getQueryType();
+      if (QueryType.CONSTRUCT === queryType || QueryType.DESCRIBE === queryType) {
+        element.classList.remove('hidden');
+      }
+    },
+    getOrder: () => {
+      return 3;
+    },
+    destroy(element: HTMLElement) {
+      element.remove();
+    }
+  };
   private readonly tabIdToConnectorProgressModalMapping = new Map<string, DynamicDialogRef>();
   private internallyReloaded = false;
   // This is used to determine whether the view is embedded in another application. When embedded, we want to hide
@@ -226,6 +252,21 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Navigates to the Reactodia visualization page, passing the current query.
+   *
+   * @param yasr - YASR result renderer instance containing the current query context.
+   */
+  private navigateToReactodia(yasr: Yasr) {
+    this.router.navigate(['reactodia'], {
+      queryParams: {
+        query: yasr.yasqe.getValue(),
+        sameAs: yasr.yasqe.getSameAs(),
+        inference: yasr.yasqe.getInfer(),
+      }
+    });
+  }
+
+  /**
    * Builds an event handler for graph exploration actions emitted by the `onto-graph-explore-split-button` component.
    *
    * The handler interprets the event payload and routes the user accordingly:
@@ -259,7 +300,7 @@ export class SparqlEditorPageComponent implements OnInit, OnDestroy {
     config.prefixes = this.prefixes?.namespaces;
     config.infer = this.isOntopRepo || this.inferUserSetting;
     config.sameAs = this.isOntopRepo || this.sameAsUserSetting;
-    config.yasrToolbarPlugins = this.embedded ? [] : [this.exploreVisualGraphYasrToolbarElementBuilder];
+    config.yasrToolbarPlugins = this.embedded ? [] : [this.exploreVisualGraphYasrToolbarElementBuilder, this.exploreReactodiaYasrToolbarElementBuilder];
     config.beforeUpdateQuery = (query: string, tabId: string) => this.getBeforeUpdateQueryHandler(query, tabId);
     config.outputHandlers = {
       [EventDataType.QUERY_EXECUTED]: (event: QueryExecutedEvent) => this.queryExecutedHandler(event),

--- a/packages/workbench/src/assets/i18n/en.json
+++ b/packages/workbench/src/assets/i18n/en.json
@@ -151,7 +151,10 @@
           "toolbar": {
             "btn": {
               "visual_graph_btn": {
-                "label": "Visualize"
+                "label": "VizGraph"
+              },
+              "reactodia_btn": {
+                "label": "Visualize Reactodia"
               }
             }
           }

--- a/packages/workbench/src/assets/i18n/fr.json
+++ b/packages/workbench/src/assets/i18n/fr.json
@@ -151,7 +151,10 @@
           "toolbar": {
             "btn": {
               "visual_graph_btn": {
-                "label": "Visualiser"
+                "label": "VizGraph "
+              },
+              "reactodia_btn": {
+                "label": "Visualiser Reactodia"
               }
             }
           }


### PR DESCRIPTION
## What
Visualize construct queries with Reactodia.

## Why
This feature allows users to visualize the results of SPARQL `CONSTRUCT` queries directly in the Reactodia graph explorer, just like visual graph

## How
- Added a new `exploreReactodiaYasrToolbarElementBuilder` to create a button for navigating to the Reactodia visualization.
- Implemented the `navigateToReactodia` method to handle navigation with query parameters.
- Updated the `config.yasrToolbarPlugins` to include the new toolbar element.
- Created a new `GraphExploreService` to compute graphs based on SPARQL queries.
- Introduced `GraphExploreLink` and related models to manage graph data.
- Updated the `ReactodiaPageComponent` to initialize the graph based on query parameters.
- Added relevant services

## Testing
jest/cypress

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified
