### PR TITLE
GDB-14855: Prevent repository sync on login page

### DIFF
--- a/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
+++ b/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
@@ -250,6 +250,18 @@ describe('User and Access', () => {
         });
 
         context('Login / return URL redirects', () => {
+            it.only('should not add the active repository to the login page URL', () => {
+                cy.presetRepository(repoName);
+                UserAndAccessSteps.visit();
+                cy.url().should('include', `repositoryId=${repoName}`);
+
+                UserAndAccessSteps.toggleSecurity();
+
+                cy.url()
+                    .should('include', '/login')
+                    .and('not.include', 'repositoryId=');
+            });
+
             it('should redirect to previous page after logout and then login', () => {
                 UserAndAccessSteps.toggleSecurity();
                 LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);

--- a/packages/workbench/src/app/services/repository-url-sync.service.ts
+++ b/packages/workbench/src/app/services/repository-url-sync.service.ts
@@ -5,7 +5,7 @@ import {
   getCurrentRoute,
   REPOSITORY_ID_PARAM,
   RepositoryContextService,
-  WindowService,
+  WindowService, isLoginPage,
 } from '@ontotext/workbench-api';
 import {ConfirmationProviderService} from './dialog/confirmation-provider.service';
 import {TranslocoService} from '@jsverse/transloco';
@@ -47,6 +47,10 @@ export class RepositoryUrlSyncService {
     const isSameRepository = !!selectedRepository && repositoryIdParam === selectedRepository.id;
 
     try {
+      // --- if on login page, do nothing
+      if (isLoginPage()) {
+        return;
+      }
       // --- no selected repository ---
 
       if (!selectedRepository) {


### PR DESCRIPTION
## What
Added a condition to stop repository synchronization while on the login page.

## Why
To avoid unnecessary operations and potential errors when the user is not logged into the application.

## How
- Integrated `isLoginPage()` check in `repository-url-sync.service.ts` to bypass sync logic if on the login page.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified
