### PR TITLE
GDB-14998: Add a scrollbar to the Cluster Settings sidebar for identifier tags

### DIFF
--- a/packages/legacy-workbench/src/css/cluster-configuration/cluster-configuration.css
+++ b/packages/legacy-workbench/src/css/cluster-configuration/cluster-configuration.css
@@ -1,0 +1,23 @@
+.cluster-configuration {
+     /*Add top margin to match the other side panels.*/
+    margin-top: 48px;
+    height: calc(100vh - 48px);
+    color: var(--gw-panel-color);
+    background-color: var(--gw-panel-background);
+    border: 1px solid var(--gw-panel-border-color);
+    -webkit-box-shadow: var(--gw-dialog-shadow-1-offset-x) var(--gw-dialog-shadow-1-offset-y) var(--gw-dialog-shadow-1-blur) var(--gw-dialog-shadow-1-spread) var(--gw-dialog-shadow-1-color);
+    box-shadow: var(--gw-dialog-shadow-1-offset-x) var(--gw-dialog-shadow-1-offset-y) var(--gw-dialog-shadow-1-blur) var(--gw-dialog-shadow-1-spread) var(--gw-dialog-shadow-1-color);
+
+    display: flex;
+    flex-direction: column;
+}
+
+.cluster-configuration .cluster-configuration-tabs-content {
+    flex: 1;
+    min-height: 0;
+}
+
+.cluster-configuration .multi-region-tab-content {
+    height: 100%;
+    min-height: 0;
+}

--- a/packages/legacy-workbench/src/css/cluster-configuration/multi-region.css
+++ b/packages/legacy-workbench/src/css/cluster-configuration/multi-region.css
@@ -1,0 +1,81 @@
+.multi-region {
+    display: flex;
+    height: 100%;
+}
+
+.multi-region .multi-region-content {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.multi-region .multi-region-form {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.multi-region .multi-region-table {
+    overflow: auto;
+}
+
+.multi-region .multi-region-error {
+    flex: 0 0 auto;
+}
+
+.multi-region-loader .ot-loader-new-content {
+    background-color: var(--gw-neutral-50-alpha-50);
+    height: 100%;
+    position: absolute;
+    width: 100%;
+}
+
+.cluster-status-loader {
+    color: var(--gw-foreground-on-surface-secondary);
+    font-size: 1.5rem;
+}
+
+.multi-region .tags-table {
+    border-collapse: separate;
+    border-spacing: 0;
+}
+
+.multi-region .tags-table td,
+.multi-region .tags-table th {
+    padding: .4rem;
+}
+
+.multi-region .tags-table .tag-column {
+    width: auto;
+}
+
+.multi-region .tags-table .tag-index-column {
+    width: 16%;
+}
+
+.multi-region .tags-table .index-column {
+    width: 10%;
+}
+
+.multi-region .multi-region-table thead th {
+    border-bottom: var(--gw-datatable-header-background);
+    height: 2rem;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+.multi-region .multi-region-table .add-tag-row {
+    position: sticky;
+    top: 2.4rem;
+    z-index: 1;
+}
+
+.multi-region .tag-input.ng-invalid.ng-dirty {
+    border-color: var(--gw-tag-danger-color) !important;
+}
+
+.multi-region .tag-input.ng-valid.ng-dirty {
+    border-color: initial;
+}

--- a/packages/legacy-workbench/src/css/clustermanagement.css
+++ b/packages/legacy-workbench/src/css/clustermanagement.css
@@ -239,6 +239,8 @@ div.nodetooltip {
 }
 
 .cluster-configuration-panel {
+    /* adapt to view width but at least 300px, menu size ignored for all practical screen sizes */
+    max-width: max(300px, 25vw);
     z-index: 1016 !important;
 }
 
@@ -337,11 +339,6 @@ div.nodetooltip {
     background-color: var(--gw-autocomplete-option-focus-background);
 }
 
-.error-message {
-    font-size: small;
-    color: var(--gw-warning-dark);
-}
-
 .alert-save {
     margin-left: 12px;
     margin-right: 12px;
@@ -377,34 +374,8 @@ ul.nodes-list li a:hover {
     text-decoration: underline;
 }
 
-.tags-table .tag-column {
-    width: auto;
-}
-
-.tags-table .tag-index-column {
-    width: 16%;
-}
-
-
-.tags-table .index-column {
-    width: 10%;
-}
-
 .actions-column {
     width: 80px;
-}
-
-.tag-input.ng-invalid.ng-dirty {
-    border-color: var(--gw-tag-danger-color) !important;
-}
-
-.tag-input.ng-valid.ng-dirty {
-    border-color: initial;
-}
-
-.tags-table td, .tags-table th {
-    padding: .4rem;
-    border-bottom: 1px solid #eceeef;
 }
 
 .index-cell {
@@ -419,21 +390,4 @@ ul.nodes-list li a:hover {
 
 .actions-cell .btn-link, .actions-cell .btn-link a {
     padding: 0.2em .2em;
-}
-
-.secondary-tag-table td, .secondary-tag-table th {
-    padding: .4rem;
-    border-bottom: 1px solid #eceeef;
-}
-
-.cluster-status-loader {
-    color: var(--gw-foreground-on-surface-secondary);
-    font-size: 1.5rem;
-}
-
-.multi-region-loader .ot-loader-new-content {
-    background-color: var(--gw-neutral-50-alpha-50);
-    position: absolute;
-    width: 100%;
-    height: 100%;
 }

--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -111,8 +111,8 @@
 
             },
             "error": {
-                "ascii": "Invalid characters detected. Only printable ASCII characters are allowed.",
-                "length": "The input length must be between {{minLen}} and {{maxLen}} characters.",
+                "ascii": "Invalid input. Only printable ASCII characters are allowed.",
+                "length": "Input must be {{minLen}}–{{maxLen}} characters long.",
                 "creating": "Error during Tag creation",
                 "deleting": "Error during Tag deletion",
                 "disabling": "Error during secondary mode disabling",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -110,8 +110,8 @@
                 "enable_secondary_warning": "En activant le mode secondaire, ce cluster deviendrait une réplique en lecture seule du cluster principal spécifié."
             },
             "error": {
-                "ascii": "Caractères non valides détectés. Seuls les caractères ASCII imprimables sont autorisés.",
-                "length": "La longueur d'entrée doit être comprise entre {{minLen}} et {{maxLen}} caractères.",
+                "ascii": "Saisie invalide. Seuls les caractères ASCII imprimables sont autorisés.",
+                "length": "La saisie doit comporter entre {{minLen}} et {{maxLen}} caractères.",
                 "creating": "Erreur lors de la création de la balise",
                 "deleting": "Erreur lors de la suppression de la balise",
                 "disabling": "Erreur lors de la désactivation du mode secondaire",

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/cluster-configuration.html
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/cluster-configuration.html
@@ -1,8 +1,11 @@
+<link href="css/cluster-configuration/cluster-configuration.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 <div class="cluster-configuration break-word-alt p-1 pt-2">
-    <button class="close mb-1 ml-1" ng-click="closeClusterConfigurationPanel()"></button>
-    <h3 class="hovered-parent">
-        {{'cluster_management.cluster_configuration.label' | translate}}
-    </h3>
+    <div class="cluster-configuration-title">
+        <button class="close mb-1 ml-1" ng-click="closeClusterConfigurationPanel()"></button>
+        <h3 class="hovered-parent">
+            {{'cluster_management.cluster_configuration.label' | translate}}
+        </h3>
+    </div>
 
     <ul class="nav nav-tabs configuration-tabs">
         <li class="properties-tab nav-item">
@@ -22,16 +25,18 @@
         </li>
     </ul>
 
-    <div class="tab-pane fade in mt-1" ng-if="activeTab === CONFIGURATION_TABS.PROPERTIES" id="properties">
-        <cluster-properties cluster-configuration="clusterConfiguration"></cluster-properties>
-    </div>
+    <div class="cluster-configuration-tabs-content">
+        <div class="tab-pane fade in mt-1" ng-if="activeTab === CONFIGURATION_TABS.PROPERTIES" id="properties">
+            <cluster-properties cluster-configuration="clusterConfiguration"></cluster-properties>
+        </div>
 
-    <div class="tab-pane fade in mt-1" ng-if="activeTab === CONFIGURATION_TABS.NODES" id="nodes">
-        <cluster-nodes current-node="currentNode"
-                       cluster-model="clusterModel"></cluster-nodes>
-    </div>
+        <div class="tab-pane fade in mt-1" ng-if="activeTab === CONFIGURATION_TABS.NODES" id="nodes">
+            <cluster-nodes current-node="currentNode"
+                           cluster-model="clusterModel"></cluster-nodes>
+        </div>
 
-    <div class="tab-pane fade in mt-1" ng-if="activeTab === CONFIGURATION_TABS.MULTI_REGION" id="multi-region">
-        <multi-region cluster-model="clusterModel"></multi-region>
+        <div class="tab-pane fade in mt-1 multi-region-tab-content" ng-if="activeTab === CONFIGURATION_TABS.MULTI_REGION" id="multi-region">
+            <multi-region cluster-model="clusterModel"></multi-region>
+        </div>
     </div>
 </div>

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
@@ -1,11 +1,13 @@
+<link href="css/cluster-configuration/multi-region.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
+
 <div onto-loader ng-if="loader" class="multi-region-loader" message="getLoaderMessage" size="100"></div>
 
 <div class="multi-region">
-    <div ng-if="topology.state === TopologyState.PRIMARY_NODE">
+    <div class="multi-region-content" ng-if="topology.state === TopologyState.PRIMARY_NODE">
         <h4 class="title">{{'cluster_management.cluster_configuration_multi_region.primary_cluster' | translate}}
             <span ng-if="statusLoader" class="ri-reset-left-line icon-1-25x loader cluster-status-loader"></span>
         </h4>
-        <div class="mb-2" ng-if="isAdmin">
+        <div ng-if="isAdmin">
             <button type="button" class="btn btn-primary create-tag-btn"
                     ng-click="add()"
                     gdb-tooltip="{{'cluster_management.cluster_configuration_multi_region.create_tag_tooltip' | translate}}"
@@ -20,8 +22,9 @@
                 {{'cluster_management.cluster_configuration_multi_region.enable_secondary_mode' | translate}}
             </button>
         </div>
-        <div class="table-responsive" ng-if="topology.primaryTags.length || addingTag">
-            <form name="tagForm">
+
+        <form class="multi-region-form" name="tagForm" ng-if="topology.primaryTags.length || addingTag">
+            <div class="multi-region-table">
                 <table class="tags-table table-striped table-hover table" aria-describedby="tags table">
                     <thead>
                     <tr class="labels-row">
@@ -72,8 +75,7 @@
                         </td>
                     </tr>
 
-                    <tr ng-repeat-start="tag in topology.primaryTags track by $index" ng-if="0"></tr>
-                    <tr class="preview-tag-row">
+                    <tr ng-repeat="tag in topology.primaryTags track by $index">
                         <td class="index-cell"><span>{{$index + 1}}</span></td>
                         <td class="tag-name-cell">
                             {{tag[0]}}
@@ -94,17 +96,16 @@
                             </div>
                         </td>
                     </tr>
-                    <tr ng-repeat-end ng-if="0"></tr>
                     </tbody>
                 </table>
-                <div ng-show="tagForm.asciiInput.$error.asciiValidator && !tagForm.asciiInput.$pristine">
-                    <span class="error-message">{{ 'cluster_management.cluster_configuration_multi_region.error.ascii' | translate }}</span>
-                </div>
-                <div ng-show="tagForm.asciiInput.$error.lengthValidator && !tagForm.asciiInput.$pristine">
-                    <span class="error-message">{{ 'cluster_management.cluster_configuration_multi_region.error.length' | translate: {minLen: TagLengthConstraints.minLen, maxLen: TagLengthConstraints.maxLen} }}</span>
-                </div>
-            </form>
-        </div>
+            </div>
+            <div class="multi-region-error alert alert-danger" ng-show="tagForm.asciiInput.$error.asciiValidator && !tagForm.asciiInput.$pristine">
+                <span class="error-message">{{ 'cluster_management.cluster_configuration_multi_region.error.ascii' | translate }}</span>
+            </div>
+            <div class="multi-region-error alert alert-danger" ng-show="tagForm.asciiInput.$error.lengthValidator && !tagForm.asciiInput.$pristine">
+                <span class="error-message">{{ 'cluster_management.cluster_configuration_multi_region.error.length' | translate: {minLen: TagLengthConstraints.minLen, maxLen: TagLengthConstraints.maxLen} }}</span>
+            </div>
+        </form>
     </div>
 
     <div ng-if="topology.state === TopologyState.SECONDARY_NODE">

--- a/packages/legacy-workbench/src/pages/cluster-management/clusterInfo.html
+++ b/packages/legacy-workbench/src/pages/cluster-management/clusterInfo.html
@@ -1,5 +1,4 @@
 <link href="css/clustermanagement.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
-<link href="css/rdf-details-side-panel.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 <link href="js/lib/d3-tip/d3-tip.css?v=[AIV]{version}[/AIV]" rel="stylesheet"/>
 
 <title>{{'view.clusterManagement.title' | translate}}</title>
@@ -63,7 +62,7 @@
 </div>
 
 <pageslide ng-show="clusterConfiguration"
-           ps-class="cluster-configuration-panel rdf-info-side-panel"
+           ps-class="cluster-configuration-panel"
            ps-open="showClusterConfigurationPanel"
            onopen="onopen"
            onclose="onclose"


### PR DESCRIPTION
## What
Added scrolling to the identifier tags table.

## Why
When there were many tags, users could not see all of them.

## How
- Moved the multi-region-specific CSS for displaying tags into its own file.
- Reorganized the template and CSS to display a scrollbar when there are many tags.
- Made the table header and the first row, which contains the input for adding new tags, sticky so they remain visible while scrolling.
- Updated the error messages to make tag-name errors visible.
- Improved the error styling because the previous style made the messages difficult to notice.

## Screenshots
<img width="780" height="996" alt="image" src="https://github.com/user-attachments/assets/c207cc6d-4cab-4c5e-9b49-87e58a8ab72f" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
