### PR TITLE
GDB-14944 Fix repository edit test flakiness

### DIFF
--- a/e2e-tests/e2e-legacy/repository/rename-repository-restrictions.spec.js
+++ b/e2e-tests/e2e-legacy/repository/rename-repository-restrictions.spec.js
@@ -2,6 +2,7 @@ import {RepositorySteps} from "../../steps/repository-steps";
 import {OntopRepositorySteps} from "../../steps/ontop-repository-steps";
 import {ToasterSteps} from "../../steps/toaster-steps";
 import {ModalDialogSteps} from "../../steps/modal-dialog-steps";
+import {RepositoriesStubs} from '../../stubs/repositories/repositories-stubs.js';
 
 describe('Repository rename restrictions', () => {
 
@@ -34,13 +35,14 @@ describe('Repository rename restrictions', () => {
     });
 
     it('should not allow renaming of an Ontop repository', () => {
+        RepositoriesStubs.spyGetRepository(repositoryId);
         // Given there is an Ontop repository.
         createOntopRepository(repositoryId);
 
         // When I open its edit page.
         RepositorySteps.visit();
         RepositorySteps.editRepository(repositoryId);
-
+        cy.wait('@getRepository');
         // Then the repository id should be rendered as read only,
         RepositorySteps.getGDBIdInput()
             .should('have.value', repositoryId)
@@ -62,6 +64,7 @@ describe('Repository rename restrictions', () => {
     });
 
     it('should not allow renaming of a FedX repository', () => {
+        RepositoriesStubs.spyGetRepository(repositoryId);
         // Given there is a FedX repository.
         cy.createRepository({id: memberRepositoryId});
         createFedxRepository(repositoryId, memberRepositoryId);
@@ -69,6 +72,7 @@ describe('Repository rename restrictions', () => {
         // When I open its edit page.
         RepositorySteps.visit();
         RepositorySteps.editRepository(repositoryId);
+        cy.wait('@getRepository');
 
         // Then the repository id should be rendered as read only,
         RepositorySteps.getGDBIdInput()

--- a/e2e-tests/stubs/repositories/repositories-stubs.js
+++ b/e2e-tests/stubs/repositories/repositories-stubs.js
@@ -20,6 +20,10 @@ export class RepositoriesStubs extends Stubs {
         cy.intercept('GET', '/rest/locations/active').as('getActiveLocations');
     }
 
+    static spyGetRepository(id) {
+        cy.intercept(`GET`, `${REPOSITORIES_URL}/${id}?location=`).as('getRepository');
+    }
+
     static stubLocations(withDelay = 0) {
         RepositoriesStubs.stubQueryResponse('/rest/locations', '/repositories/get-locations.json', 'get-locations', withDelay);
     }


### PR DESCRIPTION
## What
Introduced a Cypress spy on repository fetching to ensure consistent test behavior.

## Why
Tests for renaming repositories occasionally failed due to asynchronous API responses not being properly awaited.

## How
- Added `spyGetRepository` in `repositories-stubs.js` to intercept repository fetch requests.
- Integrated a `cy.wait` statement in `rename-repository-restrictions.spec.js` to ensure API responses are awaited during tests.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
