### PR TITLE
Revert "GDB-14908: Sort/display identifier tag for the Secondary cluster consistently and logically"

### DIFF
--- a/packages/legacy-workbench/src/js/angular/models/clustermanagement/cluster.js
+++ b/packages/legacy-workbench/src/js/angular/models/clustermanagement/cluster.js
@@ -229,8 +229,7 @@ export class TopologyStatus {
      * @return {TopologyStatus} The mapped TopologyStatus instance.
      */
     static fromJSON({state, primaryTags = {}, primaryIndex, primaryLeader}) {
-        const primaryTagsMap = Object.entries(primaryTags)
-            .sort(([tagNameA], [tagNameB]) => tagNameA.localeCompare(tagNameB));
+        const primaryTagsMap = Object.entries(primaryTags);
         return new TopologyStatus(state, primaryTagsMap, primaryIndex, primaryLeader);
     }
 }
@@ -497,7 +496,7 @@ export class ClusterViewModel {
         const removeNodes = Array.from(this._deleteFromCluster.values()).map((node) => node.endpoint);
         const updateActions = {
             addNodes,
-            removeNodes,
+            removeNodes
         };
 
         const updatedClusterConfig = this.updateClusterConfiguration(addNodes);
@@ -724,7 +723,7 @@ export class ClusterConfiguration {
                     batchUpdateInterval = 5000,
                     nodes = [],
                     secondaryTag,
-                    primaryNodes,
+                    primaryNodes
                 } = {}) {
         this._electionMinTimeout = electionMinTimeout;
         this._electionRangeTimeout = electionRangeTimeout;
@@ -831,7 +830,7 @@ export class ClusterConfiguration {
             verificationTimeout: this._verificationTimeout,
             transactionLogMaximumSizeGB: this._transactionLogMaximumSizeGB,
             batchUpdateInterval: this._batchUpdateInterval,
-            nodes: this._nodes,
+            nodes: this._nodes
         };
         if (this._secondaryTag !== undefined) json.secondaryTag = this._secondaryTag;
         if (this._primaryNodes !== undefined) json.primaryNodes = this._primaryNodes;


### PR DESCRIPTION
## What
This reverts commit 4f45d9af8c435e267e785c9e8b7d80bf8ada80bb.

## Why
Sorting has been implemented in Graphdb and the tags in the response are now sorted.

## How


## Testing


## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
