### PR TITLE
Accept all absolute IRI schemes when validating resource URIs

### DIFF
--- a/packages/api/src/services/utils/test/uri-util.spec.ts
+++ b/packages/api/src/services/utils/test/uri-util.spec.ts
@@ -43,6 +43,44 @@ describe('UriUtil', () => {
     expect(UriUtil.isValidUri('<http://example.com')).toBe(false);
   });
 
+  test('should validate absolute URIs with schemes other than http and urn', () => {
+    expect(UriUtil.isValidUri('https://example.com/resource')).toBe(true);
+    expect(UriUtil.isValidUri('<ftp://example.com/data.rdf>')).toBe(true);
+    expect(UriUtil.isValidUri('mailto:user@example.com')).toBe(true);
+    expect(UriUtil.isValidUri('file:///data/graph.ttl')).toBe(true);
+    expect(UriUtil.isValidUri('did:example:123')).toBe(true);
+    expect(UriUtil.isValidUri('doi:10.1000/182')).toBe(true);
+    expect(UriUtil.isValidUri('xyz://abc#thing')).toBe(true);
+  });
+
+  test('should validate a urn whose namespace specific string contains "http"', () => {
+    expect(UriUtil.isValidUri('urn:example:http-server')).toBe(true);
+    expect(UriUtil.isValidUri('<urn:example:https>')).toBe(true);
+  });
+
+  test('should validate URIs with an upper case scheme', () => {
+    expect(UriUtil.isValidUri('HTTP://example.com')).toBe(true);
+    expect(UriUtil.isValidUri('URN:alabala')).toBe(true);
+  });
+
+  test('should reject URIs without a scheme or a scheme specific part', () => {
+    expect(UriUtil.isValidUri('')).toBe(false);
+    expect(UriUtil.isValidUri(undefined as unknown as string)).toBe(false);
+    expect(UriUtil.isValidUri('example.com/resource')).toBe(false);
+    expect(UriUtil.isValidUri(':no-scheme')).toBe(false);
+    expect(UriUtil.isValidUri('1nvalid:scheme')).toBe(false);
+    expect(UriUtil.isValidUri('invalid scheme:value')).toBe(false);
+    expect(UriUtil.isValidUri('urn:')).toBe(false);
+    expect(UriUtil.isValidUri('mailto:')).toBe(false);
+  });
+
+  test('should reject hierarchical URIs without an authority', () => {
+    expect(UriUtil.isValidUri('http://')).toBe(false);
+    expect(UriUtil.isValidUri('https://')).toBe(false);
+    expect(UriUtil.isValidUri('http:example.com')).toBe(false);
+    expect(UriUtil.isValidUri('ftp://')).toBe(false);
+  });
+
   test('should resolve documentation URL', () => {
     const productVersion = '7.0.0';
     const endpointPath = 'endpoint/path';

--- a/packages/api/src/services/utils/uri-util.ts
+++ b/packages/api/src/services/utils/uri-util.ts
@@ -4,7 +4,10 @@ import {BuildUtil} from './build-util';
  * Utility class for handling and manipulating URIs.
  */
 export class UriUtil {
-  private static readonly ABS_URI_REGEX = /^<?(http|urn).*>?/;
+  private static readonly IRI_SCHEME_REGEX = /^[a-zA-Z][a-zA-Z0-9+\-.]*$/;
+  private static readonly AUTHORITY_PREFIX = '//';
+  // http(s) IRIs are always hierarchical, so they stay rejected without an authority.
+  private static readonly HIERARCHICAL_SCHEMES = ['http', 'https'];
   static GRAPHS_VISUALIZATIONS_URL = 'graphs-visualizations';
   static RESOURCE_URL = 'resource';
   static BASE_DOCUMENTATION_URL = 'https://graphdb.ontotext.com/documentation/';
@@ -98,28 +101,39 @@ export class UriUtil {
   }
 
   /**
-   * Validates if a string is a properly formatted URI.
+   * Validates if a string is a properly formatted absolute URI.
    *
-   * The function checks if the URI has a valid protocol (http(s) or urn)
-   * and proper structure. For HTTP URIs, it verifies the presence of
-   * schema slashes (//) and content after them. For URN URIs, it checks
-   * if there's content after the "urn:" prefix.
+   * The function checks that the URI carries a syntactically valid scheme
+   * (a letter followed by letters, digits, `+`, `-` or `.`) and a non-empty
+   * scheme-specific part. Any registered or custom scheme is accepted, so
+   * `ftp:`, `mailto:`, `file:` and `did:` IRIs validate the same way `http:`
+   * and `urn:` ones do. Hierarchical URIs must carry an authority after the
+   * schema slashes (//), and angle brackets, when present, must be balanced.
    *
    * @param uri - The string to validate as a URI.
    * @returns `true` if the string is a valid URI, otherwise `false`.
    */
   static isValidUri(uri: string): boolean {
-    let valid = false;
-    if (this.hasValidProtocol(uri)) {
-      if (uri.indexOf('http') >= 0) {
-        const schemaSlashesIdx = uri.indexOf('//');
-        valid = schemaSlashesIdx > 4
-          && uri.substring(schemaSlashesIdx + 2).length > 0;
-      } else if (uri.indexOf('urn') >= 0) {
-        valid = uri.substring(4).length > 0;
-      }
+    if (!uri || !this.hasBalancedAngleBrackets(uri)) {
+      return false;
     }
-    return valid;
+
+    const iri = this.removeAngleBrackets(uri);
+    const schemeSeparatorIdx = iri.indexOf(':');
+    if (schemeSeparatorIdx < 0) {
+      return false;
+    }
+
+    const scheme = iri.substring(0, schemeSeparatorIdx);
+    if (!this.IRI_SCHEME_REGEX.test(scheme)) {
+      return false;
+    }
+
+    const schemeSpecificPart = iri.substring(schemeSeparatorIdx + 1);
+    if (schemeSpecificPart.startsWith(this.AUTHORITY_PREFIX)) {
+      return schemeSpecificPart.length > this.AUTHORITY_PREFIX.length;
+    }
+    return !this.HIERARCHICAL_SCHEMES.includes(scheme.toLowerCase()) && schemeSpecificPart.length > 0;
   }
 
   /**
@@ -157,7 +171,7 @@ export class UriUtil {
     return !uri.startsWith('<') && !uri.endsWith('>');
   }
 
-  private static hasValidProtocol(uri: string): boolean {
-    return this.ABS_URI_REGEX.test(uri) && (this.hasNoAngleBrackets(uri) || this.hasAngleBrackets(uri));
+  private static hasBalancedAngleBrackets(uri: string): boolean {
+    return this.hasNoAngleBrackets(uri) || this.hasAngleBrackets(uri);
   }
 }


### PR DESCRIPTION
This PR proposes accepting every absolute IRI scheme in `UriUtil.isValidUri`, so resources whose IRIs use `ftp:`, `mailto:`, `file:`, `did:` or a custom scheme can be searched and visualized instead of being refused as invalid (Fixes #337). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/283. You can sign in with your GitHub ID to claim ownership of the project.

## What changed and why

`UriUtil.isValidUri` in `packages/api/src/services/utils/uri-util.ts` gated on `ABS_URI_REGEX = /^<?(http|urn).*>?/`, so only `http`, `https` and `urn` were ever accepted. That validator is what `onto-search-resource-input.tsx` calls from `validateAndSearch`: when it returns `false` the component raises the `rdf_search.toasts.invalid_uri` toast and never runs the search. Because the RDF search box's *Visual* button redirects to `graphs-visualizations`, that same check is what stands in front of the visual graph, which is the behaviour reported in #337 and in the follow-up comment about "Invalid URI" being shown for schemes that are not `http`.

A second, smaller problem sat in the same function: the branch was chosen with `uri.indexOf('http') >= 0` rather than on the parsed scheme, so a URN whose namespace-specific string merely contains the letters `http` — `urn:example:http-server` — was routed into the http branch, found no `//`, and was refused even though the scheme check just before it had accepted it as a URN.

The function now parses the scheme the way RFC 3986 defines it (a letter followed by letters, digits, `+`, `-` or `.`), accepts any scheme that carries a non-empty scheme-specific part, still requires an authority after the schema slashes, and still requires angle brackets to be balanced. Scheme comparison is case-insensitive, so `URN:alabala` validates like `urn:alabala`.

On backward compatibility: every input the previous implementation accepted is still accepted, and every rejection its existing test pins — `invalid_uri`, `http://example.com>`, `<http://example.com` — still rejects. `http://`, `https://`, `http:example.com` and `urn:` also still reject, and each of those now has a test so the boundary cannot drift. The one deliberate widening is that a bare prefixed name such as `rdf:type` is now treated as an absolute IRI; that matches the legacy AngularJS validator `UriUtils.isValidIri`, which has accepted arbitrary schemes through its RFC 3987 fallback for years, so this brings the newer package in line with the older one rather than inventing a new rule.

## Reproducing it on master

Reproduced on `master` at `d08af8e`, by adding the new assertions to the existing spec and running it against the unmodified `uri-util.ts`:

```
$ npm ci --prefix packages/api && npm install
$ cd packages/api && BABEL_ENV=test ./node_modules/.bin/jest --coverage=false src/services/utils/test/uri-util.spec.ts

  ● UriUtil › should validate absolute URIs with schemes other than http and urn

    expect(received).toBe(expected) // Object.is equality

    Expected: true
    Received: false

      47 |     expect(UriUtil.isValidUri('https://example.com/resource')).toBe(true);
    > 48 |     expect(UriUtil.isValidUri('<ftp://example.com/data.rdf>')).toBe(true);
         |                                                                ^

  ● UriUtil › should validate a urn whose namespace specific string contains "http"
  ● UriUtil › should validate URIs with an upper case scheme

Tests:       3 failed, 10 passed, 13 total
```

## Verification

The five new tests split deliberately: three assert the widened behaviour and fail against the unmodified file, as above, while the two that assert rejections (`should reject URIs without a scheme or a scheme specific part` and `should reject hierarchical URIs without an authority`) stay green on both trees, so they document that nothing was loosened by accident.

Whole-package results, run before and after the change with `npm test --prefix packages/api`:

```
before:  Test Suites: 117 passed, 117 total   Tests: 1233 passed, 1233 total
after:   Test Suites: 117 passed, 117 total   Tests: 1238 passed, 1238 total
```

No test that passed before fails now. `npm run lint` and `npm run build:types` in `packages/api` are both clean, and the repo's own pre-commit hook ran `eslint --config packages/api/eslint.config.js --max-warnings=0` over both staged files without complaint. Statement coverage of `uri-util.ts` stays at 100% and branch coverage rises from 94.28% to 97.36%.

One limit worth stating plainly: I exercised the shared validator and the package suite, not the workbench running against a live GraphDB instance, so the end-to-end check of typing `<ftp://example.com/data.rdf>` into the RDF search box is yours to make. The change is confined to that one function and its tests.

## How this was managed

This work was tracked as [Limited support for IRI in visualization graphs](https://eastagiletracker.com/projects/283/stories/176731) on a board at https://eastagiletracker.com/projects/283 that was imported from this repository's own issues, with the story picked up and moved into progress before the code was written.

![board](https://raw.githubusercontent.com/eastagiletracker/graphdb-workbench/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
