### PR TITLE
Cherry pick: GDB-14685 Fix copy input guide button background (#3204)

### DIFF
--- a/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
+++ b/packages/legacy-workbench/src/css/lib/ontotext-yasgui-web-component.css
@@ -931,7 +931,7 @@ yasgui-component .yasr .yasr_fallback_info:not(:empty) {
 yasgui-component .yasr .explain-plan-copy-btn {
     font-weight: 400;
     color: var(--gw-button-secondary-color);
-    background-color: var(--gw-shortcuts-secondary-button-background);
+    background-color: var(--gw-shortcuts-editor-button-background);
     border-color: var(--gw-button-secondary-border-color);
     margin-right: 1px;
     margin-top: 1px;

--- a/packages/root-config/src/vendor/shepherd-custom.css
+++ b/packages/root-config/src/vendor/shepherd-custom.css
@@ -132,9 +132,9 @@
     margin-top: -52px;
 }
 
-.guide-copy-to-input-query-button,
-.guide-copy-to-editor-query-button {
+button.guide-copy-to-input-query-button,
+button.guide-copy-to-editor-query-button {
     color: var(--gw-button-secondary-color);
-    background-color: var(--gw-shortcuts-secondary-button-background);
+    background-color: var(--gw-shortcuts-editor-button-background);
     border-color: var(--gw-button-secondary-border-color);
 }

--- a/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
+++ b/packages/workbench/src/app/components/yasgui-component-facade/yasgui-component-facade.component.scss
@@ -130,11 +130,11 @@ app-yasgui-component-facade .yasqe .yasqe_buttons {
   background-color: var(--gw-editor-content-background);
 }
 
-app-yasgui-component-facade .tabPanel .yasqe  .yasqe-footer-buttons {
+app-yasgui-component-facade .tabPanel .yasqe .yasqe-footer-buttons {
   padding-top: 15px;
 }
 
-app-yasgui-component-facade .tabPanel .yasqe  .yasqe-footer-buttons .abort-button {
+app-yasgui-component-facade .tabPanel .yasqe .yasqe-footer-buttons .abort-button {
   font-family: var(--main-font);
   font-weight: 400;
   height: 38px;
@@ -174,7 +174,7 @@ app-yasgui-component-facade .yasqe_querySplitWrapper .yasqe_querySplitToggle:hov
   background-color: var(--gw-button-primary-hover-background) !important;
 }
 
-app-yasgui-component-facade  .ontotext-run-dropdown-menu {
+app-yasgui-component-facade .ontotext-run-dropdown-menu {
   background-color: var(--gw-tieredmenu-background) !important;
   border: 1px solid var(--gw-tieredmenu-border-color);
   box-shadow: var(--gw-tieredmenu-shadow-1-offset-x) var(--gw-tieredmenu-shadow-1-offset-y) var(--gw-tieredmenu-shadow-1-blur) var(--gw-tieredmenu-shadow-1-spread) var(--gw-tieredmenu-shadow-1-color);
@@ -365,6 +365,7 @@ app-yasgui-component-facade .saved-queries-container {
   -webkit-box-shadow: var(--gw-dialog-shadow-1-offset-x) var(--gw-dialog-shadow-1-offset-y) var(--gw-dialog-shadow-1-blur) var(--gw-dialog-shadow-1-spread) var(--gw-dialog-shadow-1-color);
   box-shadow: var(--gw-dialog-shadow-1-offset-x) var(--gw-dialog-shadow-1-offset-y) var(--gw-dialog-shadow-1-blur) var(--gw-dialog-shadow-1-spread) var(--gw-dialog-shadow-1-color);
 }
+
 app-yasgui-component-facade .saved-queries-container .arrow:before {
   border-left-color: var(--gw-dialog-border-color);
 }
@@ -393,7 +394,7 @@ app-yasgui-component-facade .saved-queries-container .saved-query-actions .saved
   border-bottom-color: var(--gw-dialog-border-color) !important;
 }
 
-.dialog  .dialog-header .close-button {
+.dialog .dialog-header .close-button {
   color: var(--gw-dialog-color) !important;
   background-color: var(--gw-dialog-background) !important;
 }
@@ -722,11 +723,11 @@ app-yasgui-component-facade .yasr .dataTables_wrapper .dataTable tbody tr:hover 
 }
 
 app-yasgui-component-facade .yasr .dataTables_wrapper .dataTable tbody tr.odd,
-app-yasgui-component-facade .yasr .dataTables_wrapper .dataTable.withRowNumber tr.odd>td:first-child {
+app-yasgui-component-facade .yasr .dataTables_wrapper .dataTable.withRowNumber tr.odd > td:first-child {
   background-color: var(--gw-datatable-row-striped-background) !important;
 }
 
-app-yasgui-component-facade .yasr .dataTables_wrapper .dataTable.withRowNumber tr.even>td:first-child {
+app-yasgui-component-facade .yasr .dataTables_wrapper .dataTable.withRowNumber tr.even > td:first-child {
   background-color: var(--gw-datatable-row-background) !important;
 }
 
@@ -748,11 +749,11 @@ app-yasgui-component-facade .yasr .dataTable .nonUri sup {
 
 app-yasgui-component-facade .yasr #explainPlanQuery {
   font-family: var(--mono-font);
-  background-color:  var(--gw-panel-background);
+  background-color: var(--gw-panel-background);
 }
 
 app-yasgui-component-facade .yasr .explain-plan-container {
-  background-color:  var(--gw-panel-background);
+  background-color: var(--gw-panel-background);
   border: 1px solid var(--gw-dialog-border-color);
 
   .cm-comment {
@@ -897,7 +898,7 @@ app-yasgui-component-facade .yasr .pivot-table-plugin .pvtFilterBox .pvtSearch {
 app-yasgui-component-facade .yasr .explain-plan-copy-btn {
   font-weight: 400;
   color: var(--gw-button-secondary-color);
-  background-color: var(--gw-shortcuts-secondary-button-background);
+  background-color: var(--gw-shortcuts-editor-button-background);
   border-color: var(--gw-button-secondary-border-color);
   margin-right: 1px;
   margin-top: 1px;
@@ -928,7 +929,7 @@ app-yasgui-component-facade .hidden {
 
   app-yasgui-component-facade .yasqe_queryButton,
   app-yasgui-component-facade .ontotext-dropdown-button,
-  app-yasgui-component-facade .tabPanel .yasqe  .yasqe-footer-buttons .abort-button {
+  app-yasgui-component-facade .tabPanel .yasqe .yasqe-footer-buttons .abort-button {
     height: 33px !important;
   }
 }


### PR DESCRIPTION
## What
Updated CSS styles for copy-to-input and explain-plan buttons to use consistent background color.

## Why
The previous background color caused visual inconsistencies with the updated theme.

## How
- Replaced `--gw-shortcuts-secondary-button-background` with `--gw-shortcuts-editor-button-background` in key CSS files:
  - `yasgui-component-facade.component.scss`
  - `shepherd-custom.css`
  - `ontotext-yasgui-web-component.css`.

## Testing

## Screenshots
<img width="559" height="475" alt="image"
src="https://github.com/user-attachments/assets/915c1ea9-2f87-4fd8-b487-e2b654d1af28" />

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified


(cherry picked from commit c033c792b8de2dcb11df621923875bf31c52d031)