### PR TITLE
GDB-15053 configure navigation of RDF search

### DIFF
--- a/packages/legacy-workbench/src/js/angular/core/directives.js
+++ b/packages/legacy-workbench/src/js/angular/core/directives.js
@@ -315,7 +315,10 @@ function searchResourceInput($location, toastr, ClassInstanceDetailsService, Aut
             let canceler;
 
             $scope.showClearInputIcon = false;
-            $scope.searchType = LocalStorageAdapter.get(LSKeys.RDF_SEARCH_TYPE) || SEARCH_DISPLAY_TYPE.table;
+            $scope.searchType = SEARCH_DISPLAY_TYPE.table;
+            if ($scope.radioButtons) {
+                $scope.searchType = LocalStorageAdapter.get(LSKeys.RDF_SEARCH_TYPE) || SEARCH_DISPLAY_TYPE.table;
+            }
             $scope.searchInput = "";
 
             $scope.changeSearchType = function(type) {


### PR DESCRIPTION
## What
Configure navigation of RDF search based on radio button selection.

## Why
To ensure no wrong navigations are made, which are due to the selected radio button type. For example when on the visual graph page and opening a resource, we should only be able to navigate to visual graph and not take into account the currently saved button type, which may be `reactodia`

## How
Updated the `$scope.searchType` assignment to check for the presence of `$scope.radioButtons`. If present, it retrieves the search type from `LocalStorageAdapter`, otherwise defaults to `SEARCH_DISPLAY_TYPE.table`.

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
