### PR TITLE
GDB-14872: Update TTYG View for Users with MANAGE_REPO Permissions

### DIFF
--- a/packages/api/src/services/domain/security/authorization.service.ts
+++ b/packages/api/src/services/domain/security/authorization.service.ts
@@ -325,6 +325,10 @@ export class AuthorizationService implements Service {
     this.securityContextService.updateRestrictedPages(restrictedPages);
   };
 
+  isAdminOrRepoManager() {
+    return this.hasRole(Authority.ROLE_ADMIN) || this.hasRole(Authority.ROLE_REPO_MANAGER);
+  }
+
   private resolveAuthorities(authoritiesList?: string[]) {
     // If no authorities list is provided, return empty array.
     if (!authoritiesList) {
@@ -385,9 +389,5 @@ export class AuthorizationService implements Service {
       user.authorities.hasAuthority(overAllReposGraphql as Authority) ||
       user.authorities.hasWildcardAuthority(overCurrentRepoGraphql, true)
     );
-  }
-
-  private isAdminOrRepoManager() {
-    return this.hasRole(Authority.ROLE_ADMIN) || this.hasRole(Authority.ROLE_REPO_MANAGER);
   }
 }

--- a/packages/legacy-workbench/src/js/angular/ttyg/controllers/ttyg-view.controller.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/controllers/ttyg-view.controller.js
@@ -13,7 +13,11 @@ import {TTYGEventName} from '../services/ttyg-context.service';
 import {AGENT_OPERATION, AGENTS_FILTER_ALL_KEY, TTYG_ERROR_MSG_LENGTH} from '../services/constants';
 import {AgentListFilterModel, AgentModel} from '../../models/ttyg/agents';
 import {ChatModel, ChatsListModel} from '../../models/ttyg/chats';
-import {agentFormModelMapper} from '../services/agents.mapper';
+import {
+    agentFormModelMapper,
+    mapAgentListModelToAgentViewListModel,
+    mapAgentModelToAgentViewModel,
+} from '../services/agents.mapper';
 import {SelectMenuOptionsModel} from '../../models/form-fields';
 import {repositoryInfoMapper} from '../../rest/mappers/repositories-mapper';
 import {saveAs} from 'lib/FileSaver-patch';
@@ -24,7 +28,6 @@ import {ContinueChatRun} from "../../models/ttyg/chat-answer";
 import {ChatMessageModel} from "../../models/ttyg/chat-message";
 import {
     AuthorizationService,
-    SecurityContextService,
     service,
 } from '@ontotext/workbench-api';
 
