### PR TITLE
GDB-14967: Permissions icons tooltips not loaded correctly

### DIFF
--- a/packages/legacy-workbench/src/js/angular/security/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/security/controllers.js
@@ -105,13 +105,13 @@ securityModule.controller('UsersCtrl', ['$scope', '$uibModal', 'toastr', '$windo
             let tooltipKey;
             if (rights.manage) {
                 iconClass = 'ri-folder-settings-line';
-                tooltipKey = 'security.has.manage.access';
+                tooltipKey = 'security.has.manage.permission';
             } else if (rights.write) {
                 iconClass = 'ri-edit-line';
-                tooltipKey = 'security.has.write.access';
+                tooltipKey = 'security.has.write.permission';
             } else if (rights.read) {
                 iconClass = 'ri-eye-line';
-                tooltipKey = 'security.has.read.access';
+                tooltipKey = 'security.has.read.permission';
             }
 
             return {
@@ -119,7 +119,7 @@ securityModule.controller('UsersCtrl', ['$scope', '$uibModal', 'toastr', '$windo
                 iconClass,
                 tooltipKey,
                 hasGraphqlAccess: rights.graphql,
-                graphqlTooltipKey: rights.write ? 'security.has.mutation_rights' : 'security.no.mutation_rights',
+                graphqlTooltipKey: rights.write ? 'security.has.mutation_permission' : 'security.no.mutation_permission',
             };
         });
 


### PR DESCRIPTION
## What
The tooltips for the permission icons in the **Users & Access** view were not displayed.

## Why
The translation keys were changed, but the templates were not updated accordingly. The changes were made in two different merge requests, and they became out of sync during the rebase of the second merge request.

## How
Updated the tooltip translation keys in the templates.

## Screenshots
<img width="480" height="300" alt="image" src="https://github.com/user-attachments/assets/23cb1d86-065c-431d-8574-17ac6964f559" />
<img width="480" height="300" alt="image" src="https://github.com/user-attachments/assets/0222dd29-6fd3-4ec4-be60-e9cd868ee944" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
