### PR TITLE
GDB-15060: Console error when exporting repository

### DIFF
--- a/packages/legacy-workbench/src/js/angular/export/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/export/controllers.js
@@ -166,7 +166,7 @@ exportCtrl.controller('ExportCtrl',
                 }
                 const win = window.open(url);
                 $timeout(function() {
-                    if (win.document.location.href !== 'about:blank') {
+                    if (!win.closed && win.location.href !== 'about:blank') {
                         win.close();
                         toastr.error('Could not export graph. Check GraphDB logs for detailed reason.');
                     }


### PR DESCRIPTION
## What
When exporting a repository, the export completes successfully, but the following error is logged in the browser console:
- Cannot read properties of null (reading 'href')

## Why
During the repository export flow, Workbench calls the backend API to download the file. The download URL is opened in a new tab. If the export succeeds, the browser closes the tab automatically. If the export fails, the tab remains open.

The error-handling code attempts to inspect and close the newly opened tab when the export fails. However, when the code is executed after a successful export, the tab has already been closed. Accessing its location then causes the error.

## How
Added a check to ensure that the window is still open before accessing its location and attempting to close it.

## Screenshots
<img width="1801" height="814" alt="image" src="https://github.com/user-attachments/assets/d2b5f5fc-475e-4f0c-9dfd-d6dd6c1347ee" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
