### PR TITLE
Cherry pick: GDB-14995: Disable repository renaming for manage-role users (#3124)

### DIFF
--- a/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
+++ b/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
@@ -266,6 +266,7 @@ describe('User and Access', () => {
                 UserAndAccessSteps.toggleSecurity();
                 LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);
                 MainMenuSteps.clickOnSparqlMenu();
+                cy.get('h1').should('be.visible').should('contain', 'SPARQL Query & Update');
                 cy.url().should('include', '/sparql');
 
                 LoginSteps.logout();
@@ -732,6 +733,36 @@ describe('User and Access', () => {
 
             // Then I should still see all repositories for which the user has at least read permission.
             RepositorySteps.getRepositories().should('have.length', 4);
+        });
+
+        it('should not allow a user with maintain permission to rename a repository', () => {
+            // Given there is a user with manage permission for a repository.
+            createUser(manageUser, PASSWORD, ROLE_USER, {manage: true, repoName: manageRepositoryId});
+            UserAndAccessSteps.toggleSecurity();
+            LoginSteps.loginWithUser(manageUser, PASSWORD);
+            RepositorySteps.visit(false);
+
+            // When the user opens the edit page of the repository they can manage.
+            RepositorySteps.getEditRepositoryButton(manageRepositoryId).should('be.visible');
+            RepositorySteps.editRepository(manageRepositoryId);
+
+            // Then the repository id should be rendered as read only.
+            RepositorySteps.getGDBIdInput()
+                .should('have.value', manageRepositoryId)
+                .and('be.disabled');
+
+            // And the action which unlocks the repository id field should not be available, because renaming
+            // a repository is allowed only for administrators and repository managers.
+            RepositorySteps.getRepositoryIdEditElement().should('not.exist');
+
+            // But the rest of the repository configuration should still be editable.
+            RepositorySteps.typeRepositoryTitle('Renaming is not allowed');
+            RepositorySteps.getSaveRepositoryButton().click();
+            ModalDialogSteps.clickOKButton();
+
+            // And the repository should keep its original id after the configuration is saved.
+            RepositorySteps.getRepositoryFromList(manageRepositoryId).should('be.visible');
+            RepositorySteps.getEditRepositoryButton(manageRepositoryId).should('be.visible');
         });
     });
 

--- a/packages/legacy-workbench/src/js/angular/repositories/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/controllers.js
@@ -805,12 +805,25 @@ EditRepositoryCtrl.$inject = ['$rootScope', '$scope', '$routeParams', 'toastr', 
     '$translate', 'MonitoringRestService'];
 
 function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositories, $location, ModalService, RepositoriesRestService, $translate, MonitoringRestService) {
+    // =========================
+    // Private variables
+    // =========================
+
+    const authorizationService = service(AuthorizationService);
+
+    // =========================
+    // Public variables
+    // =========================
+
     $scope.rulesets = STATIC_RULESETS.slice();
     $scope.repositoryTypes = REPOSITORY_TYPES;
     $scope.entityIndexSizeMin = ENTITY_INDEX_SIZE_MIN;
 
     $scope.editRepoPage = true;
     $scope.canEditRepoId = false;
+    // Renaming a repository is allowed only for administrators and repository managers. Users with a repository
+    // specific maintain permission may change the repository configuration, but not its id.
+    $scope.canRenameRepo = false;
     $scope.isRepoInCluster = true;
     $scope.params = $routeParams;
     $scope.loader = true;
@@ -825,6 +838,10 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
         return $repositories.hasActiveLocation();
     };
 
+    // =========================
+    // Private methods
+    // =========================
+
     const loadRepositoryData = () => {
         return getFilteredLocations($repositories).then((locations) => {
             $scope.locations = locations;
@@ -834,6 +851,7 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
 
     const initView = (repositoryInfoResponse) => {
         const repositoryInfo = repositoryInfoResponse.data;
+        $scope.canRenameRepo = authorizationService.isAdminOrRepoManager();
         if (angular.isDefined(repositoryInfo.params.ruleset)) {
             let ifRulesetExists = false;
             angular.forEach($scope.rulesets, function(item) {
@@ -852,6 +870,10 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
         $scope.repositoryInfo.saveId = $scope.saveRepoId;
         $scope.loader = false;
     };
+
+    // =========================
+    // Public methods
+    // =========================
 
     $scope.$watch($scope.hasActiveLocation, function() {
         if ($scope.hasActiveLocation) {
@@ -956,6 +978,9 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
     };
 
     $scope.editRepositoryId = function() {
+        if (!$scope.canRenameRepo) {
+            return;
+        }
         const msg = decodeHTML($translate.instant('edit.repo.id.warning.msg'));
 
         ModalService.openSimpleModal({
@@ -979,6 +1004,10 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
     $scope.getShaclOptionsClass = function() {
         return getShaclOptionsClass();
     };
+
+    // =================================
+    // Subscriptions and event handlers
+    // =================================
 
     const languageChangedSubscription = $rootScope.$on('$translateChangeSuccess', () => {
         $scope.pageTitle = $translate.instant('view.edit.repo.title', {repositoryId: $scope.params.repositoryId});

--- a/packages/legacy-workbench/src/pages/repository.html
+++ b/packages/legacy-workbench/src/pages/repository.html
@@ -38,7 +38,7 @@
                         <label for="id" class="col-md-3 col-lg-2 col-form-label">{{'repo.id.label' | translate}}</label>
                         <div class="col-md-7 col-lg-6 col-xl-5" gdb-tooltip="{{'repoTooltips.id' | translate}}">
                             <a class="btn btn-link ot-edit-input" ng-click="editRepositoryId()"
-                               ng-if="!canEditRepoId && editRepoPage"
+                               ng-if="canRenameRepo && !canEditRepoId && editRepoPage"
                                gdb-tooltip="{{'edit.repo.id.tooltip' | translate}}" tooltip-placement="right">
                                 <span class="ri-edit-line"></span>
                             </a>


### PR DESCRIPTION
## What
Restricted users with the "manage" role from editing repository IDs.

## Why
Only admins and repository managers should be allowed to rename repositories, as per the updated authorization policy.

## How
- Introduced a `canRenameRepo` scope variable, determined by the user's role via `AuthorizationService`.
- Updated repository UI to conditionally disable repository ID editing for "manage-role" users.
- Adjusted E2E tests to verify that users with the "manage" role cannot rename repositories but can edit other configurations.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified


(cherry picked from commit 1288d1f11fc9c4bee4723a7049f60a976f3bfcbe)
