### PR TITLE
GDB-15114 update input types for sensitive fields in connector forms

### DIFF
--- a/packages/legacy-workbench/src/pages/connectorsInfo.html
+++ b/packages/legacy-workbench/src/pages/connectorsInfo.html
@@ -74,7 +74,7 @@
                                             </div>
                                             <div ng-if="value != null" class="col-xs-10">
                                                 <div ng-if="option.__type == 'String'">
-                                                    <input class="form-control" type="text" readonly value="{{value}}"/>
+                                                    <input class="form-control" ng-attr-type="{{option.__sensitive ? 'password' : 'text'}}" readonly value="{{value}}"/>
                                                 </div>
                                                 <div ng-if="option.__type == 'BigString'">
                                                     <textarea class="form-control" ng-model="value" readonly>
@@ -127,7 +127,7 @@
                                                                  guide-selector="{{child.__name}}-connector-subproperty">
                                                                 <label class="col-xs-2 col-form-label">{{child.__label}}</label>
                                                                 <div class="col-xs-10">
-                                                                    <input type="text" class="form-control"
+                                                                    <input ng-attr-type="{{child.__sensitive ? 'password' : 'text'}}" class="form-control"
                                                                            ng-if="child.__type == 'String'"
                                                                            ng-model="field[child.__name]" readonly>
                                                                     <textarea class="form-control"
@@ -175,7 +175,7 @@
                                                                      guide-selector="{{child.__name}}-connector-subproperty">
                                                                     <label class="col-xs-2 col-form-label">{{child.__label}}</label>
                                                                     <div class="col-xs-10">
-                                                                        <input type="text" class="form-control"
+                                                                        <input ng-attr-type="{{child.__sensitive ? 'password' : 'text'}}" class="form-control"
                                                                                ng-if="child.__type == 'String'"
                                                                                ng-model="field[child.__name]" readonly>
                                                                         <textarea class="form-control"

--- a/packages/legacy-workbench/src/pages/createConnector.html
+++ b/packages/legacy-workbench/src/pages/createConnector.html
@@ -24,7 +24,7 @@
                         </label>
                     </div>
                     <div ng-if="option.__type == 'String'">
-                        <input type="text" class="form-control" placeholder="{{option.__hint}}" ng-model="values[option.__name]" ng-required="option.__required" uib-popover="{{option.__description}}" popover-trigger="focus" popover-placement="bottom">
+                        <input ng-attr-type="{{option.__sensitive ? 'password' : 'text'}}" class="form-control" placeholder="{{option.__hint}}" ng-model="values[option.__name]" ng-required="option.__required" uib-popover="{{option.__description}}" popover-trigger="focus" popover-placement="bottom">
                     </div>
                     <div ng-if="option.__type == 'BigString'">
                     <textarea type="text" class="form-control" placeholder="{{option.__hint}}" ng-model="values[option.__name]" ng-required="option.__required" uib-popover="{{option.__description}}" popover-trigger="focus" popover-placement="bottom">
@@ -59,7 +59,7 @@
                                                ng-class="{'col-form-label': true, 'font-weight-bold':child.__required }">{{child.__label}}<sup ng-if="child.__required">*</sup></label>
                                         <div class="col-xs-9">
                                             <div ng-if="child.__type == 'String'">
-                                                <input type="text" class="form-control" placeholder="{{child.__hint}}" ng-model="values[option.__name][fieldIndex][child.__name]" ng-required="child.__required" uib-popover="{{child.__description}}" popover-trigger="focus" popover-placement="bottom">
+                                                <input ng-attr-type="{{child.__sensitive ? 'password' : 'text'}}" class="form-control" placeholder="{{child.__hint}}" ng-model="values[option.__name][fieldIndex][child.__name]" ng-required="child.__required" uib-popover="{{child.__description}}" popover-trigger="focus" popover-placement="bottom">
                                             </div>
                                             <div ng-if="child.__type == 'JsonString'">
                                                 <input type="text" class="form-control" placeholder="{{child.__hint}}" ng-model="values[option.__name][fieldIndex][child.__name]" ng-required="child.__required" uib-popover="{{child.__description}}" popover-trigger="focus" popover-placement="bottom">


### PR DESCRIPTION
## What
Update input types for sensitive fields in connector forms to use password type when necessary.

## Why
This change addresses the need for better security by masking sensitive information in input fields.

## How
Modified the `type` attribute of input fields in `connectorsInfo.html` and `createConnector.html` to conditionally set it to `password` based on the `__sensitive` property.

## Testing
n/a

## Screenshots
<img width="947" height="268" alt="Screenshot from 2026-08-27 15-35-43" src="https://github.com/user-attachments/assets/08f2750a-8a31-4f67-9f17-48584e7f8dce" />
<img width="1165" height="620" alt="Screenshot from 2026-08-27 15-36-04" src="https://github.com/user-attachments/assets/297c4144-7b93-4d24-aa57-2d062f84609f" />


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [x] Browser support verified
