### PR TITLE
GDB-14978 Update authenticated user after repository edit

### DIFF
--- a/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
+++ b/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
@@ -266,6 +266,7 @@ describe('User and Access', () => {
                 UserAndAccessSteps.toggleSecurity();
                 LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);
                 MainMenuSteps.clickOnSparqlMenu();
+                cy.get('h1').should('be.visible').should('contain', 'SPARQL Query & Update');
                 cy.url().should('include', '/sparql');
 
                 LoginSteps.logout();
@@ -732,6 +733,34 @@ describe('User and Access', () => {
 
             // Then I should still see all repositories for which the user has at least read permission.
             RepositorySteps.getRepositories().should('have.length', 4);
+        });
+
+        it('should keep a renamed repository visible for a user with manage permission', () => {
+            // Given there is a user with manage permission for a repository.
+            createUser(manageUser, PASSWORD, ROLE_USER, {manage: true, repoName: manageRepositoryId});
+            UserAndAccessSteps.toggleSecurity();
+            LoginSteps.loginWithUser(manageUser, PASSWORD);
+            RepositorySteps.visit(false);
+
+            // When the user renames the repository.
+            RepositorySteps.getEditRepositoryButton(manageRepositoryId).should('be.visible');
+            RepositorySteps.editRepository(manageRepositoryId);
+            RepositorySteps.editRepositoryId();
+            ModalDialogSteps.clickOKButton();
+            RepositorySteps.getGDBIdInput()
+                .should('be.enabled')
+                .clear()
+                .type(`${manageRepositoryId}-renamed`);
+            SecurityStubs.spyOnAuthenticatedUser();
+            RepositorySteps.getSaveRepositoryButton().click();
+            ModalDialogSteps.clickOKButton();
+            cy.wait('@get-authenticated-user').then(() => {
+                manageRepositoryId = `${manageRepositoryId}-renamed`;
+
+                // Then the renamed repository and its management actions should remain visible without a page refresh.
+                RepositorySteps.getRepositoryFromList(manageRepositoryId).should('be.visible');
+                RepositorySteps.getEditRepositoryButton(manageRepositoryId).should('be.visible');
+            });
         });
     });
 

--- a/e2e-tests/steps/login-steps.js
+++ b/e2e-tests/steps/login-steps.js
@@ -28,9 +28,9 @@ export class LoginSteps {
 
     static loginWithUser(username, password) {
         cy.get('.login-form').should('be.visible');
-        cy.getByTestId('username-input').type(username);
-        cy.getByTestId('password-input').type(password);
-        cy.getByTestId('submit-btn').click();
+        cy.getByTestId('username-input').should('be.visible').type(username);
+        cy.getByTestId('password-input').should('be.visible').type(password);
+        cy.getByTestId('submit-btn').should('be.visible').click();
     }
 
     // TODO: Use the HeaderSteps.logout()

--- a/packages/api/src/services/domain/security/authentication.service.ts
+++ b/packages/api/src/services/domain/security/authentication.service.ts
@@ -43,6 +43,16 @@ export class AuthenticationService implements Service {
   }
 
   /**
+   * Updates the authenticated user in the security context.
+   * This method should be called whenever the authenticated user's permissions might have changed,
+   * such as after a repository save operation.
+   */
+  async updateAuthenticatedUser(): Promise<void> {
+    const authenticatedUser = await this.getCurrentUser();
+    this.securityContextService.updateAuthenticatedUser(authenticatedUser);
+  }
+
+  /**
    * Authenticates the user with username and password.
    *
    * Stores the auth token (if returned), updates the security context

--- a/packages/legacy-workbench/src/js/angular/repositories/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/controllers.js
@@ -12,6 +12,7 @@ import {
     AuthenticationStorageService,
     AuthorizationService,
     GuidesService,
+    AuthenticationService,
 } from '@ontotext/workbench-api';
 import {DocumentationUrlResolver} from "../utils/documentation-url-resolver";
 
@@ -805,6 +806,16 @@ EditRepositoryCtrl.$inject = ['$rootScope', '$scope', '$routeParams', 'toastr', 
     '$translate', 'MonitoringRestService'];
 
 function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositories, $location, ModalService, RepositoriesRestService, $translate, MonitoringRestService) {
+    // =========================
+    // Private variables
+    // =========================
+
+    const authenticationService = service(AuthenticationService);
+
+    // =========================
+    // Public variables
+    // =========================
+
     $scope.rulesets = STATIC_RULESETS.slice();
     $scope.repositoryTypes = REPOSITORY_TYPES;
     $scope.entityIndexSizeMin = ENTITY_INDEX_SIZE_MIN;
@@ -824,6 +835,10 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
     $scope.hasActiveLocation = function() {
         return $repositories.hasActiveLocation();
     };
+
+    // =========================
+    // Private methods
+    // =========================
 
     const loadRepositoryData = () => {
         return getFilteredLocations($repositories).then((locations) => {
@@ -852,6 +867,12 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
         $scope.repositoryInfo.saveId = $scope.saveRepoId;
         $scope.loader = false;
     };
+
+    const initRepositoriesAndNavigate = () => $repositories.init().finally(() => $scope.goBackToPreviousLocation());
+
+    // =========================
+    // Public methods
+    // =========================
 
     $scope.$watch($scope.hasActiveLocation, function() {
         if ($scope.hasActiveLocation) {
@@ -912,7 +933,12 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
         RepositoriesRestService.editRepository($scope.repositoryInfo.saveId, $scope.repositoryInfo)
             .success(function() {
                 toastr.success($translate.instant('edit.repo.success.msg', {saveId: $scope.repositoryInfo.saveId}));
-                $repositories.init().finally(() => $scope.goBackToPreviousLocation());
+                if ($scope.repositoryInfo.saveId !== $scope.repositoryInfo.id) {
+                    // If the repository ID has changed, update the authenticated user because the permissions become stale
+                    authenticationService.updateAuthenticatedUser().then(initRepositoriesAndNavigate);
+                } else {
+                    initRepositoriesAndNavigate();
+                }
                 if ($scope.repositoryInfo.saveId === $scope.repositoryInfo.id && $scope.repositoryInfo.restartRequested) {
                     $repositories.restartRepository($scope.repositoryInfo);
                 }
@@ -979,6 +1005,10 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
     $scope.getShaclOptionsClass = function() {
         return getShaclOptionsClass();
     };
+
+    // =================================
+    // Subscriptions and event handlers
+    // =================================
 
     const languageChangedSubscription = $rootScope.$on('$translateChangeSuccess', () => {
         $scope.pageTitle = $translate.instant('view.edit.repo.title', {repositoryId: $scope.params.repositoryId});


### PR DESCRIPTION
## What
Updated the system to refresh the authenticated user's data when a repository edit results in a change to its ID.

## Why
To ensure correct user permissions and avoid stale data when repository IDs are updated after edits.

## How
- Added `updateAuthenticatedUser` method in `authentication.service.ts` to refresh user data.
- Injected `AuthenticationService` into the repository editor controller.
- Introduced logic to refresh the authenticated user and navigate back when repository ID changes.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified
