### PR TITLE
GDB-14993 add custom colors per node type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@single-spa/import-map-injector": "^2.0.2",
                 "graphdb-workbench-plugins": "^1.0.2",
-                "graphwise-reactodia": "^0.0.1-TR9",
+                "graphwise-reactodia": "^0.0.1-TR10",
                 "import-map-overrides": "^6.1.0"
             },
             "devDependencies": {
@@ -6934,9 +6934,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/graphwise-reactodia": {
-            "version": "0.0.1-TR9",
-            "resolved": "https://registry.npmjs.org/graphwise-reactodia/-/graphwise-reactodia-0.0.1-TR9.tgz",
-            "integrity": "sha512-dzzdViv7/7zWsFScJuT79oCesaCzE8aGwOfE0wewCjuwGeeFGbD02j9n9ARET8jKRFTLbl1BvLg1ttrxEDZKHg==",
+            "version": "0.0.1-TR10",
+            "resolved": "https://registry.npmjs.org/graphwise-reactodia/-/graphwise-reactodia-0.0.1-TR10.tgz",
+            "integrity": "sha512-+OqVXRyWmCNcBmmkrq7NqC0a2Lbkct8wPXsgA/qTSbLSHP18q8XSNqnLAptMjua3fxIko8ytykpYMlcp7o3Rvg==",
             "license": "Apache-2.0"
         },
         "node_modules/gzip-size": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "dependencies": {
         "@single-spa/import-map-injector": "^2.0.2",
         "graphdb-workbench-plugins": "^1.0.2",
-        "graphwise-reactodia": "^0.0.1-TR9",
+        "graphwise-reactodia": "^0.0.1-TR10",
         "import-map-overrides": "^6.1.0"
     }
 }

--- a/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.html
+++ b/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.html
@@ -1,5 +1,6 @@
 <graphwise-reactodia
   [config]="config()"
   [currentRepository]="currentRepository()"
-  [language]="language()">
+  [language]="language()"
+  [theme]="theme()">
 </graphwise-reactodia>

