### PR TITLE
GDB-14944: Restrict renaming of ontop or fedex repository

### DIFF
--- a/e2e-tests/e2e-legacy/repository/rename-repository-restrictions.spec.js
+++ b/e2e-tests/e2e-legacy/repository/rename-repository-restrictions.spec.js
@@ -1,0 +1,125 @@
+import {RepositorySteps} from "../../steps/repository-steps";
+import {OntopRepositorySteps} from "../../steps/ontop-repository-steps";
+import {ToasterSteps} from "../../steps/toaster-steps";
+import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
+
+describe('Repository rename restrictions', () => {
+
+    let repositoryId;
+    let memberRepositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'repo-' + Date.now();
+        memberRepositoryId = 'member-' + Date.now();
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+        cy.deleteRepository(memberRepositoryId);
+    });
+
+    it('should allow renaming of a GraphDB repository', () => {
+        // Given there is a GraphDB repository.
+        cy.createRepository({id: repositoryId});
+
+        // When I open its edit page.
+        RepositorySteps.visitEditPage(repositoryId);
+
+        // Then the repository id should be rendered as read only,
+        RepositorySteps.getGDBIdInput()
+            .should('have.value', repositoryId)
+            .and('be.disabled');
+        // and the action which unlocks the repository id field should be available.
+        RepositorySteps.getRepositoryIdEditElement().should('be.visible');
+    });
+
+    it('should not allow renaming of an Ontop repository', () => {
+        // Given there is an Ontop repository.
+        createOntopRepository(repositoryId);
+
+        // When I open its edit page.
+        RepositorySteps.visit();
+        RepositorySteps.editRepository(repositoryId);
+
+        // Then the repository id should be rendered as read only,
+        RepositorySteps.getGDBIdInput()
+            .should('have.value', repositoryId)
+            .and('be.disabled');
+        // and the action which unlocks the repository id field should not be available, because
+        // renaming is allowed only for GraphDB repositories.
+        RepositorySteps.getRepositoryIdEditElement().should('not.exist');
+
+        // When the repository id is changed despite the field being disabled,
+        forceChangeRepositoryId('renamed-' + repositoryId);
+        // and I try to save the configuration.
+        RepositorySteps.clickSaveEditedRepo();
+
+        // Then I expect to see an error message,
+        ToasterSteps.verifyError('Can not change the name of ontop repository');
+        // and the repository should keep its original id.
+        RepositorySteps.visit();
+        RepositorySteps.getRepositoryFromList(repositoryId).should('be.visible');
+    });
+
+    it('should not allow renaming of a FedX repository', () => {
+        // Given there is a FedX repository.
+        cy.createRepository({id: memberRepositoryId});
+        createFedxRepository(repositoryId, memberRepositoryId);
+
+        // When I open its edit page.
+        RepositorySteps.visit();
+        RepositorySteps.editRepository(repositoryId);
+
+        // Then the repository id should be rendered as read only,
+        RepositorySteps.getGDBIdInput()
+            .should('have.value', repositoryId)
+            .and('be.disabled');
+        // and the action which unlocks the repository id field should not be available, because
+        // renaming is allowed only for GraphDB repositories.
+        RepositorySteps.getRepositoryIdEditElement().should('not.exist');
+
+        // When I save the configuration.
+        RepositorySteps.getSaveRepositoryButton().click();
+        ModalDialogSteps.clickOnConfirmButton();
+
+        // Then the repository should keep its original id.
+        RepositorySteps.visit();
+        RepositorySteps.getRepositoryFromList(repositoryId).should('be.visible');
+    });
+
+    /**
+     * Changes the repository id field although it is disabled in order to verify that the restriction is
+     * enforced by the controller too and not only by the view.
+     *
+     * @param {string} newRepositoryId The new repository id.
+     */
+    const forceChangeRepositoryId = (newRepositoryId) => {
+        RepositorySteps.getGDBIdInput()
+            .clear({force: true})
+            .type(newRepositoryId, {force: true})
+            .should('have.value', newRepositoryId);
+    };
+
+    const createOntopRepository = (repositoryId) => {
+        OntopRepositorySteps.visitCreate();
+        RepositorySteps.typeRepositoryId(repositoryId);
+        OntopRepositorySteps.selectOracleDatabase();
+        OntopRepositorySteps.typeHostName('localhost');
+        OntopRepositorySteps.typePort(5423);
+        OntopRepositorySteps.typeDatabaseName('database-name');
+        OntopRepositorySteps.clickObdaFileUploadButton();
+        OntopRepositorySteps.uploadObdaFile('fixtures/ontop/university-complete.obda');
+        // Wait the OBDA edit button to become visible to ensure that the file is uploaded.
+        OntopRepositorySteps.getOBDAFileFieldEditButton().should('be.visible');
+        OntopRepositorySteps.clickOnCreateRepositoryButton();
+    };
+
+    const createFedxRepository = (repositoryId, memberRepositoryId) => {
+        RepositorySteps.visit();
+        RepositorySteps.createRepository();
+        RepositorySteps.createFedexRepositoryType();
+        RepositorySteps.typeRepositoryId(repositoryId);
+        RepositorySteps.selectFedexMember(memberRepositoryId);
+        RepositorySteps.saveRepository();
+    };
+});

