### PR TITLE
GDB-14292 add cypress tests for explain query plan in SPARQL editor

### DIFF
--- a/docker-compose-coverage.yaml
+++ b/docker-compose-coverage.yaml
@@ -10,6 +10,8 @@ services:
         -Dgraphdb.stats.default=disabled
         -Dgraphdb.foreground=
         -Dgraphdb.logger.root.level=ERROR
+        -Dgraphdb.llm.url=http://workbench:${WORKBENCH_PORT}/llm-mock
+        -Dgraphdb.llm.api-key=e2e-mock-key
     ports:
       - '7200:7200'
     volumes:

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -10,6 +10,8 @@ services:
         -Dgraphdb.stats.default=disabled
         -Dgraphdb.foreground=
         -Dgraphdb.logger.root.level=ERROR
+        -Dgraphdb.llm.url=http://workbench:${WORKBENCH_PORT}/llm-mock
+        -Dgraphdb.llm.api-key=e2e-mock-key
     ports:
       - '7200:7200'
     volumes:

--- a/e2e-tests/e2e-legacy/sparql-editor/actions/explain-query-plan.spec.js
+++ b/e2e-tests/e2e-legacy/sparql-editor/actions/explain-query-plan.spec.js
@@ -1,0 +1,174 @@
+import {SparqlEditorSteps} from "../../../steps/sparql-editor-steps";
+import {YasguiSteps} from "../../../steps/yasgui/yasgui-steps";
+import {YasqeSteps} from "../../../steps/yasgui/yasqe-steps";
+import {YasrSteps} from "../../../steps/yasgui/yasr-steps";
+import {ErrorPluginSteps} from "../../../steps/yasgui/plugin/error-plugin-steps";
+import {ToasterSteps} from "../../../steps/toaster-steps";
+import {QueryStubs} from "../../../stubs/yasgui/query-stubs";
+import {RepositoriesStubs} from "../../../stubs/repositories/repositories-stubs";
+import {AutocompleteStubs} from "../../../stubs/autocomplete/autocomplete-stubs";
+
+// GraphDB marks every explain plan response with this comment. Yasgui recognizes it and renders the
+// response with the explain plan plugin instead of the regular table one.
+const EXPLAIN_PLAN_MARKER = '# NOTE: Optimization groups';
+const EXPLAIN_PLAN_TITLE = 'Query explain plan';
+// Comments which the LLM explain actions prepend to the query in order to narrow down what the LLM
+// should explain.
+const LLM_QUERY_ONLY_COMMENT = '# :gpt-query-only:';
+const LLM_RESULT_ONLY_COMMENT = '# :gpt-result-only:';
+
+const SELECT_QUERY = 'SELECT * WHERE { ?s ?p ?o } LIMIT 10';
+const CONSTRUCT_QUERY = 'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o } LIMIT 10';
+const DESCRIBE_QUERY = 'DESCRIBE <http://example.com/resource>';
+const UPDATE_QUERY = 'PREFIX : <http://bedrock/> INSERT DATA { :fred :hasSpouse :wilma. }';
+
+describe('Explain query plan', () => {
+
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'sparql-editor-explain-plan-' + Date.now();
+        cy.createRepository({id: repositoryId});
+        cy.presetRepository(repositoryId);
+        QueryStubs.interceptQueries(repositoryId);
+
+        SparqlEditorSteps.visitSparqlEditorPageAndWaitForEditor();
+        YasguiSteps.getYasgui().should('be.visible');
+        YasqeSteps.getRunSplitButton().should('have.class', 'hydrated');
+        YasqeSteps.pasteQuery(SELECT_QUERY);
+    });
+
+    afterEach(() => {
+        cy.deleteRepository(repositoryId);
+    });
+
+    it('Should render the query plan when explain query plan is executed', () => {
+        // Given I have opened the sparql editor with a select query
+        // When I execute the explain query plan action
+        YasqeSteps.executeExplainQueryPlan();
+        // Then I expect the query to be sent as an explain plan query
+        verifyExplainRequest('explain');
+        // And I expect the plan to be rendered instead of the regular results
+        YasrSteps.getExplainPlanHeader().should('be.visible').and('contain', EXPLAIN_PLAN_TITLE);
+        YasrSteps.getExplainPlan().should('be.visible').and('contain', EXPLAIN_PLAN_MARKER);
+        // And I expect no error to be reported
+        ErrorPluginSteps.getErrorPlugin().should('not.exist');
+    });
+
+    it('Should allow explain query plan for construct and describe queries', () => {
+        // Given I have opened the sparql editor
+        // When I execute the explain query plan action for a construct query
+        YasqeSteps.pasteQuery(CONSTRUCT_QUERY);
+        YasqeSteps.executeExplainQueryPlan();
+        // Then I expect the query to be accepted and sent as an explain plan query.
+        verifyExplainRequest('explain');
+        ErrorPluginSteps.getErrorPlugin().should('not.exist');
+
+        // When I execute the explain query plan action for a describe query
+        YasqeSteps.pasteQuery(DESCRIBE_QUERY);
+        YasqeSteps.executeExplainQueryPlan();
+        // Then I expect the query to be accepted and sent as an explain plan query
+        verifyExplainRequest('explain');
+        ErrorPluginSteps.getErrorPlugin().should('not.exist');
+    });
+
+    it('Should reset the explain plan mode when the query is executed again', () => {
+        // Given I have executed an explain query plan
+        YasqeSteps.executeExplainQueryPlan();
+        cy.wait('@explainQuery');
+        YasrSteps.getExplainPlanPlugin().should('be.visible');
+
+        // When I execute the query with the run button
+        YasqeSteps.executeQuery();
+        // Then I expect a regular query to be sent
+        cy.wait('@plainQuery').then((interception) => {
+            expect(interception.request.body).to.not.contain('explain=true');
+        });
+        // And I expect the results to be rendered with the regular plugin
+        YasrSteps.getExplainPlanPlugin().should('not.exist');
+        YasrSteps.getExtendedTablePlugin().should('be.visible');
+    });
+
+    it('Should not allow explain query plan for update queries', () => {
+        // Given I have opened the sparql editor
+        // When I execute the explain query plan action for an update query
+        YasqeSteps.pasteQuery(UPDATE_QUERY);
+        YasqeSteps.executeExplainQueryPlan();
+        // Then I expect to be warned that explain works only with select, construct or describe
+        ToasterSteps.getToasterMessage()
+            .should('contain', 'Explain only works with SELECT, CONSTRUCT or DESCRIBE queries.');
+        // And I expect no plan to be rendered
+        YasrSteps.getExplainPlanPlugin().should('not.exist');
+    });
+
+    it('Should execute an explain request when LLM explain all is selected', () => {
+        // Given I have opened the sparql editor with a select query
+        // When I execute the LLM explain all action
+        YasqeSteps.executeLlmExplainAll();
+        // Then I expect a gpt explain request to be sent
+        verifyExplainRequest('gpt');
+        // And I expect the query to be sent without any of the LLM comments
+        YasqeSteps.getQuery().should('not.contain', LLM_QUERY_ONLY_COMMENT);
+        YasqeSteps.getQuery().should('not.contain', LLM_RESULT_ONLY_COMMENT);
+    });
+
+    it('Should execute an explain request when LLM explain query is selected', () => {
+        // Given I have opened the sparql editor with a select query
+        // When I execute the LLM explain query action
+        YasqeSteps.executeLlmExplainQuery();
+        // Then I expect a gpt explain request to be sent
+        verifyExplainRequest('gpt');
+        // And I expect the query to be marked, so that only the query gets explained
+        YasqeSteps.getQuery().should('contain', LLM_QUERY_ONLY_COMMENT);
+    });
+
+    it('Should execute an explain request when LLM explain results is selected', () => {
+        // Given I have opened the sparql editor with a select query
+        // When I execute the LLM explain results action
+        YasqeSteps.executeLlmExplainResults();
+        // Then I expect a gpt explain request to be sent
+        verifyExplainRequest('gpt');
+        // And I expect the query to be marked, so that only the results get explained
+        YasqeSteps.getQuery().should('contain', LLM_RESULT_ONLY_COMMENT);
+    });
+});
+
+describe('Explain query plan for a virtual repository', () => {
+
+    let repositoryId;
+
+    beforeEach(() => {
+        repositoryId = 'sparql-editor-explain-plan-' + Date.now();
+        cy.presetRepository(repositoryId);
+        RepositoriesStubs.stubOntopRepository(repositoryId);
+        RepositoriesStubs.stubNameSpaces(repositoryId);
+        AutocompleteStubs.stubAutocompleteEnabled(false);
+
+        SparqlEditorSteps.visitSparqlEditorPageAndWaitForEditor();
+        YasguiSteps.getYasgui().should('be.visible');
+        YasqeSteps.getRunSplitButton().should('have.class', 'hydrated');
+    });
+
+    it('Should not allow explain query plan for virtual repositories', () => {
+        // Given I have opened the editor configured for a virtual repository
+        // When I execute the explain query plan action
+        YasqeSteps.executeExplainQueryPlan();
+        // Then I expect to be warned that explain is not supported
+        ToasterSteps.getToasterMessage()
+            .should('contain', 'Explain not supported for Virtual repositories.');
+        // And I expect no plan to be rendered
+        YasrSteps.getExplainPlanPlugin().should('not.exist');
+    });
+});
+
+/**
+ * Verifies that an explain request has been sent and has succeeded.
+ * @param {string} explainType - 'explain' for the query plan, 'gpt' for the LLM explanations.
+ */
+const verifyExplainRequest = (explainType) => {
+    cy.wait('@explainQuery').then((interception) => {
+        expect(interception.request.body).to.contain('explain=true');
+        expect(interception.request.body).to.contain(`explainType=${explainType}`);
+        expect(interception.response.statusCode).to.equal(200);
+    });
+};

