### PR TITLE
GDB-14831 add local store persistence to Reactodia

### DIFF
--- a/e2e-tests/e2e-legacy/reactodia/reactodia.spec.js
+++ b/e2e-tests/e2e-legacy/reactodia/reactodia.spec.js
@@ -1,6 +1,7 @@
 import {ReactodiaSteps} from '../../steps/reactodia-steps.js';
 import {LanguageSelectorSteps} from '../../steps/language-selector-steps.js';
 import {RepositorySelectorSteps} from '../../steps/repository-selector-steps.js';
+import {MainMenuSteps} from '../../steps/main-menu-steps.js';
 
 const FILE_TO_IMPORT = 'resource-test-data.ttl';
 const SEED_RESOURCE_ENCODED = 'http:%2F%2Fexample.com%2Fontology%23CustomerLoyalty';
@@ -66,6 +67,31 @@ describe('Reactodia graph explorer', () => {
         // Then I expect the same resources to remain visible because the layout is carried across the remount.
         ReactodiaSteps.getElements().should('have.length', 1);
         ReactodiaSteps.getElement(SEED_RESOURCE_LABEL).should('exist');
+    });
+
+    it('should keep the diagram on refresh but clear it when navigating away and back', () => {
+        // Given the reactodia view is opened with a start resource that gets seeded on the canvas.
+        ReactodiaSteps.visit(SEED_RESOURCE_ENCODED);
+        ReactodiaSteps.getElements().should('have.length', 1);
+        ReactodiaSteps.getElement(SEED_RESOURCE_LABEL).should('exist');
+
+        // When I refresh the page.
+        cy.reload();
+
+        // Then I expect the diagram state to be preserved across the refresh.
+        ReactodiaSteps.getElements().should('have.length', 1);
+        ReactodiaSteps.getElement(SEED_RESOURCE_LABEL).should('exist');
+
+        // When I navigate to another view via the navigation bar.
+        MainMenuSteps.clickOnSparqlMenu();
+        ReactodiaSteps.getComponent().should('not.exist');
+
+        // And I return to the reactodia view via the navigation bar.
+        MainMenuSteps.clickOnReactodia();
+
+        // Then I expect the canvas to be cleared, because leaving the view drops the persisted diagram state.
+        ReactodiaSteps.getWorkspace().should('exist');
+        ReactodiaSteps.getElements().should('not.exist');
     });
 
     describe('Repository switch', () => {

--- a/e2e-tests/steps/main-menu-steps.js
+++ b/e2e-tests/steps/main-menu-steps.js
@@ -103,6 +103,15 @@ export class MainMenuSteps {
         this.getSubMenuButton('sub-menu-visual-graph').click();
     }
 
+    static clickOnReactodia() {
+        this.clickOnExplore();
+        this.clickOnSubmenuReactodia();
+    }
+
+    static clickOnSubmenuReactodia() {
+        this.getSubMenuButton('menu-reactodia').click();
+    }
+
     static clickOnClassRelationships() {
         this.clickOnExplore();
         this.clickOnSubmenuClassRelationships();

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@single-spa/import-map-injector": "^2.0.2",
                 "graphdb-workbench-plugins": "~1.0.0",
-                "graphwise-reactodia": "^0.0.1-TR7",
+                "graphwise-reactodia": "^0.0.1-TR8",
                 "import-map-overrides": "^6.1.0"
             },
             "devDependencies": {
@@ -7009,9 +7009,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/graphwise-reactodia": {
-            "version": "0.0.1-TR7",
-            "resolved": "https://registry.npmjs.org/graphwise-reactodia/-/graphwise-reactodia-0.0.1-TR7.tgz",
-            "integrity": "sha512-h5nZINDoicQd2mmOOuZd9VUhMI+Cty/6vRYQicBsduX2E7SlfRd3cDgrEAi3g2+1ATTaRUV0DswEJ8olBucHJQ==",
+            "version": "0.0.1-TR8",
+            "resolved": "https://registry.npmjs.org/graphwise-reactodia/-/graphwise-reactodia-0.0.1-TR8.tgz",
+            "integrity": "sha512-yDyqX5HkfA1tdY/8N6mIB3vtDvVJwaKyOfGUUa/xqA1JRMduyFuExU7kKuPF0tfUrNTTRm1YGFRC/wDUVWTqXA==",
             "license": "Apache-2.0"
         },
         "node_modules/gzip-size": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "dependencies": {
         "@single-spa/import-map-injector": "^2.0.2",
         "graphdb-workbench-plugins": "~1.0.0",
-        "graphwise-reactodia": "^0.0.1-TR7",
+        "graphwise-reactodia": "^0.0.1-TR8",
         "import-map-overrides": "^6.1.0"
     }
 }

--- a/packages/workbench/src/app/pages/reactodia/reactodia-page.component.ts
+++ b/packages/workbench/src/app/pages/reactodia/reactodia-page.component.ts
@@ -1,13 +1,17 @@
 import {Component, inject, OnDestroy, OnInit, signal} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
 import {
+  EventName,
+  EventService,
   GraphExploreLink,
   GraphExploreService,
   LanguageContextService,
   RepositoryContextService,
   service,
-  SubscriptionList
+  SubscriptionList,
+  WindowService
 } from '@ontotext/workbench-api';
+import {CLEAR_DIAGRAM_STORAGE_EVENT} from 'graphwise-reactodia';
 import {
   ReactodiaComponentFacadeComponent
 } from '../../components/reactodia-component-facade/reactodia-component-facade.component';
@@ -34,6 +38,7 @@ export class ReactodiaPageComponent implements OnInit, OnDestroy {
   private readonly repositoryContextService = service(RepositoryContextService);
   private readonly languageContextService = service(LanguageContextService);
   private readonly graphExploreService = service(GraphExploreService);
+  private readonly eventService = service(EventService);
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly logger = LoggerProvider.logger;
 
@@ -54,7 +59,8 @@ export class ReactodiaPageComponent implements OnInit, OnDestroy {
   private initSubscriptions() {
     this.subscriptions.addAll([
       this.subscribeToRepositoryChanged(),
-      this.subscribeToLanguageChanged()
+      this.subscribeToLanguageChanged(),
+      this.subscribeToNavigationEnd()
     ]);
   }
 
@@ -67,6 +73,16 @@ export class ReactodiaPageComponent implements OnInit, OnDestroy {
       if (language) {
         this.language.set(language);
       }
+    });
+  }
+
+  /**
+   * Tells the `graphwise-reactodia` web component to drop its persisted diagram state whenever a
+   * navigation ends. This means the user navigated away from the page, so we clear the state.
+   */
+  private subscribeToNavigationEnd() {
+    return this.eventService.subscribe(EventName.NAVIGATION_START, () => {
+      WindowService.getWindow().dispatchEvent(new CustomEvent(CLEAR_DIAGRAM_STORAGE_EVENT));
     });
   }
 


### PR DESCRIPTION
## What
Add local store persistence to Reactodia.

## Why
This change improves user experience by ensuring that the diagram state is preserved across page refreshes.

## How
Added a subscription to navigation end event in `reactodia-page.component.ts` to clear the diagram state, when a user has navigated away from the view manually. Refreshes preserve the previous diagram

## Testing
cypress

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
