### PR TITLE
GDB-15072 refactor global loader functionality

### DIFF
--- a/packages/api/src/models/events/app-lifecycle/before-mount-routing.ts
+++ b/packages/api/src/models/events/app-lifecycle/before-mount-routing.ts
@@ -1,0 +1,20 @@
+import {Event} from '../event';
+import {EventName} from '../event-name';
+import {ApplicationsState} from '../../app-lifecycle';
+
+/**
+ * Represents a "beforeMountRoutingEvent" event.
+ *
+ * This event is triggered after the routing has been resolved but before the applications affected by it are
+ * mounted or unmounted. It carries the state the applications will be in once the mounting completes.
+ */
+export class BeforeMountRouting extends Event<ApplicationsState> {
+  /**
+   * Creates an instance of the BeforeMountRouting event.
+   *
+   * @param applicationsState - The state of the applications which are about to be mounted or unmounted.
+   */
+  constructor(applicationsState: ApplicationsState) {
+    super(EventName.BEFORE_MOUNT_ROUTING_EVENT, applicationsState);
+  }
+}

--- a/packages/api/src/models/events/event-name.ts
+++ b/packages/api/src/models/events/event-name.ts
@@ -14,5 +14,6 @@ export const EventName = {
   APPLICATION_MOUNTED: 'applicationMounted',
   APPLICATION_UNMOUNTED: 'applicationUnmounted',
   APPLICATION_CHANGED: 'applicationChanged',
-  APPLICATION_BEFORE_CHANGE: 'applicationBeforeChange'
+  APPLICATION_BEFORE_CHANGE: 'applicationBeforeChange',
+  BEFORE_MOUNT_ROUTING_EVENT: 'beforeMountRoutingEvent'
 };

--- a/packages/api/src/models/events/index.ts
+++ b/packages/api/src/models/events/index.ts
@@ -8,5 +8,6 @@ export * from './app-lifecycle/application-mounted';
 export * from './app-lifecycle/application-unmounted';
 export * from './app-lifecycle/application-before-change';
 export * from './app-lifecycle/application-changed';
+export * from './app-lifecycle/before-mount-routing';
 export * from './auth/logout';
 export * from './auth/login';

--- a/packages/api/src/services/app-lifecycle/application-lifecycle-context.service.ts
+++ b/packages/api/src/services/app-lifecycle/application-lifecycle-context.service.ts
@@ -7,14 +7,12 @@ type LifecycleDataContextFields = {
   readonly APPLICATION_DATA_STATE: string;
   readonly APPLICATIONS_STATE: string;
   readonly APPLICATIONS_STATE_BEFORE_CHANGE: string;
-  readonly NAVIGATION_BEFORE_MOUNT_ROUTING: string;
 }
 
 type LifecycleDataContextFieldParams = {
   readonly APPLICATION_DATA_STATE: LifecycleState;
   readonly APPLICATIONS_STATE: ApplicationsState;
   readonly APPLICATIONS_STATE_BEFORE_CHANGE: ApplicationsState;
-  readonly NAVIGATION_BEFORE_MOUNT_ROUTING: ApplicationsState;
 }
 
 /**
@@ -26,7 +24,6 @@ export class ApplicationLifecycleContextService extends ContextService<Lifecycle
   readonly APPLICATION_DATA_STATE = 'applicationDataLoaded';
   readonly APPLICATIONS_STATE = 'applicationsState';
   readonly APPLICATIONS_STATE_BEFORE_CHANGE = 'applicationsStateBeforeChange';
-  readonly NAVIGATION_BEFORE_MOUNT_ROUTING = 'navigationBeforeMountRouting';
 
   /**
    * Updates the application data state in the context.
@@ -100,19 +97,5 @@ export class ApplicationLifecycleContextService extends ContextService<Lifecycle
    */
   onApplicationsStateBeforeChange(callbackFn: ValueChangeCallback<ApplicationsState | undefined>): () => void {
     return this.subscribe(this.APPLICATIONS_STATE_BEFORE_CHANGE, callbackFn);
-  }
-
-  /**
-   * Set the application state before-mount-routing payload.
-   */
-  updateNavigationBeforeMountRouting(payload: ApplicationsState): void {
-    this.updateContextProperty(this.NAVIGATION_BEFORE_MOUNT_ROUTING, payload);
-  }
-
-  /**
-   * Subscribe to application state before-mount-routing events.
-   */
-  onNavigationBeforeMountRouting(callbackFn: ValueChangeCallback<ApplicationsState | undefined>, skipFirst = false): () => void {
-    return this.subscribe(this.NAVIGATION_BEFORE_MOUNT_ROUTING, callbackFn, undefined, undefined, skipFirst);
   }
 }

--- a/packages/root-config/src/ontotext-root-config.ts
+++ b/packages/root-config/src/ontotext-root-config.ts
@@ -13,6 +13,7 @@ import {
 import {bootstrapWorkbench} from './bootstrap/bootstrap';
 import {
   ApplicationLifecycleContextService,
+  BeforeMountRouting,
   ConfigurationContextService,
   EventService,
   getBasePath,
@@ -101,7 +102,7 @@ function registerSingleSpaRouterListeners(): void {
   WindowService.getWindow().addEventListener('single-spa:before-mount-routing-event', (evt: Event) => {
     // 3rd event emitted by SingleSpa, next is single-spa:before-first-mount
     const d = (evt as AppChangeEvent).detail;
-    service(ApplicationLifecycleContextService).updateNavigationBeforeMountRouting(new ApplicationsState(d.newAppStatuses));
+    service(EventService).emit(new BeforeMountRouting(new ApplicationsState(d.newAppStatuses)));
   });
 
   WindowService.getWindow().addEventListener('single-spa:app-change', (evt: Event) => {

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -3,7 +3,6 @@ import {NavbarToggledEvent} from '../onto-navbar/navbar-toggled-event';
 import {debounce} from '../../utils/function-utils';
 import {WINDOW_WIDTH_FOR_COLLAPSED_NAVBAR} from '../../models/constants';
 import {
-  ApplicationLifecycleContextService,
   AuthenticatedUser,
   AuthenticationService,
   AuthenticationStorageService,
@@ -46,7 +45,6 @@ export class OntoLayout {
   private readonly authStorageService = service(AuthenticationStorageService);
   private readonly runtimeConfigurationContextService = service(RuntimeConfigurationContextService);
   private readonly eventService = service(EventService);
-  private readonly applicationLifecycleContextService = service(ApplicationLifecycleContextService);
   private readonly userPreferencesService = service(UserPreferencesService);
   private readonly userPreferencesContextService = service(UserPreferencesContextService);
   private readonly guideContextService = service(GuideContextService);
@@ -108,7 +106,6 @@ export class OntoLayout {
     this.subscribeToUserPreferencesChange();
     this.subscribeToBeforeMountRouting();
     this.subscribeToGuideChanges();
-    this.loading = false;
   }
 
   /**
@@ -351,10 +348,8 @@ export class OntoLayout {
 
   private subscribeToBeforeMountRouting() {
     this.subscriptions.add(
-      this.applicationLifecycleContextService.onNavigationBeforeMountRouting((payload) => {
-        if (payload) {
-          this.loading = true;
-        }
+      this.eventService.subscribe(EventName.BEFORE_MOUNT_ROUTING_EVENT, () => {
+        this.loading = true;
       }));
   }
 

--- a/packages/shared-components/src/pages/js/main.js
+++ b/packages/shared-components/src/pages/js/main.js
@@ -76,6 +76,28 @@ const openConfirmCancelDialog = (dontShowAgain) => {
   testContext.openConfirmCancel(dontShowAgain);
 };
 
+const emitNavigationEndEvent = (oldUrl, newUrl) => {
+  testContext.emitNavigateEndEvent(oldUrl, newUrl);
+};
+
+const waitForElement = (selector) => {
+  return new Promise((resolve, reject) => {
+    const observer = new MutationObserver(() => {
+      try {
+        const element = document.querySelector(selector);
+        if (element) {
+          observer.disconnect();
+          resolve(element);
+        }
+      } catch (error) {
+        observer.disconnect();
+        reject(error);
+      }
+    });
+    observer.observe(document.body, { subtree: true, childList: true, attributes: true });
+  });
+};
+
 window.PluginRegistry = {
   get: () => menuItems
 };

--- a/packages/shared-components/src/pages/layout/index.html
+++ b/packages/shared-components/src/pages/layout/index.html
@@ -16,8 +16,8 @@
 
     <script type="module" src="/build/shared-components.esm.js"></script>
     <script nomodule src="/build/shared-components.js"></script>
-    <script src="./main.js" defer></script>
-    <script src="../js/main.js" defer></script>
+  <script src="../js/main.js" defer></script>
+  <script src="./main.js" defer></script>
     <script src="../navbar/main.js" defer></script>
     <link rel="stylesheet" href="../css/bootstrap.min.css">
     <link rel="stylesheet" href="../css/remixicon.css">

--- a/packages/shared-components/src/pages/layout/main.js
+++ b/packages/shared-components/src/pages/layout/main.js
@@ -58,3 +58,9 @@ const authorityToRolesMap = {
     'ROLE_USER'
   ]
 };
+
+waitForElement('onto-loader').then(() => {
+  // Mimic the single spa navigation end, since there is no single spa in stencil's dev server
+  // This is for convenience to hide the loader
+  emitNavigationEndEvent('/oldUrl', '/newUrl');
+});


### PR DESCRIPTION
## What
refactor global loader functionality

## Why
There are issues around it. It works flaky and small changes have broken GDB builds recently

## How
- Replaced NAVIGATION_BEFORE_MOUNT_ROUTING with a new event dispatch, since there are cases where the payload is deeply equal, in which cases the context service doesn't emit. The event emits always.
- Removed the loader removal inside the `connectedCallback`. There is different behavior depending on the machine, so removing it makes logic simpler

## Testing
n/a

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
