### PR TITLE
Cherry-pick: GDB-14999 preserve agent temperature and topP values when toggling (#3187)

### DIFF
--- a/e2e-tests/e2e-legacy/ttyg/create-agent.spec.js
+++ b/e2e-tests/e2e-legacy/ttyg/create-agent.spec.js
@@ -536,8 +536,10 @@ describe('TTYG create new agent', () => {
 
         // WHEN: I enable the temperature setting.
         TtygAgentSettingsModalSteps.toggleTemperature();
-        // THEN: I expect the default temperature value to be restored.
-        TtygAgentSettingsModalSteps.getTemperatureSliderField().should('have.value', '0.7');
+        // THEN: I expect the last set temperature value to be restored instead of the default one.
+        TtygAgentSettingsModalSteps.getTemperatureSliderField().should('have.value', '1.2');
+        // AND: I expect the high-temperature warning to be displayed again.
+        TtygAgentSettingsModalSteps.getTemperatureField().should('have.class', 'has-warning');
     });
 
     it('should toggle the topP setting', () => {
@@ -556,8 +558,8 @@ describe('TTYG create new agent', () => {
 
         // WHEN: I enable the topP setting.
         TtygAgentSettingsModalSteps.toggleTop();
-        // THEN: I expect the default topP value to be restored.
-        TtygAgentSettingsModalSteps.getTopPField().should('have.value', '1');
+        // THEN: I expect the last set topP value to be restored instead of the default one.
+        TtygAgentSettingsModalSteps.getTopPField().should('have.value', '0.3');
     });
 
     it('Should warn the user when he changes the default value of the base instruction', () => {

--- a/e2e-tests/e2e-legacy/ttyg/edit-agent.spec.js
+++ b/e2e-tests/e2e-legacy/ttyg/edit-agent.spec.js
@@ -45,6 +45,55 @@ describe('TTYG edit an agent', () => {
         ToasterSteps.verifySuccess('The agent \'agent-1\' was saved successfully.');
     });
 
+    it('should preserve the temperature and topP values of the edited agent', () => {
+        TTYGStubs.stubChatsListGet();
+        TTYGStubs.stubAgentListGet();
+        TTYGStubs.stubChatGet();
+        // GIVEN: I have opened the ttyg page
+        TTYGViewSteps.visit();
+        cy.wait('@get-chat-list');
+        cy.wait('@get-agent-list');
+        cy.wait('@get-chat');
+
+        // WHEN: I open the settings of an agent whose temperature and topP differ from the default values
+        TTYGViewSteps.openAgentSettingsModalForAgent(0);
+
+        // THEN: I expect the values of the agent to be loaded instead of the default ones
+        TtygAgentSettingsModalSteps.getTemperatureSliderField().should('have.value', '0');
+        TtygAgentSettingsModalSteps.getTopPField().should('have.value', '0');
+
+        // WHEN: I disable the temperature setting
+        TtygAgentSettingsModalSteps.toggleTemperature();
+        // THEN: I expect the temperature controls to be disabled
+        TtygAgentSettingsModalSteps.getTemperatureField().should('be.disabled');
+        TtygAgentSettingsModalSteps.getTemperatureSliderField().should('be.disabled');
+
+        // WHEN: I enable the temperature setting again
+        TtygAgentSettingsModalSteps.toggleTemperature();
+        // THEN: I expect the temperature value of the agent to be restored instead of the default one
+        TtygAgentSettingsModalSteps.getTemperatureSliderField().should('have.value', '0');
+
+        // WHEN: I disable the topP setting
+        TtygAgentSettingsModalSteps.toggleTop();
+        // THEN: I expect the topP control to be disabled
+        TtygAgentSettingsModalSteps.getTopPField().should('be.disabled');
+
+        // WHEN: I enable the topP setting again
+        TtygAgentSettingsModalSteps.toggleTop();
+        // THEN: I expect the topP value of the agent to be restored instead of the default one
+        TtygAgentSettingsModalSteps.getTopPField().should('have.value', '0');
+
+        // WHEN: I save the agent
+        TTYGStubs.stubAgentEdit();
+        TtygAgentSettingsModalSteps.saveAgent();
+        // THEN: I expect the values of the agent to be sent instead of the default ones
+        cy.wait('@edit-agent').then((interception) => {
+            expect(interception.request.body.temperature).to.equal(0);
+            expect(interception.request.body.topP).to.equal(0);
+        });
+        ToasterSteps.verifySuccess('The agent \'agent-1\' was saved successfully.');
+    });
+
     it('should not be able to edit an agent if an extraction method is selected but the precondition has failed', () => {
         TTYGStubs.stubChatsListGet();
         TTYGStubs.stubAgentListGet();

--- a/packages/legacy-workbench/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js
@@ -103,6 +103,8 @@ function AgentSettingsModalController(
     // =========================
 
     const CHAT_GPT_RETRIEVAL_CONNECTOR_NAME = 'ChatGPT Retrieval';
+    let lastTemperatureValue = DEFAULT_TEMPERATURE_RANGE.value;
+    let lastTopPValue = DEFAULT_TOP_P_RANGE.value;
 
     // =========================
     // Public variables
@@ -253,7 +255,10 @@ function AgentSettingsModalController(
     $scope.toggleTemperature = () => {
         const temperature = new NumericRangeModel({...DEFAULT_TEMPERATURE_RANGE});
         if (!$scope.agentFormModel.temperatureEnabled) {
+            lastTemperatureValue = $scope.agentFormModel.temperature.value;
             temperature.value = undefined;
+        } else {
+            temperature.value = lastTemperatureValue;
         }
         $scope.agentFormModel.temperature = temperature;
         updateShowHighTemperatureWarning();
@@ -267,7 +272,10 @@ function AgentSettingsModalController(
     $scope.toggleTopP = () => {
         const topP = new NumericRangeModel({...DEFAULT_TOP_P_RANGE});
         if (!$scope.agentFormModel.topPEnabled) {
+            lastTopPValue = $scope.agentFormModel.topP.value;
             topP.value = undefined;
+        } else {
+            topP.value = lastTopPValue;
         }
         $scope.agentFormModel.topP = topP;
     };
@@ -987,6 +995,7 @@ function AgentSettingsModalController(
         $scope.updateSimilaritySearchPanel(clearIndexSelection);
         $scope.updateRetrievalConnectorPanel(clearRetrievalConnectorSelection);
         $scope.checkAutocompleteIndexEnabled();
+        updateShowHighTemperatureWarning();
     };
 
     const onTabVisibilityChanged = () => {

--- a/packages/legacy-workbench/src/js/angular/ttyg/services/agents.mapper.js
+++ b/packages/legacy-workbench/src/js/angular/ttyg/services/agents.mapper.js
@@ -31,6 +31,7 @@ export const agentFormModelMapper = (agentModel, defaultAgentModel, operation ) 
     if (!agentModel) {
         return;
     }
+    const isNewAgent = operation === AGENT_OPERATION.CREATE;
     const agentFormModel = new AgentFormModel();
     agentFormModel.id = agentModel.id || defaultAgentModel.id;
     agentFormModel.name = agentModel.name || defaultAgentModel.name;
@@ -38,16 +39,15 @@ export const agentFormModelMapper = (agentModel, defaultAgentModel, operation ) 
     agentFormModel.model = agentModel.model || defaultAgentModel.model;
     agentFormModel.contextSize = agentModel.contextSize || defaultAgentModel.contextSize;
     agentFormModel.contextSizeCopy = defaultAgentModel.contextSize;
-
     // Set temperature related properties.
     const temperatureFormModel = new NumericRangeModel({...DEFAULT_TEMPERATURE_RANGE});
-    temperatureFormModel.value = agentModel.temperature !== undefined ? agentModel.temperature : defaultAgentModel.temperature;
+    temperatureFormModel.value = isNewAgent ? defaultAgentModel.temperature : agentModel.temperature;
     agentFormModel.temperature = temperatureFormModel;
     agentFormModel.temperatureEnabled = !ObjectUtil.isNullOrUndefined(agentFormModel.temperature.value);
 
     // Set topP related properties.
     const topPFormModel = new NumericRangeModel({...DEFAULT_TOP_P_RANGE});
-    topPFormModel.value = agentModel.topP !== undefined ? agentModel.topP : defaultAgentModel.topP;
+    topPFormModel.value = isNewAgent ? defaultAgentModel.topP : agentModel.topP;
     agentFormModel.topP = topPFormModel;
     agentFormModel.topPEnabled = !ObjectUtil.isNullOrUndefined(agentFormModel.topP.value);
 


### PR DESCRIPTION
## What
Ensure agent temperature and topP fields preserve their current values when toggled and initialize based on whether an agent is new or existing.

## Why
When editing an agent, the temperature and topP fields appeared reset to defaults in the form and saving overwrote the persisted values with default settings.

## How
- Updated packages/legacy-workbench/src/js/angular/ttyg/controllers/agent-settings-modal.controller.js to cache and restore temperature and topP values when toggles are switched and to recalculate the high temperature warning on model updates.
- Updated packages/legacy-workbench/src/js/angular/ttyg/services/agents.mapper.js to initialize temperature and topP from defaults only when creating a new agent and from the existing agent model when editing.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified


(cherry picked from commit d268957a2827151ef55d664a67f83c06285fbe36)