### PR TITLE
GDB-14938: Remember the state of the Solr banner in WB

### DIFF
--- a/e2e-tests/e2e-legacy/home/solr-banner/solr-banner.spec.js
+++ b/e2e-tests/e2e-legacy/home/solr-banner/solr-banner.spec.js
@@ -1,0 +1,137 @@
+import HomeSteps from '../../../steps/home-steps.js';
+import {DeprecationSteps} from '../../../steps/deprecation-steps.js';
+import {LoginSteps} from '../../../steps/login-steps.js';
+import {GuidesStubs} from '../../../stubs/guides/guides-stubs.js';
+import {GuideSteps} from '../../../steps/guides/guide-steps.js';
+import {GuideDialogSteps} from '../../../steps/guides/guide-dialog-steps.js';
+
+describe('Solr deprecation banner', () => {
+    context('Security disabled', () => {
+        it('should keep the Solr deprecation banner hidden after the anonymous user dismisses it', () => {
+            // GIVEN: I have opened the application with security disabled.
+            HomeSteps.visit();
+
+            // THEN: I expect the Solr deprecation banner to be visible.
+            DeprecationSteps.getDeprecationBanner()
+                .should('be.visible')
+                .should('contain.text', 'The Solr connector is deprecated and will be removed in GraphDB 12');
+
+            // WHEN: I dismiss the Solr deprecation banner.
+            DeprecationSteps.closeBanner();
+            // THEN: I expect the Solr deprecation banner to be hidden.
+            DeprecationSteps.getDeprecationBanner().should('not.exist');
+
+            // WHEN: I reload the application.
+            HomeSteps.visit();
+            // THEN: I expect the Solr deprecation banner to remain hidden.
+            DeprecationSteps.getDeprecationBanner().should('not.exist');
+        });
+    });
+
+    context('Security enabled', () => {
+        const PASSWORD = 'root';
+        const USER_USERNAME = 'username';
+
+        beforeEach(() => {
+            cy.createUser({
+                username: USER_USERNAME,
+                password: PASSWORD
+            });
+
+            cy.switchOnSecurity()
+                .then(() => cy.loginAsAdmin())
+                .then(() => cy.switchOnFreeAccess(true));
+        });
+
+        afterEach(() => {
+            cy.loginAsAdmin()
+                .then(() => {
+                    cy.deleteUser(USER_USERNAME, true);
+                    cy.switchOffFreeAccess(true);
+                    cy.switchOffSecurity(true);
+                });
+        });
+
+        it('should persist separate Solr banner states for anonymous and logged-in users', () => {
+            // GIVEN: Security and free access are enabled, and no user is logged in.
+            HomeSteps.visit();
+
+            // THEN: I expect the Solr deprecation banner to be visible for the anonymous user.
+            DeprecationSteps.getDeprecationBanner()
+                .should('be.visible')
+                .should('contain.text', 'The Solr connector is deprecated and will be removed in GraphDB 12');
+
+            // WHEN: The anonymous user dismisses the banner.
+            DeprecationSteps.closeBanner();
+            // THEN: I expect the banner to be hidden for the anonymous user.
+            DeprecationSteps.getDeprecationBanner().should('not.exist');
+
+            // WHEN: I log in as a user who has not dismissed the banner.
+            cy.loginAs(USER_USERNAME, PASSWORD);
+            HomeSteps.visit();
+
+            // THEN: I expect the banner to be visible for the logged-in user.
+            DeprecationSteps.getDeprecationBanner()
+                .should('be.visible')
+                .should('contain.text', 'The Solr connector is deprecated and will be removed in GraphDB 12');
+
+            // WHEN: The logged-in user dismisses the banner.
+            DeprecationSteps.closeBanner();
+            // THEN: I expect the banner to be hidden for the logged-in user.
+            DeprecationSteps.getDeprecationBanner().should('not.exist');
+
+            // WHEN: The user logs out.
+            LoginSteps.logout();
+            // THEN: I expect the banner to remain hidden because the anonymous user has already dismissed it.
+            DeprecationSteps.getDeprecationBanner().should('not.exist');
+
+            // WHEN: I log in as the administrator, who has not dismissed the banner.
+            cy.loginAs('admin', 'root');
+            HomeSteps.visit();
+            // THEN: I expect the banner to be visible for the administrator.
+            DeprecationSteps.getDeprecationBanner()
+                .should('be.visible')
+                .should('contain.text', 'The Solr connector is deprecated and will be removed in GraphDB 12');
+
+            // WHEN: The administrator logs out.
+            LoginSteps.logout();
+            // THEN: I expect the banner to remain hidden because the anonymous user has already dismissed it.
+            DeprecationSteps.getDeprecationBanner().should('not.exist');
+
+            // WHEN: I log in again as the user who previously dismissed the banner.
+            cy.loginAs(USER_USERNAME, PASSWORD);
+            HomeSteps.visit();
+            // THEN: I expect the banner to remain hidden for the logged-in user.
+            DeprecationSteps.getDeprecationBanner().should('not.exist');
+        });
+    });
+
+    context('User guides', () => {
+        it.only('should hide the Solr deprecation banner while a guide is running', () => {
+            // GIVEN: The guides are loaded and ready to be started.
+            GuidesStubs.stubMainMenuGuide();
+            GuideSteps.visit();
+            GuideSteps.verifyGuidesListExists();
+            cy.wait('@getGuides');
+
+            // WHEN: I am on an application page, and the Solr deprecation banner has not been dismissed by the current user.
+            // THEN: I expect the Solr deprecation banner to be visible because it has not been dismissed by the current user.
+            DeprecationSteps.getDeprecationBanner()
+                .should('be.visible')
+                .should('contain.text', 'The Solr connector is deprecated and will be removed in GraphDB 12');
+
+            // WHEN: I start a guide.
+            GuideSteps.runFirstGuide();
+            // THEN: I expect the Solr deprecation banner to be hidden while the guide is running.
+            DeprecationSteps.getDeprecationBanner().should('not.exist');
+
+            // WHEN: I cancel the guide.
+            GuideDialogSteps.clickOnCancelButton();
+            GuideDialogSteps.clickConfirmCancelDialogExitButton();
+            // THEN: I expect the Solr deprecation banner to be visible again.
+            DeprecationSteps.getDeprecationBanner()
+                .should('be.visible')
+                .should('contain.text', 'The Solr connector is deprecated and will be removed in GraphDB 12');
+        });
+    });
+});

