### PR TITLE
Cherry-pick GDB-14999: Introduce a way to pass a null values for temperature and top P

### DIFF
--- a/e2e-tests/e2e-legacy/ttyg/create-agent.spec.js
+++ b/e2e-tests/e2e-legacy/ttyg/create-agent.spec.js
@@ -172,6 +172,60 @@ describe('TTYG create new agent', () => {
         TTYGViewSteps.getAgent(0).should('contain', 'Test Agent').and('contain', 'starwars');
     });
 
+    it('should create an agent without temperature or topP parameters', () => {
+        // GIVEN: I have opened the Create Agent dialog and filled in the minimum required fields.
+        openCreateAgentDialog(repositoryId)
+        TtygAgentSettingsModalSteps.getDialog().should('be.visible');
+
+        fillAgentName('Test Agent');
+        TtygAgentSettingsModalSteps.enableSparqlExtractionMethod();
+        TtygAgentSettingsModalSteps.selectSparqlMethodSparqlQuery();
+
+        // WHEN: I disable the temperature setting.
+        TtygAgentSettingsModalSteps.toggleTemperature();
+
+        // AND: I disable the topP setting.
+        TtygAgentSettingsModalSteps.toggleTop();
+
+        // AND: I save the agent.
+        TTYGStubs.stubAgentCreate(1000);
+        TTYGStubs.stubAgentListGet(
+            '/ttyg/agent/get-agent-list-new-agent.json',
+            1000,
+        );
+
+        TtygAgentSettingsModalSteps.saveAgent();
+        TtygAgentSettingsModalSteps.getCreatingAgentLoader().should('be.visible');
+
+        // THEN: I expect the create-agent request not to contain the temperature and topP parameters.
+        cy.wait('@create-agent').then((interception) => {
+            // eslint-disable-next-line no-undef
+            assert.deepEqual(interception.request.body, {
+                id: 'id',
+                name: 'Test Agent',
+                repositoryId: 'starwars',
+                model: 'gpt-4o',
+                contextSize: 128000,
+                seed: 0,
+                assistantsInstructions: {
+                    systemInstruction: '',
+                    userInstruction: 'If you need to write a SPARQL query, use only the classes and properties provided in the schema and don\'t invent or guess any. Always try to return human-readable names or labels and not only the IRIs. If SPARQL fails to provide the necessary information you can try another tool too.',
+                },
+                assistantExtractionMethods: [
+                    {
+                        method: 'sparql_search',
+                        sparqlQuery: 'CONSTRUCT {?s ?p ?o} WHERE {GRAPH <http://example.org/ontology> {?s ?p ?o .}}',
+                        addMissingNamespaces: false,
+                    },
+                ],
+                additionalExtractionMethods: [],
+            });
+        });
+
+        // AND: I expect the modal to be closed.
+        TtygAgentSettingsModalSteps.getDialog().should('not.exist');
+    });
+
     it('Should require FTS to be enabled for selected repository when creating agent with FTS extraction method', () => {
         RepositoriesStubs.stubGetRepositoryConfig(repositoryId, '/repositories/get-repository-config-starwars-disabled-fts.json');
         TTYGStubs.stubChatsListGetNoResults();
@@ -461,6 +515,51 @@ describe('TTYG create new agent', () => {
         TtygAgentSettingsModalSteps.getTemperatureField().should('not.have.class', 'has-warning');
     });
 
+    it('should toggle the temperature setting', () => {
+        // GIVEN: I have opened the Create Agent dialog.
+        openCreateAgentDialog(repositoryId);
+
+        // WHEN: I set a high temperature value.
+        TtygAgentSettingsModalSteps.setTemperature('1.2');
+        // THEN: I expect a warning message to be displayed.
+        TtygAgentSettingsModalSteps.getTemperatureField().should('have.class', 'has-warning');
+        TtygAgentSettingsModalSteps.getTemperatureSliderField().should('have.value', '1.2');
+
+        // WHEN: I disable the temperature setting.
+        TtygAgentSettingsModalSteps.toggleTemperature();
+        // THEN: I expect the high-temperature warning to be hidden.
+        TtygAgentSettingsModalSteps.getTemperatureWarning().should('not.exist');
+        TtygAgentSettingsModalSteps.getTemperatureField().should('not.have.class', 'has-warning');
+        // AND: I expect the temperature controls to be disabled.
+        TtygAgentSettingsModalSteps.getTemperatureField().should('be.disabled');
+        TtygAgentSettingsModalSteps.getTemperatureSliderField().should('be.disabled');
+
+        // WHEN: I enable the temperature setting.
+        TtygAgentSettingsModalSteps.toggleTemperature();
+        // THEN: I expect the default temperature value to be restored.
+        TtygAgentSettingsModalSteps.getTemperatureSliderField().should('have.value', '0.7');
+    });
+
+    it('should toggle the topP setting', () => {
+        // GIVEN: I have opened the Create Agent dialog.
+        openCreateAgentDialog(repositoryId);
+
+        // WHEN: I set a custom topP value.
+        TtygAgentSettingsModalSteps.setTopP('0.3');
+        // THEN: I expect the topP value to be updated.
+        TtygAgentSettingsModalSteps.getTopPField().should('have.value', '0.3');
+
+        // WHEN: I disable the topP setting.
+        TtygAgentSettingsModalSteps.toggleTop();
+        // THEN: I expect the topP control to be disabled.
+        TtygAgentSettingsModalSteps.getTopPField().should('be.disabled');
+
+        // WHEN: I enable the topP setting.
+        TtygAgentSettingsModalSteps.toggleTop();
+        // THEN: I expect the default topP value to be restored.
+        TtygAgentSettingsModalSteps.getTopPField().should('have.value', '1');
+    });
+
     it('Should warn the user when he changes the default value of the base instruction', () => {
         RepositoriesStubs.stubGetRepositoryConfig(repositoryId, '/repositories/get-repository-config-starwars-enabled-fts.json');
         TTYGStubs.stubChatsListGetNoResults();
@@ -540,4 +639,14 @@ function fillAgentName(name) {
     TtygAgentSettingsModalSteps.clearAgentName();
     TtygAgentSettingsModalSteps.getAgentNameError().should('be.visible').and('contain', 'This field is required');
     TtygAgentSettingsModalSteps.typeAgentName(name);
+}
+
+const openCreateAgentDialog = (repositoryId) => {
+    TTYGStubs.stubChatsListGetNoResults();
+    TTYGStubs.stubAgentListGet('/ttyg/agent/get-agent-list-0.json');
+    ConnectorStubs.stubGetConnectors();
+    TTYGStubs.getSimilarityIndexesForRepo(repositoryId );
+    TTYGViewSteps.visit();
+    cy.wait('@get-all-repositories');
+    TTYGViewSteps.createFirstAgent();
 }

--- a/e2e-tests/steps/ttyg/ttyg-agent-settings-modal.steps.js
+++ b/e2e-tests/steps/ttyg/ttyg-agent-settings-modal.steps.js
@@ -451,6 +451,14 @@ export class TtygAgentSettingsModalSteps extends ModalDialogSteps {
         return this.getDialog().find('.temperature');
     }
 
+    static getTemperatureToggle() {
+        return TtygAgentSettingsModalSteps.getTemperatureFormGroup().find('.temperature-toggle label');
+    }
+
+    static toggleTemperature() {
+        TtygAgentSettingsModalSteps.getTemperatureToggle().click();
+    }
+
     static getTemperatureField() {
         return this.getTemperatureFormGroup().find('#temperature');
     }
@@ -475,6 +483,14 @@ export class TtygAgentSettingsModalSteps extends ModalDialogSteps {
 
     static getTopPFormGroup() {
         return this.getDialog().find('.top-p');
+    }
+
+    static getTopPToggle() {
+        return TtygAgentSettingsModalSteps.getTopPFormGroup().find('.top-p-toggle label');
+    }
+
+    static toggleTop() {
+        TtygAgentSettingsModalSteps.getTopPToggle().click();
     }
 
     static getTopPField() {

--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -488,11 +488,15 @@
                     "temperature": {
                         "label": "Temperature",
                         "tooltip": "The sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.",
+                        "toggle_tooltip_enabled": "Unset the value",
+                        "toggle_tooltip_disabled": "Reset to model default",
                         "high_temperature_warning": "A temperature above 1.0 may cause the model to generate anything from creative responses to overdriven, incoherent outputs. Consider lowering the temperature for more reliable results."
                     },
                     "top_p": {
                         "label": "Top P",
-                        "tooltip": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with Top P probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. OpenAI recommends altering this or temperature but not both."
+                        "tooltip": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with Top P probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. OpenAI recommends altering this or temperature but not both.",
+                        "toggle_tooltip_enabled": "Unset the value",
+                        "toggle_tooltip_disabled": "Reset to model default"
                     },
                     "seed": {
                         "label": "Seed",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -487,11 +487,15 @@
                     "temperature": {
                         "label": "Température",
                         "tooltip": "La température d'échantillonnage à utiliser, entre 0 et 2. Des valeurs plus élevées comme 0,8 rendront la sortie plus aléatoire, tandis que des valeurs plus faibles comme 0,2 la rendront plus ciblée et déterministe.",
+                        "toggle_tooltip_enabled": "Supprimer la valeur",
+                        "toggle_tooltip_disabled": "Réinitialiser à la valeur par défaut du modèle",
                         "high_temperature_warning": "Une température supérieure à 1,0 peut amener le modèle à générer des réponses allant de créatives à incohérentes, voire incompréhensibles. Pensez à baisser la température pour des résultats plus fiables."
                     },
                     "top_p": {
                         "label": "Top P",
-                        "tooltip": "Une alternative à l'échantillonnage avec température, appelée échantillonnage du noyau, où le modèle considère les résultats des jetons avec la masse de probabilité Top P. Ainsi, 0,1 signifie que seuls les jetons comprenant la masse de probabilité supérieure de 10 % sont pris en compte. OpenAI recommande de modifier cela ou la température, mais pas les deux."
+                        "tooltip": "Une alternative à l'échantillonnage avec température, appelée échantillonnage du noyau, où le modèle considère les résultats des jetons avec la masse de probabilité Top P. Ainsi, 0,1 signifie que seuls les jetons comprenant la masse de probabilité supérieure de 10 % sont pris en compte. OpenAI recommande de modifier cela ou la température, mais pas les deux.",
+                        "toggle_tooltip_enabled": "Supprimer la valeur",
+                        "toggle_tooltip_disabled": "Réinitialiser à la valeur par défaut du modèle"
                     },
                     "seed": {
                         "label": "Graine",

--- a/packages/legacy-workbench/src/js/angular/models/ttyg/agent-form.js
+++ b/packages/legacy-workbench/src/js/angular/models/ttyg/agent-form.js
@@ -1,5 +1,8 @@
 import {NumericRangeModel, TextFieldModel} from '../form-fields';
 import {AdditionalExtractionMethod, ExtractionMethod} from './agents';
+import {
+    ObjectUtil,
+} from '@ontotext/workbench-api';
 
 const splitConnectorSelection = (value) => {
     if (!value || typeof value !== 'string') {
@@ -57,11 +60,26 @@ export class AgentFormModel {
          * @private
          */
         this._temperature = data && data.temperature || new NumericRangeModel({value: 0.7, minValue: 0, maxValue: 2, step: 0.1});
+
+        /**
+         *
+         * @type {boolean}
+         * @private
+         */
+        this._temperatureEnabled = !ObjectUtil.isNullOrUndefined(this._temperature.value);
+
         /**
          * @type {NumericRangeModel}
          * @private
          */
         this._topP = data && data.topP || new NumericRangeModel({value: 1, minValue: 0, maxValue: 1, step: 0.1});
+
+        /**
+         *
+         * @type {boolean}
+         * @private
+         */
+        this._topPEnabled = !ObjectUtil.isNullOrUndefined(this._topP.value);
         /**
          * @type {number}
          * @private
@@ -212,12 +230,28 @@ export class AgentFormModel {
         this._temperature = value;
     }
 
+    get temperatureEnabled() {
+        return this._temperatureEnabled;
+    }
+
+    set temperatureEnabled(enabled) {
+        this._temperatureEnabled = enabled;
+    }
+
     get topP() {
         return this._topP;
     }
 
     set topP(value) {
         this._topP = value;
+    }
+
+    get topPEnabled() {
+        return this._topPEnabled;
+    }
+
+    set topPEnabled(enabled) {
+        this._topPEnabled = enabled;
     }
 
     get seed() {

--- a/packages/legacy-workbench/src/js/angular/models/ttyg/agents.js
+++ b/packages/legacy-workbench/src/js/angular/models/ttyg/agents.js
@@ -583,3 +583,6 @@ export const AgentCompatibility = {
      */
     'INCOMPATIBLE': 'INCOMPATIBLE',
 };
+
+export const DEFAULT_TEMPERATURE_RANGE = {value: 0.7, minValue: 0, maxValue: 2, step: 0.1};
+export const DEFAULT_TOP_P_RANGE = {value: 1, minValue: 0, maxValue: 1, step: 0.1};

--- a/packages/legacy-workbench/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -1,5 +1,10 @@
 import {decodeHTML} from "../../../../app";
-import {AdditionalExtractionMethod, ExtractionMethod} from "../../models/ttyg/agents";
+import {
+    AdditionalExtractionMethod,
+    DEFAULT_TEMPERATURE_RANGE,
+    DEFAULT_TOP_P_RANGE,
+    ExtractionMethod,
+} from "../../models/ttyg/agents";
 import 'angular/core/services/similarity.service';
 import 'angular/core/services/connectors.service';
 import 'angular/core/services/ttyg.service';
@@ -13,7 +18,7 @@ import {AGENT_OPERATION, TTYG_ERROR_MSG_LENGTH} from "../services/constants";
 import {mapUriAsNtripleAutocompleteResponse} from "../../rest/mappers/autocomplete-mapper";
 import {DocumentationUrlResolver} from "../../utils/documentation-url-resolver";
 import {LoggerProvider} from "../../core/services/logger-provider";
-import {SelectMenuOptionsModel} from "../../models/form-fields";
+import {NumericRangeModel, SelectMenuOptionsModel} from "../../models/form-fields";
 import {SimilarityInstanceType} from '../../models/similarity/similarity-instance-type';
 
 const logger = LoggerProvider.logger;
@@ -238,6 +243,33 @@ function AgentSettingsModalController(
         $scope.agentSettingsForm.extractionMethods.$setTouched();
         setExtractionMethodValidityStatus();
         extractionPanelToggleHandlers[extractionMethod.method](extractionMethod);
+    };
+
+    /**
+     * Toggles whether the temperature value is included in the agent configuration.
+     *
+     * When disabled, the temperature value is cleared so that it is not passed in the agent configuration.
+     */
+    $scope.toggleTemperature = () => {
+        const temperature = new NumericRangeModel({...DEFAULT_TEMPERATURE_RANGE});
+        if (!$scope.agentFormModel.temperatureEnabled) {
+            temperature.value = undefined;
+        }
+        $scope.agentFormModel.temperature = temperature;
+        updateShowHighTemperatureWarning();
+    };
+
+    /**
+     * Toggles whether the top P value is included in the agent configuration.
+     *
+     * When disabled, the top P value is cleared so that it is not passed in the agent configuration.
+     */
+    $scope.toggleTopP = () => {
+        const topP = new NumericRangeModel({...DEFAULT_TOP_P_RANGE});
+        if (!$scope.agentFormModel.topPEnabled) {
+            topP.value = undefined;
+        }
+        $scope.agentFormModel.topP = topP;
     };
 
     /**
@@ -483,7 +515,7 @@ function AgentSettingsModalController(
      * when the temperature is higher than 1.
      */
     $scope.onTemperatureChange = () => {
-        $scope.showHighTemperatureWarning = $scope.agentFormModel.temperature.value > 1;
+        updateShowHighTemperatureWarning();
     };
 
     /**
@@ -968,6 +1000,10 @@ function AgentSettingsModalController(
         if (slider) {
             slider.value = value;
         }
+    };
+
+    const updateShowHighTemperatureWarning = () => {
+        $scope.showHighTemperatureWarning = $scope.agentFormModel.temperature.value > 1;
     };
 
     // =========================

--- a/packages/legacy-workbench/src/js/angular/ttyg/services/agents.mapper.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/services/agents.mapper.js
@@ -3,7 +3,7 @@ import {
     AdditionalExtractionMethodModel,
     AgentInstructionsModel,
     AgentListModel,
-    AgentModel,
+    AgentModel, DEFAULT_TEMPERATURE_RANGE, DEFAULT_TOP_P_RANGE,
     ExtractionMethodModel,
 } from '../../models/ttyg/agents';
 import {
@@ -16,6 +16,9 @@ import {NumericRangeModel, TextFieldModel} from '../../models/form-fields';
 import {md5HashGenerator} from '../../utils/hash-utils';
 import {AGENT_OPERATION} from "./constants";
 import {AgentViewModel} from '../model/agent-view';
+import {
+    ObjectUtil,
+} from '@ontotext/workbench-api';
 
 /**
  * Converts an agent model to an agent form model.
@@ -35,8 +38,19 @@ export const agentFormModelMapper = (agentModel, defaultAgentModel, operation ) 
     agentFormModel.model = agentModel.model || defaultAgentModel.model;
     agentFormModel.contextSize = agentModel.contextSize || defaultAgentModel.contextSize;
     agentFormModel.contextSizeCopy = defaultAgentModel.contextSize;
-    agentFormModel.temperature.value = agentModel.temperature !== undefined ? agentModel.temperature : defaultAgentModel.temperature;
-    agentFormModel.topP.value = agentModel.topP !== undefined ? agentModel.topP : defaultAgentModel.topP;
+
+    // Set temperature related properties.
+    const temperatureFormModel = new NumericRangeModel({...DEFAULT_TEMPERATURE_RANGE});
+    temperatureFormModel.value = agentModel.temperature !== undefined ? agentModel.temperature : defaultAgentModel.temperature;
+    agentFormModel.temperature = temperatureFormModel;
+    agentFormModel.temperatureEnabled = !ObjectUtil.isNullOrUndefined(agentFormModel.temperature.value);
+
+    // Set topP related properties.
+    const topPFormModel = new NumericRangeModel({...DEFAULT_TOP_P_RANGE});
+    topPFormModel.value = agentModel.topP !== undefined ? agentModel.topP : defaultAgentModel.topP;
+    agentFormModel.topP = topPFormModel;
+    agentFormModel.topPEnabled = !ObjectUtil.isNullOrUndefined(agentFormModel.topP.value);
+
     agentFormModel.seed = agentModel.seed || defaultAgentModel.seed;
     agentFormModel.instructions = agentInstructionsFormMapper(agentModel.instructions, defaultAgentModel.instructions);
     extractionMethodsFormMapper(agentFormModel, operation, defaultAgentModel.assistantExtractionMethods, agentModel.assistantExtractionMethods);

--- a/packages/legacy-workbench/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
+++ b/packages/legacy-workbench/src/js/angular/ttyg/templates/modal/agent-settings-modal.html
@@ -98,23 +98,64 @@
                        uib-popover="{{'ttyg.agent.create_agent_modal.form.temperature.high_temperature_warning' | translate}}"
                        popover-trigger="mouseenter"></i>
                 </label>
+                <span class="mr-0 temperature-toggle pull-right"
+                      uib-popover="{{(agentFormModel.temperatureEnabled ? 'ttyg.agent.create_agent_modal.form.temperature.toggle_tooltip_enabled' : 'ttyg.agent.create_agent_modal.form.temperature.toggle_tooltip_disabled') | translate}}"
+                      popover-trigger="mouseenter">
+                        <input type="checkbox" id="temperature_checkbox"
+                               class="switch"
+                               ng-click="toggleTemperature()"
+                               ng-model="agentFormModel.temperatureEnabled"/>
+                        <label for="temperature_checkbox"></label>
+                </span>
                 <input type="text" id="temperature" name="temperature" readonly
                        class="form-control" ng-class="{'has-warning': showHighTemperatureWarning}"
-                       ng-model="agentFormModel.temperature.value">
+                       ng-model="agentFormModel.temperature.value"
+                       ng-disabled="!agentFormModel.temperatureEnabled">
+                <!--
+                   Set min, max, and step dynamically because rerendering a disabled input causes
+                   its default value to be displayed instead of leaving it empty.
+                   Steps to reproduce:
+                      1. Disable the temperature setting.
+                      2. Click the top P input to focus it.
+                      3. Click outside the input.
+                 -->
                 <input id="temperatureSlider" name="temperature" type="range" guide-selector="temperature-control-input"
-                       min="{{agentFormModel.temperature.minValue}}"
-                       max="{{agentFormModel.temperature.maxValue}}" step="{{agentFormModel.temperature.step}}"
+                       ng-attr-min="{{agentFormModel.temperatureEnabled ? agentFormModel.temperature.minValue : undefined}}"
+                       ng-attr-max="{{agentFormModel.temperatureEnabled ? agentFormModel.temperature.maxValue : undefined}}"
+                       ng-attr-step="{{agentFormModel.temperatureEnabled ? agentFormModel.temperature.step : undefined}}"
+                       ng-disabled="!agentFormModel.temperatureEnabled"
                        ng-change="onTemperatureChange()"
                        ng-model="agentFormModel.temperature.value"/>
             </div>
             <div class="form-group top-p" ng-class="{'col-md-3': showContextSize, 'col-md-4': !showContextSize}" guide-selector="top-p-control">
                 <label for="topP" uib-popover="{{'ttyg.agent.create_agent_modal.form.top_p.tooltip' | translate}}"
-                       popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.top_p.label' |
-                translate}}</label>
+                       popover-trigger="mouseenter">{{'ttyg.agent.create_agent_modal.form.top_p.label' | translate}}
+                </label>
+                <span class="mr-0 top-p-toggle pull-right"
+                      uib-popover="{{(agentFormModel.topPEnabled ? 'ttyg.agent.create_agent_modal.form.top_p.toggle_tooltip_enabled' : 'ttyg.agent.create_agent_modal.form.top_p.toggle_tooltip_disabled') | translate}}"
+                      popover-trigger="mouseenter">
+                        <input type="checkbox" id="top_p_checkbox"
+                               class="switch"
+                               ng-click="toggleTopP()"
+                               ng-model="agentFormModel.topPEnabled"/>
+                        <label for="top_p_checkbox"></label>
+                </span>
                 <input type="text" class="form-control" id="topP" name="topP" readonly
+                       ng-disabled="!agentFormModel.topPEnabled"
                        ng-model="agentFormModel.topP.value">
-                <input id="topPSlider" name="topP" type="range" min="{{agentFormModel.topP.minValue}}" guide-selector="top-p-control-input"
-                       max="{{agentFormModel.topP.maxValue}}" step="{{agentFormModel.topP.step}}"
+                <!--
+                   Set min, max, and step dynamically because rerendering a disabled input causes its default value
+                   to be displayed instead of leaving it empty.
+                   Steps to reproduce:
+                      1. Disable the topP setting.
+                      2. Click the temperatur input to focus it.
+                      3. Click outside the input.
+                 -->
+                <input id="topPSlider" name="topP" type="range" guide-selector="top-p-control-input"
+                       ng-attr-min="{{agentFormModel.topPEnabled ? agentFormModel.topP.minValue : undefined}}"
+                       ng-attr-max="{{agentFormModel.topPEnabled ? agentFormModel.topP.maxValue : undefined}}"
+                       ng-attr-step="{{agentFormModel.topPEnabled ? agentFormModel.topP.step : undefined}}"
+                       ng-disabled="!agentFormModel.topPEnabled"
                        ng-model="agentFormModel.topP.value"/>
             </div>
             <!--            Hidden for now because currently this property doesn't work in openai, but in the future it will -->


### PR DESCRIPTION
## What
Add support for removing the configured temperature and top P values in the TTYG Create/Edit Agent dialog.

## Why
Currently, once a value is set for temperature or top P, it cannot be removed.

## How
Add controls for enabling and disabling the temperature and top P settings. When disabled, their values are omitted when the agent configuration is saved.

## Screenshots
| Temperature | top P |
|-------------|-----------------------------|
|<img width="545" height="227" alt="image" src="https://github.com/user-attachments/assets/4abccfba-33bf-4780-ab74-67bc357e1d6a" />|<img width="545" height="227" alt="image" src="https://github.com/user-attachments/assets/ceefdc57-7900-413c-ad6c-e0569df62c6e" />|
|<img width="545" height="227" alt="image" src="https://github.com/user-attachments/assets/b560fa46-b3d1-4154-8552-94900c5f630c" />|<img width="545" height="227" alt="image" src="https://github.com/user-attachments/assets/6303c6ec-7fdf-482d-9dea-c87a571fc8b0" />|

(cherry picked from commit 15c0ae29274746c4ad98ba37dbfefafc4304fe3f)

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
