### PR TITLE
Cherry pick: GDB-15007: Fix cancel button tag addition issue (#3132)

### DIFF
--- a/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
@@ -57,7 +57,7 @@
                         </td>
                         <td class="actions-cell">
                             <div class="actions">
-                                <button ng-click="cancel()"
+                                <button type="button" ng-click="cancel()"
                                         class="btn btn-link cancel-tag-add-btn secondary"
                                         gdb-tooltip="{{'cluster_management.cluster_configuration_multi_region.cancel_tooltip' | translate}}">
                                     <i class="ri-close-line"></i>


### PR DESCRIPTION
## What
Ensured the cancel button in the multi-region cluster configuration template has an explicit `type="button"` to prevent unintended form submissions.

## Why
Previously, the absence of the `type` attribute caused the button to default to `submit`, leading to unexpected behavior when pressing "Enter" in form contexts.

## How
- Added `type="button"` to the cancel button in the multi-region HTML template.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified