### PR TITLE
Cherry pick: GDB-14848: Remove minimum length constraint for multi-region tags (#3199)

### DIFF
--- a/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-configuration/multi-region.directive.js
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-configuration/multi-region.directive.js
@@ -14,7 +14,7 @@ const modules = [
 ];
 
 const TagLengthConstraints = {
-    minLen: '3',
+    minLen: '1',
     maxLen: '255',
 };
 


### PR DESCRIPTION
## What
Relaxed the minimum length constraint for identifier tags in the multi-region directive.

## Why
The 3-character limitation was enforced only on the UI, while no such restriction exists in the API. To align the behavior and avoid unnecessary restrictions, the UI validation was updated.

## How
- Changed the `minLen` constraint from "3" to "1" in the `TagLengthConstraints` of the multi-region directive.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified


(cherry picked from commit c0de9def649f0daa50d5bdc03664b90057fd70b4)