### PR TITLE
Replace display name with release version

### DIFF
--- a/release.Jenkinsfile
+++ b/release.Jenkinsfile
@@ -91,6 +91,11 @@ pipeline {
     }
 
     post {
+        always {
+            script {
+              currentBuild.displayName = "${params.RELEASE_VERSION ?: currentBuild.displayName}"
+            }
+        }
         success {
             script {
                 performCleanup()


### PR DESCRIPTION
## What
Modified the build process to ensure the display name is updated with the release version.

## Why
To provide a more accurate and consistent representation of the release version during the build process.

## How
- Updated `release.Jenkinsfile` to set `currentBuild.displayName` to the `RELEASE_VERSION` parameter, if provided.
- Ensured the change takes effect in the `post` build stage under the `always` block.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
