### PR TITLE
Cherry-pick GDB-14912: Reduce the size of the Solr connector banner title

### DIFF
--- a/packages/shared-components/cypress/e2e/layout/layout.cy.js
+++ b/packages/shared-components/cypress/e2e/layout/layout.cy.js
@@ -171,7 +171,7 @@ describe('Layout', () => {
     // THEN: I expect the Solr deprecation banner to be visible.
     DeprecationSteps.getDeprecationBanner()
       .should('be.visible')
-      .should('contain.text', 'Solr Connector Deprecation Notice');
+      .should('contain.text', 'The Solr connector is deprecated and will be removed in GraphDB 12');
 
     // WHEN: I click the close button.
     DeprecationSteps.closeBanner();
@@ -183,6 +183,6 @@ describe('Layout', () => {
     // THEN: I expect the Solr deprecation banner to be visible again.
     DeprecationSteps.getDeprecationBanner()
       .should('be.visible')
-      .should('contain.text', 'Solr Connector Deprecation Notice');
+      .should('contain.text', 'The Solr connector is deprecated and will be removed in GraphDB 12');
   });
 });

--- a/packages/shared-components/src/assets/i18n/en.json
+++ b/packages/shared-components/src/assets/i18n/en.json
@@ -225,8 +225,7 @@
   },
   "deprecation-banner": {
     "solr": {
-      "header": "Solr Connector Deprecation Notice",
-      "content": "The Solr connector has been deprecated and will be removed in version 12 of GraphDB. If you are using it, please contact us via the available support channels to discuss the alternatives."
+      "content": "The Solr connector is deprecated and will be removed in GraphDB 12. If you use it, <b>contact us</b> through the available support channels."
     }
   }
 }

--- a/packages/shared-components/src/assets/i18n/fr.json
+++ b/packages/shared-components/src/assets/i18n/fr.json
@@ -225,8 +225,7 @@
   },
   "deprecation-banner": {
     "solr": {
-      "header": "Avis de dépréciation du connecteur Solr",
-      "content": "Le connecteur Solr est obsolète et sera supprimé dans la version 12 de GraphDB. Si vous l'utilisez, veuillez nous contacter via les canaux de support disponibles afin de discuter des alternatives."
+      "content": "Le connecteur Solr est obsolète et sera supprimé dans GraphDB 12. Si vous l'utilisez, <b>contactez-nous</b> via les canaux d'assistance disponibles."
     }
   }
 }

