### PR TITLE
Cherry pick: GDB-15134: Fix masking of sensitive fields in connector creation

### DIFF
--- a/packages/legacy-workbench/src/js/angular/externalsync/controllers.js
+++ b/packages/legacy-workbench/src/js/angular/externalsync/controllers.js
@@ -117,7 +117,7 @@ function buildNamePrefix(prefix) {
     return prefix.substring(0, prefix.length - 1) + '/instance#';
 }
 
-function createConnectorQuery(name, prefix, fields, options, reportError) {
+function createConnectorQuery(name, prefix, fields, options, reportError, maskSensitiveFields = true) {
     // Returns a copy of the parameter obj sorted according to the order in options
     function sortObject(obj, options) {
         const newObject = {};
@@ -144,7 +144,7 @@ function createConnectorQuery(name, prefix, fields, options, reportError) {
                 fcopy[options[i].__name] = fromArrayMap(fcopy[options[i].__name], $translate);
             } else if (options[i].__type === 'JsonString') {
                 fcopy[options[i].__name] = angular.fromJson(fcopy[options[i].__name]);
-            } else if (options[i].__sensitive === true && fcopy[options[i].__name]) {
+            } else if (maskSensitiveFields && options[i].__sensitive === true && fcopy[options[i].__name]) {
                 fcopy[options[i].__name] = SENSITIVE_FIELD_MASK;
             }
         } catch (e) {
@@ -620,16 +620,16 @@ function ExtendNewConnectorCtrl($scope, $uibModalInstance, connector, $uibModal,
         array.splice(index, 1);
     };
 
-    function toQuery() {
+    function toQuery(maskSensitiveFields = true) {
         return createConnectorQuery($scope.name, connector.value, $scope.values, $scope.options,
             function(label, error) {
                 toastr.error(error, label);
-            });
+            }, maskSensitiveFields);
     }
 
     $scope.ok = function() {
         if ($scope.form.$valid) {
-            const query = toQuery();
+            const query = toQuery(false);
 
             if (query) {
                 $uibModalInstance.close({name: $scope.name, values: $scope.values, options: $scope.options, query: query});
@@ -638,7 +638,7 @@ function ExtendNewConnectorCtrl($scope, $uibModalInstance, connector, $uibModal,
     };
 
     $scope.viewQuery = function() {
-        const query = toQuery();
+        const query = toQuery(true);
 
         if (query) {
             $uibModal.open({


### PR DESCRIPTION
## What
Added functionality to toggle masking of sensitive fields during connector creation and query generation.

## Why
When the query is generated to create/clone a connector the fields must not be masked. When the query is used for UI visualization, only then should the query fields be masked.

## How
- Introduced `maskSensitiveFields` parameter to the `createConnectorQuery` and `toQuery` functions.
- Updated logic to conditionally mask sensitive fields based on the `maskSensitiveFields` flag.

## Testing

## Screenshots

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [ ] Tests
- [ ] Browser support verified
