### PR TITLE
GDB-14873: Update GraphQL Endpoint Management for Users with MANAGE_REPO Permissions

### DIFF
--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -1094,7 +1094,9 @@
                 }
             },
             "warnings": {
-                "unexpected_remote_repository": "The selected repository is in a remote location, and its endpoints aren’t accessible here. Select a repository from the current location."
+                "unexpected_remote_repository": "The selected repository is in a remote location, and its endpoints aren’t accessible here. Select a repository from the current location.",
+                "no_managed_repository": "Endpoints can only be created for repositories you are authorized to manage.",
+                "no_graphdb_repository": "Endpoints can only be created in GraphDB repositories. Please select a GraphDB repository to continue."
             }
         },
         "create_endpoint": {
@@ -1338,7 +1340,9 @@
                 }
             },
             "warnings": {
-                "unexpected_remote_repository": "Endpoints can only be created for repositories in the current location. Select a local repository to continue."
+                "unexpected_remote_repository": "Endpoints can only be created for repositories in the current location. Select a local repository to continue.",
+                "no_managed_repository": "Endpoints can only be created for repositories you are authorized to manage.",
+                "no_graphdb_repository": "Endpoints can only be created in GraphDB repositories. Please select a GraphDB repository to continue."
             }
         }
     },

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -1093,7 +1093,9 @@
                 }
             },
             "warnings": {
-                "unexpected_remote_repository": "Le dépôt sélectionné se trouve dans un emplacement distant et ses endpoints ne sont pas accessibles ici. Sélectionnez un dépôt de l’emplacement actuel."
+                "unexpected_remote_repository": "Le dépôt sélectionné se trouve dans un emplacement distant et ses endpoints ne sont pas accessibles ici. Sélectionnez un dépôt de l’emplacement actuel.",
+                "no_managed_repository": "Les points de terminaison ne peuvent être créés que pour les référentiels que vous êtes autorisé à gérer.",
+                "no_graphdb_repository": "Les endpoints ne peuvent être créés que dans des référentiels GraphDB. Veuillez sélectionner un référentiel GraphDB pour continuer."
             }
         },
         "create_endpoint": {
@@ -1337,7 +1339,9 @@
                 }
             },
             "warnings": {
-                "unexpected_remote_repository": "Les endpoints ne peuvent être créés que pour les dépôts situés dans l’emplacement actuel. Sélectionnez un dépôt local pour continuer."
+                "unexpected_remote_repository": "Les endpoints ne peuvent être créés que pour les dépôts situés dans l’emplacement actuel. Sélectionnez un dépôt local pour continuer.",
+                "no_managed_repository": "Les points de terminaison ne peuvent être créés que pour les référentiels que vous êtes autorisé à gérer.",
+                "no_graphdb_repository": "Les endpoints ne peuvent être créés que dans des référentiels GraphDB. Veuillez sélectionner un référentiel GraphDB pour continuer."
             }
         }
     },

--- a/packages/legacy-workbench/src/js/angular/core/directives.js
+++ b/packages/legacy-workbench/src/js/angular/core/directives.js
@@ -1,6 +1,14 @@
 import 'angular/utils/local-storage-adapter';
 import {decodeHTML} from "../../../app";
