### PR TITLE
GDB-14908 fix multi-region panel primary tags and scrolling

### DIFF
--- a/e2e-tests/e2e-legacy/cluster/cluster-configuration/cluster-configuration-multi-region.spec.js
+++ b/e2e-tests/e2e-legacy/cluster/cluster-configuration/cluster-configuration-multi-region.spec.js
@@ -42,7 +42,9 @@ describe('Cluster configuration', () => {
         });
 
         ClusterStubs.stubClusterGroupStatusWithTag();
+        ClusterStubs.stubClusterConfigWithTag();
         cy.wait('@3-nodes-cluster-group-status-tag');
+        cy.wait('@cluster-config-with-tag');
         // Assert the tags table contains the expected tag
         ClusterConfigurationSteps.getTagsTable().should('be.visible');
         ClusterConfigurationSteps.getTagsTableRows().should('contain.text', tagName);
@@ -62,6 +64,11 @@ describe('Cluster configuration', () => {
         cy.wait('@delete-tag').then((interception) => {
             expect(interception.request.body).to.deep.equal({tag: tagName});
         });
+        ClusterStubs.stubClusterGroupStatus();
+        ClusterStubs.stubClusterConfig();
+        cy.wait('@3-nodes-cluster-group-status');
+        cy.wait('@cluster-config');
+        ClusterConfigurationSteps.getTagsTable().should('not.exist');
     });
 
     it('should show an alert when there is no elected leader in the cluster', () => {

--- a/e2e-tests/e2e-legacy/cluster/edit-cluster-nodes-modal.spec.js
+++ b/e2e-tests/e2e-legacy/cluster/edit-cluster-nodes-modal.spec.js
@@ -460,7 +460,7 @@ describe('Cluster management', () => {
                 "verificationTimeout": 1500,
                 "transactionLogMaximumSizeGB": 50.0,
                 "batchUpdateInterval": 5000,
-                "nodes": ['http://pc-desktop:7200', 'http://pc-desktop:7203']
+                "nodes": ['http://pc-desktop:7200', 'http://pc-desktop:7203'],
             });
         });
         // And expect success message to be displayed.

--- a/e2e-tests/fixtures/cluster/cluster-config-with-tag.json
+++ b/e2e-tests/fixtures/cluster/cluster-config-with-tag.json
@@ -1,0 +1,17 @@
+{
+    "electionMinTimeout": 8000,
+    "electionRangeTimeout": 6000,
+    "heartbeatInterval": 2000,
+    "messageSizeKB": 64,
+    "verificationTimeout": 1500,
+    "transactionLogMaximumSizeGB": 50.0,
+    "batchUpdateInterval": 5000,
+    "nodes": [
+        "pc-desktop:7302",
+        "pc-desktop:7300",
+        "pc-desktop:7301"
+    ],
+    "primaryTags": [
+        "test"
+    ]
+}

--- a/e2e-tests/stubs/cluster/cluster-stubs.js
+++ b/e2e-tests/stubs/cluster/cluster-stubs.js
@@ -77,6 +77,13 @@ export class ClusterStubs extends Stubs {
         }).as('cluster-config');
     }
 