--- a/packages/shared-components/src/components.d.ts
+++ b/packages/shared-components/src/components.d.ts
@@ -399,11 +399,11 @@ export namespace Components {
      */
     interface TranslateLabel {
         /**
-          * Represents a label key.
+          * The translation label key.
          */
         "labelKey": string;
         /**
-          * Represents an array of translation parameters.
+          * The parameters passed to the translation.
           * @default []
          */
         "translationParameters": TranslationParameter[];
@@ -1082,11 +1082,11 @@ declare namespace LocalJSX {
      */
     interface TranslateLabel {
         /**
-          * Represents a label key.
+          * The translation label key.
          */
         "labelKey"?: string;
         /**
-          * Represents an array of translation parameters.
+          * The parameters passed to the translation.
           * @default []
          */
         "translationParameters"?: TranslationParameter[];

--- a/packages/shared-components/src/components/onto-deprecation-banner/onto-deprecation-banner.scss
+++ b/packages/shared-components/src/components/onto-deprecation-banner/onto-deprecation-banner.scss
@@ -6,7 +6,7 @@
   display: flex;
   align-items: flex-start;
   gap: 1rem;
-  padding: 1rem;
+  padding: 0.3rem;
   background: #384252;
   color: #FFF;
 
@@ -15,7 +15,7 @@
     text-align: center;
 
     .banner-message {
-      font-size: 1.2em;
+      font-size: 1rem;
     }
   }
 

--- a/packages/shared-components/src/components/onto-deprecation-banner/onto-deprecation-banner.tsx
+++ b/packages/shared-components/src/components/onto-deprecation-banner/onto-deprecation-banner.tsx
@@ -21,10 +21,6 @@ export class OntoDeprecationBanner {
       <Host>
         <div class="deprecation-banner">
           <div class="banner-content">
-            <h3 class="banner-header">
-              <slot name="header"></slot>
-            </h3>
-
             <div class="banner-message">
               <slot name="content"></slot>
             </div>

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -131,9 +131,6 @@ export class OntoLayout {
         {!this.isEmbedded &&<div class="wb-header">
           {!this.hideSolrDeprecationBanner &&
             <onto-deprecation-banner class='onto-deprecation-banner' onCloseBanner={this.onSolrDeprecationBannerClosedHandler()}>
-              <span slot='header'>
-                <translate-label labelKey='deprecation-banner.solr.header'></translate-label>
-              </span>
               <span slot='content'>
                 <translate-label labelKey='deprecation-banner.solr.content'></translate-label>
               </span>

--- a/packages/shared-components/src/components/translate-label/readme.md
+++ b/packages/shared-components/src/components/translate-label/readme.md
@@ -18,10 +18,10 @@ Example of usage:
 
 ## Properties
 
-| Property                | Attribute                | Description                                    | Type                     | Default     |
-| ----------------------- | ------------------------ | ---------------------------------------------- | ------------------------ | ----------- |
-| `labelKey`              | `label-key`              | Represents a label key.                        | `string`                 | `undefined` |
-| `translationParameters` | `translation-parameters` | Represents an array of translation parameters. | `TranslationParameter[]` | `[]`        |
+| Property                | Attribute                | Description                               | Type                     | Default     |
+| ----------------------- | ------------------------ | ----------------------------------------- | ------------------------ | ----------- |
+| `labelKey`              | `label-key`              | The translation label key.                | `string`                 | `undefined` |
+| `translationParameters` | `translation-parameters` | The parameters passed to the translation. | `TranslationParameter[]` | `[]`        |
 
 
 ## Dependencies

--- a/packages/shared-components/src/components/translate-label/translate-label.tsx
+++ b/packages/shared-components/src/components/translate-label/translate-label.tsx
@@ -1,5 +1,8 @@
 import {Component, Host, h, Prop, State} from '@stencil/core';
-import {TranslationParameter} from '@ontotext/workbench-api';
+import {
+  TranslationParameter,
+  HtmlUtil,
+} from '@ontotext/workbench-api';
 import {TranslationService} from '../../services/translation.service';
 
 /**
@@ -17,23 +20,28 @@ import {TranslationService} from '../../services/translation.service';
   styleUrl: 'translate-label.scss',
 })
 export class TranslateLabel {
-
   private unsubscribeTranslationChanged: (() => void) | null = null;
 
   /**
-   * Represents a label key.
+   * The translation label key.
    */
   @Prop() labelKey: string;
 
   /**
-   * Represents an array of translation parameters.
+   * The parameters passed to the translation.
    */
   @Prop() translationParameters: TranslationParameter[] = [];
 
   @State() translatedLabel: string;
 
-  connectedCallback() {
-    this.unsubscribeTranslationChanged = TranslationService.onTranslate(this.labelKey, this.translationParameters, (translatedLabel) => this.translatedLabel = translatedLabel);
+  connectedCallback(): void {
+    this.unsubscribeTranslationChanged = TranslationService.onTranslate(
+      this.labelKey,
+      this.translationParameters,
+      (translatedLabel) => {
+        this.translatedLabel = HtmlUtil.sanitize(translatedLabel);
+      }
+    );
   }
 
   disconnectedCallback(): void {
@@ -44,10 +52,6 @@ export class TranslateLabel {
   }
 
   render() {
-    return (
-      <Host>
-        {this.translatedLabel}
-      </Host>
-    );
+    return <Host innerHTML={this.translatedLabel}></Host>;
   }
 }


### PR DESCRIPTION
## What
- Remove the Solr banner header.
- Update the banner message.
- Reduce the message font size.

## Why
The banner was too verbose and occupied too much space.

## How
- Remove the banner header.
- Update the banner message.
- Reduce the message font size.

(cherry picked from commit 318ee70b3f56ad815ac8aebbd7ceef4301fd55b1)
(cherry picked from commit a988a56050797124d5175cb711381c584a430335)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