-import {service, LicenseContextService, ResourceSearchStorageService, Suggestion, GuidesService} from '@ontotext/workbench-api';
+import {
+    Authority,
+    AuthorizationService,
+    service,
+    LicenseContextService,
+    ResourceSearchStorageService,
+    Suggestion,
+    GuidesService,
+} from '@ontotext/workbench-api';
 
 angular
     .module('graphdb.framework.core.directives', [
@@ -115,6 +123,12 @@ function coreErrors($timeout, $location) {
         transclude: true,
         templateUrl: 'js/angular/core/templates/core-errors.html',
         link: function(scope, element, attrs) {
+            const authorizationService = service(AuthorizationService);
+
+            const canManageRepositoryFilter = Authority.ROLE_MANAGE_REPO === attrs.role ? (repo) => authorizationService.canManageRepo(repo) : () => true;
+            const filterByType = attrs.filterByType?.split(',');
+            const filterByTypeFilter = (repo) => !filterByType || filterByType.includes(repo.type);
+
             // watch for changes in the active repository hide host element of this directive
             scope.$watch('getActiveRepository()', function(newValue) {
                 if (newValue && !scope.isRestricted) {
@@ -146,11 +160,12 @@ function coreErrors($timeout, $location) {
                 if (!scope.showRemoteLocations) {
                     remoteLocationsFilter = (repo) => repo.local;
                 }
-                if (scope.isRestricted) {
-                    return scope.getWritableRepositories().filter(remoteLocationsFilter);
-                } else {
-                    return scope.getReadableRepositories().filter(remoteLocationsFilter);
-                }
+
+                const repositories = scope.isRestricted ? scope.getWritableRepositories() : scope.getReadableRepositories();
+                return repositories
+                    .filter(remoteLocationsFilter)
+                    .filter(canManageRepositoryFilter)
+                    .filter(filterByTypeFilter);
             };
 
             scope.showPopoverForRepo = function(event, repository) {

--- a/packages/legacy-workbench/src/js/angular/graphql/controllers/create-graphql-endpoint-view.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphql/controllers/create-graphql-endpoint-view.controller.js
@@ -12,7 +12,12 @@ import 'angular/graphql/directives/configure-endpoint.directive';
 import 'angular/graphql/directives/generate-endpoint.directive';
 import {GraphqlEventName} from "../services/graphql-context.service";
 import {resolvePlaygroundUrlWithEndpoint} from "../services/endpoint-utils";
-import {RepositoryContextService, service} from '@ontotext/workbench-api';
+import {
+    RepositoryContextService,
+    RepositoryType,
+    service,
+    AuthorizationService,
+} from '@ontotext/workbench-api';
 
 const modules = [
     'graphdb.framework.core.services.graphql-service',
@@ -34,6 +39,7 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
     // =========================
 
     const repositoryContextService = service(RepositoryContextService);
+    const authorizationService = service(AuthorizationService);
 
     const subscriptions = [];
 
@@ -84,6 +90,26 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
      * @type {boolean}
      */
     $scope.isSelectedRepositoryLocal = false;
+
+    /**
+     * A flag indicating whether the selected repository is of type 'graphdb'
+     * @type {boolean}
+     */
+    $scope.isGraphDBRepository = false;
+
+    /**
+     * A flag indicating if user can manage the selected repository.
+     * @type {boolean}
+     */
+    $scope.canManageSelectedRepository = false;
+
+    /**
+     * A flag indicating if there is a selected repository.
+     * @type {boolean}
+     */
+    $scope.hasSelectedRepository = false;
+
+    $scope.RepositoryType = RepositoryType;
 
     // =========================
     // Public methods
@@ -284,16 +310,22 @@ function CreateGraphqlEndpointViewCtrl($scope, $location, $repositories, $transl
      */
     const setupSourceRepositories = () => {
         $scope.sourceRepositories = $repositories.getRepositoriesAsSelectMenuOptions(
-            () => $repositories.getLocalReadableGraphdbRepositories(),
+            () => $repositories.getLocalReadableGraphdbRepositories()
+                .filter((repository) => authorizationService.canManageRepo(repository)),
         );
         const activeRepository = repositoryContextService.getSelectedRepository();
+        $scope.hasSelectedRepository = !!activeRepository;
         $scope.isSelectedRepositoryLocal = !!activeRepository?.local;
+        $scope.isGraphDBRepository = RepositoryType.GRAPH_DB === activeRepository.type;
         // Graphql endpoints can't be created on remote repositories.
         if ($scope.isSelectedRepositoryLocal) {
             $scope.selectedSourceRepository = $scope.sourceRepositories
                 .find((repo) => repo.value === activeRepository.id);
-            GraphqlContextService.updateSourceRepository($scope.selectedSourceRepository.value);
+            GraphqlContextService.updateSourceRepository($scope.selectedSourceRepository?.value);
             $scope.previousSelectedSourceRepository = $scope.selectedSourceRepository;
+
+            // Sets a flag indicating whether the user has management permissions for the selected repository.
+            $scope.canManageSelectedRepository = $scope.hasSelectedRepository && authorizationService.canManageRepo(activeRepository);
         }
     };
 

--- a/packages/legacy-workbench/src/js/angular/graphql/controllers/graphql-endpoint-management-view.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphql/controllers/graphql-endpoint-management-view.controller.js
@@ -8,7 +8,12 @@ import {resolvePlaygroundUrlWithEndpoint} from "../services/endpoint-utils";
 import {saveAs} from 'lib/FileSaver-patch';
 import {GraphqlEndpointInfo} from "../../models/graphql/graphql-endpoints-info";
 import {LoggerProvider} from "../../core/services/logger-provider";
-import {RepositoryContextService, service} from '@ontotext/workbench-api';
+import {
+    AuthorizationService,
+    RepositoryContextService,
+    RepositoryType,
+    service,
+} from '@ontotext/workbench-api';
 
 const logger = LoggerProvider.logger;
 const modules = [
@@ -52,6 +57,7 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
      */
     const ENDPOINTS_INFO_POLLING_INTERVAL = 5000;
     const repositoryContextService = service(RepositoryContextService);
+    const authorizationService = service(AuthorizationService);
 
     // =========================
     // Public variables
@@ -122,6 +128,20 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
      * @type {boolean}
      */
     $scope.isSelectedRepositoryLocal = false;
+
+    /**
+     * A flag indicating whether the selected repository is of type 'graphdb'
+     * @type {boolean}
+     */
+    $scope.isGraphDBRepository = false;
+
+    /**
+     * A flag indicating if user can manage the selected repository.
+     * @type {boolean}
+     */
+    $scope.canManageSelectedRepository = false;
+
+    $scope.RepositoryType = RepositoryType;
 
     // =========================
     // Public methods
@@ -369,6 +389,9 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
      */
     const getSelectedRepositoryChangeHandler = (repositoryObject) => {
         if (!repositoryObject) {
+            $scope.isSelectedRepositoryLocal = false;
+            $scope.isGraphDBRepository = false;
+            $scope.canManageSelectedRepository = false;
             return;
         }
         // Close any open dialogs before reloading repository-specific data. Dialogs are tied to the currently selected
@@ -377,6 +400,8 @@ function GraphqlEndpointManagementViewCtrl($scope, $location, $interval, $reposi
         // This can occur when a dialog is open and the repository is changed from another browser tab.
         closeDialogs();
         $scope.isSelectedRepositoryLocal = repositoryObject.local;
+        $scope.isGraphDBRepository = RepositoryType.GRAPH_DB === repositoryObject.type;
+        $scope.canManageSelectedRepository = authorizationService.canManageRepo(repositoryObject);
         if ($scope.isSelectedRepositoryLocal) {
             onInit();
         }

--- a/packages/legacy-workbench/src/js/angular/graphql/plugin.js
+++ b/packages/legacy-workbench/src/js/angular/graphql/plugin.js
@@ -46,7 +46,7 @@ PluginRegistry.add('main.menu', {
             labelKey: 'menu.graphql-endpoint-management.label',
             href: 'graphql/endpoints',
             order: 10,
-            role: 'ROLE_REPO_MANAGER',
+            role: 'ROLE_MANAGE_REPO',
             parent: 'GraphQL',
             children: [
                 {

--- a/packages/legacy-workbench/src/js/angular/graphql/templates/create-graphql-endpoint.html
+++ b/packages/legacy-workbench/src/js/angular/graphql/templates/create-graphql-endpoint.html
@@ -7,14 +7,23 @@
         <page-info-tooltip></page-info-tooltip>
     </h1>
 
-    <div class="core-errors-container" core-errors write></div>
+    <div class="core-errors-container" core-errors role="ROLE_MANAGE_REPO" filter-by-type="{{RepositoryType.GRAPH_DB}}"></div>
 
-    <div class="create-graphql-endpoint-container">
+    <div class="create-graphql-endpoint-container" ng-if="hasSelectedRepository">
+
         <div ng-if="!isSelectedRepositoryLocal" class="warnings unexpected-remote-repository-warning">
             <div class="alert alert-warning">{{'graphql.create_endpoint.warnings.unexpected_remote_repository' | translate}}</div>
         </div>
 
-        <div class="content" ng-if="selectedSourceRepository">
+        <div ng-if="!isGraphDBRepository">
+            <div class="alert alert-warning">{{'graphql.create_endpoint.warnings.no_graphdb_repository' | translate}}</div>
+        </div>
+
+        <div ng-if="!canManageSelectedRepository && isSelectedRepositoryLocal && isGraphDBRepository">
+            <div class="alert alert-warning">{{'graphql.create_endpoint.warnings.no_managed_repository' | translate}}</div>
+        </div>
+
+        <div class="content" ng-if="selectedSourceRepository && isSelectedRepositoryLocal && isGraphDBRepository && canManageSelectedRepository">
             <div class="toolbar">
                 <div class="form-inline">
                     <label

--- a/packages/legacy-workbench/src/js/angular/graphql/templates/graphql-endpoint-management.html
+++ b/packages/legacy-workbench/src/js/angular/graphql/templates/graphql-endpoint-management.html
@@ -6,7 +6,7 @@
         <page-info-tooltip></page-info-tooltip>
     </h1>
 
-    <div core-errors></div>
+    <div core-errors role="ROLE_MANAGE_REPO" filter-by-type="{{RepositoryType.GRAPH_DB}}"></div>
 
     <div onto-loader
          ng-show="loadingEndpointsInfo"
@@ -14,181 +14,191 @@
          size="100">
     </div>
 
-    <div ng-if="!isSelectedRepositoryLocal && getActiveRepository()" class="warnings unexpected-remote-repository-warning">
-        <div class="alert alert-warning">{{'graphql.endpoints_management.warnings.unexpected_remote_repository' | translate}}</div>
-    </div>
-
-    <div ng-if="isSelectedRepositoryLocal && getActiveRepository() && !loadingEndpointsInfo" class="endpoint-management-container">
-
-        <div class="toolbar">
-            <div class="endpoints-filter">
-                <input type="text" ng-if="hasEndpoints" class="form-control endpoints-filter-field"
-                       placeholder="{{'graphql.endpoints_management.toolbar.endpoints_filter.placeholder' | translate}}"
-                       ng-model="filterTerm" ng-change="onEndpointsFilter(filterTerm)" aria-label="Filter endpoints"
-                       autocomplete="off">
-            </div>
-
-            <div class="actions">
-                <button class="btn btn-primary create-endpoint-btn" ng-click="startCreateEndpointWizard()"
-                        gdb-tooltip="{{'graphql.endpoints_management.toolbar.create_endpoint.tooltip' | translate}}">
-                    <span class="icon-graphql"></span>&nbsp;
-                    <span>{{'graphql.endpoints_management.toolbar.create_endpoint.label' | translate}}</span>
-                </button>
-                <button class="btn btn-secondary import-schema-definition-btn ml-1" ng-click="importSchema()"
-                        gdb-tooltip="{{'graphql.endpoints_management.toolbar.import_schema.tooltip' | translate}}">
-                    <span class="ri-upload-2-line"></span>&nbsp;
-                    <span>{{'graphql.endpoints_management.toolbar.import_schema.label' | translate}}</span>
-                </button>
-            </div>
+    <div ng-if="getActiveRepository()">
+        <div ng-if="!isSelectedRepositoryLocal" class="warnings unexpected-remote-repository-warning">
+            <div class="alert alert-warning">{{'graphql.endpoints_management.warnings.unexpected_remote_repository' | translate}}</div>
         </div>
 
-        <div ng-if="!hasEndpoints" class="alert alert-info no-endpoints mt-2">
-            <span>{{'graphql.endpoints_management.table.messages.no_endpoints_in_repository' | translate}}</span>
+        <div ng-if="!isGraphDBRepository">
+            <div class="alert alert-warning">{{'graphql.endpoints_management.warnings.no_graphdb_repository' | translate}}</div>
         </div>
 
-        <table ng-if="hasEndpoints" class="endpoints-info-table table mt-1"
-               aria-describedby="GraphQL endpoints info table">
-            <thead>
-            <tr>
-                <th scope="col" class="toggle-col"></th>
-                <th scope="col" class="status-col"></th>
-                <th scope="col" class="endpoint-id-col">
+        <div ng-if="!canManageSelectedRepository && isSelectedRepositoryLocal && isGraphDBRepository">
+            <div class="alert alert-warning">{{'graphql.endpoints_management.warnings.no_managed_repository' | translate}}</div>
+        </div>
+
+        <div ng-if="isSelectedRepositoryLocal && !loadingEndpointsInfo && canManageSelectedRepository && isGraphDBRepository" class="endpoint-management-container">
+
+            <div class="toolbar">
+                <div class="endpoints-filter">
+                    <input type="text" ng-if="hasEndpoints" class="form-control endpoints-filter-field"
+                           placeholder="{{'graphql.endpoints_management.toolbar.endpoints_filter.placeholder' | translate}}"
+                           ng-model="filterTerm" ng-change="onEndpointsFilter(filterTerm)" aria-label="Filter endpoints"
+                           autocomplete="off">
+                </div>
+
+                <div class="actions">
+                    <button class="btn btn-primary create-endpoint-btn" ng-click="startCreateEndpointWizard()"
+                            gdb-tooltip="{{'graphql.endpoints_management.toolbar.create_endpoint.tooltip' | translate}}">
+                        <span class="icon-graphql"></span>&nbsp;
+                        <span>{{'graphql.endpoints_management.toolbar.create_endpoint.label' | translate}}</span>
+                    </button>
+                    <button class="btn btn-secondary import-schema-definition-btn ml-1" ng-click="importSchema()"
+                            gdb-tooltip="{{'graphql.endpoints_management.toolbar.import_schema.tooltip' | translate}}">
+                        <span class="ri-upload-2-line"></span>&nbsp;
+                        <span>{{'graphql.endpoints_management.toolbar.import_schema.label' | translate}}</span>
+                    </button>
+                </div>
+            </div>
+
+            <div ng-if="!hasEndpoints" class="alert alert-info no-endpoints mt-2">
+                <span>{{'graphql.endpoints_management.table.messages.no_endpoints_in_repository' | translate}}</span>
+            </div>
+
+            <table ng-if="hasEndpoints" class="endpoints-info-table table mt-1"
+                   aria-describedby="GraphQL endpoints info table">
+                <thead>
+                <tr>
+                    <th scope="col" class="toggle-col"></th>
+                    <th scope="col" class="status-col"></th>
+                    <th scope="col" class="endpoint-id-col">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.id.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.id.label' | translate}}
                     </span>
-                </th>
-                <th scope="col" class="endpoint-label-col">
+                    </th>
+                    <th scope="col" class="endpoint-label-col">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.label.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.label.label' | translate}}
                     </span>
-                </th>
-                <th scope="col" class="endpoint-is-default-col text-center">
+                    </th>
+                    <th scope="col" class="endpoint-is-default-col text-center">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.is_default.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.is_default.label' | translate}}
                     </span>
-                </th>
-                <th scope="col" class="endpoint-is-active-col text-center">
+                    </th>
+                    <th scope="col" class="endpoint-is-active-col text-center">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.is_active.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.is_active.label' | translate}}
                     </span>
-                </th>
-                <th scope="col" class="endpoint-modified-on-col">
+                    </th>
+                    <th scope="col" class="endpoint-modified-on-col">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.modified_on.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.modified_on.label' | translate}}
                     </span>
-                </th>
-                <th scope="col" class="endpoint-types-count-col numeric">
+                    </th>
+                    <th scope="col" class="endpoint-types-count-col numeric">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.types_count.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.types_count.label' | translate}}
                     </span>
-                </th>
-                <th scope="col" class="endpoint-props-count-col numeric">
+                    </th>
+                    <th scope="col" class="endpoint-props-count-col numeric">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.props_count.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.props_count.label' | translate}}
                     </span>
-                </th>
-                <th scope="col" class="endpoint-actions-col">
+                    </th>
+                    <th scope="col" class="endpoint-actions-col">
                     <span gdb-tooltip="{{'graphql.endpoints_management.table.column.actions.tooltip' | translate}}">
                         {{'graphql.endpoints_management.table.column.actions.label' | translate}}
                     </span>
-                </th>
-            </tr>
-            </thead>
+                    </th>
+                </tr>
+                </thead>
 
-            <tr ng-if="operationInProgress" class="overlay-row">
-                <td colspan="9">
-                    <div class="endpoint-operation-progress" onto-loader size="100"></div>
-                </td>
-            </tr>
+                <tr ng-if="operationInProgress" class="overlay-row">
+                    <td colspan="9">
+                        <div class="endpoint-operation-progress" onto-loader size="100"></div>
+                    </td>
+                </tr>
 
-            <tbody>
-            <tr ng-repeat-start="endpoint in endpointsInfoList.endpoints track by endpoint.endpointId">
-                <td class="toggle-row">
-                    <a href="#" ng-click="toggleRow($event, $index)">
-                        <i class="ri-arrow-right-s-line" ng-if="expandedRow !== $index"></i>
-                        <i class="ri-arrow-down-s-line" ng-if="expandedRow === $index"></i>
-                    </a>
-                </td>
-                <td class="status-cell">
-                    <a href="#"
-                       ng-click="onShowEndpointReport(endpoint)"
-                       gdb-tooltip="{{'graphql.endpoints_management.table.actions.view_report.tooltip' | translate}}"
-                       class="endpoint-report-link btn btn-link">
-                        <i ng-if="!endpoint.createdSuccessfully" class="ri-close-circle-line status-failed"></i>
-                        <i ng-if="endpoint.createdSuccessfully" class="ri-checkbox-circle-line status-success"></i>
-                    </a>
-                </td>
-                <td>
+                <tbody>
+                <tr ng-repeat-start="endpoint in endpointsInfoList.endpoints track by endpoint.endpointId">
+                    <td class="toggle-row">
+                        <a href="#" ng-click="toggleRow($event, $index)">
+                            <i class="ri-arrow-right-s-line" ng-if="expandedRow !== $index"></i>
+                            <i class="ri-arrow-down-s-line" ng-if="expandedRow === $index"></i>
+                        </a>
+                    </td>
+                    <td class="status-cell">
+                        <a href="#"
+                           ng-click="onShowEndpointReport(endpoint)"
+                           gdb-tooltip="{{'graphql.endpoints_management.table.actions.view_report.tooltip' | translate}}"
+                           class="endpoint-report-link btn btn-link">
+                            <i ng-if="!endpoint.createdSuccessfully" class="ri-close-circle-line status-failed"></i>
+                            <i ng-if="endpoint.createdSuccessfully" class="ri-checkbox-circle-line status-success"></i>
+                        </a>
+                    </td>
+                    <td>
                     <span ng-if="!endpoint.active"
                           gdb-tooltip="{{'graphql.endpoints_management.table.actions.explore_endpoint.inactive.tooltip' | translate}}"
                           class="endpoint-id">{{endpoint.endpointId}}</span>
-                    <a ng-if="endpoint.active" href="#" ng-click="onExploreEndpoint(endpoint)"
-                       gdb-tooltip="{{'graphql.endpoints_management.table.actions.explore_endpoint.active.tooltip' | translate}}"
-                       class="endpoint-link">{{endpoint.endpointId}}</a>
-                </td>
-                <td>{{endpoint.label}}</td>
-                <td class="default-endpoint-selector">
-                    <label class="endpoint-default-state">
-                        <input type="radio" ng-model="selectedDefaultEndpoint.default" ng-value="endpoint.default"
-                               ng-disabled="!endpoint.createdSuccessfully"
-                               ng-change="setEndpointAsDefault(endpoint)"/>
-                    </label>
-                </td>
-                <td class="active-endpoint-selector">
+                        <a ng-if="endpoint.active" href="#" ng-click="onExploreEndpoint(endpoint)"
+                           gdb-tooltip="{{'graphql.endpoints_management.table.actions.explore_endpoint.active.tooltip' | translate}}"
+                           class="endpoint-link">{{endpoint.endpointId}}</a>
+                    </td>
+                    <td>{{endpoint.label}}</td>
+                    <td class="default-endpoint-selector">
+                        <label class="endpoint-default-state">
+                            <input type="radio" ng-model="selectedDefaultEndpoint.default" ng-value="endpoint.default"
+                                   ng-disabled="!endpoint.createdSuccessfully"
+                                   ng-change="setEndpointAsDefault(endpoint)"/>
+                        </label>
+                    </td>
+                    <td class="active-endpoint-selector">
                     <span ng-click="!endpoint.createdSuccessfully || toggleEndpointActiveState(endpoint)"
                           class="toggle-active-state">
                         <input type="checkbox" class="switch" ng-checked="endpoint.active"
                                ng-disabled="!endpoint.createdSuccessfully"/>
                         <label></label>
                     </span>
-                </td>
-                <td title="{{endpoint.lastModified}}">{{endpoint.lastModified | date: 'yyyy-MM-dd'}}</td>
-                <td class="objects-count numeric">{{endpoint.objectsCount}}</td>
-                <td class="properties-count numeric">{{endpoint.propertiesCount}}</td>
-                <td class="endpoint-actions">
-                    <div class="btn-group">
-                        <button class="btn btn-link secondary btn-sm open-endpoint-actions-btn"
-                                data-toggle="dropdown" aria-expanded="false"
-                                ng-if="true"
-                                ng-disabled="false">
-                            <i class="ri-more-line"></i>
-                        </button>
-                        <div class="dropdown-menu dropdown-menu-right endpoint-actions-menu">
-                            <button class="dropdown-item export-schema-btn" type="button"
-                                    ng-click="onExportSchema(endpoint)">
-                                <i class="ri-download-2-line"></i>&nbsp;
-                                <span>{{'graphql.endpoints_management.table.actions.export_schema.label' | translate}}</span>
+                    </td>
+                    <td title="{{endpoint.lastModified}}">{{endpoint.lastModified | date: 'yyyy-MM-dd'}}</td>
+                    <td class="objects-count numeric">{{endpoint.objectsCount}}</td>
+                    <td class="properties-count numeric">{{endpoint.propertiesCount}}</td>
+                    <td class="endpoint-actions">
+                        <div class="btn-group">
+                            <button class="btn btn-link secondary btn-sm open-endpoint-actions-btn"
+                                    data-toggle="dropdown" aria-expanded="false"
+                                    ng-if="true"
+                                    ng-disabled="false">
+                                <i class="ri-more-line"></i>
                             </button>
-                            <button class="dropdown-item configure-endpoint-btn" type="button"
-                                    ng-click="onConfigureEndpoint(endpoint)">
-                                <i class="ri-settings-3-line"></i>&nbsp;
-                                <span>{{'graphql.endpoints_management.table.actions.configure_endpoint.label' | translate}}</span>
-                            </button>
-                            <div class="dropdown-divider"></div>
-                            <button class="dropdown-item delete-endpoint-btn" type="button"
-                                    ng-click="onDeleteEndpoint(endpoint)">
-                                <i class="ri-delete-bin-6-line"></i>&nbsp;
-                                <span>{{'graphql.endpoints_management.table.actions.delete_endpoint.label' | translate}}</span>
-                            </button>
+                            <div class="dropdown-menu dropdown-menu-right endpoint-actions-menu">
+                                <button class="dropdown-item export-schema-btn" type="button"
+                                        ng-click="onExportSchema(endpoint)">
+                                    <i class="ri-download-2-line"></i>&nbsp;
+                                    <span>{{'graphql.endpoints_management.table.actions.export_schema.label' | translate}}</span>
+                                </button>
+                                <button class="dropdown-item configure-endpoint-btn" type="button"
+                                        ng-click="onConfigureEndpoint(endpoint)">
+                                    <i class="ri-settings-3-line"></i>&nbsp;
+                                    <span>{{'graphql.endpoints_management.table.actions.configure_endpoint.label' | translate}}</span>
+                                </button>
+                                <div class="dropdown-divider"></div>
+                                <button class="dropdown-item delete-endpoint-btn" type="button"
+                                        ng-click="onDeleteEndpoint(endpoint)">
+                                    <i class="ri-delete-bin-6-line"></i>&nbsp;
+                                    <span>{{'graphql.endpoints_management.table.actions.delete_endpoint.label' | translate}}</span>
+                                </button>
+                            </div>
                         </div>
-                    </div>
-                </td>
-            </tr>
-            <tr ng-repeat-end ng-if="expandedRow === $index" class="endpoint-description-row">
-                <td></td>
-                <td colspan="8">
-                    <strong>{{'graphql.endpoints_management.table.labels.description' | translate}}</strong>
-                    <div class="endpoint-description">{{endpoint.description}}</div>
-                </td>
-            </tr>
-            <tr ng-if="endpointsInfoList.endpoints.length === 0" class="no-results">
-                <td colspan="9">
-                    <div class="alert alert-info">
-                        <span>{{'graphql.endpoints_management.table.messages.endpoints_filter_no_result' | translate}}</span>
-                    </div>
-            </tr>
-            </tbody>
-        </table>
+                    </td>
+                </tr>
+                <tr ng-repeat-end ng-if="expandedRow === $index" class="endpoint-description-row">
+                    <td></td>
+                    <td colspan="8">
+                        <strong>{{'graphql.endpoints_management.table.labels.description' | translate}}</strong>
+                        <div class="endpoint-description">{{endpoint.description}}</div>
+                    </td>
+                </tr>
+                <tr ng-if="endpointsInfoList.endpoints.length === 0" class="no-results">
+                    <td colspan="9">
+                        <div class="alert alert-info">
+                            <span>{{'graphql.endpoints_management.table.messages.endpoints_filter_no_result' | translate}}</span>
+                        </div>
+                </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
## What
Updated the GraphQL Endpoint Management views to support the new ROLE_MANAGE_REPO role.

## Why
The GraphQL Endpoint Management functionality was previously restricted to users with the repository manager role. With the introduction of the ROLE_MANAGE_REPO role, users with repository-specific management permissions should be able to manage GraphQL endpoints for the repositories they are authorized to manage.

## How
- Replaced the repository manager role restriction for the GraphQL management view with the new repository management permission.
- Extended the core-errors directive to support repository filtering based on the configured authorization role.
- Applied repository filtering across the Create, Manage, and Playground views when no repository is selected.
- Filtered the Source Repository dropdown to expose only repositories for which the user has management permissions in create endpoint view.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
