### PR TITLE
Cherry-pick GDB-15032: Introduce a mechanism that loads the correct labels in the new workbench

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -827,7 +827,7 @@ interceptorService.registerResponseInterceptors(new HttpInterceptorList([new MyR
 The system ensures that translations from different modules are merged into a single bundle per language,
 using the [merge-i18n-plugin.js](./webpack/merge-i18n-plugin.js). After they are merged, all `.json`
 files from `src/assets/i18n` directories are transferred to the webpack output directory. That includes
-[language-config.json](packages/root-config/src/assets/i18n/language-config.json), which contains the default language
+[language-config.json](packages/root-config/src/assets/i18n/language-config.json), which contains the default language, the translation bundle version
 and the available languages for the application. The configuration file is read, upon starting the application inside
 [ontotext-root-config.js#getLanguageConfig](packages/root-config/src/ontotext-root-config.js). The default language
 is loaded and the app starts listening for [ontotext-root-config.js#onLanguageChange](packages/root-config/src/ontotext-root-config.js)

--- a/packages/api/src/models/language/language-config.ts
+++ b/packages/api/src/models/language/language-config.ts
@@ -9,6 +9,7 @@ export const SUPPORTED_LANGUAGES = ['en', 'fr'];
  * Represents the configuration for language settings in the application.
  */
 export class LanguageConfig extends Model<LanguageConfig> {
+  readonly languageBundleVersion: string;
   readonly defaultLanguage: string;
   readonly availableLanguages: AvailableLanguagesList;
 
@@ -16,5 +17,6 @@ export class LanguageConfig extends Model<LanguageConfig> {
     super();
     this.defaultLanguage = props.defaultLanguage || DEFAULT_LANGUAGE;
     this.availableLanguages = props.availableLanguages || new AvailableLanguagesList();
+    this.languageBundleVersion = props.languageBundleVersion || '';
   }
 }

--- a/packages/api/src/services/language/language-rest.service.ts
+++ b/packages/api/src/services/language/language-rest.service.ts
@@ -12,10 +12,14 @@ export class LanguageRestService extends HttpService {
    * Retrieves the translation bundle for a specific language.
    *
    * @param languageCode - The code of the language for which to fetch translations.
+   * @param languageBundleVersion - A language bundle version identifier used for cache busting
    * @returns A Promise that resolves to a TranslationBundle containing the translations for the specified language.
    */
-  getLanguage(languageCode: string): Promise<TranslationBundle> {
-    return this.get<TranslationBundle>(`${this.I18N_ENDPOINT}/${languageCode}.json`);
+  getLanguage(languageCode: string, languageBundleVersion?: string): Promise<TranslationBundle> {
+    return this.get<TranslationBundle>(
+      `${this.I18N_ENDPOINT}/${languageCode}.json`,
+      languageBundleVersion ? {params: {version: languageBundleVersion}} : undefined
+    );
   }
 
   /**

--- a/packages/api/src/services/language/language.service.ts
+++ b/packages/api/src/services/language/language.service.ts
@@ -37,7 +37,7 @@ export class LanguageService implements Service {
    * containing the translations for the specified language.
    */
   getLanguage(languageCode: string): Promise<TranslationBundle> {
-    return this.languageRestService.getLanguage(languageCode);
+    return this.languageRestService.getLanguage(languageCode, this.languageContextService.getLanguageConfig()?.languageBundleVersion);
   }
 
   /**

--- a/packages/api/src/services/language/mappers/language-config-mapper.ts
+++ b/packages/api/src/services/language/mappers/language-config-mapper.ts
@@ -9,7 +9,8 @@ import {AvailableLanguage} from '../../../models/language/available-language';
 export const mapLanguageConfigResponseToModel: MapperFn<LanguageConfigResponse, LanguageConfig> = (data) => {
   return new LanguageConfig({
     defaultLanguage: data.defaultLanguage,
-    availableLanguages: mapAvailableLanguagesListToModel(data.availableLanguages)
+    availableLanguages: mapAvailableLanguagesListToModel(data.availableLanguages),
+    languageBundleVersion: data.languageBundleVersion,
   });
 };
 

--- a/packages/api/src/services/language/response/language-config-response.ts
+++ b/packages/api/src/services/language/response/language-config-response.ts
@@ -1,4 +1,5 @@
 export interface LanguageConfigResponse {
+  languageBundleVersion: string;
   defaultLanguage: string;
   availableLanguages: AvailableLanguageResponse[];
 }

--- a/packages/api/src/services/language/test/language-test-util.ts
+++ b/packages/api/src/services/language/test/language-test-util.ts
@@ -4,6 +4,7 @@ import {AvailableLanguagesList, LanguageConfig} from '../../../models/language';
 
 const languageConfigResponse: LanguageConfigResponse = {
   defaultLanguage: 'en',
+  languageBundleVersion: '1',
   availableLanguages: [
     {key: 'de', name: 'German'},
     {key: 'es', name: 'Spanish'}
@@ -17,6 +18,7 @@ export const createlanguageConfig = (customResponse?: LanguageConfigResponse) =>
   });
   return new LanguageConfig({
     defaultLanguage: response.defaultLanguage,
-    availableLanguages: new AvailableLanguagesList(availableLanguageList)
+    availableLanguages: new AvailableLanguagesList(availableLanguageList),
+    languageBundleVersion: response.languageBundleVersion
   });
 };

--- a/packages/api/src/services/language/test/language.service.spec.ts
+++ b/packages/api/src/services/language/test/language.service.spec.ts
@@ -72,6 +72,7 @@ describe('LanguageService', () => {
   test('Should retrieve the language configuration', async () => {
     // Given, I have a mocked language configuration
     const languageConfigResponse: LanguageConfigResponse = {
+      languageBundleVersion: '1',
       defaultLanguage: 'en',
       availableLanguages: [
         {key: 'de', name: 'German'},

--- a/packages/root-config/src/assets/i18n/language-config.json
+++ b/packages/root-config/src/assets/i18n/language-config.json
@@ -1,5 +1,6 @@
 {
   "defaultLanguage": "en",
+  "languageBundleVersion": "[AIV]{version}[/AIV]",
   "availableLanguages": [
     {
       "key": "en",

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -120,7 +120,8 @@ module.exports = (webpackConfigEnv, argv) => {
             }),
             new MergeI18nPlugin({
               startDirectory: './packages',
-              outputDirectory: 'assets/i18n'
+              outputDirectory: 'assets/i18n',
+              replaceVersion
             }),
             new MergeJsonPlugin({
                 files: [

--- a/webpack/merge-i18n-plugin.js
+++ b/webpack/merge-i18n-plugin.js
@@ -13,6 +13,7 @@ class MergeI18nPlugin {
   constructor(options) {
     this.outputDirectory = options.outputDirectory;
     this.startDirectory = options.startDirectory;
+    this.replaceVersion = options.replaceVersion ?? ((content) => content);
   }
 
   apply(compiler) {
@@ -87,7 +88,7 @@ class MergeI18nPlugin {
           console.log(`Processing file: ${file}`);
           const language = path.basename(file, '.json');
           const filePath = path.join(i18nPath, file);
-          const fileContent = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+          const fileContent = JSON.parse(this.replaceVersion(fs.readFileSync(filePath, 'utf-8')));
 
           if (!mergedBundles[language]) {
             mergedBundles[language] = {};


### PR DESCRIPTION
## What
Add version-based cache busting for language bundles

## Why
Ensure users receive updated translations after a new application build instead of reusing cached language JSON files.

## How
- Extend the language configuration model with a new `languageBundleVersion` property. This value is used as the version parameter when loading language bundles.
- The default configuration sets the value to `[AIV]{version}[/AIV]`, which is replaced with the actual Workbench version during the build process. This mechanism is already used for other resources to prevent browsers from serving stale cached files.

(cherry picked from commit fcf383ce8f700e48a6780c7bfe7caadbe5acb65b)

## Screenshots
<img width="1056" height="368" alt="image" src="https://github.com/user-attachments/assets/e102dc52-b11e-47d9-984f-2c38a966a8f7" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
