### PR TITLE
GDB-14206: Update Accept headers to request RDF 1.2

### DIFF
--- a/packages/api/src/services/domain/rdf4j/rdf4j-rest.service.ts
+++ b/packages/api/src/services/domain/rdf4j/rdf4j-rest.service.ts
@@ -57,11 +57,13 @@ export class Rdf4jRestService extends HttpService {
       .map(([property, value]) => `${property}=${encodeURIComponent(value)}`);
     const payloadString = properties.join('&');
 
+    const version12AcceptHeader = acceptHeader + ';version=1.2';
+
     return this.post(`${this.REPOSITORIES_ENDPOINT}/${repositoryId}`, {
       responseType: 'blob',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
-        'Accept': acceptHeader,
+        'Accept': version12AcceptHeader,
         'Link': linkHeader
       },
       body: payloadString,
@@ -85,11 +87,12 @@ export class Rdf4jRestService extends HttpService {
    * @returns A promise resolving to the raw SPARQL SELECT results.
    */
   executeSparqlQuery(repositoryId: string, query: string): Promise<SparqlResultsResponse> {
+    const version12AcceptHeader = 'application/sparql-results+json;version=1.2';
     return this.post<SparqlResultsResponse>(`${this.REPOSITORIES_ENDPOINT}/${repositoryId}`, {
       body: new URLSearchParams({query}),
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
-        'Accept': 'application/sparql-results+json',
+        'Accept': version12AcceptHeader,
         'X-GraphDB-Local-Consistency': 'updating',
       }
     });

--- a/packages/api/src/services/domain/rdf4j/test/rdf4j-repository.service.spec.ts
+++ b/packages/api/src/services/domain/rdf4j/test/rdf4j-repository.service.spec.ts
@@ -74,6 +74,7 @@ describe('Rdf4jRepositoryService', () => {
       const repositoryId = 'my-repository';
       const data = {query: 'SELECT * WHERE { ?s ?p ?o }', infer: true};
       const acceptHeader = 'application/sparql-results+json';
+      const expectedAcceptHeader = 'application/sparql-results+json;version=1.2';
       const linkHeader = '<http://example.org>; rel="related"';
       const mockBlob = new Blob(['{}'], {type: 'application/json'});
       TestUtil.mockResponse(new ResponseMock(`repositories/${repositoryId}`).setBlob(mockBlob));
@@ -84,7 +85,7 @@ describe('Rdf4jRepositoryService', () => {
       // Then fetch should have been called with the correct URL and headers
       const request = TestUtil.getRequest(`repositories/${repositoryId}`);
       expect(request).toBeDefined();
-      expect((request!.headers as Record<string, string>)['Accept']).toBe(acceptHeader);
+      expect((request!.headers as Record<string, string>)['Accept']).toBe(expectedAcceptHeader);
       expect((request!.headers as Record<string, string>)['Link']).toBe(linkHeader);
     });
 

--- a/packages/legacy-workbench/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
+++ b/packages/legacy-workbench/src/js/angular/core/directives/yasgui-component/yasgui-component.directive.js
@@ -593,11 +593,11 @@ function yasguiComponentDirective(
 
                 const queryType = yasqe.getQueryType();
                 if (QueryMode.UPDATE === yasqe.getQueryMode()) {
-                    headers['Accept'] = 'text/plain,/;q=0.9';
+                    headers['Accept'] = 'text/plain,/;q=0.9;version=1.2';
                 } else if (QueryType.CONSTRUCT === queryType || QueryType.DESCRIBE === queryType) {
-                    headers['Accept'] = 'application/x-graphdb-table-results+json, application/rdf+json;q=0.9, */*;q=0.8';
+                    headers['Accept'] = 'application/x-graphdb-table-results+json, application/rdf+json;q=0.9, */*;q=0.8;version=1.2';
                 } else {
-                    headers['Accept'] = 'application/x-sparqlstar-results+json, application/sparql-results+json;q=0.9, */*;q=0.8';
+                    headers['Accept'] = 'application/x-sparqlstar-results+json, application/sparql-results+json;q=0.9, */*;q=0.8;version=1.2';
                 }
                 return headers;
             };

--- a/packages/legacy-workbench/src/js/angular/core/services.js
+++ b/packages/legacy-workbench/src/js/angular/core/services.js
@@ -299,7 +299,7 @@ function ClassInstanceDetailsService($http) {
             //   uri: encodedUri
             //},
             headers: {
-                Accept: 'application/rdf+json',
+                Accept: 'application/rdf+json;version=1.2',
             },
         });
     }

--- a/packages/legacy-workbench/src/js/angular/export/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/export/controllers.js
@@ -159,7 +159,7 @@ exportCtrl.controller('ExportCtrl',
             };
 
             $scope.downloadExport = function(downloadUrl, format) {
-                let url = downloadUrl + '&Accept=' + encodeURIComponent(format.type);
+                let url = downloadUrl + '&Accept=' + encodeURIComponent(format.type + ';version=1.2');
                 const auth = authStorageService.getAuthToken().getValue();
                 if (auth) {
                     url = url + '&authToken=' + encodeURIComponent(auth);

--- a/packages/legacy-workbench/src/js/angular/externalsync/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/externalsync/controllers.js
@@ -106,7 +106,7 @@ function _evaluateSparqlQuery(http, repository, query) {
         {
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
-                'Accept': 'application/sparql-results+json',
+                'Accept': 'application/sparql-results+json;version=1.2',
                 'X-GraphDB-Local-Consistency': 'updating',
             },
         });

--- a/packages/legacy-workbench/src/js/angular/rest/explore.rest.service.js
+++ b/packages/legacy-workbench/src/js/angular/rest/explore.rest.service.js
@@ -16,7 +16,7 @@ function ExploreRestService($http) {
                 context
             },
             headers: {
-                'Accept': accept || 'application/json'
+                'Accept': accept || 'application/json' + ';version=1.2'
             }
         });
     };
@@ -41,7 +41,7 @@ function ExploreRestService($http) {
                 context: resourceInfo.context
             },
             headers: {
-                'Accept': accept || 'application/x-graphdb-table-results+json',
+                'Accept': accept || 'application/x-graphdb-table-results+json' + ';version=1.2',
                 'Link': link ? '<' + link + '>' : ""
             }
         })

