### PR TITLE
GDB-14905: Improve multi-region cluster loaders

### DIFF
--- a/packages/legacy-workbench/src/css/clustermanagement.css
+++ b/packages/legacy-workbench/src/css/clustermanagement.css
@@ -425,3 +425,15 @@ ul.nodes-list li a:hover {
     padding: .4rem;
     border-bottom: 1px solid #eceeef;
 }
+
+.cluster-status-loader {
+    color: var(--gw-foreground-on-surface-secondary);
+    font-size: 1.5rem;
+}
+
+.multi-region-loader .ot-loader-new-content {
+    background-color: var(--gw-neutral-50-alpha-50);
+    position: absolute;
+    width: 100%;
+    height: 100%;
+}

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-configuration/multi-region.directive.js
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-configuration/multi-region.directive.js
@@ -1,7 +1,7 @@
 import 'angular/core/directives/ascii-validator.directive';
 import 'angular/core/directives/length-validator.directive';
-import {ClusterConfiguration, ClusterModel} from "../../../models/clustermanagement/cluster";
-import {NodeState, TopologyState} from "../../../models/clustermanagement/states";
+import {ClusterConfiguration, ClusterModel} from '../../../models/clustermanagement/cluster';
+import {NodeState, TopologyState} from '../../../models/clustermanagement/states';
 import {
     AuthorizationService,
     AuthenticationService,
@@ -10,12 +10,12 @@ import {
 
 const modules = [
     'graphdb.framework.core.directives.ascii-validator',
-    'graphdb.framework.core.directives.length-validator'
+    'graphdb.framework.core.directives.length-validator',
 ];
 
 const TagLengthConstraints = {
     minLen: '3',
-    maxLen: '255'
+    maxLen: '255',
 };
 
 angular
@@ -30,7 +30,7 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
         templateUrl: 'js/angular/clustermanagement/templates/cluster-configuration/multi-region.html',
         scope: {
             clusterModel: '=',
-            clusterConfiguration: '='
+            clusterConfiguration: '=',
         },
         link: ($scope) => {
             // =========================
@@ -53,6 +53,8 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
             $scope.loaderTimeout = undefined;
             $scope.secondaryTag = undefined;
             $scope.TagLengthConstraints = TagLengthConstraints;
+            $scope.loader = false;
+            $scope.statusLoader = false;
 
             // =========================
             // Public functions
@@ -67,7 +69,7 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
 
             $scope.createTag = (tag) => {
                 const payload = {
-                    tag
+                    tag,
                 };
                 setLoader(true);
                 return ClusterRestService.addCusterTag(payload)
@@ -88,7 +90,7 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
                     message: $translate.instant('cluster_management.cluster_configuration_multi_region.confirm.warning'),
                     warning: true,
                     backdrop: 'static',
-                    stopPropagation: true
+                    stopPropagation: true,
                 }).result
                     .then(() => {
                         setLoader(true);
@@ -113,7 +115,7 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
                     warning: true,
                     backdrop: 'static',
                     confirmButtonKey: 'common.ok.btn',
-                    stopPropagation: true
+                    stopPropagation: true,
                 };
 
                 ModalService.openSimpleModal(confirmConfig).result
@@ -139,7 +141,7 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
                     message: $translate.instant('cluster_management.cluster_configuration_multi_region.confirm.disable_secondary_mode_warning'),
                     warning: true,
                     backdrop: 'static',
-                    stopPropagation: true
+                    stopPropagation: true,
                 }).result
                     .then(() => {
                         setLoader(true);
@@ -168,10 +170,10 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
                 const secondaryModalConfig = {
                     title: $translate.instant('cluster_management.cluster_configuration_multi_region.secondary_cluster_settings'),
                     templateUrl: 'js/angular/clustermanagement/templates/modal/secondary-mode-modal.html',
-                    controller:  ['$scope', '$uibModalInstance', 'config', secondaryModeModalController],
+                    controller: ['$scope', '$uibModalInstance', 'config', secondaryModeModalController],
                     size: 'lg',
                     warning: true,
-                    backdrop: 'static'
+                    backdrop: 'static',
                 };
 
                 return ModalService.openCustomModal(secondaryModalConfig).result;
@@ -186,7 +188,7 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
                     $scope.ok = () => {
                         $uibModalInstance.close({
                             primaryNode: $scope.rpcAddress,
-                            tag: $scope.tag
+                            tag: $scope.tag,
                         });
                     };
                     $scope.cancel = () => {
@@ -196,16 +198,16 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
             };
 
             const updateClusterData = (clusterModel) => {
-                setLoader(true);
+                setStatusLoader(true);
                 ClusterRestService.getClusterConfig()
                     .then((response) => {
                         $scope.secondaryTag = ClusterConfiguration.fromJSON(response.data).secondaryTag;
                         setTopology(ClusterModel.fromJSON(clusterModel));
                     }).catch((response) => {
-                        const msg = getError(response);
-                        toastr.error(msg, $translate.instant('cluster_management.cluster_configuration_multi_region.error.disabling'));
-                    })
-                    .finally(() => setLoader(false));
+                    const msg = getError(response);
+                    toastr.error(msg, $translate.instant('cluster_management.cluster_configuration_multi_region.error.disabling'));
+                })
+                    .finally(() => setStatusLoader(false));
             };
 
             const handleClusterConfigurationPanelVisibility = (show) => {
@@ -226,6 +228,18 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
                 }
             };
 