--- a/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.ts
+++ b/packages/workbench/src/app/components/reactodia-component-facade/reactodia-component-facade.component.ts
@@ -39,10 +39,12 @@ export class ReactodiaComponentFacadeComponent {
   readonly currentRepository = input.required<string>();
   /** The selected UI language passed to the web component. */
   readonly language = input<string>();
-  /** The resource IRIs the diagram starts from (Reactodia's `seed`). */
+  /** The applied theme passed to the web component. */
+  readonly theme = input<string>();
+  /** The resource IRIs to seed the diagram with */
   readonly seedIris = input<string[]>([]);
   /**
-   * Pre-resolved edges to place on the canvas (Reactodia's `seedGraph`). Used for query-driven
+   * Pre-resolved graph to place on the canvas. Used for query-driven
    * graphs (e.g. CONSTRUCT results) whose links are not persisted in the repository and therefore
    * cannot be resolved lazily from the SPARQL endpoint.
    */

--- a/packages/workbench/src/app/pages/reactodia/reactodia-page.component.html
+++ b/packages/workbench/src/app/pages/reactodia/reactodia-page.component.html
@@ -4,6 +4,7 @@
       <app-reactodia-component-facade
         [currentRepository]="currentRepository()"
         [language]="language()"
+        [theme]="theme()"
         [seedIris]="seedIris()"
         [seedGraph]="seedGraph()">
       </app-reactodia-component-facade>

--- a/packages/workbench/src/app/pages/reactodia/reactodia-page.component.ts
+++ b/packages/workbench/src/app/pages/reactodia/reactodia-page.component.ts
@@ -7,9 +7,11 @@ import {
   GraphExploreService,
   LanguageContextService,
   RepositoryContextService,
+  RuntimeConfigurationContextService,
   service,
   SubscriptionList,
-  WindowService
+  WindowService,
+  ThemeMode
 } from '@ontotext/workbench-api';
 import {CLEAR_DIAGRAM_STORAGE_EVENT} from 'graphwise-reactodia';
 import {
@@ -19,10 +21,10 @@ import {PageLayoutComponent} from '../../components/page-layout/page-layout.comp
 import {LoggerProvider} from '../../services/logger/logger-provider';
 
 /**
- * Page that hosts the Reactodia graph. It owns the context subscriptions (repository and language),
- * gates between the "repository required" banner and the {@link ReactodiaComponentFacadeComponent}
+ * Page that hosts the Reactodia graph. It owns the context subscriptions (repository, language and
+ * theme), gates between the "repository required" banner and the {@link ReactodiaComponentFacadeComponent}
  * (which owns the `graphwise-reactodia` web component and its wiring) based on the active
- * repository, and feeds the current repository/language down to the facade.
+ * repository, and feeds the current repository/language/theme down to the facade.
  */
 @Component({
   selector: 'app-reactodia-page',
@@ -39,6 +41,7 @@ export class ReactodiaPageComponent implements OnInit, OnDestroy {
   private readonly languageContextService = service(LanguageContextService);
   private readonly graphExploreService = service(GraphExploreService);
   private readonly eventService = service(EventService);
+  private readonly runtimeConfigurationContextService = service(RuntimeConfigurationContextService);
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly logger = LoggerProvider.logger;
 
@@ -46,6 +49,7 @@ export class ReactodiaPageComponent implements OnInit, OnDestroy {
 
   readonly currentRepository = signal('');
   readonly language = signal(this.languageContextService.getSelectedLanguage());
+  readonly theme = signal<ThemeMode | undefined>(undefined);
   readonly seedIris = signal<string[]>([]);
   readonly seedGraph = signal<GraphExploreLink[]>([]);
   readonly loading = signal(false);
@@ -60,7 +64,8 @@ export class ReactodiaPageComponent implements OnInit, OnDestroy {
     this.subscriptions.addAll([
       this.subscribeToRepositoryChanged(),
       this.subscribeToLanguageChanged(),
-      this.subscribeToNavigationEnd()
+      this.subscribeToNavigationStart(),
+      this.subscribeToThemeChanged()
     ]);
   }
 
@@ -78,11 +83,19 @@ export class ReactodiaPageComponent implements OnInit, OnDestroy {
 
   /**
    * Tells the `graphwise-reactodia` web component to drop its persisted diagram state whenever a
-   * navigation ends, so a stale diagram is not restored on the next visit to the page.
+   * navigation to another view is made, so a stale diagram is not restored on the next visit to the page.
    */
-  private subscribeToNavigationEnd() {
-    return this.eventService.subscribe(EventName.NAVIGATION_END, () => {
+  private subscribeToNavigationStart() {
+    return this.eventService.subscribe(EventName.NAVIGATION_START, () => {
       WindowService.getWindow().dispatchEvent(new CustomEvent(CLEAR_DIAGRAM_STORAGE_EVENT));
+    });
+  }
+
+  private subscribeToThemeChanged() {
+    return this.runtimeConfigurationContextService.onThemeModeChanged((themeMode) => {
+      if (themeMode) {
+        this.theme.set(themeMode);
+      }
     });
   }
 


### PR DESCRIPTION
## What
Add support for custom colors based on node type in Reactodia.

## Why
So they can be styled using the graphwise styleguide

## How
- Introduced a new `theme` signal to manage color themes.
- Updated the `reactodia-page.component.ts` to subscribe to theme changes.
- Modified the `reactodia-component-facade.component.html` and `reactodia-component-facade.component.ts` to pass the `theme` to the `graphwise-reactodia` component.

## Testing
n/a

## Screenshots
<img width="1578" height="757" alt="Screenshot from 2026-08-11 14-48-53" src="https://github.com/user-attachments/assets/88645c75-b9d5-4b7a-b538-6d7a92d125a5" />
<img width="1578" height="757" alt="Screenshot from 2026-08-12 09-20-12" src="https://github.com/user-attachments/assets/558c676f-10c6-4e93-92d3-95144db24eeb" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
