### PR TITLE
GDB-14973: Fix repository id name in ontop upload url

### DIFF
--- a/packages/legacy-workbench/src/js/angular/repositories/ontop-repo.directive.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/ontop-repo.directive.js
@@ -210,7 +210,7 @@ function ontopRepoDirective($uibModal, RepositoriesRestService, toastr, Upload, 
                     data: {
                         file: uploadFile,
                         location: repositoryReference?.location,
-                        repositoryId: repositoryReference?.id,
+                        repositoryID: repositoryReference?.id,
                     },
                 };
                 Upload.upload(uploadData)


### PR DESCRIPTION
## What
The repository ID parameter name in the Ontop file upload URL did not match the name expected by the backend.

## Why
This parameter was missed when the other repository ID parameters were renamed.

## How
Updated the repository ID parameter name to match the backend.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
