### PR TITLE
GDB-14969 update user permissions table header layout

### DIFF
--- a/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
+++ b/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
@@ -128,7 +128,6 @@ describe('User and Access', () => {
                 UserAndAccessSteps.getCustomRoleFieldError().should('not.be.visible');
 
                 // When I create the user with a valid custom role
-                UserAndAccessSteps.toggleWriteAccessAny();
                 SecurityStubs.spyOnUserCreate();
                 UserAndAccessSteps.confirmUserCreate();
                 // Then the user should be created with that custom role

--- a/e2e-tests/steps/setup/user-and-access-steps.js
+++ b/e2e-tests/steps/setup/user-and-access-steps.js
@@ -1,5 +1,7 @@
 import {EnvironmentStubs} from "../../stubs/environment-stubs";
 
+const CENTER_SCROLL = {scrollBehavior: 'center'};
+
 export class UserAndAccessSteps {
     static visit() {
         cy.visit('/users');
@@ -118,7 +120,9 @@ export class UserAndAccessSteps {
     }
 
     static typeUsername(text) {
-        this.getUsernameField().type(text);
+        this.getUsernameField()
+            .focus()
+            .type(text);
     }
 
     static getPasswordField() {
@@ -238,13 +242,13 @@ export class UserAndAccessSteps {
             .contains('Global (any data repository)')
             .parent('tr')
             .find('.graphql')
-            .realClick();
+            .click(CENTER_SCROLL);
     }
 
     static clickGraphqlAccessRepo(repoName) {
         this.getRepositoryRightsLine(repoName)
             .find('.graphql')
-            .realClick();
+            .click(CENTER_SCROLL);
     }
 
     static clickReadAccessAny() {
@@ -252,7 +256,7 @@ export class UserAndAccessSteps {
             .contains('Global (any data repository)')
             .parent('tr')
             .find('.read')
-            .realClick();
+            .click(CENTER_SCROLL);
     }
 
     static clickReadAccessRepo(repoName) {
@@ -260,7 +264,7 @@ export class UserAndAccessSteps {
             .contains(repoName)
             .parent('tr')
             .find('.read')
-            .realClick();
+            .click(CENTER_SCROLL);
     }
 
     static clickWriteAccessAny() {
@@ -268,7 +272,7 @@ export class UserAndAccessSteps {
             .contains('Global (any data repository)')
             .parent('tr')
             .find('.write')
-            .realClick();
+            .click(CENTER_SCROLL);
     }
 
     static clickWriteAccessRepo(repoName) {
@@ -276,7 +280,7 @@ export class UserAndAccessSteps {
             .contains(repoName)
             .parent('tr')
             .find('.write')
-            .realClick();
+            .click(CENTER_SCROLL);
     }
 
     static findUserRowAlias(username, aliasName = 'userRow') {
@@ -351,7 +355,7 @@ export class UserAndAccessSteps {
     }
 
     static toggleReadAccessForRepo(repoName) {
-        return this.getReadAccessForRepo(repoName).realClick();
+        return this.getReadAccessForRepo(repoName).click(CENTER_SCROLL);
     }
 
     static validateReadAccessForRepo(repoName, expectedState) {
@@ -374,7 +378,7 @@ export class UserAndAccessSteps {
     }
 
     static toggleWriteAccessForRepo(repoName) {
-        return this.getWriteAccessForRepo(repoName).realClick();
+        return this.getWriteAccessForRepo(repoName).click(CENTER_SCROLL);
     }
 
     static validateWriteAccessForRepo(repoName, expectedState) {
@@ -390,7 +394,7 @@ export class UserAndAccessSteps {
     }
 
     static clickMaintainAccessRepo(repoName) {
-        UserAndAccessSteps.getMaintainAccessRepoCheckbox(repoName).realClick();
+        UserAndAccessSteps.getMaintainAccessRepoCheckbox(repoName).click(CENTER_SCROLL);
     }
 
     static toggleMaintainRepoForRepo(repoName) {
@@ -410,7 +414,7 @@ export class UserAndAccessSteps {
     }
 
     static toggleGraphqlAccessForRepo(repoName) {
-        return this.getGraphqlAccessForRepo(repoName).realClick();
+        return this.getGraphqlAccessForRepo(repoName).click(CENTER_SCROLL);
     }
 
     static validateGraphqlAccessForRepo(repoName, expectedState) {
@@ -455,19 +459,19 @@ export class UserAndAccessSteps {
             .contains(repoName)
             .parent('.row')
             .find('.read')
-            .realClick();
+            .click(CENTER_SCROLL);
     }
 
     static clickFreeWriteAccessRepo(repoName) {
         cy.get('.repo-fields').contains(repoName).parent('.row').as('row');
         cy.get('@row').scrollIntoView();
-        cy.get('@row').find('.write').realClick();
+        cy.get('@row').find('.write').click(CENTER_SCROLL);
     }
 
     static clickFreeGraphqlAccessRepo(repoName) {
         cy.get('.repo-fields').contains(repoName).parent('.row').as('row');
         cy.get('@row').scrollIntoView();
-        cy.get('@row').find('.graphql').realClick();
+        cy.get('@row').find('.graphql').click(CENTER_SCROLL);
     }
 
 }

--- a/packages/legacy-workbench/src/css/user.css
+++ b/packages/legacy-workbench/src/css/user.css
@@ -3,7 +3,8 @@
 }
 
 .wb-user .repository-column {
-    width: 50%;
+    width: 40%;
+    vertical-align: top;
 }
 
 .wb-user .read-column {
@@ -22,6 +23,8 @@
     width: 15%;
 }
 
+.wb-user .permissions-column,
+.wb-user .read-column,
 .wb-user .graphql-column,
 .wb-user .graphql-rights,
 .wb-user .graphql-any {
@@ -35,8 +38,12 @@
 
 .wb-user .bordered-table {
     border: 1px solid var(--gw-datatable-border-color);
-    border-collapse: collapse;
+    border-collapse: separate;
     width: 100%;
+}
+
+.wb-user .permissions-subheader th {
+    border-bottom: 1px solid var(--gw-datatable-header-cell-border-color);
 }
 
 .wb-user .graphql-icon {

--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -1673,6 +1673,7 @@
     "security.tooltip.not.available.for.role": "Not available for the selected role",
     "security.tooltip.not.available.for.repository.type": "Not available for this repository type",
     "security.tooltip.graphql": "GraphQL only rights",
+    "security.label.permissions": "Permissions",
     "security.label.read": "Read",
     "security.label.write": "Write",
     "security.label.maintain_repository": "Maintain",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -1672,6 +1672,7 @@
     "security.tooltip.maintain_repository": "Autorisations de maintenance",
     "security.tooltip.not.available.for.role": "Non disponible pour le rôle sélectionné",
     "security.tooltip.not.available.for.repository.type": "Non disponible pour ce type de dépôt",
+    "security.label.permissions": "Autorisations",
     "security.label.read": "Lire",
     "security.label.write": "Ecriture",
     "security.label.maintain_repository": "Maintenance",

--- a/packages/legacy-workbench/src/js/angular/security/templates/user.html
+++ b/packages/legacy-workbench/src/js/angular/security/templates/user.html
@@ -253,14 +253,17 @@
                             <table class="table table-hover table-sm table-fixed bordered-table" aria-describedby="User rights table">
                                 <thead>
                                 <tr>
-                                    <th id="repositoryIdColumn" class="repository-column auth-column">{{'security.repository.title' | translate}}</th>
+                                    <th id="repositoryIdColumn" rowspan="2" class="repository-column auth-column">{{'security.repository.title' | translate}}</th>
+                                    <th id="permissionsColumn" colspan="3" class="text-xs-center permissions-column auth-column">{{'security.label.permissions' | translate}}</th>
+                                    <th id="graphql" rowspan="2" class="text-xs-center auth-column graphql-column"><span
+                                        class="auth-column-label">{{'security.label.graphql' | translate}}</span></th>
+                                </tr>
+                                <tr class="permissions-subheader">
                                     <th id="readRightsColumn" class="text-xs-center read-column auth-column"><span class="auth-column-label">{{'security.label.read' | translate}}</span><em
                                         class="ri-eye-line icon-lg" gdb-tooltip="{{'security.tooltip.read' | translate}}"></em></th>
                                     <th id="writeRightColumn" class="text-xs-center write-column auth-column"><span class="auth-column-label">{{'security.label.write' | translate}}</span><em
                                         class="ri-edit-line icon-lg" gdb-tooltip="{{'security.tooltip.write' | translate}}"></em></th>
                                     <th id="maintainRepositoryColumn" class="text-xs-center maintain-repository-column auth-column"><span class="auth-column-label">{{'security.label.maintain_repository' | translate}}</span><em class="ri-folder-settings-line icon-lg" gdb-tooltip="{{'security.tooltip.maintain_repository' | translate}}"></em></th>
-                                        <th id="graphql" class="text-xs-center auth-column graphql-column"><span
-                                        class="auth-column-label">{{'security.label.graphql' | translate}}</span></th>
                                 </tr>
                                 <tr class="any-repo">
                                     <th>{{'security.any.data.repo' | translate}}


### PR DESCRIPTION
## What
Update the user permissions table layout

## Why
It was missed during implementation

## How
Modified the `user.html` file to adjust the table structure and added a new column for permissions.

## Testing
n/a

## Screenshots
<img width="1640" height="922" alt="Screenshot from 2026-08-25 16-40-48" src="https://github.com/user-attachments/assets/ac502c2e-3123-4f6e-a004-6a633948ec3f" />
<img width="1640" height="922" alt="Screenshot from 2026-08-25 16-40-55" src="https://github.com/user-attachments/assets/a9b92dd1-d184-4390-aaba-7280d905d266" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [x] Browser support verified
