### PR TITLE
GDB-15028: Show the Copy button for remote repositories when the user  has read/write rights

### DIFF
--- a/packages/legacy-workbench/src/pages/repositories.html
+++ b/packages/legacy-workbench/src/pages/repositories.html
@@ -286,18 +286,17 @@
                                             </div>
                                         </td>
                                         <td class="text-nowrap repository-actions">
-                                            <div ng-if="canMaintainRepo(repository)">
-                                                <button class="btn btn-link p-0"
-                                                        ng-click="copyToClipboard(repository.externalUrl)"
-                                                        gdb-tooltip="{{'copy.repo.url' | translate}}">
-                                                    <span class="ri-links-line"></span>
-                                                </button>
-                                                <span ng-if="location.degradedReason">
+                                            <button class="btn btn-link p-0"
+                                                    ng-click="copyToClipboard(repository.externalUrl)"
+                                                    gdb-tooltip="{{'copy.repo.url' | translate}}">
+                                                <span class="ri-links-line"></span>
+                                            </button>
+                                            <span ng-if="location.degradedReason">
                                                 <em class="ri-alert-line icon-lg text-warning"
                                                     gdb-tooltip="{{location.degradedReason}}{{'repo.not.supported.delete.or.edit' | translate}}"
                                                     tooltip-placement="top"></em>
                                             </span>
-                                                <span ng-if="repository.type !== 'system' && !location.degradedReason">
+                                            <span ng-if="canMaintainRepo(repository) && repository.type !== 'system' && !location.degradedReason">
                                                 <a class="btn btn-link p-0 edit-repository-btn"
                                                    href="repository/edit/{{repository.id}}?location={{repository.location}}"
                                                    gdb-tooltip="{{'repoTooltips.editRepository' | translate}}"
@@ -327,7 +326,6 @@
                                                     <em class="ri-delete-bin-6-line"></em>
                                                 </button>
                                             </span>
-                                            </div>
                                         </td>
                                         <td>
                                             <button class="btn btn-link p-0 pin-repository-btn"


### PR DESCRIPTION
## What
Show the Copy button for remote repositories when the user has permissions

## Why
Users with maintain permissions and read/write access should be able to copy remote repository URLs

## How
Remove the restriction on the Copy button to allow users with maintain permissions to use it, even without maintain permissions on the repository.

## Screenshots
<img width="1664" height="523" alt="image" src="https://github.com/user-attachments/assets/256ca159-c27a-4743-b264-7fc3514f2c3f" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
