### PR TITLE
GDB-14919: Fix broken test

### DIFF
--- a/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
+++ b/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
@@ -250,7 +250,7 @@ describe('User and Access', () => {
         });
 
         context('Login / return URL redirects', () => {
-            it.only('should not add the active repository to the login page URL', () => {
+            it('should not add the active repository to the login page URL', () => {
                 cy.presetRepository(repoName);
                 UserAndAccessSteps.visit();
                 cy.url().should('include', `repositoryId=${repoName}`);
@@ -699,22 +699,24 @@ describe('User and Access', () => {
             // with manage permission are not allowed to set the default repository.
             RepositorySteps.getSetDefaultRepositoryButton(manageRepositoryId).should('not.exist');
 
+            // And should see the copy action for all repositories.
+            RepositorySteps.getCopyRepositoryButton(writeRepositoryId).should('be.visible');
+            RepositorySteps.getCopyRepositoryButton(readRepositoryId).should('be.visible');
+            RepositorySteps.getCopyRepositoryButton(graphQLOnlyRepositoryId).should('be.visible');
+
             // And no repository management actions should be available for the other repositories.
-            RepositorySteps.getCopyRepositoryButton(readRepositoryId).should('not.exist');
             RepositorySteps.getEditRepositoryButton(readRepositoryId).should('not.exist');
             RepositorySteps.getDownloadRepositoryConfigurationButton(readRepositoryId).should('not.exist');
             RepositorySteps.getRestartRepositoryButton(readRepositoryId).should('not.exist');
             RepositorySteps.getDeleteRepositoryButton(readRepositoryId).should('not.exist');
             RepositorySteps.getSetDefaultRepositoryButton(readRepositoryId).should('not.exist');
 
-            RepositorySteps.getCopyRepositoryButton(writeRepositoryId).should('not.exist');
             RepositorySteps.getEditRepositoryButton(writeRepositoryId).should('not.exist');
             RepositorySteps.getDownloadRepositoryConfigurationButton(writeRepositoryId).should('not.exist');
             RepositorySteps.getRestartRepositoryButton(writeRepositoryId).should('not.exist');
             RepositorySteps.getDeleteRepositoryButton(writeRepositoryId).should('not.exist');
             RepositorySteps.getSetDefaultRepositoryButton(writeRepositoryId).should('not.exist');
 
-            RepositorySteps.getCopyRepositoryButton(graphQLOnlyRepositoryId).should('not.exist');
             RepositorySteps.getEditRepositoryButton(graphQLOnlyRepositoryId).should('not.exist');
             RepositorySteps.getDownloadRepositoryConfigurationButton(graphQLOnlyRepositoryId).should('not.exist');
             RepositorySteps.getRestartRepositoryButton(graphQLOnlyRepositoryId).should('not.exist');

--- a/packages/legacy-workbench/package-lock.json
+++ b/packages/legacy-workbench/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
                 "ontotext-graphql-playground-component": "^0.0.9",
-                "ontotext-yasgui-web-component": "^1.7.0",
+                "ontotext-yasgui-web-component": "^1.7.2",
                 "single-spa-angularjs": "^4.3.1"
             },
             "devDependencies": {
@@ -5674,9 +5674,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.7.0.tgz",
-            "integrity": "sha512-s2gqGmu4fT9CmueOYkosTx1v9N/dRE2YZvWegRnPt8Jp0Iqp8IE/CaSg2XlfKZRVumCxCiDhtfGmfTYJ4s1wFg==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.7.2.tgz",
+            "integrity": "sha512-IRwwjlct+dgVMte6h29b9EZ8Q7gvptdBeVUkLRd9v0n/jPHpb+9tR8ZaUnOjB1gCkcS5dLSQwpdJotumhN9crQ==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.7.4",

--- a/packages/legacy-workbench/package.json
+++ b/packages/legacy-workbench/package.json
@@ -76,7 +76,7 @@
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
         "ontotext-graphql-playground-component": "^0.0.9",
-        "ontotext-yasgui-web-component": "^1.7.0",
+        "ontotext-yasgui-web-component": "^1.7.2",
         "single-spa-angularjs": "^4.3.1"
     },
     "resolutions": {

--- a/packages/workbench/package-lock.json
+++ b/packages/workbench/package-lock.json
@@ -20,7 +20,7 @@
         "@jsverse/transloco-messageformat": "^8.3.0",
         "@primeuix/themes": "^2.0.3",
         "file-saver": "^2.0.5",
-        "ontotext-yasgui-web-component": "^1.7.0",
+        "ontotext-yasgui-web-component": "^1.7.2",
         "primeng": "^21.1.8",
         "rxjs": "~7.8.2",
         "single-spa": "^6.0.3",
@@ -16926,9 +16926,9 @@
       }
     },
     "node_modules/ontotext-yasgui-web-component": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.7.0.tgz",
-      "integrity": "sha512-s2gqGmu4fT9CmueOYkosTx1v9N/dRE2YZvWegRnPt8Jp0Iqp8IE/CaSg2XlfKZRVumCxCiDhtfGmfTYJ4s1wFg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.7.2.tgz",
+      "integrity": "sha512-IRwwjlct+dgVMte6h29b9EZ8Q7gvptdBeVUkLRd9v0n/jPHpb+9tR8ZaUnOjB1gCkcS5dLSQwpdJotumhN9crQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -28,7 +28,7 @@
     "@jsverse/transloco-messageformat": "^8.3.0",
     "@primeuix/themes": "^2.0.3",
     "file-saver": "^2.0.5",
-    "ontotext-yasgui-web-component": "^1.7.0",
+    "ontotext-yasgui-web-component": "^1.7.2",
     "primeng": "^21.1.8",
     "rxjs": "~7.8.2",
     "single-spa": "^6.0.3",


### PR DESCRIPTION
## What
Code changes were made without updating the affected tests. The merge request was merged because the failing tests were not executed.

## Why
One of the tests was accidentally marked with `.only`. As a result, Cypress executed only that test and skipped the rest of the test suite, so the affected tests were never run.

Previously, headless test execution appeared to ignore the `.only` marker and execute the entire test suite. This behaviour seems to have changed, possibly after a Cypress upgrade. Because of this change, the CI build executed only the selected test, allowing the build to pass and the merge request to be merged despite the broken tests.

## How
- Remove the `.only` marker.
- Fix the affected tests.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified
