### PR TITLE
Add ESLint rule and pre-commit check for Cypress `.only`

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -19,6 +19,41 @@ if ! command -v npx >/dev/null 2>&1; then
   exit 0
 fi
 
+# Guard against exclusive Cypress tests (.only), which silently skip the rest of the suite.
+# The whole e2e-tests tree is checked against the index, i.e. the content that is about to be committed.
+echo "Checking for exclusive tests (.only) in e2e-tests..."
+# "|| true" is required: git grep exits with 1 when there is no match and this hook runs under "sh -e".
+EXCLUSIVE_TESTS=$(git grep --cached -nE '\b(describe|context|it|specify|test|suite)\.only\b' -- \
+  'e2e-tests/*.js' 'e2e-tests/*.mjs' 'e2e-tests/*.cjs' || true)
+
+if [ -n "$EXCLUSIVE_TESTS" ]; then
+  # Colours only when attached to a terminal, so IDEs and CI logs do not show raw escape codes.
+  if [ -t 1 ]; then
+    RED=$(printf '\033[1;31m')
+    YELLOW=$(printf '\033[1;33m')
+    RESET=$(printf '\033[0m')
+  else
+    RED='' YELLOW='' RESET=''
+  fi
+
+  echo ""
+  echo "${RED}################################################################################${RESET}"
+  echo "${RED}#                                                                              #${RESET}"
+  echo "${RED}#   COMMIT ABORTED - EXCLUSIVE TESTS (.only) FOUND IN e2e-tests                 #${RESET}"
+  echo "${RED}#                                                                              #${RESET}"
+  echo "${RED}################################################################################${RESET}"
+  echo ""
+  echo "${YELLOW}$EXCLUSIVE_TESTS${RESET}"
+  echo ""
+  echo "${RED}--------------------------------------------------------------------------------${RESET}"
+  echo "  A committed .only silently skips every other test in the suite."
+  echo "  Remove \".only\" from the lines above and stage the change."
+  echo "  To run a single spec instead, use: npx cypress run --spec <path>"
+  echo "${RED}################################################################################${RESET}"
+  echo ""
+  exit 1
+fi
+
 echo "Running lint-staged..."
 npx lint-staged --debug
 LINT_EXIT_CODE=$?

--- a/e2e-tests/eslint.config.js
+++ b/e2e-tests/eslint.config.js
@@ -35,6 +35,11 @@ export default [
         rules: {
             ...pluginJs.configs.recommended.rules,
             ...pluginCypress.configs.recommended.rules,
+            // Exclusive tests (.only) silently skip the rest of the suite, so they must never be committed.
+            'no-restricted-syntax': ['error', {
+                selector: "MemberExpression[computed=false][property.name='only'][object.name=/^(describe|context|it|specify|test|suite)$/]",
+                message: 'Exclusive tests are not allowed: remove ".only" before committing.'
+            }],
         },
     },
 ];


### PR DESCRIPTION
## What
Introduced an ESLint rule and a pre-commit hook to prevent committing `.only` in Cypress tests.

## Why
To avoid accidentally committing exclusive tests, which can cause other test cases to be silently skipped during execution.

## How
- Added a `no-restricted-syntax` rule in the ESLint config to flag `.only` usage in test blocks.
- Updated pre-commit script to check staged files for `.only` usage using `git grep`.
- Configured the pre-commit script to block commits with `.only` and provide guidance on fixing the issue.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
