### PR TITLE
Improve NPM authentication error handling in Jenkinsfile

### DIFF
--- a/release.Jenkinsfile
+++ b/release.Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
                         ]
                     ]) {
                         sh "echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc"
-                        sh "npm whoami || echo 'whoami failed'"
+                        sh "npm whoami || { echo 'ERROR: NPM authentication failed! Invalid or expired NPM_TOKEN.'; exit 1; }"
                         sh "npm publish"
                         dir("e2e-tests/") {
                             sh "echo //registry.npmjs.org/:_authToken=\${NPM_TOKEN} > .npmrc"


### PR DESCRIPTION
## What
Enhanced the error message for NPM authentication failure in the release Jenkinsfile.

## Why
To provide clearer feedback when NPM authentication fails, helping developers quickly identify issues with the NPM_TOKEN.

## How
- Updated the shell command to output a specific error message when `npm whoami` fails.
- Added an exit code to ensure the build process stops on authentication failure.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
