### PR TITLE
GDB-14921: Fix alignment of repository ID in selector

### DIFF
--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.scss
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.scss
@@ -36,7 +36,7 @@
       min-width: 0;
 
       .repository-id {
-        line-height: 1.1em;
+        line-height: 1.2em;
         overflow-x: hidden;
         text-overflow: ellipsis;
       }


### PR DESCRIPTION
## What
Adjusted the line height of repository IDs in the repository selector for better visual alignment.

## Why
The previous line height caused slight misalignment, which showed vertical scroll handles in case of a 125% browser zoom

## How
- Increased the `line-height` property for `.repository-id` from `1.1em` to `1.2em` in the SCSS file.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
