### PR TITLE
GDB-14474: Remove brackets from BNodes in visual graph

### DIFF
--- a/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
+++ b/packages/legacy-workbench/src/js/angular/graphexplore/controllers/graphs-visualizations.controller.js
@@ -822,7 +822,14 @@ function GraphsVisualizationsCtrl(
 
     const createTriple = (value) => {
         const tripleParts = value.trim().split(' ');
-        return `<<(<${tripleParts[0]}> <${tripleParts[1]}> <${tripleParts[2]}>)>>`;
+        return `<<(${wrapTriplePart(tripleParts[0])} ${wrapTriplePart(tripleParts[1])} ${wrapTriplePart(tripleParts[2])})>>`;
+    };
+
+    const wrapTriplePart = (value) => {
+        if (value.startsWith('_:')) {
+            return value;
+        }
+        return `<${value}>`;
     };
 
     /**


### PR DESCRIPTION
## What
Refactored the `createTriple` function to utilize a new helper function `wrapTriplePart` for formatting triple parts. This change removes unnecessary brackets around BNode identifiers.

## Why
This update is needed for proper communication with GDB

## How
- Introduced `wrapTriplePart` function to handle the formatting of triple parts.
- Updated `createTriple` to call `wrapTriplePart` for each part of the triple.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