--- a/e2e-tests/steps/yasgui/yasqe-steps.js
+++ b/e2e-tests/steps/yasgui/yasqe-steps.js
@@ -218,4 +218,64 @@ export class YasqeSteps {
     static getActionButton(index) {
         return YasqeSteps.getActionButtons().eq(index);
     }
+
+    static getRunSplitButton() {
+        return YasqeSteps.getYasqe().find('query-split-button');
+    }
+
+    static getRunSplitButtonToggle() {
+        return YasqeSteps.getRunSplitButton().find('.yasqe_querySplitToggle');
+    }
+
+    static openRunDropdown() {
+        YasqeSteps.getRunSplitButtonToggle().click({scrollBehavior: false});
+    }
+
+    static getRunDropdownMenu() {
+        return YasqeSteps.getRunSplitButton().find('.ontotext-run-dropdown-menu');
+    }
+
+    static getRunDropdownItems() {
+        return YasqeSteps.getRunDropdownMenu().find('.ontotext-run-dropdown-menu-item');
+    }
+
+    static getRunDropdownItem(index) {
+        return YasqeSteps.getRunDropdownItems().eq(index);
+    }
+
+    static selectRunDropdownItem(index) {
+        YasqeSteps.openRunDropdown();
+        YasqeSteps.getRunDropdownItem(index).click({scrollBehavior: false});
+        // Hides the tooltip of the split button, which otherwise stays visible and overlaps both
+        // the run button and the toggle itself. The mouseleave has to be forced, because the
+        // tooltip covers the very element it is triggered on, which fails Cypress's actionability
+        // check. This mirrors YasqeSteps.clickExecuteQueryButtonAndHideTooltip.
+        YasqeSteps.getRunSplitButtonToggle().trigger('mouseleave', {force: true});
+    }
+
+    static executeExplainQueryPlan() {
+        YasqeSteps.selectRunDropdownItem(RunDropdownOption.EXPLAIN_PLAN);
+    }
+
+    static executeLlmExplainAll() {
+        YasqeSteps.selectRunDropdownItem(RunDropdownOption.LLM_EXPLAIN_ALL);
+    }
+
+    static executeLlmExplainQuery() {
+        YasqeSteps.selectRunDropdownItem(RunDropdownOption.LLM_EXPLAIN_QUERY);
+    }
+
+    static executeLlmExplainResults() {
+        YasqeSteps.selectRunDropdownItem(RunDropdownOption.LLM_EXPLAIN_RESULTS);
+    }
 }
