### PR TITLE
Cherry-pici GDB-14988: Repository dropdown going out of bounds and creating a side scroll

### DIFF
--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.scss
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.scss
@@ -59,7 +59,7 @@
   background-color: var(--gw-dialog-background) !important;
   border: 1px solid var(--gw-dialog-border-color) !important;
   box-shadow: var(--gw-dialog-shadow-1-offset-x) var(--gw-dialog-shadow-1-offset-y) var(--gw-dialog-shadow-1-blur) var(--gw-dialog-shadow-1-spread) var(--gw-dialog-shadow-1-color);
-  max-width: 350px;
+  min-width: 22rem;
   opacity: 1 !important;
 
   .tooltip-arrow::before {
@@ -68,7 +68,6 @@
   }
 
   .tooltip-content {
-    min-width: 22rem;
     padding: 0;
 
     .repository-tooltip-title {


### PR DESCRIPTION
## What
Move the minimum-width constraint from the tooltip content to the tooltip box.

## Why
When security is disabled and the selected repository name contains fewer than five characters, the tooltip appears close to the browser’s right edge. Floating UI positions the tooltip box using its calculated width, without accounting for the larger minimum width applied to its content.

As a result, the content overflows the tooltip box and causes a body scrollbar to appear. The scrollbar changes the viewport width, which triggers the tooltip to be repositioned repeatedly.

## How
- Apply the minimum width directly to the tooltip box so Floating UI includes the full required width when calculating its position and keeps the tooltip within the viewport.
- Remove the max-width from the tooltip box because it is defined by the design system (onto-tooltip.scss).

(cherry picked from commit 256176290defb713168ba055618a66c00988e1c9)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
