### PR TITLE
GDB-15131 fix flaky repositories import test selectors

### DIFF
--- a/e2e-tests/e2e-flaky/import/import-server-files-operations.spec.js
+++ b/e2e-tests/e2e-flaky/import/import-server-files-operations.spec.js
@@ -31,7 +31,7 @@ describe('Import server files - Operations', () => {
         ImportServerFilesSteps.importResourceByName(FILE_FOR_IMPORT);
         ImportSettingsDialogSteps.import();
         // Then I should see the file imported successfully
-        ImportServerFilesSteps.checkImportedResource(0, FILE_FOR_IMPORT);
+        ImportServerFilesSteps.checkImportedResourceByIndex(0, FILE_FOR_IMPORT);
         // TODO: this and all similar check in the tests below are a checking for the default import settings which we probably should not verify here.
         // ImportServerFilesSteps.verifyImportStatusDetails(FILE_FOR_IMPORT, '"preserveBNodeIds": false,');
     });
@@ -42,7 +42,7 @@ describe('Import server files - Operations', () => {
         ImportServerFilesSteps.importResourceByName(FILE_FROM_DIRECTORY_FOR_IMPORT);
         ImportSettingsDialogSteps.import();
         // Then I should see the file imported successfully
-        ImportServerFilesSteps.checkImportedResource(0, FILE_FROM_DIRECTORY_FOR_IMPORT);
+        ImportServerFilesSteps.checkImportedResourceByIndex(0, FILE_FROM_DIRECTORY_FOR_IMPORT);
     });
 
     it('Should import Server files successfully with changing settings', () => {
@@ -57,7 +57,7 @@ describe('Import server files - Operations', () => {
         ImportSettingsDialogSteps.enablePreserveBNodes();
         ImportSettingsDialogSteps.import();
         // Then I should see the file imported successfully
-        ImportServerFilesSteps.checkImportedResource(0, FILE_FOR_IMPORT);
+        ImportServerFilesSteps.checkImportedResourceByIndex(0, FILE_FOR_IMPORT);
         // ImportSteps.verifyImportStatusDetails(FILE_FOR_IMPORT, [CONTEXT, BASE_URI, '"preserveBNodeIds": true,']);
     });
 
@@ -75,7 +75,7 @@ describe('Import server files - Operations', () => {
         ImportSettingsDialogSteps.enablePreserveBNodes();
         ImportSettingsDialogSteps.import();
         // Then I should see the file imported successfully
-        ImportServerFilesSteps.checkImportedResource(0, JSONLD_FILE_FOR_IMPORT);
+        ImportServerFilesSteps.checkImportedResourceByIndex(0, JSONLD_FILE_FOR_IMPORT);
         // ImportSteps.verifyImportStatusDetails(JSONLD_FILE_FOR_IMPORT, [CONTEXT, BASE_URI, '"preserveBNodeIds": true,', JSONLD_CONTEXT]);
     });
 
@@ -92,7 +92,7 @@ describe('Import server files - Operations', () => {
         ImportSettingsDialogSteps.enablePreserveBNodes();
         ImportSettingsDialogSteps.import();
         // Then I should see the file imported successfully
-        ImportServerFilesSteps.checkImportedResource(0, JSONLD_FILE_FOR_IMPORT);
+        ImportServerFilesSteps.checkImportedResourceByIndex(0, JSONLD_FILE_FOR_IMPORT);
         // ImportSteps.verifyImportStatusDetails(JSONLD_FILE_FOR_IMPORT, [CONTEXT, BASE_URI, '"preserveBNodeIds": true,']);
     });
 
@@ -101,7 +101,7 @@ describe('Import server files - Operations', () => {
         // And I have imported a file
         ImportServerFilesSteps.importResourceByName(FILE_FOR_IMPORT);
         ImportSettingsDialogSteps.import();
-        ImportServerFilesSteps.checkImportedResource(0, FILE_FOR_IMPORT);
+        ImportServerFilesSteps.checkImportedResourceByIndex(0, FILE_FOR_IMPORT);
         // When I reset the status of the imported file
         ImportServerFilesSteps.resetResourceStatusByName(FILE_FOR_IMPORT);
         // Then Import status of the file should not be visible
@@ -113,7 +113,7 @@ describe('Import server files - Operations', () => {
         // And I have imported a file
         ImportServerFilesSteps.importResourceByName(FILE_FROM_DIRECTORY_FOR_IMPORT);
         ImportSettingsDialogSteps.import();
-        ImportServerFilesSteps.checkImportedResource(0, FILE_FROM_DIRECTORY_FOR_IMPORT);
+        ImportServerFilesSteps.checkImportedResourceByIndex(0, FILE_FROM_DIRECTORY_FOR_IMPORT);
         // When I reset the status of the imported file
         ImportServerFilesSteps.resetResourceStatusByName(FILE_FROM_DIRECTORY_FOR_IMPORT);
         // Then Import status of the file should not be visible
@@ -126,7 +126,7 @@ describe('Import server files - Operations', () => {
         // When I select to import a ttl file without changing settings
         ImportSettingsDialogSteps.import();
         // Then I should see the file imported successfully
-        ImportServerFilesSteps.checkImportedResource(0, TTLS_FOR_IMPORT);
+        ImportServerFilesSteps.checkImportedResourceByIndex(0, TTLS_FOR_IMPORT);
         // ImportSteps.verifyImportStatusDetails(TTLS_FOR_IMPORT, '"preserveBNodeIds": false,');
     });
 
@@ -136,7 +136,7 @@ describe('Import server files - Operations', () => {
         // When I select to import a trigstar file without changing settings
         ImportSettingsDialogSteps.import();
         // Then I should see the file imported successfully
-        ImportServerFilesSteps.checkImportedResource(0, TRIGS_FOR_IMPORT);
+        ImportServerFilesSteps.checkImportedResourceByIndex(0, TRIGS_FOR_IMPORT);
         // ImportSteps.verifyImportStatusDetails(TRIGS_FOR_IMPORT, '"preserveBNodeIds": false,');
     });
 });

--- a/e2e-tests/e2e-flaky/import/import-user-data-batch-operations.spec.js
+++ b/e2e-tests/e2e-flaky/import/import-user-data-batch-operations.spec.js
@@ -56,7 +56,7 @@ describe('Import user data: Batch operations', () => {
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         ImportSettingsDialogSteps.import();
         ImportUserDataSteps.getResources().should('have.length', 3);
-        ImportUserDataSteps.checkImportedResource(0, 'jsonld-2.jsonld');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'jsonld-2.jsonld');
         // When I select Imported from the menu
         ImportUserDataSteps.selectImportedResources();
         // Then I should see only imported files selected
@@ -83,7 +83,7 @@ describe('Import user data: Batch operations', () => {
         ImportUserDataSteps.batchImport();
         ImportSettingsDialogSteps.import();
         // Then the file should be imported
-        ImportUserDataSteps.checkImportedResource(0, 'jsonld-2.jsonld');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'jsonld-2.jsonld');
         ImportUserDataSteps.selectImportedResources();
         ImportUserDataSteps.getSelectedResources().should('have.length', 1);
         ImportUserDataSteps.deselectAllResources();
@@ -94,8 +94,8 @@ describe('Import user data: Batch operations', () => {
         ImportUserDataSteps.batchImport();
         ImportSettingsDialogSteps.import();
         // Then the files should be imported
-        ImportUserDataSteps.checkImportedResource(1, 'jsonld.jsonld');
-        ImportUserDataSteps.checkImportedResource(2, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(1, 'jsonld.jsonld');
+        ImportUserDataSteps.checkImportedResourceByIndex(2, 'bnodes.ttl');
         ImportUserDataSteps.selectImportedResources();
         ImportUserDataSteps.getSelectedResources().should('have.length', 3);
     });
@@ -162,9 +162,9 @@ function uploadWithImportFiles(files) {
     ImportUserDataSteps.selectFile([file1, file2, file3]);
     ImportSettingsDialogSteps.import();
     ImportUserDataSteps.getResources().should('have.length', 3);
-    ImportUserDataSteps.checkImportedResource(0, 'jsonld-2.jsonld');
-    ImportUserDataSteps.checkImportedResource(1, 'jsonld.jsonld');
-    ImportUserDataSteps.checkImportedResource(2, 'bnodes.ttl');
+    ImportUserDataSteps.checkImportedResourceByIndex(0, 'jsonld-2.jsonld');
+    ImportUserDataSteps.checkImportedResourceByIndex(1, 'jsonld.jsonld');
+    ImportUserDataSteps.checkImportedResourceByIndex(2, 'bnodes.ttl');
 }
 
 function uploadFiles(data) {

--- a/e2e-tests/e2e-flaky/import/import-user-data-url.spec.js
+++ b/e2e-tests/e2e-flaky/import/import-user-data-url.spec.js
@@ -58,6 +58,6 @@ describe('Import user data: URL import', () => {
                 return xhr.response.body[0]?.status === 'ERROR'
             }), {timeout: 10000, interval: 1000}
         )
-        ImportUserDataSteps.checkImportedResource(0, IMPORT_JSONLD_URL, 'https://example.com/0007-context.jsonld');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, IMPORT_JSONLD_URL, 'https://example.com/0007-context.jsonld');
     });
 });

--- a/e2e-tests/e2e-legacy/guides/import-rdf-file/confirm-duplicate-rdf-file.spec.js
+++ b/e2e-tests/e2e-legacy/guides/import-rdf-file/confirm-duplicate-rdf-file.spec.js
@@ -33,7 +33,7 @@ describe('Confirm duplicate RDF file', () => {
         GuideDialogSteps.assertDialogWithTitleIsVisible('Import file');
         GuideDialogSteps.assertDialogWithContentIsVisible('Click on the Import button.');
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, GUIDE_RESOURCE_FILE);
+        ImportUserDataSteps.checkImportedResourceByIndex(0, GUIDE_RESOURCE_FILE);
 
         // WHEN: I run a guide that includes the Import RDF File step.
         GuideDialogSteps.assertDialogWithTitleIsVisible('Import file — 1/6');

--- a/e2e-tests/e2e-legacy/import/import-server-files-batch-operations.spec.js
+++ b/e2e-tests/e2e-legacy/import/import-server-files-batch-operations.spec.js
@@ -57,7 +57,7 @@ describe('Import server files - Batch operations', () => {
         // precondition for the next step
         ImportServerFilesSteps.importResourceByName(FILE_FOR_IMPORT);
         ImportSettingsDialogSteps.import();
-        ImportServerFilesSteps.checkImportedResource(0, FILE_FOR_IMPORT);
+        ImportServerFilesSteps.checkImportedResourceByName(FILE_FOR_IMPORT);
         // When I select Imported from the menu
         ImportServerFilesSteps.selectImportedResources();
         // Then I should see only imported files selected
@@ -97,8 +97,8 @@ describe('Import server files - Batch operations', () => {
         // Then the files should be imported
         // We send only the files in the folder for import
         // ImportServerFilesSteps.checkImportedResource(0, 'more-files');
-        ImportServerFilesSteps.checkImportedResource(0, 'jsonld-file.jsonld');
-        ImportServerFilesSteps.checkImportedResource(0, 'rdfxml.rdf');
+        ImportServerFilesSteps.checkImportedResourceByName('jsonld-file.jsonld');
+        ImportServerFilesSteps.checkImportedResourceByName('rdfxml.rdf');
         ImportServerFilesSteps.deselectFileByName('more-files');
         // When I select the folder and click on the batch reset button
         ImportServerFilesSteps.selectFileByName('more-files');
@@ -116,7 +116,7 @@ describe('Import server files - Batch operations', () => {
         // Then the files should be imported
         // We send only the files in the folder for import
         // ImportServerFilesSteps.checkImportedResource(0, 'more-files');
-        ImportServerFilesSteps.checkImportedResource(0, 'jsonld-file.jsonld');
-        ImportServerFilesSteps.checkImportedResource(0, 'rdfxml.rdf');
+        ImportServerFilesSteps.checkImportedResourceByName('jsonld-file.jsonld');
+        ImportServerFilesSteps.checkImportedResourceByName('rdfxml.rdf');
     });
 });

--- a/e2e-tests/e2e-legacy/import/import-server-files.spec.js
+++ b/e2e-tests/e2e-legacy/import/import-server-files.spec.js
@@ -87,8 +87,8 @@ describe('Import server files', () => {
         // Then I expect all files to be successfully imported.
         // TODO: this check is failing right now because the fix https://ontotext.atlassian.net/browse/GDB-10295 is not yet completed.
         // ImportServerFilesSteps.checkImportedResource(0, 'more-files', 'Imported successfully in');
-        ImportServerFilesSteps.checkImportedResource(1, 'jsonld-file.jsonld', 'Imported successfully in');
-        ImportServerFilesSteps.checkImportedResource(2, 'rdfxml.rdf', 'Imported successfully in');
+        ImportServerFilesSteps.checkImportedResourceByIndex(1, 'jsonld-file.jsonld', 'Imported successfully in');
+        ImportServerFilesSteps.checkImportedResourceByIndex(2, 'rdfxml.rdf', 'Imported successfully in');
 
         // When I try to import a directory that contains resources with incorrect rdf data.
         ImportServerFilesSteps.importResourceByName('more-files-with-error');
@@ -119,7 +119,7 @@ describe('Import server files', () => {
         ImportSettingsDialogSteps.import();
 
         // I expect only part of the error be displayed,
-        ImportServerFilesSteps.checkImportedResource(0, importResourceName, 'RDF Parse Error: The element type ');
+        ImportServerFilesSteps.checkImportedResourceByName(importResourceName, 'RDF Parse Error: The element type ');
         // and when click on that error
         ImportServerFilesSteps.openErrorDialog(importResourceName);
 
@@ -152,39 +152,39 @@ describe('Import server files', () => {
         ImportServerFilesSteps.orderBySize();
 
         // Then I expect the directories to be sorted in ascending order,
-        ImportServerFilesSteps.getResource(0).should('contain', "more-files");
-        ImportServerFilesSteps.getResource(3).should('contain', "more-files-with-error");
+        ImportServerFilesSteps.getResourceTitleRow(0).should('contain', "more-files");
+        ImportServerFilesSteps.getResourceTitleRow(3).should('contain', "more-files-with-error");
 
         // and inner files to be sorted ascending as well.
         // checks first folder files
-        ImportServerFilesSteps.getResource(1).should('contain', "jsonld-file.jsonld");
-        ImportServerFilesSteps.getResource(2).should('contain', "rdfxml.rdf");
+        ImportServerFilesSteps.getResourceTitleRow(1).should('contain', "jsonld-file.jsonld");
+        ImportServerFilesSteps.getResourceTitleRow(2).should('contain', "rdfxml.rdf");
         // checks second folder files
-        ImportServerFilesSteps.getResource(4).should('contain', "import-resource-with-correct-data.jsonld");
-        ImportServerFilesSteps.getResource(5).should('contain', "import-resource-with-incorrect-data.rdf");
-        ImportServerFilesSteps.getResource(6).should('contain', "import-resource-with-long-error.rdf");
+        ImportServerFilesSteps.getResourceTitleRow(4).should('contain', "import-resource-with-correct-data.jsonld");
+        ImportServerFilesSteps.getResourceTitleRow(5).should('contain', "import-resource-with-incorrect-data.rdf");
+        ImportServerFilesSteps.getResourceTitleRow(6).should('contain', "import-resource-with-long-error.rdf");
         // checks files in root
-        ImportServerFilesSteps.getResource(7).should('contain', "bnodes.ttl");
-        ImportServerFilesSteps.getResource(8).should('contain', "test_turtlestar.ttls");
-        ImportServerFilesSteps.getResource(9).should('contain', "0007-import-file.jsonld");
+        ImportServerFilesSteps.getResourceTitleRow(7).should('contain', "bnodes.ttl");
+        ImportServerFilesSteps.getResourceTitleRow(8).should('contain', "test_turtlestar.ttls");
+        ImportServerFilesSteps.getResourceTitleRow(9).should('contain', "0007-import-file.jsonld");
 
         // When I change the order by size.
         ImportServerFilesSteps.orderBySize();
 
         // Then I expect the directories to be sorted in descending order,
-        ImportServerFilesSteps.getResource(0).should('contain', "more-files-with-error");
-        ImportServerFilesSteps.getResource(4).should('contain', "more-files");
+        ImportServerFilesSteps.getResourceTitleRow(0).should('contain', "more-files-with-error");
+        ImportServerFilesSteps.getResourceTitleRow(4).should('contain', "more-files");
         // checks first folder files
-        ImportServerFilesSteps.getResource(1).should('contain', "import-resource-with-long-error.rdf");
-        ImportServerFilesSteps.getResource(2).should('contain', "import-resource-with-incorrect-data.rdf");
-        ImportServerFilesSteps.getResource(3).should('contain', "import-resource-with-correct-data.jsonld");
+        ImportServerFilesSteps.getResourceTitleRow(1).should('contain', "import-resource-with-long-error.rdf");
+        ImportServerFilesSteps.getResourceTitleRow(2).should('contain', "import-resource-with-incorrect-data.rdf");
+        ImportServerFilesSteps.getResourceTitleRow(3).should('contain', "import-resource-with-correct-data.jsonld");
         // checks second folder files
-        ImportServerFilesSteps.getResource(5).should('contain', "rdfxml.rdf");
-        ImportServerFilesSteps.getResource(6).should('contain', "jsonld-file.jsonld");
+        ImportServerFilesSteps.getResourceTitleRow(5).should('contain', "rdfxml.rdf");
+        ImportServerFilesSteps.getResourceTitleRow(6).should('contain', "jsonld-file.jsonld");
         // checks files in root
-        ImportServerFilesSteps.getResource(17).should('contain', "0007-import-file.jsonld");
-        ImportServerFilesSteps.getResource(18).should('contain', "test_turtlestar.ttls");
-        ImportServerFilesSteps.getResource(19).should('contain', "bnodes.ttl");
+        ImportServerFilesSteps.getResourceTitleRow(17).should('contain', "0007-import-file.jsonld");
+        ImportServerFilesSteps.getResourceTitleRow(18).should('contain', "test_turtlestar.ttls");
+        ImportServerFilesSteps.getResourceTitleRow(19).should('contain', "bnodes.ttl");
     });
 
     it('should allow importing jsonld with empty "JSON-LD Context"', () => {

--- a/e2e-tests/e2e-legacy/import/import-user-data-file-upload.spec.js
+++ b/e2e-tests/e2e-legacy/import/import-user-data-file-upload.spec.js
@@ -46,7 +46,7 @@ describe('Import user data: File upload', () => {
         ImportSettingsDialogSteps.getDialog().should('not.exist');
         // Then I should see the uploaded file
         ImportUserDataSteps.getResources().should('have.length', 1);
-        ImportUserDataSteps.checkImportedResource(0, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'bnodes.ttl');
         // When I try to import the same file again
         ImportUserDataSteps.importFile(0);
         // Then I should not see the upload only option
@@ -56,7 +56,7 @@ describe('Import user data: File upload', () => {
         ImportSettingsDialogSteps.import();
         ImportSettingsDialogSteps.getDialog().should('not.exist');
         ImportUserDataSteps.getResources().should('have.length', 1);
-        ImportUserDataSteps.checkImportedResource(0, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'bnodes.ttl');
     });
 
     it('Should be able to cancel the file upload', () => {
@@ -106,15 +106,15 @@ describe('Import user data: File upload', () => {
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         ImportSettingsDialogSteps.import();
         // Then I should see the uploaded file
-        ImportUserDataSteps.checkImportedResource(0, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'bnodes.ttl');
         // When I upload another file
         const file2 = ImportUserDataSteps.createFile(testFiles[1], jsonld);
         ImportUserDataSteps.selectFile(file2);
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         ImportSettingsDialogSteps.import();
         // Then I should see the uploaded file - it becomes first in the list
-        ImportUserDataSteps.checkImportedResource(0, 'jsonld.jsonld');
-        ImportUserDataSteps.checkImportedResource(1, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'jsonld.jsonld');
+        ImportUserDataSteps.checkImportedResourceByIndex(1, 'bnodes.ttl');
         // When I override the first file
         const file3 = ImportUserDataSteps.createFile(testFiles[0], bnodes);
         ImportUserDataSteps.selectFile(file3);
@@ -123,16 +123,16 @@ describe('Import user data: File upload', () => {
         ImportSettingsDialogSteps.import();
         // Then I should see the uploaded file - it becomes first in the list
         // TODO: timestamps currently seems to not be changed on reimport
-        ImportUserDataSteps.checkImportedResource(0, 'jsonld.jsonld');
-        ImportUserDataSteps.checkImportedResource(1, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'jsonld.jsonld');
+        ImportUserDataSteps.checkImportedResourceByIndex(1, 'bnodes.ttl');
         // When I override the second file
         ImportUserDataSteps.selectFile(file2);
         FileOverwriteDialogSteps.overwrite();
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         ImportSettingsDialogSteps.import();
         // Then I should see the uploaded file - it becomes first in the list
-        ImportUserDataSteps.checkImportedResource(0, 'jsonld.jsonld');
-        ImportUserDataSteps.checkImportedResource(1, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'jsonld.jsonld');
+        ImportUserDataSteps.checkImportedResourceByIndex(1, 'bnodes.ttl');
     });
 
     it('should be able to only upload a single file without importing it', () => {
@@ -165,8 +165,8 @@ describe('Import user data: File upload', () => {
         ImportSettingsDialogSteps.import();
         // Then I should see the uploaded file
         ImportUserDataSteps.getResources().should('have.length', 2);
-        ImportUserDataSteps.checkImportedResource(0, 'jsonld.jsonld');
-        ImportUserDataSteps.checkImportedResource(1, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'jsonld.jsonld');
+        ImportUserDataSteps.checkImportedResourceByIndex(1, 'bnodes.ttl');
         // And the files should really be there
         HeaderSteps.openHomePage();
         ImportUserDataSteps.visit();
@@ -182,7 +182,7 @@ describe('Import user data: File upload', () => {
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         ImportSettingsDialogSteps.import();
         ImportUserDataSteps.getResources().should('have.length', 1);
-        ImportUserDataSteps.checkImportedResource(0, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'bnodes.ttl');
         // When I upload a file with the same name
         ImportUserDataSteps.selectFile(file1);
         // Then I should see a file override confirmation dialog
@@ -193,7 +193,7 @@ describe('Import user data: File upload', () => {
         ImportSettingsDialogSteps.import();
         // Then The file should be overridden
         ImportUserDataSteps.getResources().should('have.length', 1);
-        ImportUserDataSteps.checkImportedResource(0, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'bnodes.ttl');
     });
 
     it('Should be able to upload file with same name and preserve the existing file', () => {
@@ -205,7 +205,7 @@ describe('Import user data: File upload', () => {
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         ImportSettingsDialogSteps.import();
         ImportUserDataSteps.getResources().should('have.length', 1);
-        ImportUserDataSteps.checkImportedResource(0, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'bnodes.ttl');
         // When I upload a file with the same name
         ImportUserDataSteps.selectFile(file1);
         // Then I should see a file override confirmation dialog
@@ -215,8 +215,8 @@ describe('Import user data: File upload', () => {
         ImportSettingsDialogSteps.import();
         // Then The file should not be overridden but prefixed instead
         ImportUserDataSteps.getResources().should('have.length', 2);
-        ImportUserDataSteps.checkImportedResource(0, 'bnodes-0.ttl');
-        ImportUserDataSteps.checkImportedResource(1, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'bnodes-0.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(1, 'bnodes.ttl');
         // When I upload two files, one with the same name and second new one
         const file2 = ImportUserDataSteps.createFile(testFiles[1], jsonld);
         ImportUserDataSteps.selectFile([file1, file2]);
@@ -225,10 +225,10 @@ describe('Import user data: File upload', () => {
         ImportSettingsDialogSteps.import();
         // Then The file should not be overridden but prefixed with increased index instead
         ImportUserDataSteps.getResources().should('have.length', 4);
-        ImportUserDataSteps.checkImportedResource(0, 'jsonld.jsonld');
-        ImportUserDataSteps.checkImportedResource(1, 'bnodes-1.ttl');
-        ImportUserDataSteps.checkImportedResource(2, 'bnodes-0.ttl');
-        ImportUserDataSteps.checkImportedResource(3, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'jsonld.jsonld');
+        ImportUserDataSteps.checkImportedResourceByIndex(1, 'bnodes-1.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(2, 'bnodes-0.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(3, 'bnodes.ttl');
     });
 
     it('should see error message when uploaded file has invalid format', () => {
@@ -242,6 +242,6 @@ describe('Import user data: File upload', () => {
         ImportSettingsDialogSteps.import();
         // Then I should see an error message
         ImportUserDataSteps.getResources().should('have.length', 1);
-        ImportUserDataSteps.checkImportedResource(0, 'invalid-format.json', 'RDF Parse Error: Invalid file format');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'invalid-format.json', 'RDF Parse Error: Invalid file format');
     });
 });

--- a/e2e-tests/e2e-legacy/import/import-user-data-text-snippet.spec.js
+++ b/e2e-tests/e2e-legacy/import/import-user-data-text-snippet.spec.js
@@ -75,7 +75,7 @@ describe('Import user data: Text snippet', () => {
         ImportUserDataSteps.fillRDFTextSnippet(RDF_TEXT_SNIPPET_1);
         ImportUserDataSteps.clickImportTextSnippetButton();
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, TEXT_SNIPPET);
+        ImportUserDataSteps.checkImportedResourceByIndex(0, TEXT_SNIPPET);
     });
 
     it('Should import RDF text snippet with invalid RDF format selected', () => {
@@ -84,7 +84,7 @@ describe('Import user data: Text snippet', () => {
         ImportUserDataSteps.selectRDFFormat(JSONLD_FORMAT);
         ImportUserDataSteps.clickImportTextSnippetButton();
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, TEXT_SNIPPET, RDF_ERROR_MESSAGE);
+        ImportUserDataSteps.checkImportedResourceByIndex(0, TEXT_SNIPPET, RDF_ERROR_MESSAGE);
     });
 
     it('Should import RDF text snippet successfully with valid RDF format selected', () => {
@@ -93,7 +93,7 @@ describe('Import user data: Text snippet', () => {
         ImportUserDataSteps.selectRDFFormat(VALID_SNIPPET_RDF_FORMAT);
         ImportUserDataSteps.clickImportTextSnippetButton();
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, TEXT_SNIPPET);
+        ImportUserDataSteps.checkImportedResourceByIndex(0, TEXT_SNIPPET);
     });
 
     it('Should import Turtle* text snippet successfully with valid RDF star format selected', () => {
@@ -102,7 +102,7 @@ describe('Import user data: Text snippet', () => {
         ImportUserDataSteps.selectRDFFormat(VALID_SNIPPET_TURTLESTAR_FORMAT);
         ImportUserDataSteps.clickImportTextSnippetButton();
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, TEXT_SNIPPET);
+        ImportUserDataSteps.checkImportedResourceByIndex(0, TEXT_SNIPPET);
     });
 
     it('Should import TriG* text snippet successfully with valid RDF star format selected', () => {
@@ -111,7 +111,7 @@ describe('Import user data: Text snippet', () => {
         ImportUserDataSteps.selectRDFFormat(VALID_SNIPPET_TRIGSTAR_FORMAT);
         ImportUserDataSteps.clickImportTextSnippetButton();
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, TEXT_SNIPPET);
+        ImportUserDataSteps.checkImportedResourceByIndex(0, TEXT_SNIPPET);
     });
 
     it('Should import RDF text snippet successfully with filled base URI and context', () => {
@@ -123,7 +123,7 @@ describe('Import user data: Text snippet', () => {
         ImportSettingsDialogSteps.selectNamedGraph();
         ImportSettingsDialogSteps.fillNamedGraph(CONTEXT);
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, TEXT_SNIPPET);
+        ImportUserDataSteps.checkImportedResourceByIndex(0, TEXT_SNIPPET);
 
         // Go to Graphs overview
         cy.visit('/graphs');
@@ -211,7 +211,7 @@ describe('Import user data: Text snippet', () => {
         ImportSettingsDialogSteps.selectNamedGraph();
         ImportSettingsDialogSteps.fillNamedGraph(CONTEXT);
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, TEXT_SNIPPET);
+        ImportUserDataSteps.checkImportedResourceByIndex(0, TEXT_SNIPPET);
 
         // Go to Graphs overview
         cy.visit('/graphs');
@@ -235,7 +235,7 @@ describe('Import user data: Text snippet', () => {
         ImportSettingsDialogSteps.fillContextLink('https://w3c.github.io/json-ld-api/tests/compact/0007-context.jsonld');
         // ImportUserDataSteps.importFromSettingsDialog();
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, TEXT_SNIPPET);
+        ImportUserDataSteps.checkImportedResourceByIndex(0, TEXT_SNIPPET);
         const graphName = CONTEXT.slice(0, CONTEXT.lastIndexOf('.'));
         // Verify that created graph can be found
         ImportUserDataSteps.verifyGraphData(graphName, "rdf:Property", "rdf:Property", "rdf:Property", "http://example.org/graph", false);

--- a/e2e-tests/e2e-legacy/import/import-user-data-url.spec.js
+++ b/e2e-tests/e2e-legacy/import/import-user-data-url.spec.js
@@ -59,7 +59,7 @@ describe('Import user data: URL import', () => {
         ImportUserDataSteps.clickImportUrlButton();
         // Without changing settings
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, IMPORT_URL);
+        ImportUserDataSteps.checkImportedResourceByIndex(0, IMPORT_URL);
     });
 
     it('Test import file via URL with invalid RDF format selected', () => {
@@ -67,7 +67,7 @@ describe('Import user data: URL import', () => {
         ImportUserDataSteps.selectRDFFormat(JSONLD_FORMAT);
         ImportUserDataSteps.clickImportUrlButton();
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, IMPORT_URL, RDF_ERROR_MESSAGE);
+        ImportUserDataSteps.checkImportedResourceByIndex(0, IMPORT_URL, RDF_ERROR_MESSAGE);
     });
 
     it('Test import file via URL successfully with valid RDF format selected', () => {
@@ -75,6 +75,6 @@ describe('Import user data: URL import', () => {
         ImportUserDataSteps.selectRDFFormat(VALID_URL_RDF_FORMAT);
         ImportUserDataSteps.clickImportUrlButton();
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, IMPORT_URL);
+        ImportUserDataSteps.checkImportedResourceByIndex(0, IMPORT_URL);
     });
 });

--- a/e2e-tests/e2e-legacy/import/import-view.spec.js
+++ b/e2e-tests/e2e-legacy/import/import-view.spec.js
@@ -46,7 +46,7 @@ describe('Import view', () => {
         // Then I should see the uploaded file
         ImportUserDataSteps.getResources().should('have.length', 1);
         ImportUserDataSteps.getResourceByName('bnodes.ttl').should('be.visible');
-        ImportUserDataSteps.checkImportedResource(0, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'bnodes.ttl');
     });
 
     it('Should display/hide help message depends on resource result', () => {
@@ -108,7 +108,7 @@ describe('Import view', () => {
         ImportSettingsDialogSteps.getDialog().should('be.visible');
         ImportSettingsDialogSteps.import();
         ImportUserDataSteps.getResources().should('have.length', 1);
-        ImportUserDataSteps.checkImportedResource(0, 'bnodes.ttl');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'bnodes.ttl');
 
         // Then I expect the help message not exist, because user because there are resource displayed
         ImportUserDataSteps.getHelpMessage().should('not.exist');

--- a/e2e-tests/e2e-legacy/repository/repositories.spec.js
+++ b/e2e-tests/e2e-legacy/repository/repositories.spec.js
@@ -452,7 +452,7 @@ describe('Repositories', () => {
             .selectRDFFormat("TriG")
             .clickImportTextSnippetButton();
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, 'Text snippet');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'Text snippet');
         // Import data that conforms with the shape - import is successfully
         // The newly imported file is first in the list
         ImportUserDataSteps
@@ -461,7 +461,7 @@ describe('Repositories', () => {
             .selectRDFFormat("Turtle")
             .clickImportTextSnippetButton();
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, 'Text snippet');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'Text snippet');
         // Import data that does not conform with the shape - GraphDBShaclSailValidationException
         // The newly imported file is first in the list
         ImportUserDataSteps
@@ -470,7 +470,7 @@ describe('Repositories', () => {
             .selectRDFFormat("Turtle")
             .clickImportTextSnippetButton();
         ImportSettingsDialogSteps.import();
-        ImportUserDataSteps.checkImportedResource(0, 'Text snippet', 'org.eclipse.rdf4j.sail.shacl.GraphDBShaclSailValidationException: Failed SHACL validation');
+        ImportUserDataSteps.checkImportedResourceByIndex(0, 'Text snippet', 'org.eclipse.rdf4j.sail.shacl.GraphDBShaclSailValidationException: Failed SHACL validation');
     });
 
     it('should allow editing of repository name if repository is in cluster', () => {

--- a/e2e-tests/steps/import/import-steps.js
+++ b/e2e-tests/steps/import/import-steps.js
@@ -161,8 +161,20 @@ class ImportSteps {
         return this.getSelectedResources().eq(index).closest('.title-row');
     }
 
-    static getResource(index) {
+    static getResourceTitleRow(index) {
         return this.getResources().eq(index);
+    }
+
+    static getResourceByIndex(index) {
+        return this.getResourcesTable().find(`[data-test="resource-${index}"]`);
+    }
+
+    static getResourceNameByIndex(index) {
+        return this.getResourceByIndex(index).find('.cell-title').invoke('text');
+    }
+
+    static getResourceStatusByIndex(index) {
+        return this.getResourceByIndex(index).find('.import-resource-message');
     }
 
     static getResourceByName(name) {
@@ -171,7 +183,7 @@ class ImportSteps {
     }
 
     static selectFileByIndex(index) {
-        this.getResource(index).find('.select-checkbox').click();
+        this.getResourceTitleRow(index).find('.select-checkbox').click();
     }
 
     static selectFileByName(name) {
@@ -194,8 +206,16 @@ class ImportSteps {
         return this.getResources().find('.import-resource-message');
     }
 
-    static checkImportedResource(index, resourceName, expectedStatus) {
+    static checkImportedResourceByIndex(index, resourceName, expectedStatus) {
         const status = expectedStatus || 'Imported successfully';
+
+        this.getResourceNameByIndex(index).should('contain', resourceName);
+        this.getResourceStatusByIndex(index).should('contain', status);
+    }
+
+    static checkImportedResourceByName(resourceName, expectedStatus) {
+        const status = expectedStatus || 'Imported successfully';
+
         this.getResourceByName(resourceName).should('contain', resourceName);
         this.getResourceStatus(resourceName).should('contain', status);
     }
@@ -263,11 +283,11 @@ class ImportSteps {
     }
 
     static deleteUploadedFile(index) {
-        this.getResource(index).find('.import-resource-action-remove-btn').invoke('show').trigger('click');
+        this.getResourceTitleRow(index).find('.import-resource-action-remove-btn').invoke('show').trigger('click');
     }
 
     static importFile(index) {
-        this.getResource(index).find('.import-resource-action-import-btn').invoke('show').trigger('click');
+        this.getResourceTitleRow(index).find('.import-resource-action-import-btn').invoke('show').trigger('click');
     }
 
     static importResourceByName(name) {
@@ -275,7 +295,7 @@ class ImportSteps {
     }
 
     static resetFileStatus(index) {
-        this.getResource(index).find('.import-resource-action-reset-btn').click();
+        this.getResourceTitleRow(index).find('.import-resource-action-reset-btn').click();
     }
 
     static resetResourceStatusByName(name) {

--- a/packages/legacy-workbench/src/js/angular/import/templates/import-resource-tree.html
+++ b/packages/legacy-workbench/src/js/angular/import/templates/import-resource-tree.html
@@ -146,7 +146,7 @@
         </thead>
         <tbody>
         <tr ng-repeat-start="resource in displayResources track by resource.importResource.hash"
-            class="row title-row"
+            class="row title-row" data-test="resource-{{$index}}"
             ng-class="{ 'even-row-start': $even, 'odd-row-start': $odd}">
             <td class="cell cell-select">
                 <input type="checkbox" ng-model="resource.selected" ng-click="selectionChanged(resource)"
@@ -223,7 +223,7 @@
                 </div>
             </td>
         </tr>
-        <tr ng-repeat-end class="row info-row" ng-class="{ 'even-row-end': $even, 'odd-row-end': $odd}">
+        <tr ng-repeat-end class="row info-row" ng-class="{ 'even-row-end': $even, 'odd-row-end': $odd}" data-test="resource-{{$index}}">
             <td class="cell cell-select"></td>
             <td colspan="6" ng-style="{'padding-left': (filterByType !== TYPE_FILTER_OPTIONS.FILE ? resource.indent : '8px')}"
                 class="cell">


### PR DESCRIPTION
## What
Make import server files E2E tests use index-based selectors instead of text-based matching and add index-specific classes to import resource rows.

## Why
The repositories import tests were flaky because selectors relied on text matching, which sometimes targeted the wrong resource row.

## How
- e2e-tests/steps/import/import-steps.js: Replaced generic getResource with getResourceTitleRow, added index-based resource accessors, and updated selection, status checks, delete, import, and reset helpers to use index-based queries.
- packages/legacy-workbench/src/js/angular/import/templates/import-resource-tree.html: Added resource-{{$index}} class to both title and info rows to allow stable index-based selection in tests.
- e2e-tests/e2e-legacy/import/import-server-files.spec.js: Updated all expectations to use getResourceTitleRow and rely on index-based selection instead of text matching.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