--- a/packages/legacy-workbench/src/js/angular/rest/export.rest.service.js
+++ b/packages/legacy-workbench/src/js/angular/rest/export.rest.service.js
@@ -27,7 +27,7 @@ function ExportRestService($http, $repositories, $translate) {
         };
 
         const httpHeaders = {
-            accept: headers.accept
+            accept: headers.accept + ';version=1.2'
         };
 
         if (Array.isArray(context)) {

--- a/packages/legacy-workbench/src/js/angular/rest/jdbc.rest.service.js
+++ b/packages/legacy-workbench/src/js/angular/rest/jdbc.rest.service.js
@@ -103,7 +103,7 @@ function JdbcRestService($http, $translate) {
             params: {
                 limit
             },
-            headers: {Accept: 'application/sparql-results+json'}
+            headers: {Accept: 'application/sparql-results+json;version=1.2'}
         });
     }
 }

--- a/packages/legacy-workbench/src/js/angular/rest/rdf4j.repositories.rest.service.js
+++ b/packages/legacy-workbench/src/js/angular/rest/rdf4j.repositories.rest.service.js
@@ -80,7 +80,7 @@ function RDF4JRepositoriesRestService($http, $translate) {
                 query: CHECK_PLUGIN_ACTIVE_QUERY.replace('{{pluginName}}', pluginName)
             },
             headers: {
-                'Accept': '*/*'
+                'Accept': '*/*;version=1.2'
             }
         });
     }
@@ -90,7 +90,8 @@ function RDF4JRepositoriesRestService($http, $translate) {
     }
 
     function getGraphs(repositoryId, limit) {
-        return $http.get(`${REPOSITORIES_ENDPOINT}/${repositoryId}/contexts`, {params: {limit}});
+        const version12AcceptHeader = 'application/sparql-results+json;version=1.2';
+        return $http.get(`${REPOSITORIES_ENDPOINT}/${repositoryId}/contexts`, {params: {limit}, headers: {'Accept': version12AcceptHeader}});
     }
 
 