+
+/**
+ * The order of the options in the run dropdown of the query split button.
+ */
+export const RunDropdownOption = {
+    'EXPLAIN_PLAN': 0,
+    'LLM_EXPLAIN_ALL': 1,
+    'LLM_EXPLAIN_QUERY': 2,
+    'LLM_EXPLAIN_RESULTS': 3
+};

--- a/e2e-tests/steps/yasgui/yasr-steps.js
+++ b/e2e-tests/steps/yasgui/yasr-steps.js
@@ -135,6 +135,21 @@ export class YasrSteps extends BaseSteps {
         return YasrSteps.getYasr().find('.dataTables_wrapper');
     }
 
+    static getExplainPlanPlugin() {
+        return YasrSteps.getYasr().find('.yasr-explain-plan-plugin');
+    }
+
+    /**
+     * While an explain plan is rendered, the regular yasr header is replaced with a plain title.
+     */
+    static getExplainPlanHeader() {
+        return YasrSteps.getYasr().find('.yasr-header-replacement');
+    }
+
+    static getExplainPlan() {
+        return YasrSteps.getExplainPlanPlugin().find('.explainPlanQuery');
+    }
+
     static getFullscreenButton() {
         return cy.get('.yasr-fullscreen-button');
     }

--- a/e2e-tests/stubs/yasgui/query-stubs.js
+++ b/e2e-tests/stubs/yasgui/query-stubs.js
@@ -225,6 +225,25 @@ export class QueryStubs {
     static interceptSavedQueryCreation() {
         cy.intercept('POST', '/rest/sparql/saved-queries').as('saveQuery');
     }
+
+    /**
+     * Aliases the requests towards the repository endpoint, so that an explain plan query can be
+     * told apart from a regular query and from the count query which yasgui sends for the
+     * pagination. They all go to the same endpoint and can only be distinguished by their body.
+     * @param {string} repositoryId - the repository against which the queries are executed.
+     */
+    static interceptQueries(repositoryId) {
+        cy.intercept('POST', `/repositories/${repositoryId}`, (req) => {
+            const body = typeof req.body === 'string' ? req.body : '';
+            if (body.includes('count=1')) {
+                req.alias = 'countQuery';
+            } else if (body.includes('explain=true')) {
+                req.alias = 'explainQuery';
+            } else {
+                req.alias = 'plainQuery';
+            }
+        });
+    }
 }
 
 export class QueryStubDescription {

--- a/scripts/docker-rootfs/etc/nginx/conf.d/default.conf
+++ b/scripts/docker-rootfs/etc/nginx/conf.d/default.conf
@@ -24,4 +24,21 @@ server {
   location /protocol {
     proxy_pass ${GRAPHDB_URL}/protocol;
   }
+
+  # Mocks the LLM provider for the e2e tests.
+  #
+  # GraphDB's LLM-backed features (GPT explain, GPT functions, Talk to Your Graph) call an external
+  # provider. The test compose files point graphdb.llm.url here instead, so the tests need no API
+  # key and make no outbound calls.
+  #
+  # Mocked: only the provider call. GraphDB still parses the explain request parameters and runs the
+  # query itself before reaching this endpoint, so those stay covered by the tests.
+  #
+  # graphdb.llm.url is a base URL that GraphDB appends the operation to, so the request that
+  # actually arrives is /llm-mock/chat/completions. Every path below /llm-mock answers any method
+  # with the same canned OpenAI-completions response.
+  location /llm-mock {
+    default_type application/json;
+    return 200 '{"id":"chatcmpl-e2e-mock","object":"chat.completion","created":0,"model":"gpt-4.1","choices":[{"index":0,"message":{"role":"assistant","content":"This is a mocked LLM explanation of the query plan."},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}';
+  }
 }


### PR DESCRIPTION
## What
add cypress tests for explain query plan in SPARQL editor

## Why
There was a bug in the backend, when running the query. The backend can't effectively validate it through tests, so we are adding e2e tests to catch potential regression

## How
droAdded `explain-query-plan.spec.js` to validate behavior, including support for query types (SELECT, CONSTRUCT, DESCRIBE) and handling of unsupported types (UPDATE queries, virtual repositories).

## Testing
cypress

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified
