### PR TITLE
GDB-14880: Solr banner preventing navbar from being shown

### DIFF
--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -90,9 +90,12 @@ export class OntoLayout {
     WindowService.getWindow().addEventListener('storage', this.handleStorageChange);
   }
 
+  componentDidRender() {
+    this.windowResizeHandler();
+  }
+
   componentDidLoad() {
     this.updateShowSolrDeprecationBanner();
-    this.windowResizeHandler();
   }
 
   connectedCallback() {
@@ -204,7 +207,7 @@ export class OntoLayout {
 
     if (navbar) {
       const cookieBanner = document.querySelector('.cookie-consent-banner');
-      const header = document.querySelector('.header-component');
+      const header = document.querySelector('.wb-header');
 
       const headerHeight = header?.getBoundingClientRect()?.height ?? 0;
       const bannerHeight = cookieBanner?.getBoundingClientRect()?.height ?? 0;


### PR DESCRIPTION
## What
Fix inaccessible navbar links when the Solr deprecation banner is displayed.

## Why
The Solr deprecation banner was added to the same container as the header component, but its height was not taken into account. As a result, some navbar links became inaccessible.

## How
- Updated the layout calculation to account for the wrapper container that contains both the header and the Solr deprecation banner, instead of only the header.
- Moved the window resize handler to componentDidRender(). This ensures that the navbar height is updated whenever the layout is rendered, both initially and after subsequent updates. As a result, closing the Solr deprecation banner triggers a layout re-render, allowing the navbar height to be recalculated correctly.

(cherry picked from commit b754a00140a49a1de3774f346781fe5adf3daa12)

## Screenshots
<img width="628" height="1229" alt="image" src="https://github.com/user-attachments/assets/4c31162f-dee7-4af0-ab2b-8d650a151f93" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