@@ -135,12 +136,15 @@ function RDF4JRepositoriesRestService($http, $translate) {
             .filter(([property, value]) => value !== undefined)
             .map(([property, value]) => `${property}=${encodeURIComponent(value)}`);
         const payloadString = properties.join('&');
+
+        const version12AcceptHeader = acceptHeader + ';version=1.2';
+
         return $http({
             method: 'POST',
             url: `${REPOSITORIES_ENDPOINT}/${repositoryId}`,
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
-                'Accept': acceptHeader,
+                'Accept': version12AcceptHeader,
                 'Link': linkHeader
             },
             data: payloadString,
@@ -156,11 +160,16 @@ function RDF4JRepositoriesRestService($http, $translate) {
      * @return {Promise<{data: Blob, filename: string}>} A promise resolving to an object containing the file data (Blob) and its filename.
      */
     function downloadGraphsAsFile(repositoryId, limit) {
+        const version12AcceptHeader = 'version=1.2';
+
         return $http({
             method: 'GET',
             url: `${REPOSITORIES_ENDPOINT}/${repositoryId}/contexts`,
             params: { limit },
-            responseType: "blob"
+            responseType: "blob",
+            headers: {
+                'Accept': version12AcceptHeader
+            }
         }).then((response) => HttpUtils.extractFileFromResponse(response));
     }
 }

--- a/packages/legacy-workbench/src/js/angular/rest/rdf4j.repositories.rest.service.js
+++ b/packages/legacy-workbench/src/js/angular/rest/rdf4j.repositories.rest.service.js
@@ -160,7 +160,7 @@ function RDF4JRepositoriesRestService($http, $translate) {
      * @return {Promise<{data: Blob, filename: string}>} A promise resolving to an object containing the file data (Blob) and its filename.
      */
     function downloadGraphsAsFile(repositoryId, limit) {
-        const version12AcceptHeader = 'version=1.2';
+        const version12AcceptHeader = 'application/json, text/plain, */*;version=1.2';
 
         return $http({
             method: 'GET',

--- a/packages/legacy-workbench/src/js/angular/rest/repositories.rest.service.js
+++ b/packages/legacy-workbench/src/js/angular/rest/repositories.rest.service.js
@@ -201,7 +201,7 @@ function RepositoriesRestService($http) {
     function getRepositoryTurtleConfig(repository) {
         return $http.get('rest/repositories/' + repository.id, {
             headers: {
-                'Accept': 'text/turtle',
+                'Accept': 'text/turtle;version=1.2',
             },
         });
     }

--- a/packages/legacy-workbench/src/js/angular/rest/sparql.rest.service.js
+++ b/packages/legacy-workbench/src/js/angular/rest/sparql.rest.service.js
@@ -121,7 +121,7 @@ function SparqlRestService($http) {
         return $http.get(`repositories/${repositoryId}`, {
             params: sendData,
             headers: {
-                Accept: accept
+                Accept: accept + ';version=1.2'
             }
         });
     }

--- a/packages/legacy-workbench/src/js/angular/similarity/controllers/similarity-list.controller.js
+++ b/packages/legacy-workbench/src/js/angular/similarity/controllers/similarity-list.controller.js
@@ -53,7 +53,7 @@ function SimilarityCtrl(
 
     const PREFIX = 'http://www.ontotext.com/graphdb/similarity/';
     const PREFIX_PREDICATION = 'http://www.ontotext.com/graphdb/similarity/psi/';
-    const acceptContent = 'application/x-sparqlstar-results+json, application/sparql-results+json;q=0.9, */*;q=0.8';
+    const acceptContent = 'application/x-sparqlstar-results+json, application/sparql-results+json;q=0.9, */*;q=0.8;version=1.2';
     const PREFIX_INSTANCE = PREFIX + 'instance/';
     const ANY_PREDICATE = PREFIX_PREDICATION + 'any';
     const licenseContextService = service(LicenseContextService);

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.ts
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.ts
@@ -949,11 +949,11 @@ export class YasguiComponentFacadeComponent implements OnInit, OnDestroy {
 
     const queryType = yasqe.getQueryType();
     if (QueryMode.UPDATE === yasqe.getQueryMode()) {
-      headers['Accept'] = 'text/plain,/;q=0.9';
+      headers['Accept'] = 'text/plain,/;q=0.9;version=1.2';
     } else if (QueryType.CONSTRUCT === queryType || QueryType.DESCRIBE === queryType) {
-      headers['Accept'] = 'application/x-graphdb-table-results+json, application/rdf+json;q=0.9, */*;q=0.8';
+      headers['Accept'] = 'application/x-graphdb-table-results+json, application/rdf+json;q=0.9, */*;q=0.8;version=1.2';
     } else {
-      headers['Accept'] = 'application/x-sparqlstar-results+json, application/sparql-results+json;q=0.9, */*;q=0.8';
+      headers['Accept'] = 'application/x-sparqlstar-results+json, application/sparql-results+json;q=0.9, */*;q=0.8;version=1.2';
     }
     return headers;
   }


### PR DESCRIPTION
## What
Modified various service files to append version=1.2 to the Accept headers for RDF/SPARQL requests.

## Why
This sets the workbench to request version 1.2 regardles of the default configuration in GraphDB.

## How
- Updated Accept headers in `rdf4j-rest.service.ts` to include `;version=1.2`.
- Adjusted headers in `yasgui-component.directive.js` for different query types to support versioning.
- Modified headers in `services.js`, `controllers.js`, and other service files to append `;version=1.2`.
- Ensured consistent application of versioning across all relevant service calls.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
