### PR TITLE
GDB-14888 Reconfigure PrimeNG theme to use Aura preset and add CSS layer for style overrides

### DIFF
--- a/packages/workbench/src/app/app.config.ts
+++ b/packages/workbench/src/app/app.config.ts
@@ -11,6 +11,7 @@ import {providePrimeNG} from 'primeng/config';
 import {DialogService} from 'primeng/dynamicdialog';
 import {ConfirmationService} from 'primeng/api';
 import {provideTranslocoMessageformat} from '@jsverse/transloco-messageformat';
+import Aura from '@primeuix/themes/aura';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -23,8 +24,16 @@ export const appConfig: ApplicationConfig = {
     provideAnimationsAsync(),
     providePrimeNG({
       theme: {
+        preset: Aura,
         options: {
           prefix: 'gw',
+          // Wrap PrimeNG's own generated styles in a cascade layer so the
+          // unlayered `:root` overrides from the styleguide always win,
+          // regardless of stylesheet insertion order.
+          cssLayer: {
+            name: 'primeng',
+            order: 'primeng',
+          },
         }
       }
     }),


### PR DESCRIPTION
## What
Reconfigure PrimeNG theme to use Aura preset and add CSS layer for style overrides

## Why
With the current primeng configuration we experience broken looking components.

## How
Adding an actual primeng theme preset and configured overrides come from our design system

## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
