### PR TITLE
Cherry pick GDB-15106 handle cluster without leader in multi-region tab (#3188)

### DIFF
--- a/e2e-tests/e2e-legacy/cluster/cluster-configuration/cluster-configuration-multi-region.spec.js
+++ b/e2e-tests/e2e-legacy/cluster/cluster-configuration/cluster-configuration-multi-region.spec.js
@@ -64,6 +64,26 @@ describe('Cluster configuration', () => {
         });
     });
 
+    it('should show an alert when there is no elected leader in the cluster', () => {
+        // Given there is no elected leader in the cluster
+        ClusterStubs.stubClusterGroupStatusWithoutLeader();
+
+        // When I have opened the cluster management page
+        ClusterPageSteps.visit();
+        // And I click on edit properties and open Multi-region tab
+        ClusterPageSteps.previewClusterConfig();
+        ClusterConfigurationSteps.selectMultiRegionConfigTab();
+
+        // Then I expect to see an alert that the leader is not elected
+        ClusterConfigurationSteps.getNoLeaderAlert().should('be.visible')
+            .and('contain.text', 'Leader is not elected');
+        // And no primary or secondary cluster configuration should be rendered
+        ClusterConfigurationSteps.getMultiRegionHeader().should('not.exist');
+        ClusterConfigurationSteps.getAddTagButton().should('not.exist');
+        ClusterConfigurationSteps.getEnableSecondaryModeButton().should('not.exist');
+        ClusterConfigurationSteps.getTagsTable().should('not.exist');
+    });
+
     it('should be able to switch modes', () => {
         ClusterStubs.stubEnableSecondaryMode();
         const rpcAddress = 'node-name:7300';

--- a/e2e-tests/fixtures/cluster/3-nodes-cluster-group-status-no-leader.json
+++ b/e2e-tests/fixtures/cluster/3-nodes-cluster-group-status-no-leader.json
@@ -1,0 +1,41 @@
+[
+    {
+        "address": "pc-desktop:7300",
+        "nodeState": "FOLLOWER",
+        "term": 2,
+        "syncStatus": {},
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7200",
+        "recoveryStatus": {},
+        "topologyStatus": {
+            "state": "PRIMARY_NODE"
+        }
+    },
+    {
+        "address": "pc-desktop:7301",
+        "nodeState": "FOLLOWER",
+        "term": 2,
+        "syncStatus": {},
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7201",
+        "recoveryStatus": {},
+        "topologyStatus": {
+            "state": "PRIMARY_NODE"
+        }
+    },
+    {
+        "address": "pc-desktop:7302",
+        "nodeState": "FOLLOWER",
+        "term": 2,
+        "syncStatus": {},
+        "lastLogTerm": 0,
+        "lastLogIndex": 0,
+        "endpoint": "http://pc-desktop:7202",
+        "recoveryStatus": {},
+        "topologyStatus": {
+            "state": "PRIMARY_NODE"
+        }
+    }
+]

--- a/e2e-tests/steps/cluster/cluster-configuration-steps.js
+++ b/e2e-tests/steps/cluster/cluster-configuration-steps.js
@@ -119,6 +119,10 @@ export class ClusterConfigurationSteps {
         return this.getMultiRegionTabContent().find('.title');
     }
 
+    static getNoLeaderAlert() {
+        return this.getMultiRegionTabContent().find('.no-leader-alert');
+    }
+
     static getAddTagButton() {
         return this.getMultiRegionTabContent().find('.create-tag-btn');
     }

--- a/e2e-tests/stubs/cluster/cluster-stubs.js
+++ b/e2e-tests/stubs/cluster/cluster-stubs.js
@@ -132,7 +132,7 @@ export class ClusterStubs extends Stubs {
         added.forEach((node) => {
             response[node] = "Node was successfully added in the cluster.";
         });
-        added.forEach((node) => {
+        removed.forEach((node) => {
             response[node] = "Node was successfully removed from the cluster.";
         });
 
@@ -208,6 +208,13 @@ export class ClusterStubs extends Stubs {
             fixture: '/cluster/3-nodes-cluster-group-status-with-tag.json',
             statusCode: 200
         }).as('3-nodes-cluster-group-status-tag');
+    }
+
+    static stubClusterGroupStatusWithoutLeader() {
+        cy.intercept('/rest/cluster/group/status', {
+            fixture: '/cluster/3-nodes-cluster-group-status-no-leader.json',
+            statusCode: 200
+        }).as('3-nodes-cluster-group-status-no-leader');
     }
 
     static stubDeleteTag(uri) {

--- a/packages/legacy-workbench/src/css/cluster-configuration/multi-region.css
+++ b/packages/legacy-workbench/src/css/cluster-configuration/multi-region.css
@@ -1,13 +1,9 @@
-.multi-region {
-    display: flex;
-    height: 100%;
-}
-
 .multi-region .multi-region-content {
     display: flex;
     flex: 1;
     flex-direction: column;
     gap: 1.5rem;
+    height: 100%;
 }
 
 .multi-region .multi-region-form {

--- a/packages/legacy-workbench/src/i18n/locale-en.json
+++ b/packages/legacy-workbench/src/i18n/locale-en.json
@@ -96,6 +96,7 @@
             "secondary_enabled": "Successfully enabled secondary mode",
             "disabled_secondary_mode": "Secondary mode is disabled",
             "secondary_cluster_settings": "Secondary cluster settings",
+            "leader_not_elected": "Leader is not elected",
             "column": {
                 "index": "",
                 "tag": "Identifier tag",

--- a/packages/legacy-workbench/src/i18n/locale-fr.json
+++ b/packages/legacy-workbench/src/i18n/locale-fr.json
@@ -96,6 +96,7 @@
             "secondary_enabled": "Mode secondaire activé avec succès",
             "disabled_secondary_mode": "Le mode secondaire est désactivé",
             "secondary_cluster_settings": "Paramètres du cluster secondaire",
+            "leader_not_elected": "Aucun leader n'est élu",
             "column": {
                 "index": "",
                 "tag": "Balise d'identification",

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-configuration/multi-region.directive.js
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-configuration/multi-region.directive.js
@@ -163,7 +163,7 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
             // =========================
             const setTopology = (clusterModel) => {
                 const leader = clusterModel.nodes.find((node) => node.nodeState === NodeState.LEADER);
-                $scope.topology = leader.topologyStatus;
+                $scope.topology = leader?.topologyStatus;
             };
 
             const openSecondaryModeModal = () => {

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
@@ -3,7 +3,11 @@
 <div onto-loader ng-if="loader" class="multi-region-loader" message="getLoaderMessage" size="100"></div>
 
 <div class="multi-region">
-    <div class="multi-region-content" ng-if="topology.state === TopologyState.PRIMARY_NODE">
+    <div ng-if="!topology" class="no-leader-alert">
+        <div class="alert alert-info">{{'cluster_management.cluster_configuration_multi_region.leader_not_elected' | translate}}</div>
+    </div>
+
+    <div ng-if="topology.state === TopologyState.PRIMARY_NODE" class="multi-region-content">
         <h4 class="title">{{'cluster_management.cluster_configuration_multi_region.primary_cluster' | translate}}
             <span ng-if="statusLoader" class="ri-reset-left-line icon-1-25x loader cluster-status-loader"></span>
         </h4>


### PR DESCRIPTION
## What
Handle clusters without an elected leader in the multi-region configuration tab and add an informational alert when no topology is available.

## Why
The multi-region tab threw "Cannot read properties of undefined (reading 'topologyStatus')" when the cluster had no elected leader due to slow loading.

## How
- Updated multi-region.directive.js to safely set `$scope.topology` using optional chaining when no leader is present and added a debug log for the cluster configuration response.
- Adjusted multi-region.html to show an info alert when `topology` is missing and guard primary/secondary sections with explicit `topology` checks.
- Refined layout in multi-region.css to move the height constraint from the container to `.multi-region-content`.

## Testing
Added

## Screenshots
<img width="536" height="358" alt="image"
src="https://github.com/user-attachments/assets/2e298f9a-3419-4980-91a2-52a4bc794df8" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified


(cherry picked from commit 3248c4a3d4be0fe7f277fa6ee4f655ea34b7dced)