--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -2474,6 +2474,7 @@
     "edit.repo.restart.requested.msg": "<span class=\"ri-2x ri-alert-line\" style=\"color: var(--gw-primary-dark)\"></span>The repository will be restarted.",
     "edit.repo.restart.needed.msg": "<span class=\"ri-2x ri-alert-line\" style=\"color: var(--gw-primary-dark)\"></span>Repository restart required for changes to take effect.",
     "edit.repo.id.warning.msg": "<p>Changing the repository ID is a dangerous operation since it renames the repository folder and enforces repository shutdown.</p>",
+    "edit.repo.id.change.error": "Can not change the name of {{repoType}} repository",
     "confirm.enable.edit": "Confirm enable edit",
     "repo.description": "Repository description",
     "repo.indexing.section": "Indexing",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -2472,6 +2472,7 @@
     "edit.repo.restart.requested.msg": "<span class=\"ri-2x ri-alert-line\" style=\"color: var(--gw-primary-dark)\"></span>Le dépôt sera redémarré.",
     "edit.repo.restart.needed.msg": "<span class=\"ri-2x ri-alert-line\" style=\"color: var(--gw-primary-dark)\"></span>Le redémarrage du dépôt est nécessaire pour que les changements prennent effet.",
     "edit.repo.id.warning.msg": "<p>Changer l'ID du dépôt est une opération dangereuse puisqu'elle renomme le dossier du dépôt et impose l'arrêt du dépôt.</p>",
+    "edit.repo.id.change.error": "Impossible de changer le nom du dépôt {{repoType}}",
     "confirm.enable.edit": "Confirmation de l'activation de l'édition",
     "repo.description": "Description du dépôt",
     "repo.indexing.section": "Indexage",

--- a/packages/legacy-workbench/src/js/angular/repositories/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/repositories/controllers.js
@@ -851,7 +851,7 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
 
     const initView = (repositoryInfoResponse) => {
         const repositoryInfo = repositoryInfoResponse.data;
-        $scope.canRenameRepo = authorizationService.isAdminOrRepoManager();
+        $scope.canRenameRepo = authorizationService.isAdminOrRepoManager() && repositoryInfo.type === REPOSITORY_TYPES.graphdbRepo;
         if (angular.isDefined(repositoryInfo.params.ruleset)) {
             let ifRulesetExists = false;
             angular.forEach($scope.rulesets, function(item) {
@@ -965,6 +965,8 @@ function EditRepositoryCtrl($rootScope, $scope, $routeParams, toastr, $repositor
             toastr.error(numberFormatError);
         } else if ($scope.isInvalidEntityIndexSizeMin) {
             toastr.error($translate.instant('repo.error.entityIndex.min'));
+        } else if (!$scope.canRenameRepo && $scope.repositoryInfo.saveId !== $scope.repositoryInfo.id) {
+            toastr.error($translate.instant('edit.repo.id.change.error', {repoType: $scope.repositoryInfo.type}));
         } else {
             ModalService.openSimpleModal({
                 title: $translate.instant('common.confirm.save'),


### PR DESCRIPTION
## What
Added error messages for restricted repository renaming and updated the renaming permission logic.

## Why
To prevent renaming of repository types fedex and ontop.

## How
- Introduced a new error message for failed renaming attempts in both English and French locale files.
- Updated the logic in `controllers.js` to restrict renaming to only `graphdbRepo` types.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified
