### PR TITLE
Cherry pick: GDB-15136: Fix text button color in cluster management

### DIFF
--- a/packages/legacy-workbench/src/css/clustermanagement.css
+++ b/packages/legacy-workbench/src/css/clustermanagement.css
@@ -176,7 +176,7 @@ text.links-statuses {
 }
 
 .text-btn {
-    color: #000000;
+    color: var(--gw-body-color);
     background: none;
     border: none;
     margin: 0;


### PR DESCRIPTION
## What
Updated the `.text-btn` color in the cluster management CSS to use a CSS variable (`--gw-body-color`) instead of a hardcoded black color.

## Why
To ensure consistent theming across the application and improve visual adaptability.

## How
- Replaced the hardcoded color `#000000` with the CSS variable `var(--gw-body-color)` in `clustermanagement.css`.

(cherry picked from commit 3fff64422fc5753384fa13b8146ed16917de187e)