### PR TITLE
GDB-15006: SPARQL view run button dropdown containing white borders

### DIFF
--- a/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
+++ b/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
@@ -171,6 +171,7 @@ yasgui-component .yasqe_querySplitWrapper .yasqe_querySplitToggle:hover {
 }
 
 yasgui-component  .ontotext-run-dropdown-menu {
+    background-color: var(--gw-tieredmenu-background) !important;
     border: 1px solid var(--gw-tieredmenu-border-color);
     box-shadow: var(--gw-tieredmenu-shadow-1-offset-x) var(--gw-tieredmenu-shadow-1-offset-y) var(--gw-tieredmenu-shadow-1-blur) var(--gw-tieredmenu-shadow-1-spread) var(--gw-tieredmenu-shadow-1-color);
     border-radius: 0;
@@ -178,7 +179,6 @@ yasgui-component  .ontotext-run-dropdown-menu {
 
 yasgui-component .ontotext-run-dropdown-menu-item {
     color: var(--gw-tieredmenu-color) !important;
-    background-color: var(--gw-tieredmenu-background) !important;
 }
 
 yasgui-component .ontotext-run-dropdown-menu-item:hover {

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
@@ -171,6 +171,7 @@ app-yasgui-component-facade .yasqe_querySplitWrapper .yasqe_querySplitToggle:hov
 }
 
 app-yasgui-component-facade  .ontotext-run-dropdown-menu {
+  background-color: var(--gw-tieredmenu-background) !important;
   border: 1px solid var(--gw-tieredmenu-border-color);
   box-shadow: var(--gw-tieredmenu-shadow-1-offset-x) var(--gw-tieredmenu-shadow-1-offset-y) var(--gw-tieredmenu-shadow-1-blur) var(--gw-tieredmenu-shadow-1-spread) var(--gw-tieredmenu-shadow-1-color);
   border-radius: 0;
@@ -178,7 +179,6 @@ app-yasgui-component-facade  .ontotext-run-dropdown-menu {
 
 app-yasgui-component-facade .ontotext-run-dropdown-menu-item {
   color: var(--gw-tieredmenu-color) !important;
-  background-color: var(--gw-tieredmenu-background) !important;
 }
 
 app-yasgui-component-facade .ontotext-run-dropdown-menu-item:hover {


### PR DESCRIPTION
## What
White borders appear at the top and bottom of the run-button dropdown.

## Why
The container holding the dropdown items has top and bottom padding, but no background color. This causes the white borders to appear.

## How
Move the background-color declaration from the dropdown items to their container.

## Screenshots
<img width="344" height="236" alt="image" src="https://github.com/user-attachments/assets/9aa4c839-1230-43f1-a2aa-746b7a575fdd" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