+            const setStatusLoader = (loader, message) => {
+                $timeout.cancel($scope.loaderTimeout);
+                if (loader) {
+                    $scope.loaderMessage = message;
+                    $scope.loaderTimeout = $timeout(() => {
+                        $scope.statusLoader = loader;
+                    }, 150);
+                } else {
+                    $scope.statusLoader = false;
+                }
+            };
+
             // =========================
             // Events and watchers
             // =========================
@@ -242,7 +256,7 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
                 subscriptions.forEach((subscription) => subscription());
             };
 
-            $scope.$on('$destroy', function () {
+            $scope.$on('$destroy', function() {
                 removeAllListeners();
             });
 
@@ -255,6 +269,6 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
                 updateClusterData($scope.clusterModel);
             };
             init();
-        }
+        },
     };
 }

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
@@ -2,7 +2,9 @@
 
 <div class="multi-region">
     <div ng-if="topology.state === TopologyState.PRIMARY_NODE">
-        <h4 class="title">{{'cluster_management.cluster_configuration_multi_region.primary_cluster' | translate}}</h4>
+        <h4 class="title">{{'cluster_management.cluster_configuration_multi_region.primary_cluster' | translate}}
+            <span ng-if="statusLoader" class="ri-reset-left-line icon-1-25x loader cluster-status-loader"></span>
+        </h4>
         <div class="mb-2" ng-if="isAdmin">
             <button type="button" class="btn btn-primary create-tag-btn"
                     ng-click="add()"
@@ -106,7 +108,9 @@
     </div>
 
     <div ng-if="topology.state === TopologyState.SECONDARY_NODE">
-        <h4>{{'cluster_management.cluster_configuration_multi_region.secondary_cluster' | translate}}</h4>
+        <h4>{{'cluster_management.cluster_configuration_multi_region.secondary_cluster' | translate}}
+            <span ng-if="statusLoader" class="ri-reset-left-line icon-1-25x loader cluster-status-loader"></span>
+        </h4>
         <div class="primary-leader mb-2">{{'cluster_management.cluster_configuration_multi_region.primary_leader' | translate: {primaryLeader:topology.primaryLeader} }}
         </div>
         <div class="mb-2" ng-if="isAdmin">


### PR DESCRIPTION
## What
Enhanced loader behavior and styling for multi-region cluster management UI.

## Why
To improve the user experience and provide better visual feedback during cluster data updates.

## How
- Introduced `statusLoader` for displaying loaders in the primary and secondary cluster headers.
- Added new CSS styles (`.cluster-status-loader`, `.multi-region-loader`) for consistent loader design.
- Refactored `setLoader` to `setStatusLoader` for clearer purpose and better timeout handling.
- Ensured accurate toggling of loader visibility in directive logic.

## Testing

## Screenshots
<img width="565" height="335" alt="image" src="https://github.com/user-attachments/assets/e92babe8-7c31-46c0-b8bd-f3d3590ff2d9" />
<img width="565" height="503" alt="image" src="https://github.com/user-attachments/assets/e396b441-c589-40aa-b9ee-1b999feca46d" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
