### PR TITLE
Update the timeout of the Workbench release job

### DIFF
--- a/release.Jenkinsfile
+++ b/release.Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
 
     options {
         disableConcurrentBuilds()
-        timeout(time: 15, unit: 'MINUTES')
+        timeout(time: 20, unit: 'MINUTES')
         timestamps()
     }
 


### PR DESCRIPTION
## What
Increase the timeout of the Workbench release job.

## Why
The job is currently configured with a 15-minute timeout, which is sometimes insufficient.

## How
Increase the timeout from 15 to 20 minutes.

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
