### PR TITLE
GDB-14890: Update YASGUI component version

### DIFF
--- a/packages/legacy-workbench/package-lock.json
+++ b/packages/legacy-workbench/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
                 "ontotext-graphql-playground-component": "^0.0.9",
-                "ontotext-yasgui-web-component": "^1.6.5",
+                "ontotext-yasgui-web-component": "^1.7.0",
                 "single-spa-angularjs": "^4.3.1"
             },
             "devDependencies": {
@@ -5674,9 +5674,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.5.tgz",
-            "integrity": "sha512-Cdc2jcAYMco1RX1mNSyFALigf8mP+4CcwJnBjCqx+BmF8S90U9lUUSWEwKSvutM5ow+AgfZgH9In2ijyJ/BjsQ==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.7.0.tgz",
+            "integrity": "sha512-s2gqGmu4fT9CmueOYkosTx1v9N/dRE2YZvWegRnPt8Jp0Iqp8IE/CaSg2XlfKZRVumCxCiDhtfGmfTYJ4s1wFg==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.7.4",

--- a/packages/legacy-workbench/package.json
+++ b/packages/legacy-workbench/package.json
@@ -76,7 +76,7 @@
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
         "ontotext-graphql-playground-component": "^0.0.9",
-        "ontotext-yasgui-web-component": "^1.6.5",
+        "ontotext-yasgui-web-component": "^1.7.0",
         "single-spa-angularjs": "^4.3.1"
     },
     "resolutions": {

--- a/packages/workbench/package-lock.json
+++ b/packages/workbench/package-lock.json
@@ -20,7 +20,7 @@
         "@jsverse/transloco-messageformat": "^8.3.0",
         "@primeuix/themes": "^2.0.3",
         "file-saver": "^2.0.5",
-        "ontotext-yasgui-web-component": "^1.6.5",
+        "ontotext-yasgui-web-component": "^1.7.0",
         "primeng": "^21.1.8",
         "rxjs": "~7.8.2",
         "single-spa": "^6.0.3",
@@ -16926,9 +16926,9 @@
       }
     },
     "node_modules/ontotext-yasgui-web-component": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.5.tgz",
-      "integrity": "sha512-Cdc2jcAYMco1RX1mNSyFALigf8mP+4CcwJnBjCqx+BmF8S90U9lUUSWEwKSvutM5ow+AgfZgH9In2ijyJ/BjsQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.7.0.tgz",
+      "integrity": "sha512-s2gqGmu4fT9CmueOYkosTx1v9N/dRE2YZvWegRnPt8Jp0Iqp8IE/CaSg2XlfKZRVumCxCiDhtfGmfTYJ4s1wFg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -28,7 +28,7 @@
     "@jsverse/transloco-messageformat": "^8.3.0",
     "@primeuix/themes": "^2.0.3",
     "file-saver": "^2.0.5",
-    "ontotext-yasgui-web-component": "^1.6.5",
+    "ontotext-yasgui-web-component": "^1.7.0",
     "primeng": "^21.1.8",
     "rxjs": "~7.8.2",
     "single-spa": "^6.0.3",


### PR DESCRIPTION
## What
Updated the `ontotext-yasgui-web-component` to version `1.7.0`

## Why
To align with the latest improvements and fixes provided in the updated version

## How
- Modified `package.json` and `package-lock.json` files in multiple packages to update the `ontotext-yasgui-web-component` to `^1.7.0`.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
