### PR TITLE
Cherry pick: GDB-14833 increase autocomplete waiting time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@single-spa/import-map-injector": "^2.0.2",
-                "graphdb-workbench-plugins": "~1.0.0",
+                "graphdb-workbench-plugins": "^1.0.1",
                 "import-map-overrides": "^6.1.0"
             },
             "devDependencies": {
@@ -6927,9 +6927,9 @@
             "license": "ISC"
         },
         "node_modules/graphdb-workbench-plugins": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/graphdb-workbench-plugins/-/graphdb-workbench-plugins-1.0.0.tgz",
-            "integrity": "sha512-bnYFVBGxR6AphR2tutjJ4+W3bHaQgpjdCGp+xZ2rqXwCmzNOAu36c/NmM4cJB1YY6OdtoXGizSqnUJU8m3W/dQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/graphdb-workbench-plugins/-/graphdb-workbench-plugins-1.0.1.tgz",
+            "integrity": "sha512-YYhggjfYNLqdS/NyB4ldpADVsgbhPf7pSCRuFGEeT71FW9zb5mSpE9bz1Tn18knep7qR7Ewrn8CWA0/BamqbUQ==",
             "license": "Apache-2.0"
         },
         "node_modules/gzip-size": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "resolutions": {},
     "dependencies": {
         "@single-spa/import-map-injector": "^2.0.2",
-        "graphdb-workbench-plugins": "~1.0.0",
+        "graphdb-workbench-plugins": "^1.0.1",
         "import-map-overrides": "^6.1.0"
     }
 }


### PR DESCRIPTION
## What
Increase waiting time for autocomplete to improve responsiveness.

## Why
It was using the default 1 second, which isn't enough on slower networks

## How
Added a 5 second max waiting time, instead of the default 1

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