--- a/e2e-tests/e2e-legacy/ttyg/chat-list.spec.js
+++ b/e2e-tests/e2e-legacy/ttyg/chat-list.spec.js
@@ -230,7 +230,7 @@ describe('TTYG chat list', () => {
         HomeSteps.visit();
         cy.wait('@get-chat');
         // and came back to the ttyg page
-        TTYGViewSteps.visit();
+        TTYGViewSteps.visit(false);
 
         // Then I expect to last used chat be selected.
         TTYGViewSteps.getChatFromGroup(0, 2).should('have.class', 'selected');

--- a/e2e-tests/e2e-legacy/ttyg/create-chat.spec.js
+++ b/e2e-tests/e2e-legacy/ttyg/create-chat.spec.js
@@ -61,7 +61,7 @@ describe('TTYG create chat', () => {
         // and returns to the TTYG page
         TTYGStubs.stubChatsListGet("/ttyg/chats/create/get-chats-after-create.json");
         TTYGStubs.stubAgentGet();
-        TTYGViewSteps.visit();
+        TTYGViewSteps.visit(false);
         cy.wait('@get-chat-list');
         // Then I expect newly created chat be selected.
         TTYGViewSteps.getChatFromGroup(0, 0).should('contain', 'New chat of Han Solo is a character');

--- a/e2e-tests/steps/deprecation-steps.js
+++ b/e2e-tests/steps/deprecation-steps.js
@@ -1,0 +1,13 @@
+export class DeprecationSteps {
+  static getDeprecationBanner() {
+    return cy.get('onto-deprecation-banner');
+  }
+
+  static getCloseButton() {
+    return DeprecationSteps.getDeprecationBanner().find('.close-button');
+  }
+
+  static closeBanner() {
+    DeprecationSteps.getCloseButton().click();
+  }
+}

--- a/e2e-tests/steps/ttyg/ttyg-view-steps.js
+++ b/e2e-tests/steps/ttyg/ttyg-view-steps.js
@@ -2,9 +2,20 @@ import {BaseSteps} from "../base-steps";
 import {DeprecationSteps} from '../deprecation-banner/deprecation-banner-steps.js';
 
 export class TTYGViewSteps extends BaseSteps {
-    static visit() {
+    /**
+     * Visits the TTYG page and closes the Solr deprecation banner by default.
+     *
+     * @param {boolean} closeSolrBanner Whether to close the banner. Set to `false`
+     * when revisiting the page after the banner has already been closed.
+     */
+    static visit(closeSolrBanner = true) {
         cy.visit('/ttyg');
-        DeprecationSteps.closeBanner();
+        // Temporary workaround until the Solr deprecation banner is removed.
+        // The banner changes the page layout, causing tests to fail randomly.
+        // This quick fix prevents GraphDB build failures and should be deleted together with the banner.
+        if (closeSolrBanner) {
+            DeprecationSteps.closeBanner();
+        }
     }
 
     static getTtygView() {

--- a/e2e-tests/support/security-command.js
+++ b/e2e-tests/support/security-command.js
@@ -29,6 +29,30 @@ Cypress.Commands.add('loginAsAdmin', () => {
     });
 });
 
+Cypress.Commands.add('loginAs', (username, password) => {
+    return cy.request({
+        method: 'POST',
+        url: '/rest/login',
+        body: {
+            username,
+            password,
+        },
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        failOnStatusCode: true,
+    }).then((response) => {
+        const authHeader = response.headers['authorization'];
+        const token = Array.isArray(authHeader)
+            ? authHeader[0]
+            : authHeader;
+        cy.window().then((win) => {
+            win.localStorage.setItem('ontotext.gdb.auth.jwt', token);
+            win.localStorage.setItem('ontotext.gdb.auth.authenticated', 'true');
+        });
+    });
+});
+
 Cypress.Commands.add('switchOffSecurity', (secured = false) => {
     let headers = {'Content-Type': 'application/json'};
     if (secured) {
@@ -62,5 +86,24 @@ Cypress.Commands.add('switchOffFreeAccess', (secured = false) => {
         },
         headers,
         failOnStatusCode: true,
+    });
+});
+
+Cypress.Commands.add('switchOnFreeAccess', (secured = false) => {
+    let headers = {'Content-Type': 'application/json'};
+    if (secured) {
+        const authHeader = Cypress.env('adminToken');
+        headers = {...headers,
+            'Authorization': authHeader
+        }
+    }
+    return cy.request({
+        method: 'POST',
+        url: '/rest/security/free-access',
+        body: {
+            'enabled': true
+        },
+        headers,
+        failOnStatusCode: false,
     });
 });

--- a/packages/api/src/services/domain/guides/guide-context.service.ts
+++ b/packages/api/src/services/domain/guides/guide-context.service.ts
@@ -1,12 +1,16 @@
 import {ContextService} from '../../context';
 import {DeriveContextServiceContract} from '../../../models/context/update-context-method';
+import {ValueChangeCallback} from '../../../models/context/value-change-callback';
+import {Repository} from '../../../models/repositories';
 
 type GuideContextFields = {
   readonly PAUSED: string;
+  readonly HAS_RUNNING_GUIDE: string;
 }
 
 type GuideContextFieldParams = {
   readonly PAUSED: boolean;
+  readonly HAS_RUNNING_GUIDE: boolean;
 };
 
 /**
@@ -17,6 +21,11 @@ export class GuideContextService extends ContextService<GuideContextFields> impl
    * Context property key for the paused state.
    */
   readonly PAUSED = 'isPaused';
+
+  /**
+   * Context property key indicating whether a guide is currently running.
+   */
+  readonly HAS_RUNNING_GUIDE = 'hasRunningGuide';
 
   /**
    * Updates the paused state in the context.
@@ -34,5 +43,33 @@ export class GuideContextService extends ContextService<GuideContextFields> impl
    */
   isPaused(): boolean | undefined {
     return this.getContextPropertyValue<boolean>(this.PAUSED);
+  }
+
+  /**
+   * Returns whether a guide is currently running.
+   *
+   * @returns `true` if a guide is currently running; otherwise, `false`.
+   */
+  hasRunningGuide(): boolean {
+    return this.getContextPropertyValue(this.HAS_RUNNING_GUIDE) ?? false;
+  }
+
+  /**
+   * Updates whether a guide is currently running.
+   *
+   * @param isRunning - `true` if a guide is currently running, otherwise, `false`.
+   */
+  updateHasRunningGuide(isRunning: boolean): void {
+    this.updateContextProperty(this.HAS_RUNNING_GUIDE, isRunning);
+  }
+
+  /**
+   * Registers a callback to be notified whenever the running state of the guide changes.
+   *
+   * @param callbackFunction - The callback invoked when the running state of the guide changes.
+   * @returns A function that unsubscribes the callback from further updates.
+  */
+  onHasRunningGuideChanged(callbackFunction: ValueChangeCallback<Repository | undefined>): () => void {
+    return this.subscribe(this.HAS_RUNNING_GUIDE, callbackFunction);
   }
 }

--- a/packages/api/src/services/domain/guides/guides.service.ts
+++ b/packages/api/src/services/domain/guides/guides.service.ts
@@ -72,6 +72,13 @@ export class GuidesService implements Service {
       }
     });
 
+    this.guideContextService.updateHasRunningGuide(true);
+
+    const unsubscribeOnGuideEnd = this.shepherdService.subscribeOnGuideEnd(() => {
+      this.guideContextService.updateHasRunningGuide(false);
+      unsubscribeOnGuideEnd();
+    });
+
     if (startStepId) {
       this.shepherdService.resumeGuide(guide.getId(), stepDescriptions, startStepId);
     } else {

--- a/packages/api/src/services/domain/guides/shepherd.service.ts
+++ b/packages/api/src/services/domain/guides/shepherd.service.ts
@@ -18,6 +18,9 @@ import {ApplicationLifecycleContextService} from '../../app-lifecycle';
 const SMOOTH = 'smooth' as const;
 const NEAREST = 'nearest' as const;
 
+export type GuideEndListener = () => void;
+export type UnsubscribeFunction = () => void;
+
 /**
  * Service wrapper around the <a href="https://shepherdjs.dev/docs/">Shepherd.js</a> tour library.
  *
@@ -79,9 +82,8 @@ export class ShepherdService implements Service {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   onPause: () => void = () => {
   };
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onCancel: () => void = () => {
-  };
+
+  private endSubscribers: GuideEndListener[] = [];
 
   /**
    * Creates and starts a guide.
@@ -163,14 +165,20 @@ export class ShepherdService implements Service {
   }
 
   /**
-   * Registers a callback to be invoked when the active guide is cancelled or completed.
+   * Registers a callback to be invoked when the active guide ends, regardless of whether it is completed, cancelled, or terminated unexpectedly.
    *
-   * @param onCancel - Callback function to call on guide cancel/complete.
+   * @param subscriber - The callback to invoke when cancellation is requested.
+   * @returns A function that unregisters the subscriber. Calling the returned function multiple times has no effect.
    */
-  subscribeToGuideCancel(onCancel: () => void): void {
-    if (typeof onCancel === 'function') {
-      this.onCancel = onCancel;
-    }
+  subscribeOnGuideEnd(subscriber: GuideEndListener): UnsubscribeFunction {
+    this.endSubscribers.push(subscriber);
+
+    return () => {
+      const index = this.endSubscribers.indexOf(subscriber);
+      if (index !== -1) {
+        this.endSubscribers.splice(index, 1);
+      }
+    };
   }
 
   /**
@@ -242,7 +250,6 @@ export class ShepherdService implements Service {
     if (url && url !== getPathName()) {
       navigate(url);
     }
-
     const attachTo = stepOptions.attachTo;
     if (attachTo?.element) {
       const maxWaitTime = stepOptions.maxWaitTime as number | undefined;
@@ -251,6 +258,7 @@ export class ShepherdService implements Service {
         .catch((error) => {
           this.logger.error(String(error));
           this.toastrService.error(this.guideApi.translate(undefined, 'guide.start.unexpected.error.message'));
+          guide.complete();
         });
     } else {
       guide.show(stepIndex);
@@ -265,9 +273,7 @@ export class ShepherdService implements Service {
         currentStep.hide();
       }
       this.guideAutostarted = null;
-      if (this.onCancel) {
-        this.onCancel();
-      }
+      this.endSubscribers.forEach((subscribe) => subscribe());
     };
 
     if (!this.guideCancelSubscription) {
@@ -423,18 +429,28 @@ export class ShepherdService implements Service {
     guideStep: GuideStep,
   ): (() => Promise<unknown>) | undefined {
     return async () => {
-      await new Promise<void>((resolve) => {
-        setTimeout(() => {
-          if (this.waitForApplicationMount && !this.beforeShowResolver) {
-            this.beforeShowResolver = resolve;
-          } else if (!this.waitForApplicationMount) {
-            resolve();
-          }
+      try {
+        await new Promise<void>((resolve) => {
+          setTimeout(() => {
+            if (this.waitForApplicationMount && !this.beforeShowResolver) {
+              this.beforeShowResolver = resolve;
+            } else if (!this.waitForApplicationMount) {
+              resolve();
+            }
+          });
         });
-      });
+      } catch (err) {
+        guide.complete();
+        throw err;
+      }
 
       if (typeof guideStep.beforeShowPromise === 'function') {
-        return await guideStep.beforeShowPromise(guide, guideStep);
+        try {
+          return await guideStep.beforeShowPromise(guide, guideStep);
+        } catch (err) {
+          guide.complete();
+          throw err;
+        }
       }
       return undefined;
     };

--- a/packages/api/src/services/domain/guides/test/shepherd.service.spec.ts
+++ b/packages/api/src/services/domain/guides/test/shepherd.service.spec.ts
@@ -126,22 +126,6 @@ describe('ShepherdService', () => {
     });
   });
 
-  describe('subscribeToGuideCancel', () => {
-    test('should register the callback when a function is provided', () => {
-      const onCancel = jest.fn();
-      shepherdService.subscribeToGuideCancel(onCancel);
-
-      expect(shepherdService.onCancel).toBe(onCancel);
-    });
-
-    test('should not replace the callback when a non-function is provided', () => {
-      const original = shepherdService.onCancel;
-      shepherdService.subscribeToGuideCancel(null as unknown as () => void);
-
-      expect(shepherdService.onCancel).toBe(original);
-    });
-  });
-
   describe('subscribeToGuidePause', () => {
     test('should register the callback when a function is provided', () => {
       const onPause = jest.fn();

--- a/packages/api/src/services/user-preferences/test/user-preferences.service.spec.ts
+++ b/packages/api/src/services/user-preferences/test/user-preferences.service.spec.ts
@@ -70,16 +70,22 @@ describe('UserPreferencesService', () => {
       expect(updateUserPreferencesSpy).toHaveBeenCalledWith(SOLR_BANNER_DISMISSED_USER_PREFERENCES);
     });
 
-    it('should update only context when user is not logged in', () => {
+    it('should persist preferences under the anonymous user key and update the context when the user is not logged in', () => {
       // GIVEN: No user is authenticated.
       mockIsLoggedIn(false);
+      const expectedStorageObject = new UsersPreferences({
+        preferences: {
+          admin: ADMIN_STORED_PREFERENCES,
+          anonymous: new UserPreferences({isSolrDeprecationBannerDismissed: true})
+        }
+      });
 
       // WHEN: The Solr deprecation banner is dismissed.
       userPreferencesService.dismissSolrDeprecationBanner();
 
-      // THEN: I expect the preference not to be persisted.
-      expect(setUsersPreferencesSpy).not.toHaveBeenCalled();
-      // AND: I expect only the context to be updated.
+      // THEN: I expect the preferences to be persisted under the shared anonymous user.
+      expect(setUsersPreferencesSpy).toHaveBeenCalledWith(expectedStorageObject);
+      // AND: I expect the context to be updated.
       expect(updateUserPreferencesSpy).toHaveBeenCalledWith(SOLR_BANNER_DISMISSED_USER_PREFERENCES);
     });
   });

--- a/packages/api/src/services/user-preferences/user-preferences.service.ts
+++ b/packages/api/src/services/user-preferences/user-preferences.service.ts
@@ -1,41 +1,43 @@
 import { service } from '../../providers';
 import { UserPreferencesStorageService } from './user-preferences-storage.service';
-import {AuthenticationService, SecurityContextService} from '../domain/security';
+import { AuthenticationService, SecurityContextService } from '../domain/security';
 import { UserPreferencesContextService } from './user-preferences-context.service';
 import { UserPreferences } from '../../models/user-preference/user-preferences';
 
 /**
  * Service for loading, updating, and persisting user preferences.
  *
- * Preferences are persisted only when the current user is authenticated.
- * Anonymous users keep their preferences only in the current application context,
- * so their choices are reset after a page refresh.
+ * Preferences are stored per current user:
+ * - A currently logged-in user has an individual set of preferences.
+ * - The anonymous user, used when security is disabled or free access is enabled,
+ *   has a shared persisted set of preferences identified by the {@link ANONYMOUS_USER} key.
  */
 export class UserPreferencesService {
+
+  private static readonly ANONYMOUS_USER = 'anonymous';
+
   private readonly userPreferencesStorageService = service(UserPreferencesStorageService);
   private readonly userPreferencesContextService = service(UserPreferencesContextService);
   private readonly securityContextService = service(SecurityContextService);
   private readonly authenticationService = service(AuthenticationService);
 
   /**
-   * Marks the Solr deprecation banner as dismissed.
+   * Marks the Solr deprecation banner as dismissed for the current user.
    *
-   * For authenticated users, the preference is persisted and restored after refresh.
-   * For anonymous users, including non-secured access and free-access mode, the preference is stored
-   * only in the current application context.
+   * The preference is updated in the application context and persisted for the current user.
+   * A currently logged-in user has individual preferences, while the anonymous user shares
+   * a common persisted set of preferences.
    */
   dismissSolrDeprecationBanner(): void {
     const userPreferences = this.getCurrentUserPreferences();
     userPreferences.isSolrDeprecationBannerDismissed = true;
-    this.userPreferencesContextService.updateUserPreferences(userPreferences);
 
-    if (this.authenticationService.isLoggedIn()) {
-      this.persistCurrentUserPreferences(userPreferences);
-    }
+    this.userPreferencesContextService.updateUserPreferences(userPreferences);
+    this.persistCurrentUserPreferences(userPreferences);
   }
 
   /**
-   * Checks whether the Solr deprecation banner has been dismissed.
+   * Checks whether the Solr deprecation banner has been dismissed by the current user.
    *
    * @returns {@code true} if the banner was dismissed, otherwise {@code false}.
    */
@@ -46,54 +48,74 @@ export class UserPreferencesService {
   /**
    * Loads the preferences for the current user into the application context.
    *
-   * Authenticated users receive their persisted preferences.
-   * Anonymous users receive a new in-memory preferences instance.
+   * A currently logged-in user receives their individual persisted preferences.
+   * The anonymous user receives the shared anonymous preferences.
    */
   loadUserPreferences(): void {
-    if (this.authenticationService.isLoggedIn()) {
-      this.userPreferencesContextService.updateUserPreferences(this.loadCurrentUserPreferences() ?? new UserPreferences());
-    } else {
-      this.userPreferencesContextService.updateUserPreferences(new UserPreferences());
+    const currentUsername = this.getCurrentUsername();
+
+    // The username is expected to be available for a currently logged-in user,
+    // but the service API allows it to be undefined.
+    if (!currentUsername) {
+      return;
     }
+
+    const currentUserPreferences = this.loadCurrentUserPreferences(currentUsername) ?? new UserPreferences();
+    this.userPreferencesContextService.updateUserPreferences(currentUserPreferences);
   }
 
   /**
-   * Loads preferences for the current user.
+   * Returns the username of the current user.
    *
-   * @returns Persisted preferences for authenticated users, or a new preferences instance for anonymous users.
+   * A currently logged-in user is identified by their username.
+   * The anonymous user is identified by the {@link ANONYMOUS_USER} key.
+   *
+   * @returns The username of the current user, or {@code undefined} if the username
+   * of the currently logged-in user cannot be determined.
    */
-  private loadCurrentUserPreferences(): UserPreferences | undefined {
-    const username = this.getAuthenticatedUsername();
-
-    // The username is expected to be available for authenticated users, but the service API allows it to be undefined.
-    if (!username) {
-      return new UserPreferences();
+  private getCurrentUsername(): string | undefined {
+    if (this.authenticationService.isLoggedIn()) {
+      return this.securityContextService.getAuthenticatedUser()?.toUser().username;
     }
 
+    return UserPreferencesService.ANONYMOUS_USER;
+  }
+
+  /**
+   * Loads the persisted preferences for the specified user.
+   *
+   * @param username - The username of the user whose preferences should be loaded.
+   * @returns The persisted preferences, or {@code undefined} if no preferences exist.
+   */
+  private loadCurrentUserPreferences(username: string): UserPreferences | undefined {
     return this.userPreferencesStorageService
       .getPreferences()
       .getUserPreferences(username);
   }
 
   /**
-   * Returns the current user preferences from the context.
+   * Returns the current user's preferences from the application context.
    *
    * If no preferences exist in the context, a new preferences instance is created.
    *
-   * @returns The current user preferences.
+   * @returns The current user's preferences.
    */
   private getCurrentUserPreferences(): UserPreferences {
     return this.userPreferencesContextService.getUserPreferences() ?? new UserPreferences();
   }
 
   /**
-   * Persists the preferences for the current authenticated user.
+   * Persists the preferences for the current user.
    *
-   * @param userPreferences - Preferences to persist for the authenticated user.
+   * A currently logged-in user's preferences are stored under their username.
+   * The anonymous user's preferences are stored under the {@link ANONYMOUS_USER} key.
+   *
+   * @param userPreferences - The current user's preferences to persist.
    */
   private persistCurrentUserPreferences(userPreferences: UserPreferences): void {
-    const username = this.getAuthenticatedUsername();
+    const username = this.getCurrentUsername();
 
+    // The username is expected to be available for a currently logged-in user, but the service API allows it to be undefined.
     if (!username) {
       return;
     }
@@ -101,14 +123,5 @@ export class UserPreferencesService {
     const usersPreferences = this.userPreferencesStorageService.getPreferences();
     usersPreferences.setUserPreferences(username, userPreferences);
     this.userPreferencesStorageService.setUsersPreferences(usersPreferences);
-  }
-
-  /**
-   * Returns the username of the authenticated user.
-   *
-   * @returns The authenticated username, or {@code undefined} if no user is authenticated.
-   */
-  private getAuthenticatedUsername(): string | undefined {
-    return this.securityContextService.getAuthenticatedUser()?.toUser().username;
   }
 }

--- a/packages/shared-components/cypress/e2e/layout/layout.cy.js
+++ b/packages/shared-components/cypress/e2e/layout/layout.cy.js
@@ -164,7 +164,7 @@ describe('Layout', () => {
     NavbarSteps.getRootMenuItems().should('have.length', 7);
   });
 
-  it('should hide the Solr deprecation notice until the page is refreshed when security is disabled', () => {
+  it('should hide the Solr deprecation notice when security is disabled', () => {
     // GIVEN: I have visited the layout page with security disabled.
     LayoutSteps.visit();
 
@@ -178,11 +178,14 @@ describe('Layout', () => {
     // THEN: I expect the Solr deprecation banner to not be visible.
     DeprecationSteps.getDeprecationBanner().should('not.exist');
 
-    // WHEN: I refresh the page.
-    LayoutSteps.visit();
-    // THEN: I expect the Solr deprecation banner to be visible again.
-    DeprecationSteps.getDeprecationBanner()
-      .should('be.visible')
-      .should('contain.text', 'The Solr connector is deprecated and will be removed in GraphDB 12');
+    // AND: I expect the dismissed state to be persisted for the anonymous user.
+    cy.window().then((win) => {
+      const preferences = JSON.parse(
+        win.localStorage.getItem('ontotext.gdb.userPreferences.preferences')
+      );
+
+      expect(preferences.preferences.anonymous.isSolrDeprecationBannerDismissed)
+        .to.equal(true);
+    });
   });
 });

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -9,6 +9,7 @@ import {
   AuthenticationStorageService,
   Authority,
   AuthorizationService,
+  GuideContextService,
   EventName,
   EventService,
   LocalStorageSubscriptionHandlerService,
@@ -48,6 +49,7 @@ export class OntoLayout {
   private readonly applicationLifecycleContextService = service(ApplicationLifecycleContextService);
   private readonly userPreferencesService = service(UserPreferencesService);
   private readonly userPreferencesContextService = service(UserPreferencesContextService);
+  private readonly guideContextService = service(GuideContextService);
 
   private readonly fullJwtKey = `${StorageKey.GLOBAL_NAMESPACE}.${this.authStorageService.NAMESPACE}.${this.authStorageService.jwtKey}`;
   private readonly fullAuthenticatedKey = `${StorageKey.GLOBAL_NAMESPACE}.${this.authStorageService.NAMESPACE}.${this.authStorageService.authenticatedKey}`;
@@ -95,7 +97,7 @@ export class OntoLayout {
   }
 
   componentDidLoad() {
-    this.updateShowSolrDeprecationBanner();
+    this.updateSolrDeprecationBannerVisibility();
   }
 
   connectedCallback() {
@@ -105,6 +107,7 @@ export class OntoLayout {
     this.subscribeToRuntimeConfigurationChanges();
     this.subscribeToUserPreferencesChange();
     this.subscribeToBeforeMountRouting();
+    this.subscribeToGuideChanges();
     this.loading = false;
   }
 
@@ -191,7 +194,6 @@ export class OntoLayout {
   private onSolrDeprecationBannerClosedHandler(): () => void {
     return () => {
       this.userPreferencesService.dismissSolrDeprecationBanner();
-      this.updateShowSolrDeprecationBanner();
     };
   }
 
@@ -285,6 +287,7 @@ export class OntoLayout {
   }
 
   private updateVisibility() {
+    this.updateSolrDeprecationBannerVisibility();
     if (!this.authenticationService.isSecurityEnabled()) {
       this.showNavbar = true;
       this.showHeader = true;
@@ -358,11 +361,15 @@ export class OntoLayout {
   private subscribeToUserPreferencesChange() {
     this.subscriptions.add(
       this.userPreferencesContextService.onUserPreferencesChanged(() => {
-        this.updateShowSolrDeprecationBanner();
+        this.updateSolrDeprecationBannerVisibility();
       }));
   }
 
-  private updateShowSolrDeprecationBanner(): void {
-    this.hideSolrDeprecationBanner = this.userPreferencesService.isSolrDeprecationBannerDismissed();
+  private subscribeToGuideChanges(): void {
+    this.subscriptions.add(this.guideContextService.onHasRunningGuideChanged(() => this.updateSolrDeprecationBannerVisibility()));
+  }
+
+  private updateSolrDeprecationBannerVisibility() {
+    return this.hideSolrDeprecationBanner = this.userPreferencesService.isSolrDeprecationBannerDismissed() || this.guideContextService.hasRunningGuide();
   }
 }


### PR DESCRIPTION
## What
Changed how the Solr deprecation banner state is persisted.

## Why
The requirements have been revised:
- When security is enabled, the banner state is persisted per user. If User 1 closes the banner, they will not see it again in the current or subsequent sessions. If another user logs in, they will see the banner until they close it.
- When security is disabled, the banner state is global. Once any user closes the banner, it will never be displayed again.
- When security is enabled, free access is enabled, and the user is not logged in, the behavior is the same as when security is disabled.
- When a guide is started, the banner is hidden regardless of whether the user has previously closed it.
- When the guide finishes, the banner is shown or hidden depending on whether the user had previously dismissed it.

## How
- The UserPreferencesService has been updated to store preferences for the shared anonymous user whenever there is no currently logged-in user (that is, when security is disabled or when free access is enabled). This allows all anonymous users to share the same persisted preferences through the anonymous preference key.
- The guide functionality has also been updated to expose whether a guide is currently running:
 - GuideContextService now includes a new HAS_RUNNING_GUIDE field that indicates whether a guide is currently running.
 - GuideService now updates the guide context when a guide starts or finishes, regardless of whether it completes normally or due to an exception.
- The onto-layout component now listens for changes to the guide state and hides the Solr banner while a guide is running. When the guide finishes, the banner is shown again only if it has not been previously dismissed by the current user.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
