### PR TITLE
GDB-13849 refactor navigate to login functionality

### DIFF
--- a/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
+++ b/e2e-tests/e2e-legacy/setup/users-and-access/user-and-access.spec.js
@@ -280,7 +280,7 @@ describe('User and Access', () => {
                 LoginSteps.loginWithUser('admin', DEFAULT_ADMIN_PASSWORD);
                 UserAndAccessSteps.getUsersTable().should('be.visible');
 
-                cy.visit('/login?r=%252Fsparql');
+                cy.visit('/login?r=%2Fsparql');
                 cy.reload();
                 UserAndAccessSteps.getUrl().should('include', '/sparql');
             });

--- a/packages/api/src/interceptor/auth/test/unauthenticated-interceptor.spec.ts
+++ b/packages/api/src/interceptor/auth/test/unauthenticated-interceptor.spec.ts
@@ -9,7 +9,7 @@ describe('UnauthenticatedInterceptor', () => {
   const authStorage = service(AuthenticationStorageService);
   const authService = service(AuthenticationService);
 
-  let navigateSpy: jest.SpyInstance;
+  let navigateToLoginPageSpy: jest.SpyInstance;
   let windowReloadSpy: jest.SpyInstance;
   let clearAuthTokenSpy: jest.SpyInstance;
   let isExternalUserSpy: jest.SpyInstance;
@@ -18,8 +18,8 @@ describe('UnauthenticatedInterceptor', () => {
   beforeEach(() => {
     interceptor = new UnauthenticatedInterceptor();
 
-    // Mock navigate function
-    navigateSpy = jest.spyOn(routingUtils, 'navigate').mockImplementation(() => {
+    // Mock navigateToLoginPage function
+    navigateToLoginPageSpy = jest.spyOn(routingUtils, 'navigateToLoginPage').mockImplementation(() => {
       // Mock implementation
     });
 
@@ -153,7 +153,7 @@ describe('UnauthenticatedInterceptor', () => {
       // Then it should clear auth token, navigate to login, reload page, and reject
       await expect(resultPromise).rejects.toBe(response);
       expect(clearAuthTokenSpy).toHaveBeenCalledTimes(1);
-      expect(navigateSpy).toHaveBeenCalledWith('login');
+      expect(navigateToLoginPageSpy).toHaveBeenCalledTimes(1);
       expect(windowReloadSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -168,7 +168,7 @@ describe('UnauthenticatedInterceptor', () => {
       // Then it should resolve without redirecting
       expect(result).toBe(response);
       expect(clearAuthTokenSpy).not.toHaveBeenCalled();
-      expect(navigateSpy).not.toHaveBeenCalled();
+      expect(navigateToLoginPageSpy).not.toHaveBeenCalled();
       expect(windowReloadSpy).not.toHaveBeenCalled();
     });
 
@@ -183,7 +183,7 @@ describe('UnauthenticatedInterceptor', () => {
       // Then it should resolve without redirecting
       expect(result).toBe(response);
       expect(clearAuthTokenSpy).not.toHaveBeenCalled();
-      expect(navigateSpy).not.toHaveBeenCalled();
+      expect(navigateToLoginPageSpy).not.toHaveBeenCalled();
       expect(windowReloadSpy).not.toHaveBeenCalled();
     });
 
@@ -198,7 +198,7 @@ describe('UnauthenticatedInterceptor', () => {
       // Then it should resolve without redirecting
       expect(result).toBe(response);
       expect(clearAuthTokenSpy).not.toHaveBeenCalled();
-      expect(navigateSpy).not.toHaveBeenCalled();
+      expect(navigateToLoginPageSpy).not.toHaveBeenCalled();
       expect(windowReloadSpy).not.toHaveBeenCalled();
     });
 
@@ -213,7 +213,7 @@ describe('UnauthenticatedInterceptor', () => {
       // Then it should not redirect (because indexOf finds "authenticated-user" substring in the URL)
       expect(result).toBe(response);
       expect(clearAuthTokenSpy).not.toHaveBeenCalled();
-      expect(navigateSpy).not.toHaveBeenCalled();
+      expect(navigateToLoginPageSpy).not.toHaveBeenCalled();
       expect(windowReloadSpy).not.toHaveBeenCalled();
     });
 
@@ -229,7 +229,7 @@ describe('UnauthenticatedInterceptor', () => {
       // Then it should clear auth token but not navigate or reload
       await expect(resultPromise).rejects.toBe(response);
       expect(clearAuthTokenSpy).toHaveBeenCalledTimes(1);
-      expect(navigateSpy).not.toHaveBeenCalled();
+      expect(navigateToLoginPageSpy).not.toHaveBeenCalled();
       expect(windowReloadSpy).not.toHaveBeenCalled();
     });
   });

--- a/packages/api/src/interceptor/auth/unauthenticated-interceptor.ts
+++ b/packages/api/src/interceptor/auth/unauthenticated-interceptor.ts
@@ -1,5 +1,5 @@
 import {HttpInterceptor} from '../../models/interceptor/http-interceptor';
-import {isLoginPage, navigate} from '../../services/utils';
+import {isLoginPage, navigateToLoginPage} from '../../services/utils';
 import {WindowService} from '../../services/window';
 import {service} from '../../providers';
 import {AuthenticationStorageService} from '../../services/domain/security/authentication-storage.service';
@@ -27,7 +27,7 @@ export class UnauthenticatedInterceptor extends HttpInterceptor<Response> {
 
       this.authenticationStorageService.clearAuthToken();
       if (!isLoginPage()) {
-        navigate('login');
+        navigateToLoginPage();
         // There is scenario when 401 is thrown during bootstrap and
         // when user is logged the workbench is not properly loaded
         // For example if languages are not loaded.

--- a/packages/api/src/services/domain/security/authentication.service.ts
+++ b/packages/api/src/services/domain/security/authentication.service.ts
@@ -6,12 +6,10 @@ import {Logout} from '../../../models/events';
 import {SecurityContextService} from './security-context.service';
 import {AuthStrategyResolver} from './auth-strategy-resolver';
 import {Login} from '../../../models/events/auth/login';
-import {getPathName, isLoginPage, navigate} from '../../utils';
 import {AuthorizationService} from './authorization.service';
 import {AuthenticationStrategyNotSet} from './errors/authentication-strategy-not-set';
 import {AuthStrategy} from '../../../models/security/authentication';
 import {AuthenticationStorageService} from './authentication-storage.service';
-import {NavigationContextService} from '../../navigation';
 import {GdbTokenAuthStrategy} from './auth-strategies/gdb-token-auth-strategy';
 import {OpenidAuthStrategy} from './auth-strategies/openid-auth-strategy';
 
@@ -27,7 +25,6 @@ export class AuthenticationService implements Service {
   private readonly authorizationService = service(AuthorizationService);
   private readonly securityContextService = service(SecurityContextService);
   private readonly authenticationStorageService = service(AuthenticationStorageService);
-  private readonly navigationContextService = service(NavigationContextService);
 
   /**
    * Checks if an authentication strategy has been configured.
@@ -71,18 +68,13 @@ export class AuthenticationService implements Service {
   logout(): Promise<void> {
     const authStrategy = this.getAuthenticationStrategy();
     this.authenticationStorageService.setAuthenticated(false);
-    const returnUrl = getPathName();
     return authStrategy.logout()
       .then(() => {
-        if (!isLoginPage()) {
-          this.navigationContextService.updateReturnUrl(returnUrl);
-        }
         this.securityContextService.updateIsLoggedIn(false);
         if (this.authorizationService.hasFreeAccess()) {
           this.authorizationService.initializeFreeAccess();
           this.eventService.emit(new Login());
         } else {
-          navigate('login');
           this.eventService.emit(new Logout());
         }
       });

--- a/packages/api/src/services/domain/security/test/authentication.service.spec.ts
+++ b/packages/api/src/services/domain/security/test/authentication.service.spec.ts
@@ -9,14 +9,6 @@ import {WindowService} from '../../../window';
 import {AuthStrategy, AuthStrategyType} from '../../../../models/security/authentication';
 import {AuthStrategyResolver} from '../auth-strategy-resolver';
 import {SecurityConfigTestUtil} from '../../../utils/test/security-config-test-util';
-import {NavigationContextService} from '../../../navigation';
-import {getPathName, isLoginPage} from '../../../utils';
-
-jest.mock('@api/services/utils/routing-utils', () => ({
-  ...(jest.requireActual('@api/services/utils/routing-utils')),
-  getPathName: jest.fn(),
-  isLoginPage: jest.fn(() => false)
-}));
 
 class TestAuthStrategy implements AuthStrategy {
   type = AuthStrategyType.NO_SECURITY;
@@ -110,22 +102,6 @@ describe('AuthenticationService', () => {
       expect(emitSpy).toHaveBeenCalledTimes(1);
       expect(emitSpy).toHaveBeenCalledWith(expect.any(Logout));
       expect(testAuthStrategySpy).toHaveBeenCalled();
-    });
-
-    test('should store returnUrl on logout if not on login page', async () => {
-      const navigationContextService = service(NavigationContextService);
-      jest.spyOn(navigationContextService, 'updateReturnUrl');
-      (getPathName as jest.Mock).mockReturnValue('/sparql');
-      await authService.logout();
-      expect(navigationContextService.updateReturnUrl).toHaveBeenCalledWith('/sparql');
-    });
-
-    test('should not store returnUrl on logout if on login page', async () => {
-      const navigationContextService = service(NavigationContextService);
-      jest.spyOn(navigationContextService, 'updateReturnUrl');
-      (isLoginPage as jest.Mock).mockReturnValue(true);
-      await authService.logout();
-      expect(navigationContextService.updateReturnUrl).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/api/src/services/navigation/navigation-context.service.ts
+++ b/packages/api/src/services/navigation/navigation-context.service.ts
@@ -3,12 +3,10 @@ import {ContextService} from '../context';
 
 type NavigationContextFields = {
   readonly PREVIOUS_ROUTE: string;
-  readonly RETURN_URL: string;
 }
 
 type NavigationContextFieldParams = {
   readonly PREVIOUS_ROUTE: string;
-  readonly RETURN_URL: string;
 }
 
 /**
@@ -17,7 +15,6 @@ type NavigationContextFieldParams = {
 export class NavigationContextService extends ContextService<NavigationContextFields> implements DeriveContextServiceContract<NavigationContextFields, NavigationContextFieldParams> {
   /** Key used to store the previous route in the context */
   readonly PREVIOUS_ROUTE = 'previousRoute';
-  readonly RETURN_URL = 'returnUrl';
 
   /**
    * Updates the previous route in the navigation context.
@@ -43,30 +40,5 @@ export class NavigationContextService extends ContextService<NavigationContextFi
       previousRoute = previousRoute.slice(0, -1);
     }
     return previousRoute;
-  }
-
-  /**
-   * Updates the return URL in the navigation context.
-   *
-   * @param value - The return URL to store
-   */
-  updateReturnUrl(value: string): void {
-    this.updateContextProperty(this.RETURN_URL, value);
-  }
-
-  /**
-   * Retrieves the return URL from the navigation context.
-   *
-   * @returns The return URL or undefined if not set
-   */
-  getReturnUrl(): string | undefined {
-    return this.getContextPropertyValue<string>(this.RETURN_URL);
-  }
-
-  /**
-   * Clears the return URL from the navigation context.
-   */
-  clearReturnUrl() {
-    this.updateContextProperty(this.RETURN_URL, undefined);
   }
 }

--- a/packages/api/src/services/utils/routing-utils.ts
+++ b/packages/api/src/services/utils/routing-utils.ts
@@ -1,4 +1,5 @@
 import {WindowService} from '../window';
+import {UrlPathParams} from '../../models/url';
 
 /**
  * Redirects the current page to a specified URL using the single-spa framework.
@@ -29,6 +30,14 @@ export function navigate(targetUrl: string) {
     url = getBasePath().slice(0, -1) + url;
   }
   WindowService.navigateSingleSpa(url);
+}
+
+/**
+ * Navigates to the login page and adds a return url along with all query params
+ */
+export function navigateToLoginPage() {
+  const returnUrl = encodeURIComponent(getLocationPathWithQueryParams());
+  navigate(`login?${UrlPathParams.RETURN_URL}=${returnUrl}`);
 }
 
 /**

--- a/packages/api/src/services/utils/test/routing-utils.spec.ts
+++ b/packages/api/src/services/utils/test/routing-utils.spec.ts
@@ -1,5 +1,6 @@
 import {WindowService} from '../../window';
-import {navigate, navigateTo} from '../routing-utils';
+import {UrlPathParams} from '../../../models/url';
+import {navigate, navigateTo, navigateToLoginPage} from '../routing-utils';
 
 describe('Routing Util Functions', () => {
 
@@ -19,6 +20,92 @@ describe('Routing Util Functions', () => {
 
       navigate('/graphs');
       expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith('contextName/graphs');
+    });
+  });
+
+  describe('navigateToLoginPage', () => {
+    beforeEach(() => {
+      jest.spyOn(WindowService, 'navigateSingleSpa').mockImplementation(jest.fn());
+      jest.spyOn(WindowService, 'getBaseHref').mockReturnValue('/');
+      jest.spyOn(WindowService, 'getLocationQueryParams').mockReturnValue('');
+    });
+
+    it('should add the current path as an encoded return url', () => {
+      jest.spyOn(WindowService, 'getLocationPathname').mockReturnValue('/sparql');
+
+      navigateToLoginPage();
+
+      expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith('login?r=%2Fsparql');
+    });
+
+    it('should keep the query params of the current page in the return url', () => {
+      jest.spyOn(WindowService, 'getLocationPathname').mockReturnValue('/sparql');
+      jest.spyOn(WindowService, 'getLocationQueryParams').mockReturnValue('?query=SELECT%20*&name=q1');
+
+      navigateToLoginPage();
+
+      expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith(
+        'login?r=%2Fsparql%3Fquery%3DSELECT%2520*%26name%3Dq1'
+      );
+    });
+
+    it('should strip the context path from the return url', () => {
+      jest.spyOn(WindowService, 'getBaseHref').mockReturnValue('/graphdb/');
+      jest.spyOn(WindowService, 'getLocationPathname').mockReturnValue('/graphdb/graphql/endpoints');
+
+      navigateToLoginPage();
+
+      expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith('login?r=%2Fgraphql%2Fendpoints');
+    });
+
+    it('should add the home page as return url when on the home page', () => {
+      jest.spyOn(WindowService, 'getLocationPathname').mockReturnValue('/');
+
+      navigateToLoginPage();
+
+      expect(WindowService.navigateSingleSpa).toHaveBeenCalledWith('login?r=%2F');
+    });
+  });
+
+  describe('navigateToLoginPage return url round trip', () => {
+    // Mirrors how the readers of the `r` param decode it: Angular's `queryParamMap.get`
+    // (login page) and `URLSearchParams.get` (security bootstrap). Both decode exactly once
+    // and both turn a bare '+' into a space, so a single `encodeURIComponent` on the writer
+    // side must survive them untouched.
+    const readWithUrlSearchParams = (loginUrl: string) =>
+      new URLSearchParams(loginUrl.substring(loginUrl.indexOf('?'))).get(UrlPathParams.RETURN_URL);
+    const readWithAngularQueryParamMap = (loginUrl: string) => {
+      const value = loginUrl.substring(loginUrl.indexOf('=') + 1);
+      return decodeURIComponent(value.replace(/\+/g, '%20'));
+    };
+
+    const navigateToLoginPageFrom = (pathname: string, queryParams: string): string => {
+      jest.spyOn(WindowService, 'navigateSingleSpa').mockImplementation(jest.fn());
+      jest.spyOn(WindowService, 'getBaseHref').mockReturnValue('/');
+      jest.spyOn(WindowService, 'getLocationPathname').mockReturnValue(pathname);
+      jest.spyOn(WindowService, 'getLocationQueryParams').mockReturnValue(queryParams);
+
+      navigateToLoginPage();
+
+      return (WindowService.navigateSingleSpa as jest.Mock).mock.calls[0][0] as string;
+    };
+
+    test.each([
+      ['a plain route', '/sparql', ''],
+      ['a nested route', '/graphql/endpoints', ''],
+      ['an encoded space in a query param', '/sparql', '?query=SELECT%20*'],
+      ['an encoded ampersand in a query param', '/sparql', '?name=a%26b'],
+      ['an encoded slash in a query param', '/sparql', '?name=a%2Fb'],
+      ['a plus sign in a query param', '/sparql', '?query=a+b'],
+      ['a literal percent sign in a query param', '/sparql', '?query=100%'],
+      ['multiple query params', '/sparql', '?query=SELECT%20*&name=q1'],
+    ])('should return the original url unchanged for %s', (_description, pathname, queryParams) => {
+      const expected = pathname + queryParams;
+
+      const loginUrl = navigateToLoginPageFrom(pathname, queryParams);
+
+      expect(readWithUrlSearchParams(loginUrl)).toEqual(expected);
+      expect(readWithAngularQueryParamMap(loginUrl)).toEqual(expected);
     });
   });
 

--- a/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
+++ b/packages/legacy-workbench/src/js/angular/core/services/jwt-auth.service.js
@@ -65,7 +65,8 @@ angular.module('graphdb.framework.core.services.jwtauth', [
 
                 const params = {};
                 if ($rootScope.returnToUrl) {
-                    params.r = encodeURIComponent($rootScope.returnToUrl);
+                    // `$location.search` encodes the value when serializing it, so it must be passed raw.
+                    params.r = $rootScope.returnToUrl;
                 }
 
                 if (noaccess) {

--- a/packages/root-config/src/bootstrap/security/security-bootstrap.ts
+++ b/packages/root-config/src/bootstrap/security/security-bootstrap.ts
@@ -10,9 +10,8 @@ import {
   SecurityService,
   service,
   WindowService,
-  UrlPathParams,
   SecurityConfig,
-  getLocationPathWithQueryParams,
+  navigateToLoginPage,
 } from '@ontotext/workbench-api';
 import {LoggerProvider} from '../../services/logger-provider';
 
@@ -75,7 +74,8 @@ const resolveNavigation = (): void => {
     // On login page but already logged in, navigate to return url or home page
     const params = new URLSearchParams(WindowService.getLocationQueryParams());
     const returnUrlParam = params.get('r');
-    const returnUrl = returnUrlParam ? decodeURIComponent(returnUrlParam) : './';
+    // `URLSearchParams.get` already decodes the value, so no further decoding is needed here.
+    const returnUrl = returnUrlParam || './';
 
     navigate(returnUrl);
     eventService.emit(new Login());
@@ -86,8 +86,7 @@ const resolveNavigation = (): void => {
     eventService.emit(new Login());
   } else if (!authStrategy.isAuthenticated()) {
     // Not on login page and not authenticated, navigate to login page with return url
-    const returnUrl = encodeURIComponent(getLocationPathWithQueryParams());
-    navigate(`login?${UrlPathParams.RETURN_URL}=${returnUrl}`);
+    navigateToLoginPage();
   }
 };
 

--- a/packages/shared-components/cypress/e2e/header/header.cy.js
+++ b/packages/shared-components/cypress/e2e/header/header.cy.js
@@ -159,7 +159,7 @@ describe('Header', () => {
       // When, I click it
       HeaderSteps.clickLoginButton();
       // Then, I should still not see the search
-      BaseSteps.getRedirectUrl().should('have.text', 'redirect to login?r=pages%252Fheader%252Findex.html')
+      BaseSteps.getRedirectUrl().should('have.text', 'redirect to login?r=%2Fpages%2Fheader%2Findex.html')
 
       // When I deactivate free access
       HeaderSteps.deactivateFreeAccess();

--- a/packages/shared-components/src/components/onto-layout/onto-layout.tsx
+++ b/packages/shared-components/src/components/onto-layout/onto-layout.tsx
@@ -26,7 +26,8 @@ import {
   MainMenuItem,
   MainMenuExtensionPoint,
   UserPreferencesService,
-  UserPreferencesContextService
+  UserPreferencesContextService,
+  navigateToLoginPage
 } from '@ontotext/workbench-api';
 import {TranslationService} from '../../services/translation.service';
 
@@ -234,7 +235,7 @@ export class OntoLayout {
       if (authenticated) {
         navigate(this.navigationContextService.getPreviousRoute() ?? './');
       } else {
-        navigate('login');
+        navigateToLoginPage();
       }
       WindowService.getWindow().location.reload();
     }
@@ -270,7 +271,7 @@ export class OntoLayout {
       this.eventService.subscribe(EventName.LOGOUT, () => {
         this.setNavbarItemVisibility();
         this.updateVisibility();
-        navigate('login');
+        navigateToLoginPage();
       })
     );
   }

--- a/packages/shared-components/src/components/onto-user-login/onto-user-login.tsx
+++ b/packages/shared-components/src/components/onto-user-login/onto-user-login.tsx
@@ -1,5 +1,5 @@
 import {Component, h} from '@stencil/core';
-import {getCurrentRoute, navigate} from '@ontotext/workbench-api';
+import {navigateToLoginPage} from '@ontotext/workbench-api';
 
 @Component({
   tag: 'onto-user-login',
@@ -11,8 +11,7 @@ export class OntoUserLogin {
   private navigateToLogin() {
     return (event: PointerEvent) => {
       event.preventDefault();
-      const returnUrl = encodeURIComponent(getCurrentRoute());
-      navigate(`login?r=${encodeURIComponent(returnUrl)}`);
+      navigateToLoginPage();
     };
   }
 

--- a/packages/workbench/src/app/pages/login/login-page.component.ts
+++ b/packages/workbench/src/app/pages/login/login-page.component.ts
@@ -5,7 +5,6 @@ import {TranslocoPipe, TranslocoService} from '@jsverse/transloco';
 import {
   AuthenticationService,
   ConfigurationContextService,
-  NavigationContextService,
   OntoToastrService,
   OpenidStorageService,
   RuntimeConfigurationContextService,
@@ -35,7 +34,6 @@ export class LoginPageComponent implements OnInit, OnDestroy {
   private readonly securityService = service(SecurityService);
   private readonly authenticationService = service(AuthenticationService);
   private readonly openidStorageService = service(OpenidStorageService);
-  private readonly navigationContextService = service(NavigationContextService);
   private readonly configurationContextService = service(ConfigurationContextService);
   private readonly runtimeConfigurationContextService = service(RuntimeConfigurationContextService);
 
@@ -55,7 +53,7 @@ export class LoginPageComponent implements OnInit, OnDestroy {
       username: ['', Validators.required],
       password: ['', Validators.required]
     });
-    this.returnUrl = '/';
+    this.returnUrl = './';
   }
 
   ngOnInit(): void {
@@ -70,7 +68,8 @@ export class LoginPageComponent implements OnInit, OnDestroy {
   private handleQueryParams(): void {
     const params = this.route.snapshot.queryParamMap;
     const rawReturnUrl = params.get(UrlPathParams.RETURN_URL);
-    this.returnUrl = rawReturnUrl ? decodeURIComponent(rawReturnUrl) : this.navigationContextService.getReturnUrl() ?? '/';
+    // `queryParamMap.get` already decodes the value, so no further decoding is needed here.
+    this.returnUrl = rawReturnUrl || './';
 
     if (params.has(UrlPathParams.NO_ACCESS)) {
       this.toastrService.error(
@@ -108,7 +107,6 @@ export class LoginPageComponent implements OnInit, OnDestroy {
     this.authenticationService.login(loginData)
       .then(() => {
         this.router.navigateByUrl(this.returnUrl);
-        this.navigationContextService.clearReturnUrl();
       })
       .catch((err) => {
         if (err.status === 401) {


### PR DESCRIPTION
## What
Refactor navigate to login functionality.

## Why
There are multiple instances of `navigate('login')` across the codebase which lacked uniform handling of query and path params.

## How
- Replaced `navigate('login')` calls with the newly introduced `navigateToLoginPage` method.
- Implemented `navigateToLoginPage` in `routing-utils.ts` to handle query and path params, including encoding the return URL.
- Removed the navigation the authentication.service.ts#logout as it duplicated navigation to login
- Removed duplicate encoding and decoding

## Testing
jest

## Screenshots


## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
- [ ] Browser support verified
