### PR TITLE
GDB-15136: Fix text button color in cluster management

### DIFF
--- a/packages/legacy-workbench/src/css/clustermanagement.css
+++ b/packages/legacy-workbench/src/css/clustermanagement.css
@@ -176,7 +176,7 @@ text.links-statuses {
 }
 
 .text-btn {
-    color: #000000;
+    color: var(--gw-body-color);
     background: none;
     border: none;
     margin: 0;


### PR DESCRIPTION
## What
Updated the `.text-btn` color in the cluster management CSS to use a CSS variable (`--gw-body-color`) instead of a hardcoded black color.

## Why
To ensure consistent theming across the application and improve visual adaptability.

## How
- Replaced the hardcoded color `#000000` with the CSS variable `var(--gw-body-color)` in `clustermanagement.css`.

## Testing

## Screenshots
<img width="375" height="157" alt="image" src="https://github.com/user-attachments/assets/d14d30af-ac5e-46c4-8b6e-d6ac7a9c9a8b" />
<img width="375" height="157" alt="image" src="https://github.com/user-attachments/assets/bcd2791a-4035-45fd-8080-04cdca2e8b73" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
