### PR TITLE
GDB-14891: Update comment color in YASGUI Moxer theme

### DIFF
--- a/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
+++ b/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
@@ -75,10 +75,14 @@ yasgui-component .yasgui-toolbar .btn-orientation {
         background-color: var(--gw-button-secondary-background) !important;
         border-color: var(--gw-button-secondary-border-color) !important;
     }
+
+    .cm-comment {
+        color: var(--gw-neutral-300);
+    }
 }
 
 /*----------------------------------------*/
-/*           Yasqe autocomplete            */
+/*           Yasqe autocomplete           */
 /*----------------------------------------*/
 .CodeMirror-hints {
     border: 1px solid var(--gw-autocomplete-border-color);
@@ -751,6 +755,10 @@ yasgui-component .yasr #explainPlanQuery {
 yasgui-component .yasr .explain-plan-container {
     background-color:  var(--gw-panel-background);
     border: 1px solid var(--gw-dialog-border-color);
+
+    .cm-comment {
+        color: var(--gw-neutral-300);
+    }
 }
 
 yasgui-component .yasr .yasr-header-replacement {

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
@@ -75,6 +75,10 @@ app-yasgui-component-facade .yasgui-toolbar .btn-orientation {
     background-color: var(--gw-button-secondary-background) !important;
     border-color: var(--gw-button-secondary-border-color) !important;
   }
+
+  .cm-comment {
+    color: var(--gw-neutral-300);
+  }
 }
 
 /*----------------------------------------*/
@@ -746,6 +750,10 @@ app-yasgui-component-facade .yasr #explainPlanQuery {
 app-yasgui-component-facade .yasr .explain-plan-container {
   background-color:  var(--gw-panel-background);
   border: 1px solid var(--gw-dialog-border-color);
+
+  .cm-comment {
+    color: var(--gw-neutral-300);
+  }
 }
 
 app-yasgui-component-facade .yasr .yasr-header-replacement {


### PR DESCRIPTION
## What
Changed the comment color in the Moxer theme for the YASGUI editor.

## Why
To improve readability and visual consistency in the code editor.

## How
- Updated `.cm-comment` color from `#3F445A` to `#6B7280` in both `moxer.css` files located in `workbench` and `legacy-workbench`.

## Testing


## Screenshots
<img width="1436" height="488" alt="image" src="https://github.com/user-attachments/assets/138f5c47-f82f-48b8-89a6-d15ab36aff90" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
