### PR TITLE
GDB-15134: Censor connector query secrets

### DIFF
--- a/packages/legacy-workbench/src/js/angular/externalsync/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/externalsync/controllers.js
@@ -8,6 +8,7 @@ const modules = [
 ];
 
 const logger = LoggerProvider.logger;
+const SENSITIVE_FIELD_MASK = 'MASKED_SENSITIVE_FIELD';
 
 angular
     .module('graphdb.framework.externalsync.controllers', modules)
@@ -143,6 +144,8 @@ function createConnectorQuery(name, prefix, fields, options, reportError) {
                 fcopy[options[i].__name] = fromArrayMap(fcopy[options[i].__name], $translate);
             } else if (options[i].__type === 'JsonString') {
                 fcopy[options[i].__name] = angular.fromJson(fcopy[options[i].__name]);
+            } else if (options[i].__sensitive === true && fcopy[options[i].__name]) {
+                fcopy[options[i].__name] = SENSITIVE_FIELD_MASK;
             }
         } catch (e) {
             reportError(options[i].__label, e.message);
@@ -159,6 +162,7 @@ function createConnectorQuery(name, prefix, fields, options, reportError) {
     finalString += 'INSERT DATA {\n';
     finalString += "\tinst:" + name + " :createConnector '''\n";
     finalString += angular.toJson(fcopy, 2);
+    finalString = finalString.replaceAll(`"${SENSITIVE_FIELD_MASK}"`, SENSITIVE_FIELD_MASK);
     finalString += "\n''' .\n}\n";
     finalString = finalString.replace(/\\/g, '\\\\\\');
     return finalString;


### PR DESCRIPTION
## What
Censored sensitive fields in the query visualization if marked as `sensitive`.

## Why
To prevent unintended exposure of sensitive information, such as passwords, during query visualizations, especially in scenarios like screen sharing.

## How
- Added a check for the `__sensitive` flag in fields within the query visualization logic.
- Replaced sensitive field values with a placeholder (`'********'`) when flagged as secret.

## Testing

## Screenshots
<img width="753" height="407" alt="image" src="https://github.com/user-attachments/assets/534bfa52-53cc-481b-84d5-ca97f7831cd5" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