@@ -86,7 +89,6 @@ function TTYGViewCtrl(
     // =========================
 
     const authorizationService = service(AuthorizationService);
-    const securityContextService = service(SecurityContextService);
     const subscriptions = [];
 
     const labels = {
@@ -178,10 +180,10 @@ function TTYGViewCtrl(
     $scope.connectorID = undefined;
 
     /**
-     * A flag that determines whether buttons that modify an agent should be disabled.
+     * A flag that determines whether the user has repository management permissions.
      * @type {boolean}
      */
-    $scope.canModifyAgent = false;
+    $scope.canManageRepo = false;
 
     /**
      * A list of available repository IDs as a model for the agent list filter.
@@ -408,7 +410,7 @@ function TTYGViewCtrl(
         $scope.loadingAgents = showLoader;
         return TTYGService.getAgents()
             .then((agents) => {
-                return TTYGContextService.updateAgents(agents);
+                return TTYGContextService.updateAgents(mapAgentListModelToAgentViewListModel(agents, authorizationService));
             })
             .catch((error) => {
                 toastr.error(getError(error, 0, TTYG_ERROR_MSG_LENGTH));
@@ -427,7 +429,7 @@ function TTYGViewCtrl(
         $scope.reloadingAgents = true;
         return TTYGService.getAgents()
             .then((agents) => {
-                return TTYGContextService.updateAgents(agents);
+                return TTYGContextService.updateAgents(mapAgentListModelToAgentViewListModel(agents, authorizationService));
             })
             .catch((error) => {
                 toastr.error(getError(error, 0, TTYG_ERROR_MSG_LENGTH));
@@ -435,10 +437,6 @@ function TTYGViewCtrl(
             .finally(() => {
                 $scope.reloadingAgents = false;
             });
-    };
-
-    const updateCanModifyAgent = () => {
-        TTYGContextService.setCanModifyAgent(authorizationService.isRepoManager());
     };
 
     const getActiveRepositoryObjectHandler = (activeRepo) => {
@@ -599,10 +597,6 @@ function TTYGViewCtrl(
         setupChatListPanel(chats);
     };
 
-    const onCanUpdateAgentUpdated = (canModifyAgent) => {
-        $scope.canModifyAgent = canModifyAgent;
-    };
-
     /**
      * @param {ChatsListModel} chats - the new chats list.
      */
@@ -755,7 +749,7 @@ function TTYGViewCtrl(
      * @param {AgentModel} agent
      */
     const onAgentSelected = (agent) => {
-        $scope.selectedAgent = agent;
+        $scope.selectedAgent = agent ? mapAgentModelToAgentViewModel(agent, authorizationService) : undefined;
     };
 
     /**
@@ -876,6 +870,7 @@ function TTYGViewCtrl(
 
     const buildRepositoryList = () => {
         $scope.activeRepositoryList = $repositories.getLocalReadableGraphdbRepositories()
+            .filter((repo) => authorizationService.canManageRepo(repo))
             .map((repo) => (
                 new SelectMenuOptionsModel({
                     value: repo.id,
@@ -901,7 +896,6 @@ function TTYGViewCtrl(
         $scope.$watch($scope.getActiveRepositoryObject, getActiveRepositoryObjectHandler),
         TTYGContextService.onSelectedChatChanged(onSelectedChatChanged),
         TTYGContextService.onChatsListChanged(onChatsChanged),
-        TTYGContextService.onCanUpdateAgentUpdated(onCanUpdateAgentUpdated),
         TTYGContextService.subscribe(TTYGContextService.onAgentsListChanged(onAgentListChanged)),
         TTYGContextService.subscribe(TTYGEventName.CREATE_CHAT, onCreateNewChat),
         TTYGContextService.subscribe(TTYGEventName.RENAME_CHAT, onRenameChat),
@@ -921,7 +915,6 @@ function TTYGViewCtrl(
         TTYGContextService.subscribe(TTYGEventName.GO_TO_CONNECTORS_VIEW, onGoToConnectorsView),
         TTYGContextService.subscribe(TTYGEventName.GO_TO_SPARQL_EDITOR, onGoToSparqlEditorView),
         $rootScope.$on('$translateChangeSuccess', updateLabels),
-        securityContextService.onAuthenticatedUserChanged(updateCanModifyAgent),
     );
     $scope.$on('$destroy', cleanUp);
 
@@ -938,6 +931,6 @@ function TTYGViewCtrl(
                 return loadChats();
             })
             .then(setCurrentChat);
-        updateCanModifyAgent();
+        $scope.canManageRepo = authorizationService.isAdminOrRepoManager() || authorizationService.isManageRepoUser();
     }
 }

--- a/packages/legacy-workbench/src/js/angular/ttyg/directives/agent-select-menu.directive.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/directives/agent-select-menu.directive.js
@@ -17,7 +17,6 @@ function AgentSelectMenuComponent(TTYGContextService, $translate, $sce, ModalSer
         scope: {
         },
         link: ($scope) => {
-
             // =========================
             // Public variables
             // =========================
@@ -55,12 +54,10 @@ function AgentSelectMenuComponent(TTYGContextService, $translate, $sce, ModalSer
                 TTYGStorageService.saveAgent(agent);
                 $scope.selectedAgent = agent;
                 TTYGContextService.selectAgent(agent);
-                if (agent.isRepositoryDeleted) {
+                if (agent.isRepositoryDeleted && agent.canEditAgent) {
                     const title = $translate.instant('ttyg.agent.agent_select_menu.configure_agent_modal.title');
                     const confirmMessage = $translate.instant('ttyg.agent.agent_select_menu.configure_agent_modal.body');
-                    ModalService.openConfirmation(title, confirmMessage,
-                        () => TTYGContextService.emit(TTYGEventName.EDIT_AGENT, agent)
-                    );
+                    ModalService.openConfirmation(title, confirmMessage, () => TTYGContextService.emit(TTYGEventName.EDIT_AGENT, agent));
                 }
             };
 
@@ -101,7 +98,7 @@ function AgentSelectMenuComponent(TTYGContextService, $translate, $sce, ModalSer
                     // If saved in the LocalStore, the user has selected it, so select it here
                     $scope.agentOptionsList.forEach((agent) => {
                         if (agent.data.agent.id === storedAgentId) {
-                            selectedAgent = agent.data.agent
+                            selectedAgent = agent.data.agent;
                         }
                     });
                 }
@@ -112,7 +109,7 @@ function AgentSelectMenuComponent(TTYGContextService, $translate, $sce, ModalSer
                 }
                 onSelectedAgentChanged(selectedAgent);
                 TTYGContextService.selectAgent(selectedAgent);
-            }
+            };
 
             /**
              * Handles the agent deleted event.
@@ -146,8 +143,8 @@ function AgentSelectMenuComponent(TTYGContextService, $translate, $sce, ModalSer
                         value: agent.id,
                         label: agent.name,
                         data: {
-                            agent: agent
-                        }
+                            agent: agent,
+                        },
                     });
                 });
             };
@@ -176,6 +173,6 @@ function AgentSelectMenuComponent(TTYGContextService, $translate, $sce, ModalSer
                 // buildAgentOptionsModel();
             }
             initialize();
-        }
+        },
     };
 }

--- a/packages/legacy-workbench/src/js/angular/ttyg/directives/no-agents-view.directive.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/directives/no-agents-view.directive.js
@@ -12,14 +12,12 @@ function NoAgentsView(TTYGContextService, productInfo) {
         restrict: 'E',
         templateUrl: 'js/angular/ttyg/templates/no-agents-view.html',
         scope: {
+            canCreateAgent: '=',
         },
         link: ($scope) => {
-
             // =========================
             // Public variables
             // =========================
-
-            $scope.canModifyAgent = false;
             $scope.talkToGraphDocumentationLink = DocumentationUrlResolver.getDocumentationUrl(productInfo.productShortVersion, 'talk-to-graph.html');
 
             // =========================
@@ -29,25 +27,6 @@ function NoAgentsView(TTYGContextService, productInfo) {
             $scope.onCreateAgent = () => {
                 TTYGContextService.emit(TTYGEventName.OPEN_AGENT_SETTINGS);
             };
-
-            // =========================
-            // Private functions
-            // =========================
-
-            const onCanUpdateAgentUpdated = (canModifyAgent) => {
-                $scope.canModifyAgent = canModifyAgent;
-            };
-
-            // =========================
-            // Subscriptions
-            // =========================
-            const subscriptions = [];
-
-            const onDestroy = () => {
-                subscriptions.forEach((subscription) => subscription());
-            };
-            subscriptions.push(TTYGContextService.onCanUpdateAgentUpdated(onCanUpdateAgentUpdated));
-            $scope.$on('$destroy', onDestroy);
-        }
+        },
     };
 }

--- a/packages/legacy-workbench/src/js/angular/ttyg/model/agent-view.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/model/agent-view.js
@@ -1,0 +1,15 @@
+import {AgentModel} from '../../models/ttyg/agents';
+
+export class AgentViewModel extends AgentModel {
+    /**
+     * @param agent
+     * @type {AgentModel}
+     */
+    constructor(agent) {
+        super(agent);
+        this.canEditAgent = false;
+        this.canCopyAgent = false;
+        this.canDeleteAgent = false;
+        this.canOpenExternalIntegrationConfiguration = false;
+    }
+}

--- a/packages/legacy-workbench/src/js/angular/ttyg/services/agents.mapper.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/services/agents.mapper.js
@@ -15,6 +15,7 @@ import {
 import {NumericRangeModel, TextFieldModel} from '../../models/form-fields';
 import {md5HashGenerator} from '../../utils/hash-utils';
 import {AGENT_OPERATION} from "./constants";
+import {AgentViewModel} from '../model/agent-view';
 
 /**
  * Converts an agent model to an agent form model.
@@ -245,4 +246,35 @@ const agentInstructionsMapper = (data) => {
         systemInstruction: data.systemInstruction,
         userInstruction: data.userInstruction,
     });
+};
+
+/**
+ * Converts an agent list containing {@link AgentModel} instances into an agent list
+ * containing {@link AgentViewModel} instances enriched with UI permissions.
+ *
+ * @param {AgentListModel} agentList The agent list to convert.
+ * @param {AuthorizationService} authorizationService The authorization service used to determine user permissions.
+ * @returns {AgentListModel} An agent list containing {@link AgentViewModel} instances.
+ */
+export const mapAgentListModelToAgentViewListModel = (agentList, authorizationService) => {
+    return new AgentListModel(agentList.agents.map((agent) => mapAgentModelToAgentViewModel(agent, authorizationService)));
+};
+
+/**
+ * Converts an {@link AgentModel} into an {@link AgentViewModel} by enriching it
+ * with UI-specific permissions based on the current user's repository management rights.
+ *
+ * @param {AgentModel} agent The agent to convert.
+ * @param {AuthorizationService} authorizationService The authorization service used to determine user permissions.
+ * @returns {AgentViewModel} The converted agent view model.
+ */
+export const mapAgentModelToAgentViewModel = (agent, authorizationService) => {
+    const viewAgent = new AgentViewModel(agent);
+    const canManageRepo = authorizationService.canManageRepo({id: agent.repositoryId, location: ''});
+    viewAgent.canEditAgent = canManageRepo;
+    viewAgent.canCopyAgent = true;
+    viewAgent.canDeleteAgent = canManageRepo;
+    viewAgent.canOpenExternalIntegrationConfiguration = canManageRepo;
+
+    return viewAgent;
 };

--- a/packages/legacy-workbench/src/js/angular/ttyg/services/ttyg-context.service.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/services/ttyg-context.service.js
@@ -50,8 +50,6 @@ function TTYGContextService(EventEmitterService) {
      */
     let _defaultAgent = undefined;
 
-    let _canModifyAgent = false;
-
     const resetContext = () => {
         _agents = undefined;
         _chats = undefined;
@@ -59,7 +57,6 @@ function TTYGContextService(EventEmitterService) {
         _selectedAgent = undefined;
         _explainCache = {};
         _defaultAgent = undefined;
-        _canModifyAgent = false;
     };
 
     /**
@@ -317,33 +314,6 @@ function TTYGContextService(EventEmitterService) {
     };
 
     /**
-     * Updates the "canModifyAgent" flag and emits the 'canModifyAgentUpdated' event to notify listeners that the canModifyAgent flag is changed.
-     *
-     * @param {boolean} canModifyAgent
-     */
-    const setCanModifyAgent = (canModifyAgent) => {
-        _canModifyAgent = cloneDeep(canModifyAgent);
-        emit(TTYGEventName.CAN_MODIFY_AGENT_UPDATED, getCanModifyAgent());
-    };
-
-    const getCanModifyAgent = () => {
-        return _canModifyAgent;
-    };
-
-    /**
-     * Subscribes to the 'canModifyAgentUpdated' event.
-     * @param {function} callback - The callback to be called when the event is fired.
-     *
-     * @return {function} unsubscribe function.
-     */
-    const onCanUpdateAgentUpdated = (callback) => {
-        if (angular.isFunction(callback)) {
-            callback(getCanModifyAgent());
-        }
-        return subscribe(TTYGEventName.CAN_MODIFY_AGENT_UPDATED, (canModifyAgent) => callback(canModifyAgent));
-    };
-
-    /**
      * Emits an event with a deep-cloned payload using the EventEmitterService.
      *
      * @param {string} tTYGEventName - The name of the event to emit. It must be a value from {@link TTYGEventName}.
@@ -393,9 +363,6 @@ function TTYGContextService(EventEmitterService) {
         onSelectedAgentChanged,
         getDefaultAgent,
         setDefaultAgent,
-        setCanModifyAgent,
-        getCanModifyAgent,
-        onCanUpdateAgentUpdated,
         // chat explain
         hasExplainResponse,
         toggleExplainResponse,
@@ -580,8 +547,6 @@ export const TTYGEventName = {
      * This event will trigger the opening of the sparql view.
      */
     GO_TO_SPARQL_EDITOR: "openQueryInSparqlEditor",
-
-    CAN_MODIFY_AGENT_UPDATED: "canModifyAgentUpdated",
 
     /**
      * This event will be emitted when there is a change in the state of the question being asked. (e.g., currently being sent)

--- a/packages/legacy-workbench/src/js/angular/ttyg/templates/agent-list.html
+++ b/packages/legacy-workbench/src/js/angular/ttyg/templates/agent-list.html
@@ -44,14 +44,14 @@
                         <i class="ri-more-line"></i>
                     </button>
                     <div class="dropdown-menu dropdown-menu-right agent-actions-menu">
-                        <button ng-if="agent.isCompatible"
+                        <button ng-if="agent.isCompatible && agent.canEditAgent"
                                 class="dropdown-item edit-agent-btn"
                                 type="button"
                                 ng-click="onEditAgent(agent)">
                             <i class="ri-settings-3-line"></i>
                             <span>{{'ttyg.agent.btn.edit_agent.label' | translate}}</span>
                         </button>
-                        <button ng-if="agent.isCompatible"
+                        <button ng-if="agent.isCompatible && agent.canOpenExternalIntegrationConfiguration"
                                 class="dropdown-item ext-integration-agent-btn"
                                 type="button"
                                 ng-click="onExternalIntegration(agent)">
@@ -65,9 +65,12 @@
                             <i class="ri-file-copy-line"></i>
                             <span>{{'ttyg.agent.btn.clone_agent.label' | translate}}</span>
                         </button>
-                        <div ng-if="agent.isCompatible"
+                        <div ng-if="agent.isCompatible && agent.canDeleteAgent"
                              class="dropdown-divider"></div>
-                        <button class="dropdown-item delete-agent-btn" type="button" ng-click="onDeleteAgent(agent)">
+                        <button ng-if="agent.canDeleteAgent"
+                            class="dropdown-item delete-agent-btn"
+                                type="button"
+                                ng-click="onDeleteAgent(agent)">
                             <i class="ri-delete-bin-6-line"></i>
                             <span>{{'ttyg.agent.btn.delete_agent.label' | translate}}</span>
                         </button>

--- a/packages/legacy-workbench/src/js/angular/ttyg/templates/no-agents-view.html
+++ b/packages/legacy-workbench/src/js/angular/ttyg/templates/no-agents-view.html
@@ -9,8 +9,8 @@
 
         <div class="actions">
             <button class="btn btn-secondary btn-lg text-xs-left create-agent-btn"
-                    gdb-tooltip="{{!canModifyAgent ? ('ttyg.agent.fat_btn.create_agent.tooltip_disabled' | translate) : ''}}"
-                    ng-disabled="!canModifyAgent"
+                    gdb-tooltip="{{!canCreateAgent ? ('ttyg.agent.fat_btn.create_agent.tooltip_disabled' | translate) : ''}}"
+                    ng-disabled="!canCreateAgent"
                     ng-click="onCreateAgent()" guide-selector="create-agent-btn">
                 <i class="ri-robot-2-line ri-xl"></i>
                 <span class="text">{{'ttyg.agent.fat_btn.create_agent.label' | translate}}</span>

--- a/packages/legacy-workbench/src/js/angular/ttyg/templates/ttyg.html
+++ b/packages/legacy-workbench/src/js/angular/ttyg/templates/ttyg.html
@@ -20,7 +20,10 @@
          size="100">
     </div>
 
-    <no-agents-view ng-cloak ng-if="initialized && getActiveRepository() && !loadingAgents && !reloadingAgents && (!agents || agents.isEmpty())"></no-agents-view>
+    <no-agents-view
+        ng-cloak ng-if="initialized && getActiveRepository() && !loadingAgents && !reloadingAgents && (!agents || agents.isEmpty())"
+        can-create-agent="canManageRepo">
+    </no-agents-view>
 
     <div id="ttyg-container" class="ttyg-container" ng-show="getActiveRepository() && !loadingAgents && agents && !agents.isEmpty()">
 
@@ -66,8 +69,8 @@
                     <button class="btn btn-link btn-sm edit-current-agent-btn mr-1" guide-selector="edit-current-agent"
                             ng-if="selectedAgent"
                             ng-click="onOpenAgentSettings()"
-                            ng-disabled="!canModifyAgent"
-                            gdb-tooltip="{{ (canModifyAgent ? 'ttyg.agent.btn.edit_agent.tooltip' : 'ttyg.agent.btn.edit_agent.tooltip_disabled') | translate}}">
+                            ng-disabled="!selectedAgent.canEditAgent"
+                            gdb-tooltip="{{ (selectedAgent.canEditAgent ? 'ttyg.agent.btn.edit_agent.tooltip' : 'ttyg.agent.btn.edit_agent.tooltip_disabled') | translate}}">
                         <i class="ri-settings-3-line"></i>
                     </button>
                 </div>
@@ -93,18 +96,17 @@
                     <i class="ri-question-line"></i>
                 </button>
                 <button class="btn btn-link btn-sm create-agent-btn"
-                        ng-disabled="!canModifyAgent"
+                        ng-disabled="!canManageRepo"
                         ng-click="onOpenNewAgentSettings()"
-                        ng-disabled="false"
-                        gdb-tooltip="{{ (canModifyAgent ? 'ttyg.agent.btn.create_agent.tooltip' : 'ttyg.agent.btn.create_agent.tooltip_disabled') | translate}}"
+                        gdb-tooltip="{{ (canManageRepo ? 'ttyg.agent.btn.create_agent.tooltip' : 'ttyg.agent.btn.create_agent.tooltip_disabled') | translate}}"
                         guide-selector="create-agent-btn">
                     <i class="ri-add-circle-line"></i>
                 </button>
                 <button class="btn btn-link btn-sm toggle-agents-sidebar-btn"
                         ng-if="!showAgents"
                         ng-click="toggleAgentsListSidebar()"
-                        ng-disabled="!canModifyAgent"
-                        gdb-tooltip="{{'ttyg.agent.btn.open_sidebar.' + (canModifyAgent ? 'tooltip' : 'tooltip_disabled') | translate}}">
+                        ng-disabled="!canManageRepo"
+                        gdb-tooltip="{{'ttyg.agent.btn.open_sidebar.' + (canManageRepo ? 'tooltip' : 'tooltip_disabled') | translate}}">
                     <i class="ri-robot-2-line"></i>
                 </button>
                 <button class="btn btn-link btn-sm toggle-agents-sidebar-btn"


### PR DESCRIPTION
## What
Update Agent Management to support the new ROLE_MANAGE_REPO role and introduce per-agent permission evaluation.

## Why
The creation and editing of agents were previously restricted to users with the repository manager role. With the introduction of the ROLE_MANAGE_REPO role, the actions a user can perform depend on the repository associated with each agent rather than on a single global permission. As a result, the canModifyAgent flag in TTYGContextService is no longer sufficient.

## How
- Removed the canModifyAgent flag from TTYGContextService.
- Introduced AgentViewModel to enrich AgentModel with UI-specific permissions.
- Added a mapper that converts AgentModel to AgentViewModel and evaluates the current user's permissions for each agent based on its associated repository.
- Updated the Agent Management view to use the per-agent permissions exposed by AgentViewModel.
- Allowed users to create, edit, and delete only agents associated with repositories they have management permissions for.
- Kept agent cloning available while restricting the target repository selection to repositories the user has management permissions for.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
