### PR TITLE
GDB-14839 fix issues from long tooltip in repo selector

### DIFF
--- a/packages/legacy-workbench/src/css/repository-info-popover.css
+++ b/packages/legacy-workbench/src/css/repository-info-popover.css
@@ -25,6 +25,15 @@
     .title {
         border-bottom: 1px solid var(--gw-dialog-border-color);
         margin-bottom: 0.5rem;
+
+        .property-value {
+            overflow-wrap: break-word;
+            display: -webkit-inline-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 3;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
     }
 
     .repository-id {
@@ -34,6 +43,11 @@
 
     .repository-description {
         margin-bottom: 0.5rem;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .property {

--- a/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.scss
+++ b/packages/shared-components/src/components/onto-repository-selector/onto-repository-selector.scss
@@ -79,6 +79,11 @@
       .value {
         overflow-wrap: break-word;
         font-weight: 500;
+        display: -webkit-inline-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .label {
@@ -90,6 +95,11 @@
       padding-left: 0.9rem;
       padding-right: 0.9rem;
       font-size: 0.8rem;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .repository-tooltip-content {


### PR DESCRIPTION
## What
fix issues from long tooltip in repo selector

## Why
when the tooltip is very long it causes issues

## How
Added ellipsis after 3 lines

## Testing
n/a

## Screenshots
<img width="1257" height="1041" alt="Screenshot from 2026-09-04 11-30-41" src="https://github.com/user-attachments/assets/5ad7d44d-4837-4222-a1b0-47f6c60958ee" />

<img width="1257" height="1041" alt="Screenshot from 2026-09-04 11-26-05" src="https://github.com/user-attachments/assets/96a049fd-e433-4783-be3f-43179ef73b53" />
<img width="1257" height="1041" alt="Screenshot from 2026-09-04 11-27-12" src="https://github.com/user-attachments/assets/592c3611-6e27-479c-8358-8a9a5678cba3" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
