### PR TITLE
Cherry pick: GDB-14973: Add repository to ontop related update endpoints in GDB Workbench

### DIFF
--- a/packages/legacy-workbench/src/js/angular/models/repository/repository.js
+++ b/packages/legacy-workbench/src/js/angular/models/repository/repository.js
@@ -1,3 +1,27 @@
+export class RepositoryReference {
+    constructor(id, location) {
+        /**
+         * @type {string}
+         * @private
+         */
+        this._id = id;
+
+        /**
+         * @type {string}
+         * @private
+         */
+        this._location = location;
+    }
+
+    get id() {
+        return this._id;
+    }
+
+    get location() {
+        return this._location;
+    }
+}
+
 export class RepositoryInfoModel {
     constructor(data = {}) {
         /**
@@ -402,5 +426,5 @@ export const REPOSITORY_PARAMS = {
     entityIdSize: 'entityIdSize',
     repositoryType: 'repositoryType',
     eclipseRdf4jShaclExtensions: 'eclipseRdf4jShaclExtensions',
-    validationResultsLimitTotal: 'validationResultsLimitTotal'
+    validationResultsLimitTotal: 'validationResultsLimitTotal',
 };

--- a/packages/legacy-workbench/src/js/angular/repositories/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/controllers.js
@@ -776,12 +776,12 @@ function AddRepositoryCtrl($rootScope, $scope, toastr, $repositories, $location,
     });
 }
 
-EditRepositoryFileCtrl.$inject = ['$scope', '$uibModalInstance', 'RepositoriesRestService', 'file', 'toastr', '$translate', 'dialogTitle', 'location'];
+EditRepositoryFileCtrl.$inject = ['$scope', '$uibModalInstance', 'RepositoriesRestService', 'file', 'toastr', '$translate', 'dialogTitle', 'repositoryReference'];
 
-function EditRepositoryFileCtrl($scope, $uibModalInstance, RepositoriesRestService, file, toastr, $translate, dialogTitle, location) {
+function EditRepositoryFileCtrl($scope, $uibModalInstance, RepositoriesRestService, file, toastr, $translate, dialogTitle, repositoryReference) {
     $scope.dialogTitle = dialogTitle ? dialogTitle : $translate.instant('update.file.content.header');
     if (file) {
-        RepositoriesRestService.getRepositoryFileContent(file, location).success(function(data) {
+        RepositoriesRestService.getRepositoryFileContent(file, repositoryReference).success(function(data) {
             $scope.fileContent = data;
         }).error(function(data) {
             const msg = getError(data);

--- a/packages/legacy-workbench/src/js/angular/repositories/ontop-repo.directive.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/ontop-repo.directive.js
@@ -6,6 +6,7 @@ import {OntopRepositoryError} from "../models/ontop/ontop-repository-error";
 import {OntopDriverData} from "../models/ontop/ontop-driver-data";
 import {JdbcDriverType} from "../models/ontop/jdbc-driver-type";
 import {LoggerProvider} from "../core/services/logger-provider";
+import {RepositoryReference} from '../models/repository/repository';
 
 const logger = LoggerProvider.logger;
 // A link to Ontop's website with all Ontop configuration keys
@@ -34,6 +35,13 @@ function ontopRepoDirective($uibModal, RepositoriesRestService, toastr, Upload, 
         const BACKSPACE = 8;
         const KEY_C = 67;
         const KEY_A = 65;
+        /**
+         * A reference to the otnop repository when the form was initialized.
+         * It preserves access to the initial repository object while `$scope.repositoryInfo`
+         * may be replaced or modified by the form.
+         * @type {RepositoryReference|undefined}
+         */
+        let repositoryReference = undefined;
         $scope.isGenericDriver = true;
         $scope.defaultUrlTemplate = 'jdbc:database://localhost:port/database_name';
         $scope.ontopProperiesLink = ONTOP_PROPERTIES_LINK;
@@ -175,15 +183,15 @@ function ontopRepoDirective($uibModal, RepositoriesRestService, toastr, Upload, 
                     dialogTitle: () => {
                         return title;
                     },
-                    location: () => {
-                        return $scope.repositoryInfo.location;
+                    repositoryReference: () => {
+                        return repositoryReference;
                     },
                 },
             });
 
             modalInstance.result.then((data) => {
                 // send data to backend
-                RepositoriesRestService.updateRepositoryFileContent(data.fileLocation, data.content, $scope.repositoryInfo.location)
+                RepositoriesRestService.updateRepositoryFileContent(data.fileLocation, data.content, repositoryReference)
                     .success((result) => {
                         ontopFileInfo.fileName = getFileName(result.fileLocation);
                         $scope.repositoryInfo.params[ontopFileInfo.type].value = result.fileLocation;
@@ -198,8 +206,12 @@ function ontopRepoDirective($uibModal, RepositoriesRestService, toastr, Upload, 
                 const uploadFile = files[0];
                 ontopFileInfo.loading = true;
                 const uploadData = {
-                    url: 'rest/repositories/file/upload',
-                    data: {file: uploadFile, location: $scope.repositoryInfo.location},
+                    url: `rest/repositories/file/upload`,
+                    data: {
+                        file: uploadFile,
+                        location: repositoryReference?.location,
+                        repositoryID: repositoryReference?.id,
+                    },
                 };
                 Upload.upload(uploadData)
                     .success((data) => {
@@ -371,9 +383,22 @@ function ontopRepoDirective($uibModal, RepositoriesRestService, toastr, Upload, 
             });
         };
 
+        /**
+         * Creates a reference to the repository being edited.
+         *
+         * @param {object} repositoryInfo Information about the repository.
+         * @returns {RepositoryReference|undefined} The repository reference when the edit page is open, otherwise, `undefined`.
+         */
+        const getRepositoryReference = (repositoryInfo) => {
+            if ($scope.editRepoPage) {
+                return new RepositoryReference(repositoryInfo.id, repositoryInfo.location);
+            }
+            return undefined;
+        };
+
         const loadPropertiesFile = () => {
             setLoading(true);
-            RepositoriesRestService.loadPropertiesFile($scope.repositoryInfo.params.propertiesFile.value, $scope.repositoryInfo.location, $scope.selectedDriver.driverType)
+            RepositoriesRestService.loadPropertiesFile($scope.repositoryInfo.params.propertiesFile.value, repositoryReference, $scope.selectedDriver.driverType)
                 .success((driverData) => {
                     let driver = $scope.supportedDriversData.find((driver) => driver.driverClass === driverData.driverClass);
                     // If driver not found this means that driver is generic.
@@ -433,7 +458,7 @@ function ontopRepoDirective($uibModal, RepositoriesRestService, toastr, Upload, 
             };
 
             return RepositoriesRestService
-                .updatePropertiesFile($scope.repositoryInfo.params.propertiesFile.value, jdbc, $scope.repositoryInfo.location, $scope.selectedDriver.driverType)
+                .updatePropertiesFile($scope.repositoryInfo.params.propertiesFile.value, jdbc, repositoryReference, $scope.selectedDriver.driverType)
                 .success((data) => {
                     $scope.repositoryInfo.params.propertiesFile.value = data.fileLocation;
                 }).error((data) => {
@@ -518,16 +543,21 @@ function ontopRepoDirective($uibModal, RepositoriesRestService, toastr, Upload, 
             $scope.getOntopFileInfo(OntopFileType.OBDA).required = true;
         };
 
+        const init = () => {
+            repositoryReference = getRepositoryReference($scope.repositoryInfo);
+            loadSupportedDriversData()
+                .then(() => {
+                    if ($scope.editRepoPage) {
+                        loadPropertiesFile();
+                    } else {
+                        $scope.selectDriver(JdbcDriverType.GENERIC);
+                    }
+                });
+        };
+
         // =========================
         // Initialize component data
         // =========================
-        loadSupportedDriversData()
-            .then(() => {
-                if ($scope.editRepoPage) {
-                    loadPropertiesFile();
-                } else {
-                    $scope.selectDriver(JdbcDriverType.GENERIC);
-                }
-            });
+        init();
     }
 }

--- a/packages/legacy-workbench/src/js/angular/rest/repositories.rest.service.js
+++ b/packages/legacy-workbench/src/js/angular/rest/repositories.rest.service.js
@@ -28,22 +28,22 @@ function RepositoriesRestService($http) {
         updatePropertiesFile,
         loadPropertiesFile,
         getRepositoriesFromKnownLocation,
-        getRepositoryTurtleConfig
+        getRepositoryTurtleConfig,
     };
 
     function getRepository(repoInfo) {
         return $http.get(`${REPOSITORIES_ENDPOINT}/${repoInfo.id}`, {
             params: {
-                location: repoInfo.location
-            }
+                location: repoInfo.location,
+            },
         });
     }
 
     function getRepositoryModel(repoInfo) {
         return $http.get(`${REPOSITORIES_ENDPOINT}/${repoInfo.id}`, {
             params: {
-                location: repoInfo.location
-            }
+                location: repoInfo.location,
+            },
         }).then((response) => {
             return repositoryConfigMapper(response.data);
         });
@@ -52,10 +52,10 @@ function RepositoriesRestService($http) {
     function getRepositories(location) {
         return $http.get(`${REPOSITORIES_ENDPOINT}/all`, {
             params: {
-                location: location
+                location: location,
             },
             // Added so that location changes would not cancel the request
-            noCancelOnRouteChange: true
+            noCancelOnRouteChange: true,
         });
     }
 
@@ -66,8 +66,8 @@ function RepositoriesRestService($http) {
     function deleteRepository(repo) {
         return $http.delete(`${REPOSITORIES_ENDPOINT}/${repo.id}`, {
             params: {
-                location: repo.location
-            }
+                location: repo.location,
+            },
         });
     }
 
@@ -82,8 +82,8 @@ function RepositoriesRestService($http) {
     function restartRepository(repo) {
         return $http.post(`${REPOSITORIES_ENDPOINT}/${repo.id}/restart`, null, {
             params: {
-                location: repo.location
-            }
+                location: repo.location,
+            },
         });
     }
 
@@ -94,75 +94,115 @@ function RepositoriesRestService($http) {
     function getSize(repository) {
         return $http.get(`${REPOSITORIES_ENDPOINT}/${repository.id}/size`, {
             params: {
-                location: repository.location
-            }
+                location: repository.location,
+            },
         });
     }
 
     function getPrefix(repositoryId, params) {
-        return $http.post(`${REPOSITORIES_ENDPOINT}/${repositoryId}/prefix`, null, { params })
+        return $http.post(`${REPOSITORIES_ENDPOINT}/${repositoryId}/prefix`, null, {params});
     }
 
     function getCluster() {
         return $http.get(`${REPOSITORIES_ENDPOINT}/cluster`);
     }
 
-    function getRepositoryFileContent(file, location) {
-        return $http.get(`${REPOSITORIES_ENDPOINT}/file`, {params: {fileLocation: file, location: location}});
+    /**
+     * Retrieves the content of a repository file.
+     *
+     * @param {string} file The location of the repository file.
+     * @param {RepositoryReference|undefined} repositoryReference The repository reference, if available.
+     * @returns {Promise<*>} A promise that resolves with the repository file content.
+     */
+    function getRepositoryFileContent(file, repositoryReference) {
+        return $http.get(`${REPOSITORIES_ENDPOINT}/file`, {
+            params: {
+                fileLocation: file,
+                repositoryID: repositoryReference?.id,
+                location: repositoryReference?.location,
+            }});
     }
 
-    function updateRepositoryFileContent(fileLocation, content, location) {
+    /**
+     * Updates the content of a repository file at the specified location.
+     *
+     * @param {string} fileLocation The location of the repository file.
+     * @param {string} content The updated file content.
+     * @param {RepositoryReference|undefined} repositoryReference The repository reference, if available.
+     * @returns {Promise<*>} A promise that resolves when the repository file has been updated.
+     */
+    function updateRepositoryFileContent(fileLocation, content, repositoryReference) {
         return $http.post(`${REPOSITORIES_ENDPOINT}/file/update`, JSON.stringify(content), {
             params: {
                 fileLocation: fileLocation,
-                location: location
-            }
+                repositoryID: repositoryReference?.id,
+                location: repositoryReference?.location,
+            },
         });
     }
 
     function validateOntopPropertiesConnection(repositoryInfo) {
         return $http.post(`${REPOSITORIES_ENDPOINT}/ontop/test-connection`, repositoryInfo.params.propertiesFile, {
             params: {
-                location: repositoryInfo.location
-            }
+                location: repositoryInfo.location,
+            },
         });
     }
 
     function getSupportedDriversData(repositoryInfo) {
         return $http.get(`${REPOSITORIES_ENDPOINT}/ontop/drivers`, {
             params: {
-                location: repositoryInfo.location
-            }
+                location: repositoryInfo.location,
+            },
         });
     }
 
-    function updatePropertiesFile(fileLocation, content, location, driverType) {
+    /**
+     * Updates the Ontop properties file at the specified location.
+     *
+     * @param {string} fileLocation The location of the properties file.
+     * @param {*} content The updated JDBC connection properties.
+     * @param {RepositoryReference|undefined} repositoryReference The repository reference, if available.
+     * @param {string} driverType The database driver type.
+     * @returns {Promise<*>} A promise that resolves when the properties file has been updated.
+     */
+    function updatePropertiesFile(fileLocation, content, repositoryReference, driverType) {
         return $http.post(`${REPOSITORIES_ENDPOINT}/ontop/jdbc-properties`,
             JSON.stringify(content),
             {
                 params: {
                     fileLocation,
-                    location,
-                    driverType
-                }
+                    repositoryID: repositoryReference?.id,
+                    location: repositoryReference?.location,
+                    driverType,
+                },
             });
     }
 
-    function loadPropertiesFile(fileLocation, location, driverType) {
+    /**
+     * Loads the Ontop properties from the specified file.
+     *
+     * @param {string} fileLocation The location of the properties file.
+     * @param {RepositoryReference|undefined} repositoryReference The repository reference, if available.
+     * @param {string} driverType The database driver type.
+     * @returns {*} The Ontop properties, such as the driver class and hostname.
+     */
+    function loadPropertiesFile(fileLocation, repositoryReference, driverType) {
         return $http.get(`${REPOSITORIES_ENDPOINT}/ontop/jdbc-properties`, {
             params: {
                 fileLocation,
-                location,
-                driverType
-            }
+                repositoryID: repositoryReference?.id,
+                location: repositoryReference?.location,
+                driverType,
+            },
         });
     }
 
     function getRepositoryTurtleConfig(repository) {
         return $http.get('rest/repositories/' + repository.id, {
             headers: {
-                'Accept': 'text/turtle'
-            }
+                'Accept': 'text/turtle',
+            },
         });
     }
 }


### PR DESCRIPTION
## What
Updated the file-related Ontop repository endpoints to include the repository identifier in the request body.

## Why
The previous endpoints were not repository-specific, preventing users with `MANAGE_REPO` permissions from accessing them. Including the repository identifier allows authorization to be evaluated per repository.

## How
- Updated `rest/repositories/file/upload`, `rest/repositories/file`, `rest/repositories/file/update`, and `rest/repositories/ontop/jdbc-properties` to pass the repository identifier in the request body.

(cherry picked from commit a0e164a0d974e0bc9a5bfd391e03921fa1a7f9a4)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
