### PR TITLE
Cherry pick Gdb 14890 update yasgui component version cp

### DIFF
--- a/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
+++ b/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
@@ -250,7 +250,7 @@ describe('User and Access', () => {
         });
 
         context('Login / return URL redirects', () => {
-            it.only('should not add the active repository to the login page URL', () => {
+            it('should not add the active repository to the login page URL', () => {
                 cy.presetRepository(repoName);
                 UserAndAccessSteps.visit();
                 cy.url().should('include', `repositoryId=${repoName}`);

--- a/packages/legacy-workbench/package-lock.json
+++ b/packages/legacy-workbench/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
                 "ontotext-graphql-playground-component": "^0.0.9",
-                "ontotext-yasgui-web-component": "^1.6.5",
+                "ontotext-yasgui-web-component": "^1.7.0",
                 "single-spa-angularjs": "^4.3.1"
             },
             "devDependencies": {
@@ -5674,9 +5674,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.5.tgz",
-            "integrity": "sha512-Cdc2jcAYMco1RX1mNSyFALigf8mP+4CcwJnBjCqx+BmF8S90U9lUUSWEwKSvutM5ow+AgfZgH9In2ijyJ/BjsQ==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.7.0.tgz",
+            "integrity": "sha512-s2gqGmu4fT9CmueOYkosTx1v9N/dRE2YZvWegRnPt8Jp0Iqp8IE/CaSg2XlfKZRVumCxCiDhtfGmfTYJ4s1wFg==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.7.4",

--- a/packages/legacy-workbench/package-lock.json
+++ b/packages/legacy-workbench/package-lock.json
@@ -36,7 +36,7 @@
                 "ng-tags-input": "^3.2.0",
                 "oclazyload": "^1.1.0",
                 "ontotext-graphql-playground-component": "^0.0.9",
-                "ontotext-yasgui-web-component": "^1.7.0",
+                "ontotext-yasgui-web-component": "^1.7.2",
                 "single-spa-angularjs": "^4.3.1"
             },
             "devDependencies": {
@@ -5674,9 +5674,9 @@
             }
         },
         "node_modules/ontotext-yasgui-web-component": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.7.0.tgz",
-            "integrity": "sha512-s2gqGmu4fT9CmueOYkosTx1v9N/dRE2YZvWegRnPt8Jp0Iqp8IE/CaSg2XlfKZRVumCxCiDhtfGmfTYJ4s1wFg==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.7.2.tgz",
+            "integrity": "sha512-IRwwjlct+dgVMte6h29b9EZ8Q7gvptdBeVUkLRd9v0n/jPHpb+9tR8ZaUnOjB1gCkcS5dLSQwpdJotumhN9crQ==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.7.4",

--- a/packages/legacy-workbench/package.json
+++ b/packages/legacy-workbench/package.json
@@ -76,7 +76,7 @@
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
         "ontotext-graphql-playground-component": "^0.0.9",
-        "ontotext-yasgui-web-component": "^1.6.5",
+        "ontotext-yasgui-web-component": "^1.7.0",
         "single-spa-angularjs": "^4.3.1"
     },
     "resolutions": {

--- a/packages/legacy-workbench/package.json
+++ b/packages/legacy-workbench/package.json
@@ -76,7 +76,7 @@
         "ng-tags-input": "^3.2.0",
         "oclazyload": "^1.1.0",
         "ontotext-graphql-playground-component": "^0.0.9",
-        "ontotext-yasgui-web-component": "^1.7.0",
+        "ontotext-yasgui-web-component": "^1.7.2",
         "single-spa-angularjs": "^4.3.1"
     },
     "resolutions": {

--- a/packages/workbench/package-lock.json
+++ b/packages/workbench/package-lock.json
@@ -20,7 +20,7 @@
         "@jsverse/transloco-messageformat": "^8.3.0",
         "@primeuix/themes": "^2.0.3",
         "file-saver": "^2.0.5",
-        "ontotext-yasgui-web-component": "^1.6.5",
+        "ontotext-yasgui-web-component": "^1.7.0",
         "primeng": "^21.1.8",
         "rxjs": "~7.8.2",
         "single-spa": "^6.0.3",
@@ -17504,9 +17504,9 @@
       }
     },
     "node_modules/ontotext-yasgui-web-component": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.6.5.tgz",
-      "integrity": "sha512-Cdc2jcAYMco1RX1mNSyFALigf8mP+4CcwJnBjCqx+BmF8S90U9lUUSWEwKSvutM5ow+AgfZgH9In2ijyJ/BjsQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.7.0.tgz",
+      "integrity": "sha512-s2gqGmu4fT9CmueOYkosTx1v9N/dRE2YZvWegRnPt8Jp0Iqp8IE/CaSg2XlfKZRVumCxCiDhtfGmfTYJ4s1wFg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",

--- a/packages/workbench/package-lock.json
+++ b/packages/workbench/package-lock.json
@@ -20,7 +20,7 @@
         "@jsverse/transloco-messageformat": "^8.3.0",
         "@primeuix/themes": "^2.0.3",
         "file-saver": "^2.0.5",
-        "ontotext-yasgui-web-component": "^1.7.0",
+        "ontotext-yasgui-web-component": "^1.7.2",
         "primeng": "^21.1.8",
         "rxjs": "~7.8.2",
         "single-spa": "^6.0.3",
@@ -17504,9 +17504,9 @@
       }
     },
     "node_modules/ontotext-yasgui-web-component": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.7.0.tgz",
-      "integrity": "sha512-s2gqGmu4fT9CmueOYkosTx1v9N/dRE2YZvWegRnPt8Jp0Iqp8IE/CaSg2XlfKZRVumCxCiDhtfGmfTYJ4s1wFg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/ontotext-yasgui-web-component/-/ontotext-yasgui-web-component-1.7.2.tgz",
+      "integrity": "sha512-IRwwjlct+dgVMte6h29b9EZ8Q7gvptdBeVUkLRd9v0n/jPHpb+9tR8ZaUnOjB1gCkcS5dLSQwpdJotumhN9crQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -28,7 +28,7 @@
     "@jsverse/transloco-messageformat": "^8.3.0",
     "@primeuix/themes": "^2.0.3",
     "file-saver": "^2.0.5",
-    "ontotext-yasgui-web-component": "^1.6.5",
+    "ontotext-yasgui-web-component": "^1.7.0",
     "primeng": "^21.1.8",
     "rxjs": "~7.8.2",
     "single-spa": "^6.0.3",

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -28,7 +28,7 @@
     "@jsverse/transloco-messageformat": "^8.3.0",
     "@primeuix/themes": "^2.0.3",
     "file-saver": "^2.0.5",
-    "ontotext-yasgui-web-component": "^1.7.0",
+    "ontotext-yasgui-web-component": "^1.7.2",
     "primeng": "^21.1.8",
     "rxjs": "~7.8.2",
     "single-spa": "^6.0.3",


### PR DESCRIPTION
## What
Cherry pick two commits where the version of the ontotext-yagui-web-component is updated to 1.7.2

## Why
The new version has some fixes regarding double loading of the yasr and fixes runtime changes of the theme

## How

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [ ] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
