### PR TITLE
GDB-14798: Update Home View fot the New Manage repo role

### DIFF
--- a/packages/legacy-workbench/src/js/angular/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/controllers.js
@@ -511,6 +511,11 @@ function mainCtrl($scope, $menuItems, $jwtAuth, $http, $location, $repositories,
         return authorizationService.hasRole(UserRole.ROLE_REPO_MANAGER) && !$repositories.getDegradedReason();
     };
 
+    $scope.canManageSelectedRepository = () => {
+        const selectedRepository = repositoryContextService.getSelectedRepository();
+        return authorizationService.canManageRepo(selectedRepository) && !$repositories.getDegradedReason();
+    };
+
     $scope.getSavedQueries = function() {
         SparqlRestService.getSavedQueries()
             .success(function(data) {

--- a/packages/legacy-workbench/src/pages/home.html
+++ b/packages/legacy-workbench/src/pages/home.html
@@ -77,7 +77,7 @@
                                 ng-click="copyToClipboard(getActiveRepositoryObject().externalUrl)"><span class="ri-links-line"></span>
                         </button>
                         <button type="button" ng-click="goToEditRepo(getActiveRepositoryObject())" class="btn btn-link" gdb-tooltip="{{'repoTooltips.editRepository' | translate}}"
-                                ng-if="canManageRepositories() && getActiveRepositoryObject().type !== 'system'">
+                                ng-if="canManageSelectedRepository() && getActiveRepositoryObject().type !== 'system'">
                             <span class="ri-edit-line"></span>
                         </button>
                         <span ng-show="getDegradedReason()">

--- a/packages/shared-components/src/components/onto-header/onto-header.tsx
+++ b/packages/shared-components/src/components/onto-header/onto-header.tsx
@@ -336,10 +336,8 @@ export class OntoHeader {
       });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private canWriteRepoInLocation(_repository: Repository): boolean {
-    // TODO: implement the condition when GDB-10442 is ready
-    return true;
+  private canWriteRepoInLocation(repository: Repository): boolean {
+    return this.authorizationService.canWriteRepo(repository);
   }
 
   private readonly canWriteRepo = (repo: Repository) => {


### PR DESCRIPTION
## What
- Update the repository widget on the Home page to support users with ROLE_MANAGE_REPO.
- Update the repository selector tooltip to display repository-specific read and write permissions.

## Why
- The Edit Repository action was previously visible only to users with the repository manager role. With the introduction of ROLE_MANAGE_REPO, users who have management permissions for the currently selected repository should also be able to access this action.
- The tooltip previously used a implementation that always assumed the user had read and write permissions for every repository, because the GDB-10442 was not implemented.

## How
- Updated the visibility check for the Edit Repository button in the Home page repository widget.
- Replaced the temporary implementation with implementation that evaluate user's read and write permissions for the hovered repository when generating the tooltip.

## Screenshots
Repository Edit action
<img width="1023" height="793" alt="image" src="https://github.com/user-attachments/assets/2ff4f7d0-c3ba-4aec-9763-b56e31746fab" />
Read access to repository
<img width="413" height="347" alt="image" src="https://github.com/user-attachments/assets/71f9fb2f-1574-488e-9c1c-5e1cbfd008fb" />
Read/Write access to reppository
<img width="875" height="431" alt="image" src="https://github.com/user-attachments/assets/837e8bb7-f77b-4806-836d-5293b7c612c1" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
