### PR TITLE
GDB-14908: Sort/display identifier tag for the Secondary cluster consistently and logically

### DIFF
--- a/packages/legacy-workbench/src/js/angular/models/clustermanagement/cluster.js
+++ b/packages/legacy-workbench/src/js/angular/models/clustermanagement/cluster.js
@@ -229,7 +229,8 @@ export class TopologyStatus {
      * @return {TopologyStatus} The mapped TopologyStatus instance.
      */
     static fromJSON({state, primaryTags = {}, primaryIndex, primaryLeader}) {
-        const primaryTagsMap = Object.entries(primaryTags);
+        const primaryTagsMap = Object.entries(primaryTags)
+            .sort(([tagNameA], [tagNameB]) => tagNameA.localeCompare(tagNameB));
         return new TopologyStatus(state, primaryTagsMap, primaryIndex, primaryLeader);
     }
 }
@@ -496,7 +497,7 @@ export class ClusterViewModel {
         const removeNodes = Array.from(this._deleteFromCluster.values()).map((node) => node.endpoint);
         const updateActions = {
             addNodes,
-            removeNodes
+            removeNodes,
         };
 
         const updatedClusterConfig = this.updateClusterConfiguration(addNodes);
@@ -723,7 +724,7 @@ export class ClusterConfiguration {
                     batchUpdateInterval = 5000,
                     nodes = [],
                     secondaryTag,
-                    primaryNodes
+                    primaryNodes,
                 } = {}) {
         this._electionMinTimeout = electionMinTimeout;
         this._electionRangeTimeout = electionRangeTimeout;
@@ -830,7 +831,7 @@ export class ClusterConfiguration {
             verificationTimeout: this._verificationTimeout,
             transactionLogMaximumSizeGB: this._transactionLogMaximumSizeGB,
             batchUpdateInterval: this._batchUpdateInterval,
-            nodes: this._nodes
+            nodes: this._nodes,
         };
         if (this._secondaryTag !== undefined) json.secondaryTag = this._secondaryTag;
         if (this._primaryNodes !== undefined) json.primaryNodes = this._primaryNodes;


### PR DESCRIPTION
## What
Tags in the Multi-region table are not sorted.

## Why
The backend returns tag information as an object whose keys are tag names and whose values are their indexes. In the UI, this object is converted into an array of objects, where the first item is the tag name and the second item is the tag index.

## How
Added sorting after converting the object into an array.

## Screenshots
<img width="765" height="869" alt="image" src="https://github.com/user-attachments/assets/f525275c-629d-4c0d-b5f4-04f0a3a759c4" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
