### PR TITLE
Cherry-pick GDB-15033: Add opacity from DS to disabled elements

### DIFF
--- a/packages/legacy-workbench/src/css/bootstrap-graphdb-theme.css
+++ b/packages/legacy-workbench/src/css/bootstrap-graphdb-theme.css
@@ -1135,10 +1135,12 @@ input[type=checkbox]:checked {
 input[type=checkbox]:checked:disabled {
     background-color: var(--gw-checkbox-checked-disabled-background);
     border-color: var(--gw-checkbox-checked-disabled-border-color);
+    opacity: var(--gw-checkbox-disabled-opacity);
 }
 
 input[type=checkbox]:disabled {
     background-color: var(--gw-checkbox-disabled-background);
+    opacity: var(--gw-checkbox-disabled-opacity);
 }
 
 input[type=checkbox]:checked::after {
@@ -1190,11 +1192,13 @@ input[type=radio]:checked:hover {
 input[type=radio]:checked:disabled {
     color: var(--gw-radiobutton-checked-disabled-label-color);
     border-color: var(--gw-radiobutton-checked-disabled-border-color);
+    opacity: var(--gw-button-disabled-opacity);
 }
 
 input[type=radio]:disabled {
     color: var(--gw-radiobutton-disabled-label-color);
     background-color: var(--gw-radiobutton-disabled-background);
+    opacity: var(--gw-button-disabled-opacity);
 }
 
 input[type=radio]:hover {

--- a/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
+++ b/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
@@ -148,6 +148,10 @@ yasgui-component .custom-button {
     background-color: var(--gw-editor-content-background) !important;
 }
 
+yasgui-component .yasgui .yasqe .yasqe_expandResultsButton.custom-button.disabled {
+    opacity: var(--gw-button-disabled-opacity);
+}
+
 yasgui-component .custom-button:disabled:hover, yasgui-component .custom-button:disabled:focus {
     color: #818a91 !important;
 }

--- a/packages/root-config/src/vendor/common.css
+++ b/packages/root-config/src/vendor/common.css
@@ -84,6 +84,12 @@ h1 .btn {
     transition: all 0.15s ease-out;
 }
 
+.btn:disabled,
+.btn-link.secondary:disabled,
+.text-btn:disabled {
+  opacity: var(--gw-button-disabled-opacity);
+}
+
 .btn, .btn-group > .btn:first-child:not(:last-child):not(.dropdown-toggle) {
     border-radius: 0;
 }

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
@@ -148,6 +148,10 @@ app-yasgui-component-facade .custom-button {
   background-color: var(--gw-editor-content-background) !important;
 }
 
+app-yasgui-component-facade .yasgui .yasqe .yasqe_expandResultsButton.custom-button.disabled {
+  opacity: var(--gw-button-disabled-opacity);
+}
+
 app-yasgui-component-facade .custom-button:disabled:hover, app-yasgui-component-facade .custom-button:disabled:focus {
   color: #818a91 !important;
 }


### PR DESCRIPTION
## What
Apply design system opacity tokens to disabled elements

## Why
Ensure disabled elements have consistent styling across the application.

## How
Apply the designated opacity tokens to disabled buttons, checkboxes, and radio buttons throughout the application.

(cherry picked from commit 20fde75731c1bb5e27149bc3b22968874d191b42)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
