### PR TITLE
GDB-14798: Review Repository Manager Authorization Usages for MANAGE_REPO Support

### DIFF
--- a/packages/legacy-workbench/src/js/angular/repositories/fedx-repo.directive.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/fedx-repo.directive.js
@@ -1,3 +1,8 @@
+import {
+    service,
+    AuthorizationService,
+} from '@ontotext/workbench-api';
+
 angular
     .module('graphdb.framework.repositories.fedx-repo.directive', [])
     .directive('fedxRepo', fedxRepoDirective);
@@ -10,33 +15,31 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
         scope: true,
         templateUrl: 'js/angular/repositories/templates/fedx-repo.html',
 
-        link: linkFunc
+        link: linkFunc,
     };
 
     function linkFunc($scope) {
+        const authorizationService = service(AuthorizationService);
 
         const LOCAL_REPO_STORE = 'ResolvableRepository';
         const REMOTE_REPO_STORE = 'RemoteRepository';
         const SPARQL_ENDPOINT_STORE = 'SPARQLEndpoint';
         const NATIVE_STORE = 'NativeStore';
 
+        $scope.canAddRemoteRepository = false;
         $scope.fedxMembers = [];
         $scope.knownRepos = [];
         $scope.allAttachedRepos = [];
 
-        if ($scope.editRepoPage) {
-            $scope.fedxMembers = $scope.repositoryInfo.params.member.value.slice();
-        }
-
         function getRepositories() {
             return RepositoriesRestService.getRepositories($scope.repositoryInfo.location)
-                .success(function (response) {
-                    let repos = [];
+                .success(function(response) {
+                    const repos = [];
                     _.values(response).forEach((value) => {
                         repos.push.apply(repos, value);
                     });
                     $scope.allAttachedRepos = _.cloneDeep(repos);
-                }).error(function (response) {
+                }).error(function(response) {
                     const msg = getError(response);
                     toastr.error(msg, $translate.instant('common.error'));
                 });
@@ -44,7 +47,9 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
 
         function populateKnownRepos() {
             for (const member of $scope.fedxMembers) {
-                $scope.knownRepos = $scope.knownRepos.filter(function (repo) {
+                $scope.knownRepos = $scope.knownRepos
+                    .filter((repo) => authorizationService.canManageRepo(repo))
+                    .filter((repo) => {
                     if (member.repositoryServer) {
                         // if the member is a remote attached member
                         return repo.id !== member.repositoryName || repo.location !== member.repositoryServer;
@@ -56,8 +61,8 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
             }
         }
 
-        $scope.setWritableRepo = function (member) {
-            let currentWritable = getWritableRepo();
+        $scope.setWritableRepo = function(member) {
+            const currentWritable = getWritableRepo();
             if (currentWritable) {
                 if (currentWritable.store === LOCAL_REPO_STORE && (member.store !== LOCAL_REPO_STORE || currentWritable.repositoryName !== member.repositoryName) ) {
                     currentWritable.writable = 'false';
@@ -66,50 +71,54 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
                 }
             }
             member.writable = JSON.stringify(member.writable === 'false');
-        }
+        };
 
-        $scope.getActiveClass = function (member) {
+        $scope.getActiveClass = function(member) {
             return member.writable === 'true' ? ' active' : '';
-        }
+        };
+
+        $scope.canManageRepo = (fedxMember) => {
+            return authorizationService.canManageRepo({id: fedxMember.repositoryName, location: fedxMember.repositoryServer});
+        };
 
         function getWritableRepo() {
-            return $scope.fedxMembers.find(member => member.writable === "true");
+            return $scope.fedxMembers.find((member) => member.writable === "true");
         }
 
         function getKnownRepos() {
             getRepositories()
-                .then(function () {
+                .then(function() {
                     $scope.knownRepos = $scope.allAttachedRepos.slice();
                     populateKnownRepos();
                 });
         }
 
-        $scope.checkIfRepoExist = function (member) {
+        $scope.checkIfRepoExist = function(member) {
             if (!$scope.allAttachedRepos.length) {
                 return true;
             }
             if (member.store === LOCAL_REPO_STORE) {
-                return $scope.allAttachedRepos.find(repo => repo.id === member.repositoryName && !repo.location);
+                return $scope.allAttachedRepos.find((repo) => repo.id === member.repositoryName && !repo.location);
             } else if (member.store === REMOTE_REPO_STORE) {
-                return $scope.allAttachedRepos.find(repo => repo.id === member.repositoryName && repo.location === member.repositoryServer);
+                return $scope.allAttachedRepos.find((repo) => repo.id === member.repositoryName && repo.location === member.repositoryServer);
             } else {
                 return true;
             }
-        }
+        };
 
-        $scope.getRepositoryServer = function (repo) {
+        $scope.getRepositoryServer = function(repo) {
             if (repo.local) {
                 return "Local";
             } else {
                 return repo.location;
             }
-        }
+        };
 
-        const localReposTimer = setInterval(function () {
+        const localReposTimer = setInterval(function() {
             getKnownRepos();
         }, 5000);
 
-        $scope.$on('$destroy', function () {
+        $scope.$on('$destroy', function() {
             clearInterval(localReposTimer);
         });
 
@@ -121,7 +130,7 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
                     repositoryName: repository.id,
                     repoType: repository.type,
                     respectRights: "true",
-                    writable: "false"
+                    writable: "false",
                 };
             } else {
                 member = {
@@ -131,30 +140,30 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
                     username: '',
                     password: '',
                     supportsASKQueries: "true",
-                    writable: "false"
+                    writable: "false",
                 };
             }
-            $scope.knownRepos = $scope.knownRepos.filter(repo => repo.id !== repository.id || repo.location !== repository.location);
+            $scope.knownRepos = $scope.knownRepos.filter((repo) => repo.id !== repository.id || repo.location !== repository.location);
             updateMembers(member);
-        }
+        };
 
-        $scope.removeMember = function (member) {
+        $scope.removeMember = function(member) {
             if (member.store && member.store === LOCAL_REPO_STORE) {
-                $scope.fedxMembers = $scope.fedxMembers.filter(el => el.store !== member.store || el.repositoryName !== member.repositoryName && !el.repositoryServer);
+                $scope.fedxMembers = $scope.fedxMembers.filter((el) => el.store !== member.store || el.repositoryName !== member.repositoryName && !el.repositoryServer);
                 getKnownRepos();
             } else if (member.store && member.store === SPARQL_ENDPOINT_STORE) {
-                $scope.fedxMembers = $scope.fedxMembers.filter(el => el.endpoint !== member.endpoint);
+                $scope.fedxMembers = $scope.fedxMembers.filter((el) => el.endpoint !== member.endpoint);
             } else if (member.store && member.store === NATIVE_STORE) {
-                $scope.fedxMembers = $scope.fedxMembers.filter(el => el.repositoryLocation !== member.repositoryLocation);
+                $scope.fedxMembers = $scope.fedxMembers.filter((el) => el.repositoryLocation !== member.repositoryLocation);
             } else if (member.store && member.store === REMOTE_REPO_STORE) {
-                $scope.fedxMembers = $scope.fedxMembers.filter(el => el.store !== member.store || el.repositoryName !== member.repositoryName
+                $scope.fedxMembers = $scope.fedxMembers.filter((el) => el.store !== member.store || el.repositoryName !== member.repositoryName
                                                                                                 || el.repositoryServer !== member.repositoryServer);
                 getKnownRepos();
             }
             $scope.repositoryInfo.params['member'].value = $scope.fedxMembers;
-        }
+        };
 
-        $scope.addRemoteMember = function () {
+        $scope.addRemoteMember = function() {
             $scope.mode = 'remote';
             $scope.model = {
                 editMode: false,
@@ -165,8 +174,8 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
                 username: '',
                 password: '',
                 supportsASKQueries: "true",
-                writable: "false"
-            }
+                writable: "false",
+            };
 
             $scope.$uibModalInstance = $uibModal.open({
                 templateUrl: 'js/angular/templates/modal/add-fedx-remote-repo.html',
@@ -174,7 +183,7 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
             });
         };
 
-        $scope.getMemberIcon = function (member) {
+        $scope.getMemberIcon = function(member) {
             if (member.repoType) {
                 return 'icon-repo-' + member.repoType;
             } else if (member.store === NATIVE_STORE) {
@@ -182,9 +191,9 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
             } else {
                 return 'ri-links-line';
             }
-        }
+        };
 
-        $scope.editFedXRepository = function (member) {
+        $scope.editFedXRepository = function(member) {
             if (member.store === LOCAL_REPO_STORE) {
                 $scope.mode = 'local';
                 $scope.model = {
@@ -193,8 +202,8 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
                     respectRights: member.respectRights,
                     repositoryName: member.repositoryName,
                     repoType: member.repoType,
-                    writable: member.writable
-                }
+                    writable: member.writable,
+                };
             } else {
                 $scope.mode = 'remote';
                 $scope.model = {
@@ -206,36 +215,36 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
                     username: member.username,
                     password: member.password,
                     supportsASKQueries: member.supportsASKQueries,
-                    writable: member.writable
-                }
+                    writable: member.writable,
+                };
             }
 
             $scope.$uibModalInstance = $uibModal.open({
                 templateUrl: 'js/angular/templates/modal/add-fedx-remote-repo.html',
-                scope: $scope
+                scope: $scope,
             });
         };
 
-        $scope.resolveName = function (member) {
+        $scope.resolveName = function(member) {
             switch (member.store) {
-                case LOCAL_REPO_STORE : {
+                case LOCAL_REPO_STORE: {
                     return member.repositoryName;
                 }
-                case REMOTE_REPO_STORE : {
+                case REMOTE_REPO_STORE: {
                     return member.repositoryName + '@' + member.repositoryServer;
                 }
-                case SPARQL_ENDPOINT_STORE : {
+                case SPARQL_ENDPOINT_STORE: {
                     return member.endpoint;
                 }
-                case NATIVE_STORE : {
+                case NATIVE_STORE: {
                     return member.repositoryLocation;
                 }
-                default :
+                default:
                     return "";
             }
-        }
+        };
 
-        $scope.cancel = function () {
+        $scope.cancel = function() {
             $scope.$uibModalInstance.dismiss('cancel');
         };
 
@@ -245,14 +254,14 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
         }
 
         function removeEndingSlash(url) {
-            return url.slice(-1) === '/' ? url.slice(0, -1) : url
+            return url.slice(-1) === '/' ? url.slice(0, -1) : url;
         }
 
         function checkEditMode() {
             return $scope.editRepoPage && !$scope.editRepoPage || !$scope.model.editMode;
         }
 
-        $scope.ok = function () {
+        $scope.ok = function() {
             let member;
             if ($scope.model.repositoryName && $scope.model.store === LOCAL_REPO_STORE) {
                 member = {
@@ -260,9 +269,9 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
                     repositoryName: $scope.model.repositoryName,
                     repoType: $scope.model.repoType,
                     respectRights: $scope.model.respectRights,
-                    writable: $scope.model.writable
-                }
-                $scope.fedxMembers = $scope.fedxMembers.filter(el => el.repositoryName !== member.repositoryName || el.store !== member.store );
+                    writable: $scope.model.writable,
+                };
+                $scope.fedxMembers = $scope.fedxMembers.filter((el) => el.repositoryName !== member.repositoryName || el.store !== member.store );
             } else if ($scope.model.repositoryName && $scope.model.store === REMOTE_REPO_STORE) {
                 member = {
                     store: REMOTE_REPO_STORE,
@@ -270,16 +279,16 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
                     repositoryServer: removeEndingSlash($scope.model.repositoryServer),
                     username: $scope.model.username,
                     password: $scope.model.password,
-                    writable: $scope.model.writable
+                    writable: $scope.model.writable,
                 };
-                if (checkEditMode() && $scope.fedxMembers.find(el => el.repositoryName === member.repositoryName
+                if (checkEditMode() && $scope.fedxMembers.find((el) => el.repositoryName === member.repositoryName
                     && el.repositoryServer === member.repositoryServer)) {
-                    let resolvedName = $scope.resolveName(member);
+                    const resolvedName = $scope.resolveName(member);
                     toastr.error($translate.instant('fedx.repo.already.added.member.error', {name: resolvedName}));
                     $scope.$uibModalInstance.close();
                     return;
                 }
-                $scope.fedxMembers = $scope.fedxMembers.filter(el => el.repositoryName !== member.repositoryName
+                $scope.fedxMembers = $scope.fedxMembers.filter((el) => el.repositoryName !== member.repositoryName
                     || el.repositoryServer !== member.repositoryServer);
             } else {
                 member = {
@@ -288,17 +297,17 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
                     username: $scope.model.username,
                     password: $scope.model.password,
                     supportsASKQueries: $scope.model.supportsASKQueries,
-                    writable: $scope.model.writable
+                    writable: $scope.model.writable,
                 };
 
-                if (checkEditMode() && $scope.fedxMembers.find(el => el.endpoint === member.endpoint)) {
-                    let resolvedName = $scope.resolveName(member);
+                if (checkEditMode() && $scope.fedxMembers.find((el) => el.endpoint === member.endpoint)) {
+                    const resolvedName = $scope.resolveName(member);
                     toastr.error($translate.instant('fedx.repo.already.added.sparql.endpoint.error', {name: resolvedName}));
                     $scope.$uibModalInstance.close();
                     return;
                 }
 
-                $scope.fedxMembers = $scope.fedxMembers.filter(el => el.endpoint !== member.endpoint);
+                $scope.fedxMembers = $scope.fedxMembers.filter((el) => el.endpoint !== member.endpoint);
             }
 
             updateMembers(member);
@@ -306,11 +315,19 @@ function fedxRepoDirective($uibModal, RepositoriesRestService, toastr, $translat
             $scope.$uibModalInstance.close();
         };
 
-        $scope.$on('changedLocation', function () {
+        $scope.$on('changedLocation', function() {
             $scope.fedxMembers = [];
             getKnownRepos();
         });
 
-        getKnownRepos();
+        const init = () => {
+            getKnownRepos();
+            $scope.canAddRemoteRepository = authorizationService.isRepoManager();
+            if ($scope.editRepoPage) {
+                $scope.fedxMembers = $scope.repositoryInfo.params.member.value.slice();
+            }
+        };
+
+        init();
     }
 }

--- a/packages/legacy-workbench/src/js/angular/repositories/templates/fedx-repo.html
+++ b/packages/legacy-workbench/src/js/angular/repositories/templates/fedx-repo.html
@@ -13,8 +13,9 @@
                         </span>
                         <span class="ri-alert-line" ng-if="!checkIfRepoExist(member)" gdb-tooltip="{{'repoTooltips.fedx.repositoryNotExistWarning' | translate}}"> </span>
                     </div>
-                    <div class="actions">
-                        <button class="btn btn-link p-0 edit-repository-btn" type="button">
+                    <div class="actions" ng-if="canManageRepo(member)">
+                        <button class="btn btn-link p-0 edit-repository-btn"
+                                type="button">
                                 <span id="{{member.repositoryName}}-icon-edit" class="ri-edit-line"
                                       ng-click="editFedXRepository(member)"
                                       ng-if="member.store !== 'NativeStore'"
@@ -54,7 +55,11 @@
                     </a>
                 </div>
             </div>
-            <button type="button" id="addFedXRepository" ng-click="addRemoteMember()" class="btn btn-primary">
+            <button type="button"
+                    ng-if="canAddRemoteRepository"
+                    id="addFedXRepository"
+                    ng-click="addRemoteMember()"
+                    class="btn btn-primary">
                 <span class="ri-add-circle-line"></span>
                 {{'fedx.repo.add.remote' | translate}}
             </button>


### PR DESCRIPTION
## What
Update the FedX repository editor to support users with ROLE_MANAGE_REPO.

## Why
Users with ROLE_MANAGE_REPO should be able to manage only the federation members associated with repositories they have management permissions for.

## How
- Restricted the list of repositories that can be added as federation members to those the user has management permissions for.
- Allowed users to configure and detach only federation members associated with repositories they have management permissions for.
- Hid member actions for federation members associated with repositories the user is not authorized to manage.

## Screenshots
<img width="1190" height="609" alt="image" src="https://github.com/user-attachments/assets/41695d13-23a6-446c-aa92-85a964602400" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