+    static stubClusterConfigWithTag() {
+        cy.intercept('/rest/cluster/config', {
+            fixture: '/cluster/cluster-config-with-tag.json',
+            statusCode: 200
+        }).as('cluster-config-with-tag');
+    }
+
     static stubDeleteCluster() {
         cy.intercept('/rest/cluster/config?force=false', {
             fixture: '/cluster/delete-cluster.json',

--- a/packages/legacy-workbench/src/css/cluster-configuration/multi-region.css
+++ b/packages/legacy-workbench/src/css/cluster-configuration/multi-region.css
@@ -1,6 +1,9 @@
+.multi-region {
+    height: 100%;
+}
+
 .multi-region .multi-region-content {
     display: flex;
-    flex: 1;
     flex-direction: column;
     gap: 1.5rem;
     height: 100%;
@@ -14,6 +17,7 @@
 
 .multi-region .multi-region-table {
     overflow: auto;
+    margin-bottom: 1.5rem;
 }
 
 .multi-region .multi-region-error {

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-configuration/multi-region.directive.js
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-configuration/multi-region.directive.js
@@ -203,6 +203,7 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
                     .then((response) => {
                         $scope.secondaryTag = ClusterConfiguration.fromJSON(response.data).secondaryTag;
                         setTopology(ClusterModel.fromJSON(clusterModel));
+                        $scope.primaryTags = ClusterConfiguration.fromJSON(response.data).primaryTags;
                     }).catch((response) => {
                     const msg = getError(response);
                     toastr.error(msg, $translate.instant('cluster_management.cluster_configuration_multi_region.error.disabling'));
@@ -217,12 +218,9 @@ function MultiRegion($jwtAuth, $translate, $timeout, toastr, ModalService, Clust
             };
 
             const setLoader = (loader, message) => {
-                $timeout.cancel($scope.loaderTimeout);
                 if (loader) {
                     $scope.loaderMessage = message;
-                    $scope.loaderTimeout = $timeout(() => {
-                        $scope.loader = loader;
-                    }, 150);
+                    $scope.loader = true;
                 } else {
                     $scope.loader = false;
                 }

--- a/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
+++ b/packages/legacy-workbench/src/js/angular/clustermanagement/templates/cluster-configuration/multi-region.html
@@ -27,7 +27,7 @@
             </button>
         </div>
 
-        <form class="multi-region-form" name="tagForm" ng-if="topology.primaryTags.length || addingTag">
+        <form class="multi-region-form" name="tagForm" ng-if="primaryTags.length || addingTag">
             <div class="multi-region-table">
                 <table class="tags-table table-striped table-hover table" aria-describedby="tags table">
                     <thead>
@@ -79,18 +79,18 @@
                         </td>
                     </tr>
 
-                    <tr ng-repeat="tag in topology.primaryTags track by $index">
+                    <tr ng-repeat="tag in primaryTags track by $index">
                         <td class="index-cell"><span>{{$index + 1}}</span></td>
                         <td class="tag-name-cell">
-                            {{tag[0]}}
+                            {{tag}}
                         </td>
                         <td class="tag-index-cell">
-                            <span>{{tag[1]}}</span>
+                            <span>{{topology.primaryTags[tag]}}</span>
                         </td>
                         <td class="actions-cell">
                             <div class="actions">
                                 <button ng-if="isAdmin"
-                                        ng-click="deleteTag(tag[0])"
+                                        ng-click="deleteTag(tag)"
                                         ng-disabled="addingTag"
                                         class="btn btn-link delete-tag-btn secondary"
                                         gdb-tooltip="{{ 'cluster_management.cluster_configuration_multi_region.delete_tag_tooltip' | translate }}"

--- a/packages/legacy-workbench/src/js/angular/models/clustermanagement/cluster.js
+++ b/packages/legacy-workbench/src/js/angular/models/clustermanagement/cluster.js
@@ -195,11 +195,11 @@ export class Node {
 export class TopologyStatus {
     /**
      * @param {string} state - The current state of the topology.
-     * @param {{string, number}[]} [primaryTags=[]] - A map of primary tags and their associated values (optional).
+     * @param {Object<string, number>} [primaryTags={}] - Map of primary cluster tags to their values.
      * @param {number} [primaryIndex] - The index of the primary cluster.
      * @param {string} [primaryLeader] - The leader's rpc address of the primary cluster.
      */
-    constructor(state, primaryTags = new Map(), primaryIndex, primaryLeader) {
+    constructor(state, primaryTags = {}, primaryIndex, primaryLeader) {
         this._state = state;
         this._primaryTags = primaryTags;
         this._primaryIndex = primaryIndex;
@@ -210,6 +210,7 @@ export class TopologyStatus {
         return this._state;
     }
 
+    /** @return {Object<string, number>} Map of primary cluster tags to their values. */
     get primaryTags() {
         return this._primaryTags;
     }
@@ -228,9 +229,8 @@ export class TopologyStatus {
      * @param {Object} json - The JSON data.
      * @return {TopologyStatus} The mapped TopologyStatus instance.
      */
-    static fromJSON({state, primaryTags = {}, primaryIndex, primaryLeader}) {
-        const primaryTagsMap = Object.entries(primaryTags);
-        return new TopologyStatus(state, primaryTagsMap, primaryIndex, primaryLeader);
+    static fromJSON({state, primaryTags, primaryIndex, primaryLeader}) {
+        return new TopologyStatus(state, primaryTags, primaryIndex, primaryLeader);
     }
 }
 
@@ -496,7 +496,7 @@ export class ClusterViewModel {
         const removeNodes = Array.from(this._deleteFromCluster.values()).map((node) => node.endpoint);
         const updateActions = {
             addNodes,
-            removeNodes
+            removeNodes,
         };
 
         const updatedClusterConfig = this.updateClusterConfiguration(addNodes);
@@ -722,8 +722,9 @@ export class ClusterConfiguration {
                     transactionLogMaximumSizeGB = 50,
                     batchUpdateInterval = 5000,
                     nodes = [],
+                    primaryTags,
                     secondaryTag,
-                    primaryNodes
+                    primaryNodes,
                 } = {}) {
         this._electionMinTimeout = electionMinTimeout;
         this._electionRangeTimeout = electionRangeTimeout;
@@ -733,6 +734,7 @@ export class ClusterConfiguration {
         this._transactionLogMaximumSizeGB = transactionLogMaximumSizeGB;
         this._batchUpdateInterval = batchUpdateInterval;
         this._nodes = nodes;
+        this._primaryTags = primaryTags;
         this._secondaryTag = secondaryTag;
         this._primaryNodes = primaryNodes;
     }
@@ -821,6 +823,14 @@ export class ClusterConfiguration {
         this._primaryNodes = value;
     }
 
+    get primaryTags() {
+        return this._primaryTags;
+    }
+
+    set primaryTags(value) {
+        this._primaryTags = value;
+    }
+
     toJSON() {
         const json = {
             electionMinTimeout: this._electionMinTimeout,
@@ -830,10 +840,17 @@ export class ClusterConfiguration {
             verificationTimeout: this._verificationTimeout,
             transactionLogMaximumSizeGB: this._transactionLogMaximumSizeGB,
             batchUpdateInterval: this._batchUpdateInterval,
-            nodes: this._nodes
+            nodes: this._nodes,
         };
-        if (this._secondaryTag !== undefined) json.secondaryTag = this._secondaryTag;
-        if (this._primaryNodes !== undefined) json.primaryNodes = this._primaryNodes;
+        if (this._secondaryTag !== undefined) {
+            json.secondaryTag = this._secondaryTag;
+        }
+        if (this._primaryNodes !== undefined) {
+            json.primaryNodes = this._primaryNodes;
+        }
+        if (this._primaryTags !== undefined) {
+            json.primaryTags = this._primaryTags;
+        }
         return json;
     }
 }


### PR DESCRIPTION
## What
Adjust multi-region cluster configuration to correctly handle primary tags and panel scrolling. Sorting of primary tags is done in backend.

## Why
Primary tags were not preserved in the cluster configuration and the multi-region panel scrollbar disappeared, making content inaccessible and loaders unreliable.

## How
- Updated TopologyStatus.fromJSON and the ClusterConfiguration constructor, accessors, and toJSON in packages/legacy-workbench/src/js/angular/models/clustermanagement/cluster.js to pass through and serialize primaryTags.
- Adjusted layout and scrolling styles in packages/legacy-workbench/src/css/cluster-configuration/multi-region.css to restore proper scrollbar behavior.
- Updated the multi-region directive in packages/legacy-workbench/src/js/angular/clustermanagement/directives/cluster-configuration/multi-region.directive.js to populate $scope.primaryTags from the backend response and simplified the loader logic to set the loader flag directly.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
