### PR TITLE
Cherry pick: GDB-14958: Fix visual graph explore guide step fail (#3120)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@single-spa/import-map-injector": "^2.0.2",
-                "graphdb-workbench-plugins": "^1.0.1",
+                "graphdb-workbench-plugins": "^1.0.2",
                 "import-map-overrides": "^6.1.0"
             },
             "devDependencies": {
@@ -6927,9 +6927,9 @@
             "license": "ISC"
         },
         "node_modules/graphdb-workbench-plugins": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/graphdb-workbench-plugins/-/graphdb-workbench-plugins-1.0.1.tgz",
-            "integrity": "sha512-YYhggjfYNLqdS/NyB4ldpADVsgbhPf7pSCRuFGEeT71FW9zb5mSpE9bz1Tn18knep7qR7Ewrn8CWA0/BamqbUQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/graphdb-workbench-plugins/-/graphdb-workbench-plugins-1.0.2.tgz",
+            "integrity": "sha512-sQ+BLpVflvvcPwU3mBA4ZHkQ62is8zuRo7kyenXrQfJ/n/apAbtPZ/id31jy2juVS740amR8dufQcZw+ST7tnw==",
             "license": "Apache-2.0"
         },
         "node_modules/gzip-size": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "resolutions": {},
     "dependencies": {
         "@single-spa/import-map-injector": "^2.0.2",
-        "graphdb-workbench-plugins": "^1.0.1",
+        "graphdb-workbench-plugins": "^1.0.2",
         "import-map-overrides": "^6.1.0"
     }
 }


### PR DESCRIPTION
## What
Bumped the `graphdb-workbench-plugins` dependency version from `1.0.1` to `1.0.2`.

## Why
1.0.2 fixes issue with visual graph explore guide step, where if there is difference in number of nodes or latency, the step would fail

## How
- Updated `package.json` and `package-lock.json` with the new version.
- Reflected changes in dependency integrity and resolved URLs.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified


(cherry picked from commit 6a1a89ad666ec51a69e639af8390c25954134800)
